### PR TITLE
feat(dotnet): add structured metadata.dotnet with per-TFM capabilities

### DIFF
--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -115,6 +115,75 @@ The plugin analyzes your MSBuild project files to determine:
 
 To view inferred tasks for a project, open the [project details view](/docs/features/explore-graph#explore-projects-in-your-workspace) in Nx Console or run `nx show project my-project` in the command line.
 
+## Structured .NET project metadata
+
+In addition to inferred tasks, the plugin publishes evaluated MSBuild facts about each project as
+structured, namespaced metadata under `metadata.dotnet` in the [project details view](/docs/features/explore-graph#explore-projects-in-your-workspace)
+and the [project graph API](/docs/reference/core-api/devkit/documents/ProjectGraph). This metadata
+reflects the project as MSBuild actually evaluated it — including every target framework of a
+multi-targeted project — rather than re-parsing the project file's XML.
+
+```json
+{
+  "dotnet": {
+    "packageId": "MyCompany.MyLibrary",
+    "capabilities": {
+      "test": false,
+      "executable": false,
+      "packable": true,
+      "publishable": false,
+      "tool": false
+    },
+    "targetFrameworks": [
+      {
+        "targetFramework": "net9.0",
+        "targetFrameworkIdentifier": ".NETCoreApp",
+        "targetFrameworkVersion": "v9.0",
+        "runtimeIdentifiers": [],
+        "capabilities": {
+          "test": false,
+          "executable": false,
+          "packable": true,
+          "publishable": false,
+          "tool": false
+        }
+      },
+      {
+        "targetFramework": "net9.0-ios",
+        "targetFrameworkIdentifier": ".NETCoreApp",
+        "targetFrameworkVersion": "v9.0",
+        "targetPlatformIdentifier": "ios",
+        "targetPlatformVersion": "17.0",
+        "runtimeIdentifiers": ["ios-arm64"],
+        "capabilities": {
+          "test": false,
+          "executable": false,
+          "packable": true,
+          "publishable": false,
+          "tool": false
+        }
+      }
+    ]
+  }
+}
+```
+
+- **`packageId`** — the evaluated NuGet package identity (`PackageId`, falling back to
+  `AssemblyName` as MSBuild itself does).
+- **`capabilities`** — project-level capabilities, aggregated across every target framework:
+  - `test` — the project opts in via `IsTestProject` or references `Microsoft.NET.Test.Sdk`/`Microsoft.Testing.*`.
+  - `executable` — the evaluated `OutputType` is `Exe`.
+  - `packable` — the evaluated `IsPackable` (defaults to `true`).
+  - `publishable` — the evaluated `IsPublishable` (falls back to `executable` when unset).
+  - `tool` — the evaluated `PackAsTool`.
+- **`targetFrameworks`** — one entry per evaluated target framework (in declared `TargetFrameworks`
+  order for multi-targeted projects), each with its own framework/platform identifiers, evaluated
+  `RuntimeIdentifier`/`RuntimeIdentifiers`, and its own (non-aggregated) capabilities — a project
+  can be, for example, a test project on one target framework only.
+
+These capabilities are informational: the plugin does not use them to infer a project `type`, apply
+tags, or generate additional targets.
+
 ## @nx/dotnet configuration
 
 The `@nx/dotnet` is configured in the `plugins` array in `nx.json`.

--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -136,6 +136,7 @@ multi-targeted project — rather than re-parsing the project file's XML.
     },
     "targetFrameworks": [
       {
+        "packageId": "MyCompany.MyLibrary",
         "targetFramework": "net9.0",
         "targetFrameworkIdentifier": ".NETCoreApp",
         "targetFrameworkVersion": "v9.0",
@@ -149,6 +150,7 @@ multi-targeted project — rather than re-parsing the project file's XML.
         }
       },
       {
+        "packageId": "MyCompany.MyLibrary",
         "targetFramework": "net9.0-ios",
         "targetFrameworkIdentifier": ".NETCoreApp",
         "targetFrameworkVersion": "v9.0",
@@ -168,8 +170,12 @@ multi-targeted project — rather than re-parsing the project file's XML.
 }
 ```
 
-- **`packageId`** — the evaluated NuGet package identity (`PackageId`, falling back to
-  `AssemblyName` as MSBuild itself does).
+- **`packageId`** — the project's evaluated NuGet package identity (`PackageId`, falling back to
+  `AssemblyName` as MSBuild itself does), set at the project level only when every evaluated
+  target framework agrees on it. It's omitted when no target framework evaluates one, or when
+  they disagree — e.g. a conditional `PackageId` that varies per `TargetFramework` — since a
+  single project-level value would misrepresent one of the frameworks; check each entry's own
+  `packageId` in `targetFrameworks` in that case.
 - **`capabilities`** — project-level capabilities, aggregated across every target framework:
   - `test` — the project opts in via `IsTestProject` or references `Microsoft.NET.Test.Sdk`/`Microsoft.Testing.*`.
   - `executable` — the evaluated `OutputType` is `Exe`.
@@ -177,9 +183,9 @@ multi-targeted project — rather than re-parsing the project file's XML.
   - `publishable` — the evaluated `IsPublishable` (falls back to `executable` when unset).
   - `tool` — the evaluated `PackAsTool`.
 - **`targetFrameworks`** — one entry per evaluated target framework (in declared `TargetFrameworks`
-  order for multi-targeted projects), each with its own framework/platform identifiers, evaluated
-  `RuntimeIdentifier`/`RuntimeIdentifiers`, and its own (non-aggregated) capabilities — a project
-  can be, for example, a test project on one target framework only.
+  order for multi-targeted projects), each with its own evaluated `packageId`, framework/platform
+  identifiers, evaluated `RuntimeIdentifier`/`RuntimeIdentifiers`, and its own (non-aggregated)
+  capabilities — a project can be, for example, a test project on one target framework only.
 
 These capabilities are informational: the plugin does not use them to infer a project `type`, apply
 tags, or generate additional targets.

--- a/packages/dotnet/analyzer.Tests/DotnetMetadataAnalyzerEndToEndTests.cs
+++ b/packages/dotnet/analyzer.Tests/DotnetMetadataAnalyzerEndToEndTests.cs
@@ -147,9 +147,6 @@ public class DotnetMetadataAnalyzerEndToEndTests : IDisposable
         Assert.True(capabilities.GetProperty("packable").GetBoolean());
         Assert.True(capabilities.GetProperty("publishable").GetBoolean());
         Assert.False(capabilities.GetProperty("tool").GetBoolean());
-        // Namespaced under `dotnet` per discussion #36676 — no sibling `projectType`, `tags`, or
-        // `nxTags` keys should ever appear alongside it.
-        Assert.False(node.GetProperty("metadata").TryGetProperty("projectType", out _));
 
         var targetFrameworks = dotnet.GetProperty("targetFrameworks");
         Assert.Equal(2, targetFrameworks.GetArrayLength());

--- a/packages/dotnet/analyzer.Tests/DotnetMetadataAnalyzerEndToEndTests.cs
+++ b/packages/dotnet/analyzer.Tests/DotnetMetadataAnalyzerEndToEndTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using MsbuildAnalyzer.Models;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// End-to-end coverage for the structured <c>metadata.dotnet</c> model
+/// (see https://github.com/nrwl/nx/discussions/36676), driving the real
+/// <see cref="Analyzer.AnalyzeWorkspace"/> entry point — including MSBuild property collection,
+/// per-target-framework grouping, and public JSON serialization — against an actual temporary
+/// multi-targeted project on disk. This complements <see cref="DotnetMetadataBuilderTests"/>,
+/// which drives the pure builder directly with plain dictionaries and does not exercise MSBuild
+/// evaluation, <c>Analyzer.CollectProperties</c>'s allow-list, or serialization at all.
+/// </summary>
+public class DotnetMetadataAnalyzerEndToEndTests : IDisposable
+{
+    private readonly string _workspaceRoot;
+
+    public DotnetMetadataAnalyzerEndToEndTests()
+    {
+        _workspaceRoot = Path.Combine(Path.GetTempPath(), "nx-dotnet-metadata-e2e-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_workspaceRoot);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_workspaceRoot, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; a stray locked file shouldn't fail the test run.
+        }
+    }
+
+    // A multi-targeted project where the Test and Executable capabilities genuinely differ per
+    // framework, evaluated for real (no restore is performed, matching how the analyzer's own
+    // ProjectGraph construction works):
+    //   - net8.0 only: references Microsoft.NET.Test.Sdk via a *conditional* PackageReference,
+    //     scoped to this TargetFramework via the ItemGroup Condition -> Test capability, detected
+    //     from the raw evaluated package reference items (not IsTestProject, which would require
+    //     the package's own props to be restored and imported).
+    //   - net9.0 only: an explicit OutputType=Exe -> Executable capability.
+    // PackageId is declared once, unconditionally, so it's expected to be unambiguous and
+    // surface at the project level as well as on every per-framework entry.
+    private const string ProjectXml = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+            <PackageId>Sample.MultiTarget.Package</PackageId>
+          </PropertyGroup>
+          <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
+            <OutputType>Exe</OutputType>
+          </PropertyGroup>
+          <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+            <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+          </ItemGroup>
+        </Project>
+        """;
+
+    private string WriteSampleProject()
+    {
+        var projectFile = Path.Combine(_workspaceRoot, "Sample.csproj");
+        File.WriteAllText(projectFile, ProjectXml);
+        return "Sample.csproj";
+    }
+
+    [Fact]
+    public void AnalyzeWorkspace_RealMultiTargetProject_ProducesExpectedDotnetMetadata()
+    {
+        var relativeProjectFile = WriteSampleProject();
+
+        var result = Analyzer.AnalyzeWorkspace(
+            new List<string> { relativeProjectFile },
+            new List<string>(),
+            _workspaceRoot,
+            new PluginOptions());
+
+        var node = Assert.Single(result.NodesByFile).Value;
+        var dotnet = node.Metadata?.Dotnet;
+        Assert.NotNull(dotnet);
+
+        // Project-level PackageId is unambiguous (declared unconditionally) and resolved from
+        // real MSBuild evaluation, not a test-supplied dictionary.
+        Assert.Equal("Sample.MultiTarget.Package", dotnet!.PackageId);
+
+        // Project-level capabilities are the OR across both real evaluated target frameworks:
+        // net8.0 contributes Test, net9.0 contributes Executable.
+        Assert.True(dotnet.Capabilities.Test, "net8.0 evaluates a Microsoft.NET.Test.Sdk PackageReference.");
+        Assert.True(dotnet.Capabilities.Executable, "net9.0 evaluates OutputType=Exe.");
+        Assert.True(dotnet.Capabilities.Publishable);
+        Assert.True(dotnet.Capabilities.Packable, "IsPackable defaults to true when unevaluated.");
+        Assert.False(dotnet.Capabilities.Tool);
+
+        Assert.Equal(2, dotnet.TargetFrameworks.Count);
+        Assert.Equal(new[] { "net8.0", "net9.0" }, dotnet.TargetFrameworks.Select(f => f.TargetFramework));
+
+        var net8 = dotnet.TargetFrameworks.Single(f => f.TargetFramework == "net8.0");
+        Assert.True(net8.Capabilities.Test, "The conditional PackageReference is scoped to net8.0 only.");
+        Assert.False(net8.Capabilities.Executable, "net8.0 never sets OutputType.");
+        Assert.True(net8.Capabilities.Publishable, "The evaluated IsPublishable is true independent of OutputType here.");
+        Assert.True(net8.Capabilities.Packable);
+        Assert.Equal("Sample.MultiTarget.Package", net8.PackageId);
+        Assert.Equal(".NETCoreApp", net8.TargetFrameworkIdentifier);
+
+        var net9 = dotnet.TargetFrameworks.Single(f => f.TargetFramework == "net9.0");
+        Assert.False(net9.Capabilities.Test, "The conditional test PackageReference does not apply to net9.0.");
+        Assert.True(net9.Capabilities.Executable, "net9.0 declares its own OutputType=Exe.");
+        Assert.True(net9.Capabilities.Publishable);
+        Assert.True(net9.Capabilities.Packable);
+        Assert.Equal("Sample.MultiTarget.Package", net9.PackageId);
+    }
+
+    [Fact]
+    public void AnalyzeWorkspace_RealMultiTargetProject_SerializesToExpectedPublicJsonShape()
+    {
+        var relativeProjectFile = WriteSampleProject();
+
+        var result = Analyzer.AnalyzeWorkspace(
+            new List<string> { relativeProjectFile },
+            new List<string>(),
+            _workspaceRoot,
+            new PluginOptions());
+
+        // Same serializer configuration Program.cs uses for the analyzer's actual stdout
+        // contract: camelCase property names, nulls omitted.
+        var jsonOptions = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        var json = JsonSerializer.Serialize(result, jsonOptions);
+        using var document = JsonDocument.Parse(json);
+
+        var nodesByFile = document.RootElement.GetProperty("nodesByFile");
+        var node = nodesByFile.GetProperty(relativeProjectFile);
+        var dotnet = node.GetProperty("metadata").GetProperty("dotnet");
+
+        Assert.Equal("Sample.MultiTarget.Package", dotnet.GetProperty("packageId").GetString());
+
+        var capabilities = dotnet.GetProperty("capabilities");
+        Assert.True(capabilities.GetProperty("test").GetBoolean());
+        Assert.True(capabilities.GetProperty("executable").GetBoolean());
+        Assert.True(capabilities.GetProperty("packable").GetBoolean());
+        Assert.True(capabilities.GetProperty("publishable").GetBoolean());
+        Assert.False(capabilities.GetProperty("tool").GetBoolean());
+        // Namespaced under `dotnet` per discussion #36676 — no sibling `projectType`, `tags`, or
+        // `nxTags` keys should ever appear alongside it.
+        Assert.False(node.GetProperty("metadata").TryGetProperty("projectType", out _));
+
+        var targetFrameworks = dotnet.GetProperty("targetFrameworks");
+        Assert.Equal(2, targetFrameworks.GetArrayLength());
+        Assert.Equal("net8.0", targetFrameworks[0].GetProperty("targetFramework").GetString());
+        Assert.Equal("net9.0", targetFrameworks[1].GetProperty("targetFramework").GetString());
+        Assert.Equal("Sample.MultiTarget.Package", targetFrameworks[0].GetProperty("packageId").GetString());
+    }
+}

--- a/packages/dotnet/analyzer.Tests/DotnetMetadataBuilderTests.cs
+++ b/packages/dotnet/analyzer.Tests/DotnetMetadataBuilderTests.cs
@@ -253,7 +253,10 @@ public class DotnetMetadataBuilderTests
             Evaluation(Properties(("TargetFramework", "net9.0"), ("PackageId", "My.Custom.Package"), ("AssemblyName", "MyLib"))),
         };
 
-        Assert.Equal("My.Custom.Package", DotnetMetadataBuilder.Build(evaluations).PackageId);
+        var metadata = DotnetMetadataBuilder.Build(evaluations);
+
+        Assert.Equal("My.Custom.Package", metadata.PackageId);
+        Assert.Equal("My.Custom.Package", Assert.Single(metadata.TargetFrameworks).PackageId);
     }
 
     [Fact]
@@ -273,6 +276,54 @@ public class DotnetMetadataBuilderTests
         var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
         {
             Evaluation(Properties(("TargetFramework", "net9.0"))),
+        };
+
+        Assert.Null(DotnetMetadataBuilder.Build(evaluations).PackageId);
+    }
+
+    [Fact]
+    public void Build_MultiTarget_SamePackageIdAcrossFrameworks_IsUsedAtProjectLevel()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("PackageId", "My.Custom.Package"))),
+            Evaluation(Properties(("TargetFramework", "net8.0"), ("PackageId", "My.Custom.Package"))),
+        };
+
+        var metadata = DotnetMetadataBuilder.Build(evaluations);
+
+        Assert.Equal("My.Custom.Package", metadata.PackageId);
+        Assert.All(metadata.TargetFrameworks, f => Assert.Equal("My.Custom.Package", f.PackageId));
+    }
+
+    [Fact]
+    public void Build_MultiTarget_ConditionalPackageIdPerFramework_ProjectLevelIsNullButPerFrameworkIsPreserved()
+    {
+        // A conditional `<PackageId>` that varies by `$(TargetFramework)` — no single value
+        // describes the whole project, so the project-level PackageId must not silently pick
+        // whichever framework evaluated first.
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("PackageId", "My.Package.Net9"))),
+            Evaluation(Properties(("TargetFramework", "net8.0"), ("PackageId", "My.Package.Net8"))),
+        };
+
+        var metadata = DotnetMetadataBuilder.Build(evaluations);
+
+        Assert.Null(metadata.PackageId);
+        Assert.Equal("My.Package.Net9", metadata.TargetFrameworks.Single(f => f.TargetFramework == "net9.0").PackageId);
+        Assert.Equal("My.Package.Net8", metadata.TargetFrameworks.Single(f => f.TargetFramework == "net8.0").PackageId);
+    }
+
+    [Fact]
+    public void Build_MultiTarget_DivergentAssemblyNameFallback_ProjectLevelIsNull()
+    {
+        // Even without an explicit PackageId, a per-TFM AssemblyName override means the
+        // fallback identity still diverges across frameworks — still ambiguous at project level.
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("AssemblyName", "MyLib.Net9"))),
+            Evaluation(Properties(("TargetFramework", "net8.0"), ("AssemblyName", "MyLib.Net8"))),
         };
 
         Assert.Null(DotnetMetadataBuilder.Build(evaluations).PackageId);

--- a/packages/dotnet/analyzer.Tests/DotnetMetadataBuilderTests.cs
+++ b/packages/dotnet/analyzer.Tests/DotnetMetadataBuilderTests.cs
@@ -1,0 +1,280 @@
+using MsbuildAnalyzer.Models;
+using MsbuildAnalyzer.Utilities;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="DotnetMetadataBuilder.Build"/>, which produces the structured
+/// <c>metadata.dotnet</c> model (see https://github.com/nrwl/nx/discussions/36676) from
+/// already-evaluated MSBuild property/package-reference data — the same data
+/// <see cref="Analyzer"/> collects per grouped inner-build node. These tests drive the pure
+/// builder directly with plain dictionaries, avoiding the cost of a full MSBuild project graph
+/// evaluation (matching the existing analyzer test conventions in this project).
+/// </summary>
+public class DotnetMetadataBuilderTests
+{
+    private static DotnetMetadataBuilder.TargetFrameworkEvaluation Evaluation(
+        Dictionary<string, string> properties,
+        List<PackageReference>? packageRefs = null) =>
+        new(properties, packageRefs ?? new List<PackageReference>());
+
+    private static Dictionary<string, string> Properties(params (string Key, string Value)[] entries) =>
+        entries.ToDictionary(e => e.Key, e => e.Value);
+
+    // --- Single target framework -------------------------------------------------------------
+
+    [Fact]
+    public void Build_SingleTarget_ClassLibrary_IsPackableButNotExecutableOrPublishable()
+    {
+        // A plain class library: no OutputType override (defaults away from "Exe"), no
+        // IsPackable/IsPublishable overrides.
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("AssemblyName", "MyLib"))),
+        };
+
+        var metadata = DotnetMetadataBuilder.Build(evaluations);
+
+        var tfm = Assert.Single(metadata.TargetFrameworks);
+        Assert.Equal("net9.0", tfm.TargetFramework);
+        Assert.True(tfm.Capabilities.Packable, "IsPackable defaults to true when unevaluated.");
+        Assert.False(tfm.Capabilities.Executable);
+        Assert.False(tfm.Capabilities.Publishable, "IsPublishable falls back to the executable heuristic when unevaluated.");
+        Assert.False(tfm.Capabilities.Test);
+        Assert.False(tfm.Capabilities.Tool);
+        Assert.Equal(metadata.Capabilities, tfm.Capabilities);
+    }
+
+    [Fact]
+    public void Build_SingleTarget_ConsoleApp_IsExecutableAndPublishableButNotPackable()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(
+                ("TargetFramework", "net9.0"),
+                ("OutputType", "Exe"),
+                ("IsPackable", "false"))),
+        };
+
+        var metadata = DotnetMetadataBuilder.Build(evaluations);
+
+        Assert.True(metadata.Capabilities.Executable);
+        Assert.True(metadata.Capabilities.Publishable, "Unevaluated IsPublishable falls back to the executable capability.");
+        Assert.False(metadata.Capabilities.Packable);
+    }
+
+    [Fact]
+    public void Build_TestProject_WithExeOutputType_IsNotPublishable()
+    {
+        // Microsoft.NET.Sdk sets OutputType=Exe for the test host but explicitly forces
+        // IsPublishable=false — the metadata must honor that override, not the exe heuristic.
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(
+                Properties(
+                    ("TargetFramework", "net9.0"),
+                    ("OutputType", "Exe"),
+                    ("IsPublishable", "false")),
+                new List<PackageReference> { new() { Include = "Microsoft.NET.Test.Sdk", Version = "17.11.1" } }),
+        };
+
+        var metadata = DotnetMetadataBuilder.Build(evaluations);
+
+        Assert.True(metadata.Capabilities.Test);
+        Assert.True(metadata.Capabilities.Executable);
+        Assert.False(metadata.Capabilities.Publishable);
+    }
+
+    [Theory]
+    [InlineData("Microsoft.NET.Test.Sdk")]
+    [InlineData("Microsoft.Testing.Platform")]
+    public void Build_TestPackageReference_MarksTestCapability(string packageId)
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(
+                Properties(("TargetFramework", "net9.0")),
+                new List<PackageReference> { new() { Include = packageId } }),
+        };
+
+        Assert.True(DotnetMetadataBuilder.Build(evaluations).Capabilities.Test);
+    }
+
+    [Fact]
+    public void Build_PackAsTool_MarksToolCapability()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("PackAsTool", "true"))),
+        };
+
+        Assert.True(DotnetMetadataBuilder.Build(evaluations).Capabilities.Tool);
+    }
+
+    // --- Target framework/platform facts ------------------------------------------------------
+
+    [Fact]
+    public void Build_PlatformSpecificTarget_CapturesFrameworkAndPlatformIdentifiers()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(
+                ("TargetFramework", "net9.0-ios"),
+                ("TargetFrameworkIdentifier", ".NETCoreApp"),
+                ("TargetFrameworkVersion", "v9.0"),
+                ("TargetPlatformIdentifier", "ios"),
+                ("TargetPlatformVersion", "17.0"))),
+        };
+
+        var tfm = Assert.Single(DotnetMetadataBuilder.Build(evaluations).TargetFrameworks);
+
+        Assert.Equal("net9.0-ios", tfm.TargetFramework);
+        Assert.Equal(".NETCoreApp", tfm.TargetFrameworkIdentifier);
+        Assert.Equal("v9.0", tfm.TargetFrameworkVersion);
+        Assert.Equal("ios", tfm.TargetPlatformIdentifier);
+        Assert.Equal("17.0", tfm.TargetPlatformVersion);
+    }
+
+    [Fact]
+    public void Build_NonPlatformTarget_LeavesPlatformFactsNull()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"))),
+        };
+
+        var tfm = Assert.Single(DotnetMetadataBuilder.Build(evaluations).TargetFrameworks);
+
+        Assert.Null(tfm.TargetPlatformIdentifier);
+        Assert.Null(tfm.TargetPlatformVersion);
+    }
+
+    // --- RuntimeIdentifier / RuntimeIdentifiers ------------------------------------------------
+
+    [Fact]
+    public void Build_SingleRuntimeIdentifier_IsCaptured()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("RuntimeIdentifier", "linux-x64"))),
+        };
+
+        var tfm = Assert.Single(DotnetMetadataBuilder.Build(evaluations).TargetFrameworks);
+
+        Assert.Equal("linux-x64", tfm.RuntimeIdentifier);
+        Assert.Empty(tfm.RuntimeIdentifiers);
+    }
+
+    [Fact]
+    public void Build_RuntimeIdentifiersList_IsSplitTrimmedAndDeduplicated()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(
+                ("TargetFramework", "net9.0"),
+                ("RuntimeIdentifiers", "linux-x64; win-x64;osx-arm64 ;win-x64"))),
+        };
+
+        var tfm = Assert.Single(DotnetMetadataBuilder.Build(evaluations).TargetFrameworks);
+
+        Assert.Equal(new[] { "linux-x64", "win-x64", "osx-arm64" }, tfm.RuntimeIdentifiers);
+    }
+
+    // --- Multi-targeting: aggregation and per-framework variance -------------------------------
+
+    [Fact]
+    public void Build_MultiTarget_PreservesGivenOrder()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"))),
+            Evaluation(Properties(("TargetFramework", "net8.0"))),
+            Evaluation(Properties(("TargetFramework", "net9.0-android"))),
+        };
+
+        var metadata = DotnetMetadataBuilder.Build(evaluations);
+
+        Assert.Equal(
+            new[] { "net9.0", "net8.0", "net9.0-android" },
+            metadata.TargetFrameworks.Select(f => f.TargetFramework));
+    }
+
+    [Fact]
+    public void Build_MultiTarget_ProjectCapabilities_AreOrAggregatedAcrossFrameworks()
+    {
+        // A project that is only a test project under net8.0 (e.g. a conditional
+        // PackageReference), and only produces a RID-specific executable under net9.0.
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(
+                Properties(("TargetFramework", "net8.0")),
+                new List<PackageReference> { new() { Include = "Microsoft.NET.Test.Sdk" } }),
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("OutputType", "Exe"))),
+        };
+
+        var metadata = DotnetMetadataBuilder.Build(evaluations);
+
+        // Project-level capabilities are the OR across every target framework...
+        Assert.True(metadata.Capabilities.Test);
+        Assert.True(metadata.Capabilities.Executable);
+
+        // ...while each per-framework entry keeps its own, non-aggregated capabilities.
+        var net8 = metadata.TargetFrameworks.Single(f => f.TargetFramework == "net8.0");
+        var net9 = metadata.TargetFrameworks.Single(f => f.TargetFramework == "net9.0");
+        Assert.True(net8.Capabilities.Test);
+        Assert.False(net8.Capabilities.Executable);
+        Assert.False(net9.Capabilities.Test);
+        Assert.True(net9.Capabilities.Executable);
+    }
+
+    [Fact]
+    public void Build_MultiTarget_DuplicateFramework_KeepsFirstOccurrenceOnly()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("RuntimeIdentifier", "linux-x64"))),
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("RuntimeIdentifier", "win-x64"))),
+        };
+
+        var metadata = DotnetMetadataBuilder.Build(evaluations);
+
+        var tfm = Assert.Single(metadata.TargetFrameworks);
+        Assert.Equal("linux-x64", tfm.RuntimeIdentifier);
+    }
+
+    // --- PackageId ------------------------------------------------------------------------------
+
+    [Fact]
+    public void Build_ExplicitPackageId_IsUsed()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("PackageId", "My.Custom.Package"), ("AssemblyName", "MyLib"))),
+        };
+
+        Assert.Equal("My.Custom.Package", DotnetMetadataBuilder.Build(evaluations).PackageId);
+    }
+
+    [Fact]
+    public void Build_UnsetPackageId_FallsBackToAssemblyName()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"), ("AssemblyName", "MyLib"))),
+        };
+
+        Assert.Equal("MyLib", DotnetMetadataBuilder.Build(evaluations).PackageId);
+    }
+
+    [Fact]
+    public void Build_NoPackageIdOrAssemblyName_IsNull()
+    {
+        var evaluations = new List<DotnetMetadataBuilder.TargetFrameworkEvaluation>
+        {
+            Evaluation(Properties(("TargetFramework", "net9.0"))),
+        };
+
+        Assert.Null(DotnetMetadataBuilder.Build(evaluations).PackageId);
+    }
+}

--- a/packages/dotnet/analyzer.Tests/MSBuildTestRegistration.cs
+++ b/packages/dotnet/analyzer.Tests/MSBuildTestRegistration.cs
@@ -1,0 +1,24 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Build.Locator;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// Registers the ambient .NET SDK's MSBuild assemblies for this test process, exactly once,
+/// before anything in this assembly can reference an MSBuild type. Required for the small
+/// number of tests (<see cref="DotnetMetadataAnalyzerEndToEndTests"/>) that invoke
+/// <c>Analyzer.AnalyzeWorkspace</c> against a real temporary project rather than driving
+/// <c>DotnetMetadataBuilder</c> directly with plain dictionaries — mirrors the registration
+/// <c>Program.cs</c> performs for the analyzer executable itself.
+/// </summary>
+internal static class MSBuildTestRegistration
+{
+    [ModuleInitializer]
+    public static void Register()
+    {
+        if (!MSBuildLocator.IsRegistered)
+        {
+            MSBuildLocator.RegisterDefaults();
+        }
+    }
+}

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -142,8 +142,8 @@ public static class Analyzer
                     var properties = CollectProperties(primaryNode.ProjectInstance!);
 
                     // Determine project type
-                    var isTest = IsTestProject(properties, packageRefs);
-                    var isExe = IsExecutableProject(properties);
+                    var isTest = ProjectUtilities.IsTestProject(properties, packageRefs);
+                    var isExe = ProjectUtilities.IsExecutableProject(properties);
 
                     // Build targets
                     var projectName = ProjectUtilities.GetProjectName(primaryNode.ProjectInstance);
@@ -172,6 +172,13 @@ public static class Analyzer
                         directoryBuildInputs
                     );
 
+                    // Structured, evaluated .NET metadata (metadata.dotnet): reuses the same
+                    // grouped inner-build nodes above rather than re-evaluating XML, aggregating
+                    // per-target-framework facts/capabilities across every framework the
+                    // project targets (not just the primary node used for target generation).
+                    var frameworkEvaluations = CollectTargetFrameworkEvaluations(nodes, primaryNode);
+                    var dotnetMetadata = DotnetMetadataBuilder.Build(frameworkEvaluations);
+
                     nodesByFile[relativeProjectFile] = new NxProjectGraphNode
                     {
                         Name = projectName,
@@ -179,7 +186,8 @@ public static class Analyzer
                         Targets = targets,
                         Metadata = new Models.ProjectMetadata
                         {
-                            Technologies = ProjectUtilities.GetTechnologies(projectPath)
+                            Technologies = ProjectUtilities.GetTechnologies(projectPath),
+                            Dotnet = dotnetMetadata
                         }
                     };
 
@@ -266,12 +274,25 @@ public static class Analyzer
             "TargetFrameworks",
             "OutputType",
             "AssemblyName",
+            "PackageId",
             "IsTestProject",
+
+            // Capabilities (metadata.dotnet)
+            "IsPackable",
+            "IsPublishable",
+            "PackAsTool",
+
+            // Target framework/platform facts (metadata.dotnet)
+            "TargetFrameworkIdentifier",
+            "TargetFrameworkVersion",
+            "TargetPlatformIdentifier",
+            "TargetPlatformVersion",
 
             // Build configuration
             "Configuration",
             "Platform",
             "RuntimeIdentifier",
+            "RuntimeIdentifiers",
 
             // Artifacts output (new SDK layout)
             "UseArtifactsOutput",
@@ -307,17 +328,50 @@ public static class Analyzer
         return properties;
     }
 
-    private static bool IsTestProject(
-        Dictionary<string, string> properties,
-        List<PackageReference> packageRefs)
+    /// <summary>
+    /// Collects the evaluated properties/package-references for every MSBuild inner-build node
+    /// of a project (one per target framework), ordered to match the outer build's declared
+    /// <c>TargetFrameworks</c> list so <c>metadata.dotnet.targetFrameworks</c> is deterministic.
+    /// Falls back to just <paramref name="primaryNode"/> for legacy/non-SDK projects that never
+    /// evaluate a <c>TargetFramework</c> property.
+    /// </summary>
+    private static List<DotnetMetadataBuilder.TargetFrameworkEvaluation> CollectTargetFrameworkEvaluations(
+        List<ProjectGraphNode> nodes,
+        ProjectGraphNode primaryNode)
     {
-        return properties.GetValueOrDefault("IsTestProject") == "true" ||
-               packageRefs.Any(p => p.Include == "Microsoft.NET.Test.Sdk" || p.Include.StartsWith("Microsoft.Testing"));
-    }
+        var frameworkNodes = nodes
+            .Where(n => !string.IsNullOrEmpty(n.ProjectInstance?.GetPropertyValue("TargetFramework")))
+            .ToList();
 
-    private static bool IsExecutableProject(Dictionary<string, string> properties)
-    {
-        return properties.GetValueOrDefault("OutputType")?
-            .Equals("Exe", StringComparison.OrdinalIgnoreCase) == true;
+        if (frameworkNodes.Count == 0)
+        {
+            frameworkNodes = new List<ProjectGraphNode> { primaryNode };
+        }
+        else
+        {
+            // TargetFrameworks (plural) is evaluated identically on every node for the project
+            // (it isn't batched per inner build), so the primary node's value reflects the
+            // author-declared order even when primaryNode itself is an inner build.
+            var declaredOrder = primaryNode.ProjectInstance!.GetPropertyValue("TargetFrameworks");
+            if (!string.IsNullOrEmpty(declaredOrder))
+            {
+                var order = declaredOrder
+                    .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select((tfm, index) => (tfm, index))
+                    .ToDictionary(x => x.tfm, x => x.index, StringComparer.OrdinalIgnoreCase);
+
+                frameworkNodes = frameworkNodes
+                    .OrderBy(n => order.TryGetValue(n.ProjectInstance!.GetPropertyValue("TargetFramework"), out var index)
+                        ? index
+                        : int.MaxValue)
+                    .ToList();
+            }
+        }
+
+        return frameworkNodes
+            .Select(n => new DotnetMetadataBuilder.TargetFrameworkEvaluation(
+                CollectProperties(n.ProjectInstance!),
+                CollectPackageReferences(n.ProjectInstance!)))
+            .ToList();
     }
 }

--- a/packages/dotnet/analyzer/Models/DotnetProjectMetadata.cs
+++ b/packages/dotnet/analyzer/Models/DotnetProjectMetadata.cs
@@ -48,6 +48,13 @@ public record DotnetCapabilities
 /// </summary>
 public record DotnetTargetFrameworkMetadata
 {
+    /// <summary>
+    /// The evaluated NuGet package identity for this target framework: the evaluated
+    /// <c>PackageId</c> property, falling back to <c>AssemblyName</c> when unset (matching the
+    /// NuGet packaging SDK's own default resolution), or <c>null</c> if neither is evaluated.
+    /// </summary>
+    public string? PackageId { get; init; }
+
     /// <summary>The evaluated <c>TargetFramework</c> short name (e.g. "net9.0", "net9.0-ios").</summary>
     public string TargetFramework { get; init; } = string.Empty;
 
@@ -86,9 +93,12 @@ public record DotnetTargetFrameworkMetadata
 public record DotnetProjectMetadata
 {
     /// <summary>
-    /// The project's evaluated NuGet package identity: the evaluated <c>PackageId</c> property,
-    /// falling back to <c>AssemblyName</c> when unset (matching the NuGet packaging SDK's own
-    /// default resolution), or <c>null</c> if neither is evaluated.
+    /// The project's evaluated NuGet package identity, set only when every evaluated target
+    /// framework agrees on it (see <see cref="DotnetTargetFrameworkMetadata.PackageId"/>).
+    /// <c>null</c> when no target framework evaluates one, or when they disagree — e.g. a
+    /// conditional <c>PackageId</c> that varies per <c>TargetFramework</c> — since a single
+    /// project-level value would misrepresent one of the frameworks. Consult each entry in
+    /// <see cref="TargetFrameworks"/> for the per-framework identity in that case.
     /// </summary>
     public string? PackageId { get; init; }
 

--- a/packages/dotnet/analyzer/Models/DotnetProjectMetadata.cs
+++ b/packages/dotnet/analyzer/Models/DotnetProjectMetadata.cs
@@ -1,0 +1,104 @@
+namespace MsbuildAnalyzer.Models;
+
+/// <summary>
+/// Capabilities describing what operations a project (or one evaluated target framework of a
+/// multi-targeted project) supports. These overlap rather than being mutually exclusive — a
+/// project can be both a test project and packable, for example.
+/// </summary>
+public record DotnetCapabilities
+{
+    /// <summary>
+    /// True when the project opts in via <c>IsTestProject</c> or references the test SDK/platform
+    /// packages (<c>Microsoft.NET.Test.Sdk</c>, <c>Microsoft.Testing.*</c>) — the same signal the
+    /// analyzer uses to decide whether to emit a <c>test</c> target.
+    /// </summary>
+    public bool Test { get; init; }
+
+    /// <summary>
+    /// True when the evaluated <c>OutputType</c> is <c>Exe</c> — the same signal the analyzer
+    /// uses to decide whether to emit <c>publish</c>/<c>run</c> targets.
+    /// </summary>
+    public bool Executable { get; init; }
+
+    /// <summary>
+    /// True when the evaluated <c>IsPackable</c> property allows <c>dotnet pack</c> to produce a
+    /// NuGet package. The SDK's packaging targets default this to <c>true</c>, so an unevaluated
+    /// value is treated as packable.
+    /// </summary>
+    public bool Packable { get; init; }
+
+    /// <summary>
+    /// True when the evaluated <c>IsPublishable</c> property allows <c>dotnet publish</c> to
+    /// produce output. Falls back to <see cref="Executable"/> when unevaluated, since the SDK
+    /// otherwise defaults <c>IsPublishable</c> based on whether the project produces an exe
+    /// (and explicitly turns it off for test projects).
+    /// </summary>
+    public bool Publishable { get; init; }
+
+    /// <summary>
+    /// True when the evaluated <c>PackAsTool</c> property packages this project as a .NET tool.
+    /// </summary>
+    public bool Tool { get; init; }
+}
+
+/// <summary>
+/// Evaluated MSBuild facts for a single target framework of a project — one MSBuild "inner
+/// build" node. Multi-targeted projects (<c>TargetFrameworks</c>) contribute one entry per
+/// framework; single-targeted projects contribute exactly one.
+/// </summary>
+public record DotnetTargetFrameworkMetadata
+{
+    /// <summary>The evaluated <c>TargetFramework</c> short name (e.g. "net9.0", "net9.0-ios").</summary>
+    public string TargetFramework { get; init; } = string.Empty;
+
+    /// <summary>The evaluated <c>TargetFrameworkIdentifier</c> (e.g. ".NETCoreApp").</summary>
+    public string? TargetFrameworkIdentifier { get; init; }
+
+    /// <summary>The evaluated <c>TargetFrameworkVersion</c> (e.g. "v9.0").</summary>
+    public string? TargetFrameworkVersion { get; init; }
+
+    /// <summary>
+    /// The evaluated <c>TargetPlatformIdentifier</c> (e.g. "ios", "android", "windows"), for
+    /// target frameworks that target a platform (e.g. "net9.0-ios").
+    /// </summary>
+    public string? TargetPlatformIdentifier { get; init; }
+
+    /// <summary>The evaluated <c>TargetPlatformVersion</c>, set alongside <see cref="TargetPlatformIdentifier"/>.</summary>
+    public string? TargetPlatformVersion { get; init; }
+
+    /// <summary>The evaluated single <c>RuntimeIdentifier</c> for this target framework, if set.</summary>
+    public string? RuntimeIdentifier { get; init; }
+
+    /// <summary>The evaluated <c>RuntimeIdentifiers</c> list for this target framework (multi-RID publish), if set.</summary>
+    public List<string> RuntimeIdentifiers { get; init; } = new();
+
+    /// <summary>Capabilities evaluated for this specific target framework.</summary>
+    public DotnetCapabilities Capabilities { get; init; } = new();
+}
+
+/// <summary>
+/// Structured, evaluated .NET metadata for a project (<c>metadata.dotnet</c>): project-scoped
+/// capabilities aggregated across every evaluated target framework, plus the per-framework
+/// facts they were derived from. Built from the analyzer's already-grouped MSBuild inner-build
+/// nodes — this is intentionally a small, stable model rather than a mirror of every MSBuild
+/// property.
+/// </summary>
+public record DotnetProjectMetadata
+{
+    /// <summary>
+    /// The project's evaluated NuGet package identity: the evaluated <c>PackageId</c> property,
+    /// falling back to <c>AssemblyName</c> when unset (matching the NuGet packaging SDK's own
+    /// default resolution), or <c>null</c> if neither is evaluated.
+    /// </summary>
+    public string? PackageId { get; init; }
+
+    /// <summary>
+    /// Project-level capabilities: true if any evaluated target framework has the capability.
+    /// </summary>
+    public DotnetCapabilities Capabilities { get; init; } = new();
+
+    /// <summary>
+    /// Evaluated facts for each target framework, in <c>TargetFrameworks</c> declaration order.
+    /// </summary>
+    public List<DotnetTargetFrameworkMetadata> TargetFrameworks { get; init; } = new();
+}

--- a/packages/dotnet/analyzer/Models/ProjectMetadata.cs
+++ b/packages/dotnet/analyzer/Models/ProjectMetadata.cs
@@ -9,4 +9,11 @@ public record ProjectMetadata
     /// Technologies used by this project (e.g., "dotnet", "csharp", "test").
     /// </summary>
     public List<string> Technologies { get; init; } = new();
+
+    /// <summary>
+    /// Structured, evaluated .NET metadata for this project (project-level capabilities plus
+    /// per-target-framework facts). Namespaced under <c>dotnet</c> to avoid colliding with other
+    /// technologies' metadata on the same project. Null for non-.NET projects.
+    /// </summary>
+    public DotnetProjectMetadata? Dotnet { get; init; }
 }

--- a/packages/dotnet/analyzer/Utilities/DotnetMetadataBuilder.cs
+++ b/packages/dotnet/analyzer/Utilities/DotnetMetadataBuilder.cs
@@ -1,0 +1,121 @@
+using MsbuildAnalyzer.Models;
+
+namespace MsbuildAnalyzer.Utilities;
+
+/// <summary>
+/// Builds the structured <c>metadata.dotnet</c> model (see <see cref="DotnetProjectMetadata"/>)
+/// from already-evaluated MSBuild state — one <see cref="TargetFrameworkEvaluation"/> per
+/// grouped inner-build node that <see cref="Analyzer"/> collects for a project. Pure and
+/// unit-testable: it never touches MSBuild types directly, only the property/package-reference
+/// data the analyzer already collects per node, so it does not re-evaluate or re-parse project
+/// XML.
+/// </summary>
+public static class DotnetMetadataBuilder
+{
+    /// <summary>
+    /// One MSBuild inner-build node's already-evaluated properties and package references, for
+    /// a single target framework of a project.
+    /// </summary>
+    public record TargetFrameworkEvaluation(
+        Dictionary<string, string> Properties,
+        List<PackageReference> PackageReferences);
+
+    /// <summary>
+    /// Builds project-level <c>metadata.dotnet</c> from one evaluation per target framework.
+    /// Project-level capabilities are the logical OR of every target framework's capabilities,
+    /// and <see cref="DotnetProjectMetadata.PackageId"/> is resolved from the first evaluation
+    /// that has one (package identity does not normally vary per target framework).
+    /// </summary>
+    public static DotnetProjectMetadata Build(IReadOnlyList<TargetFrameworkEvaluation> evaluations)
+    {
+        var frameworks = evaluations
+            .Select(BuildTargetFrameworkMetadata)
+            // Defend against the same TargetFramework appearing twice (e.g. duplicate graph
+            // nodes) so callers always get one entry per distinct evaluated framework.
+            .GroupBy(f => f.TargetFramework, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToList();
+
+        var capabilities = new DotnetCapabilities
+        {
+            Test = frameworks.Any(f => f.Capabilities.Test),
+            Executable = frameworks.Any(f => f.Capabilities.Executable),
+            Packable = frameworks.Any(f => f.Capabilities.Packable),
+            Publishable = frameworks.Any(f => f.Capabilities.Publishable),
+            Tool = frameworks.Any(f => f.Capabilities.Tool),
+        };
+
+        return new DotnetProjectMetadata
+        {
+            PackageId = evaluations
+                .Select(e => ResolvePackageId(e.Properties))
+                .FirstOrDefault(id => id is not null),
+            Capabilities = capabilities,
+            TargetFrameworks = frameworks,
+        };
+    }
+
+    private static DotnetTargetFrameworkMetadata BuildTargetFrameworkMetadata(TargetFrameworkEvaluation evaluation)
+    {
+        var properties = evaluation.Properties;
+
+        return new DotnetTargetFrameworkMetadata
+        {
+            TargetFramework = properties.GetValueOrDefault("TargetFramework", string.Empty),
+            TargetFrameworkIdentifier = NullIfEmpty(properties.GetValueOrDefault("TargetFrameworkIdentifier")),
+            TargetFrameworkVersion = NullIfEmpty(properties.GetValueOrDefault("TargetFrameworkVersion")),
+            TargetPlatformIdentifier = NullIfEmpty(properties.GetValueOrDefault("TargetPlatformIdentifier")),
+            TargetPlatformVersion = NullIfEmpty(properties.GetValueOrDefault("TargetPlatformVersion")),
+            RuntimeIdentifier = NullIfEmpty(properties.GetValueOrDefault("RuntimeIdentifier")),
+            RuntimeIdentifiers = SplitList(properties.GetValueOrDefault("RuntimeIdentifiers")),
+            Capabilities = BuildCapabilities(evaluation),
+        };
+    }
+
+    private static DotnetCapabilities BuildCapabilities(TargetFrameworkEvaluation evaluation)
+    {
+        var properties = evaluation.Properties;
+        var isExecutable = ProjectUtilities.IsExecutableProject(properties);
+
+        return new DotnetCapabilities
+        {
+            Test = ProjectUtilities.IsTestProject(properties, evaluation.PackageReferences),
+            Executable = isExecutable,
+            Packable = IsPackable(properties),
+            Publishable = IsPublishable(properties, isExecutable),
+            Tool = properties.GetValueOrDefault("PackAsTool") == "true",
+        };
+    }
+
+    // NuGet.Build.Tasks.Pack.targets defaults IsPackable to true for every SDK-style project, so
+    // an empty evaluated value means the project never overrode it away from that default.
+    private static bool IsPackable(Dictionary<string, string> properties)
+    {
+        var value = properties.GetValueOrDefault("IsPackable");
+        return string.IsNullOrEmpty(value) || value == "true";
+    }
+
+    // Microsoft.NET.Sdk derives IsPublishable from whether the project produces an executable
+    // when it isn't explicitly set, and forces it off for test projects even though the test
+    // host's OutputType is Exe — so only fall back to the executable heuristic when unevaluated.
+    private static bool IsPublishable(Dictionary<string, string> properties, bool isExecutable)
+    {
+        var value = properties.GetValueOrDefault("IsPublishable");
+        return string.IsNullOrEmpty(value) ? isExecutable : value == "true";
+    }
+
+    // Matches the NuGet packaging SDK's own PackageId default resolution: PackageId, else
+    // AssemblyName (which MSBuild itself defaults to the project file name when unset).
+    private static string? ResolvePackageId(Dictionary<string, string> properties) =>
+        NullIfEmpty(properties.GetValueOrDefault("PackageId")) ?? NullIfEmpty(properties.GetValueOrDefault("AssemblyName"));
+
+    private static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;
+
+    private static List<string> SplitList(string? value) =>
+        string.IsNullOrEmpty(value)
+            ? new List<string>()
+            : value
+                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+}

--- a/packages/dotnet/analyzer/Utilities/DotnetMetadataBuilder.cs
+++ b/packages/dotnet/analyzer/Utilities/DotnetMetadataBuilder.cs
@@ -22,9 +22,9 @@ public static class DotnetMetadataBuilder
 
     /// <summary>
     /// Builds project-level <c>metadata.dotnet</c> from one evaluation per target framework.
-    /// Project-level capabilities are the logical OR of every target framework's capabilities,
-    /// and <see cref="DotnetProjectMetadata.PackageId"/> is resolved from the first evaluation
-    /// that has one (package identity does not normally vary per target framework).
+    /// Project-level capabilities are the logical OR of every target framework's capabilities.
+    /// <see cref="DotnetProjectMetadata.PackageId"/> is only set when every target framework that
+    /// evaluates one agrees on the same value — see <see cref="ResolveProjectPackageId"/>.
     /// </summary>
     public static DotnetProjectMetadata Build(IReadOnlyList<TargetFrameworkEvaluation> evaluations)
     {
@@ -47,12 +47,26 @@ public static class DotnetMetadataBuilder
 
         return new DotnetProjectMetadata
         {
-            PackageId = evaluations
-                .Select(e => ResolvePackageId(e.Properties))
-                .FirstOrDefault(id => id is not null),
+            PackageId = ResolveProjectPackageId(frameworks),
             Capabilities = capabilities,
             TargetFrameworks = frameworks,
         };
+    }
+
+    // A project-level PackageId is only meaningful when it's the same for every target
+    // framework that evaluates one. A conditional `PackageId` that varies per `TargetFramework`
+    // (or, transitively, a per-TFM AssemblyName fallback) means no single value describes the
+    // whole project, so this returns null and callers must look at each entry in
+    // DotnetProjectMetadata.TargetFrameworks instead of silently picking the first one.
+    private static string? ResolveProjectPackageId(IReadOnlyList<DotnetTargetFrameworkMetadata> frameworks)
+    {
+        var distinctIds = frameworks
+            .Select(f => f.PackageId)
+            .Where(id => id is not null)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return distinctIds.Count == 1 ? distinctIds[0] : null;
     }
 
     private static DotnetTargetFrameworkMetadata BuildTargetFrameworkMetadata(TargetFrameworkEvaluation evaluation)
@@ -61,6 +75,7 @@ public static class DotnetMetadataBuilder
 
         return new DotnetTargetFrameworkMetadata
         {
+            PackageId = ResolvePackageId(properties),
             TargetFramework = properties.GetValueOrDefault("TargetFramework", string.Empty),
             TargetFrameworkIdentifier = NullIfEmpty(properties.GetValueOrDefault("TargetFrameworkIdentifier")),
             TargetFrameworkVersion = NullIfEmpty(properties.GetValueOrDefault("TargetFrameworkVersion")),

--- a/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
+++ b/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
@@ -1,4 +1,5 @@
 using Microsoft.Build.Execution;
+using MsbuildAnalyzer.Models;
 
 namespace MsbuildAnalyzer.Utilities;
 
@@ -164,6 +165,24 @@ public static class ProjectUtilities
         var rootWithSep = root + Path.DirectorySeparatorChar;
         return path.StartsWith(rootWithSep, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// A project (or one evaluated target framework of a multi-targeted project) is a test
+    /// project when it opts in via <c>IsTestProject</c> or references the test SDK/platform
+    /// packages — the same signal <see cref="Analyzer"/> uses to decide whether to emit a
+    /// <c>test</c> target, and what <c>metadata.dotnet</c> reports as the <c>test</c> capability.
+    /// </summary>
+    public static bool IsTestProject(Dictionary<string, string> properties, List<PackageReference> packageRefs) =>
+        properties.GetValueOrDefault("IsTestProject") == "true" ||
+        packageRefs.Any(p => p.Include == "Microsoft.NET.Test.Sdk" || p.Include.StartsWith("Microsoft.Testing"));
+
+    /// <summary>
+    /// A project (or one evaluated target framework) is executable when its evaluated
+    /// <c>OutputType</c> is <c>Exe</c> — the same signal <see cref="Analyzer"/> uses to decide
+    /// whether to emit <c>publish</c>/<c>run</c> targets.
+    /// </summary>
+    public static bool IsExecutableProject(Dictionary<string, string> properties) =>
+        properties.GetValueOrDefault("OutputType")?.Equals("Exe", StringComparison.OrdinalIgnoreCase) == true;
 
     /// <summary>
     /// Gets the list of technologies for a project based on its file type and characteristics.

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -157,6 +157,53 @@ export interface ProjectMetadata {
     packageMain?: string;
     isInPackageManagerWorkspaces?: boolean;
   };
+  dotnet?: {
+    packageId?: string;
+    capabilities: DotnetCapabilities;
+    targetFrameworks: DotnetTargetFrameworkMetadata[];
+  };
+}
+
+/**
+ * Capabilities describing what operations a .NET project (or one of its evaluated target
+ * frameworks) supports. These overlap rather than being mutually exclusive: a project can be
+ * both a test project and packable, for example.
+ */
+export interface DotnetCapabilities {
+  /** Opts in via `IsTestProject` or references the test SDK/platform packages. */
+  test: boolean;
+  /** The evaluated `OutputType` is `Exe`. */
+  executable: boolean;
+  /** The evaluated `IsPackable` property allows `dotnet pack` to produce a NuGet package. */
+  packable: boolean;
+  /** The evaluated `IsPublishable` property allows `dotnet publish` to produce output. */
+  publishable: boolean;
+  /** The evaluated `PackAsTool` property packages this project as a .NET tool. */
+  tool: boolean;
+}
+
+/**
+ * Evaluated MSBuild facts for a single target framework of a .NET project (one MSBuild "inner
+ * build"). Multi-targeted projects (`TargetFrameworks`) contribute one entry per framework;
+ * single-targeted projects contribute exactly one.
+ */
+export interface DotnetTargetFrameworkMetadata {
+  /** The evaluated `TargetFramework` short name (e.g. "net9.0", "net9.0-ios"). */
+  targetFramework: string;
+  /** The evaluated `TargetFrameworkIdentifier` (e.g. ".NETCoreApp"). */
+  targetFrameworkIdentifier?: string;
+  /** The evaluated `TargetFrameworkVersion` (e.g. "v9.0"). */
+  targetFrameworkVersion?: string;
+  /** The evaluated `TargetPlatformIdentifier` (e.g. "ios", "android", "windows"), when set. */
+  targetPlatformIdentifier?: string;
+  /** The evaluated `TargetPlatformVersion`, set alongside `targetPlatformIdentifier`. */
+  targetPlatformVersion?: string;
+  /** The evaluated single `RuntimeIdentifier` for this target framework, if set. */
+  runtimeIdentifier?: string;
+  /** The evaluated `RuntimeIdentifiers` list for this target framework (multi-RID publish). */
+  runtimeIdentifiers: string[];
+  /** Capabilities evaluated for this specific target framework. */
+  capabilities: DotnetCapabilities;
 }
 
 export interface TargetMetadata {

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -158,6 +158,14 @@ export interface ProjectMetadata {
     isInPackageManagerWorkspaces?: boolean;
   };
   dotnet?: {
+    /**
+     * The project's evaluated NuGet package identity, set only when every evaluated target
+     * framework agrees on it (see `DotnetTargetFrameworkMetadata.packageId`). Undefined when no
+     * target framework evaluates one, or when they disagree — e.g. a conditional `PackageId`
+     * that varies per `TargetFramework` — since a single project-level value would misrepresent
+     * one of the frameworks. Consult each entry in `targetFrameworks` for the per-framework
+     * identity in that case.
+     */
     packageId?: string;
     capabilities: DotnetCapabilities;
     targetFrameworks: DotnetTargetFrameworkMetadata[];
@@ -188,6 +196,12 @@ export interface DotnetCapabilities {
  * single-targeted projects contribute exactly one.
  */
 export interface DotnetTargetFrameworkMetadata {
+  /**
+   * The evaluated NuGet package identity for this target framework: the evaluated `PackageId`
+   * property, falling back to `AssemblyName` when unset (matching the NuGet packaging SDK's own
+   * default resolution), or undefined if neither is evaluated.
+   */
+  packageId?: string;
   /** The evaluated `TargetFramework` short name (e.g. "net9.0", "net9.0-ios"). */
   targetFramework: string;
   /** The evaluated `TargetFrameworkIdentifier` (e.g. ".NETCoreApp"). */


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

## Current Behavior

The `@nx/dotnet` analyzer infers Nx targets (build, test, publish, pack, etc.) from evaluated
MSBuild state, but it does not expose any of the underlying evaluated facts as project metadata.
Consumers that want to know a project's target framework(s), RID(s), or capabilities (is it a
test project? executable? packable? a .NET tool?) have no structured way to get that information
— they'd have to re-run/re-parse MSBuild themselves.

This addresses item 1 from #36676.

## Expected Behavior

The analyzer now publishes a small, stable, namespaced `metadata.dotnet` shape on every .NET
project node:

```json
{
  "dotnet": {
    "packageId": "MyCompany.MyLibrary",
    "capabilities": {
      "test": false,
      "executable": false,
      "packable": true,
      "publishable": false,
      "tool": false
    },
    "targetFrameworks": [
      {
        "packageId": "MyCompany.MyLibrary",
        "targetFramework": "net9.0",
        "targetFrameworkIdentifier": ".NETCoreApp",
        "targetFrameworkVersion": "v9.0",
        "runtimeIdentifiers": [],
        "capabilities": { "test": false, "executable": false, "packable": true, "publishable": false, "tool": false }
      }
    ]
  }
}
```

- **Project-level `capabilities`** are the logical OR across every evaluated target framework.
- **`targetFrameworks`** has one entry per evaluated MSBuild inner-build node (one per TFM for
  multi-targeted projects), each with its own framework/platform identifiers, evaluated
  `RuntimeIdentifier`/`RuntimeIdentifiers`, and its own non-aggregated capabilities.
- **`packageId`** is the evaluated `PackageId`, falling back to `AssemblyName` (matching the
  NuGet packaging SDK's own default resolution). Each `targetFrameworks` entry has its own
  per-framework `packageId`; the project-level `packageId` is only set when every target
  framework that evaluates one agrees on the same value, and is omitted (`undefined`/absent from
  JSON) when a conditional `PackageId` disagrees across frameworks — a single project-level value
  would otherwise silently misrepresent one of the frameworks. Consumers that need the identity
  for a specific framework should always read it from that framework's own entry.

Design notes / scope boundaries (per discussion #36676):

- **Reuses existing evaluation, doesn't add any.** `CollectTargetFrameworkEvaluations` collects
  properties/package-references from the analyzer's already-grouped MSBuild inner-build nodes
  (the same nodes multi-targeted projects already produce); it never re-parses project XML or
  triggers additional MSBuild evaluation. Ordering matches the project's declared
  `TargetFrameworks` sequence (read once from the shared outer-build property, since that
  property isn't batched per inner build), with a fallback to the primary node for legacy/non-SDK
  projects.
- **Capability derivation reuses existing signals**, not new heuristics:
  - `test` reuses the exact same `IsTestProject`/`Microsoft.NET.Test.Sdk`/`Microsoft.Testing.*`
    check the analyzer already uses to decide whether to emit a `test` target (moved to
    `ProjectUtilities` so both call sites share one implementation). This is evaluated per target
    framework, so a conditional test package reference on only one TFM is captured correctly.
  - `executable` reuses the existing `OutputType == "Exe"` check.
  - `publishable` reads evaluated `IsPublishable`, falling back to `executable` only when
    unevaluated — this matters because the SDK forces `IsPublishable=false` for test projects
    even though their `OutputType` is `Exe`, and this implementation correctly reports those as
    not publishable rather than naively deriving publishable from executable.
  - `packable` reads evaluated `IsPackable`, defaulting to `true` when unevaluated (matching the
    NuGet packaging SDK's own default).
  - `tool` reads evaluated `PackAsTool`.
- **No inference beyond capabilities/facts.** This intentionally does **not** add `projectType`
  inference, automatic tags, `NxTags`, host/OS routing, selector tags, wrappers, or target
  variants — those are separate, more opinionated items from the discussion and out of scope
  here.
- **Deterministic output.** `RuntimeIdentifiers` are split/trimmed/deduplicated
  (`OrdinalIgnoreCase`), and duplicate `TargetFramework` entries across nodes are collapsed to
  one.
- A `DotnetProjectMetadata`/`DotnetCapabilities`/`DotnetTargetFrameworkMetadata` TypeScript
  mirror was added to `ProjectMetadata` in `packages/nx/src/config/workspace-json-project-json.ts`
  (matching the existing `js?: {...}` namespace precedent) purely for typed consumption; no new
  runtime behavior lives on the TS side.

**Overlap with #36469:** that PR adds Central Package Management support and touches
`Analyzer.cs`/`PackageReference.cs` for package-dependency resolution. This PR also touches
`Analyzer.cs` (the same per-node property/package-reference collection helpers), but for an
unrelated purpose — evaluated per-TFM metadata rather than package/CPM resolution. The two are
independent and this PR does not duplicate or depend on #36469's package-dependency/CPM work
(no external/referenced-package nodes are added here; `packageId` is the project's own identity,
not a dependency).

### Testing

- 19 unit tests in `DotnetMetadataBuilderTests.cs` covering: single-target capability
  combinations, multi-target OR-aggregation with per-framework capability variance (including a
  conditional-test-package-per-TFM scenario), `RuntimeIdentifier`/`RuntimeIdentifiers`
  split/trim/dedup, framework/platform fact capture, per-TFM `PackageId` resolution/fallback,
  project-level `PackageId` agreement/disagreement (including an `AssemblyName`-fallback
  disagreement case), and duplicate-`TargetFramework` collapsing. These follow the existing
  pure-unit-test convention in this test project (plain dictionaries/lists, no real MSBuild
  project graph evaluation).
- 2 new end-to-end tests in `DotnetMetadataAnalyzerEndToEndTests.cs` drive the real
  `Analyzer.AnalyzeWorkspace` entry point against an actual temporary multi-targeted project on
  disk (`net8.0;net9.0`, with a conditional per-TFM `Microsoft.NET.Test.Sdk` package reference and
  an explicit `OutputType=Exe` on one framework only), verifying both the object-graph shape and
  the actual public `metadata.dotnet` JSON serialization output (via the same camelCase/
  null-omitting `JsonSerializerOptions` the analyzer's `Program.cs` uses). This exercises real
  MSBuild property collection and per-TFM package-reference conditions that the pure-builder
  tests above don't cover, since those drive `DotnetMetadataBuilder` directly with
  hand-constructed dictionaries. A `MSBuildTestRegistration` module initializer registers MSBuild
  once for the test assembly, mirroring `Program.cs`'s own registration.
- All 50 tests in `packages/dotnet/analyzer.Tests` pass (`dotnet test`).
- `dotnet build` on `packages/dotnet/analyzer`/`analyzer.Tests` succeeds with 0 warnings/errors.

## Related Issue(s)

Addresses item 1 of https://github.com/nrwl/nx/discussions/36676 (a discussion, not a closable
issue, so no "Fixes #" here). Related but independent: #36469.

