### PR TITLE
feat(dotnet): infer project type and SDK technologies

### DIFF
--- a/e2e/dotnet/src/dotnet-advanced-msbuild.test.ts
+++ b/e2e/dotnet/src/dotnet-advanced-msbuild.test.ts
@@ -123,6 +123,10 @@ describe('.NET Plugin - Advanced MSBuild Features', () => {
         name: 'MultiTargetLib',
         type: 'classlib',
       });
+      createDotNetProject({
+        name: 'AmbiguousMultiTarget',
+        type: 'classlib',
+      });
 
       // Enable multi-targeting
       const csprojPath = tmpProjPath('MultiTargetLib/MultiTargetLib.csproj');
@@ -132,6 +136,25 @@ describe('.NET Plugin - Advanced MSBuild Features', () => {
         '<TargetFrameworks>net8.0;net9.0</TargetFrameworks>'
       );
       updateFile('MultiTargetLib/MultiTargetLib.csproj', updatedCsproj);
+
+      const ambiguousCsprojPath = tmpProjPath(
+        'AmbiguousMultiTarget/AmbiguousMultiTarget.csproj'
+      );
+      const ambiguousCsproj = readFile(ambiguousCsprojPath)
+        .replace(
+          /<TargetFramework>.*?<\/TargetFramework>/,
+          '<TargetFrameworks>net8.0;net9.0</TargetFrameworks>'
+        )
+        .replace(
+          '</PropertyGroup>',
+          `  <OutputType Condition="'$(TargetFramework)' == 'net8.0'">Exe</OutputType>
+    <OutputType Condition="'$(TargetFramework)' == 'net9.0'">Library</OutputType>
+  </PropertyGroup>`
+        );
+      updateFile(
+        'AmbiguousMultiTarget/AmbiguousMultiTarget.csproj',
+        ambiguousCsproj
+      );
 
       // Enable artifacts output
       updateFile(
@@ -151,7 +174,15 @@ describe('.NET Plugin - Advanced MSBuild Features', () => {
       const details = JSON.parse(projectDetails);
 
       // Should have detected multi-targeting configuration
+      expect(details.projectType).toBe('library');
       expect(details.targets.build).toBeDefined();
+    });
+
+    it('should leave conflicting target framework types unclassified', () => {
+      const projectDetails = runCLI(`show project AmbiguousMultiTarget --json`);
+      const details = JSON.parse(projectDetails);
+
+      expect(details.projectType).toBeUndefined();
     });
 
     it('should build for all target frameworks', () => {

--- a/e2e/dotnet/src/dotnet-advanced-msbuild.test.ts
+++ b/e2e/dotnet/src/dotnet-advanced-msbuild.test.ts
@@ -167,6 +167,35 @@ describe('.NET Plugin - Advanced MSBuild Features', () => {
       );
 
       runCLI('run-many -t restore');
+
+      createDotNetProject({
+        name: 'ConditionalMauiBlazor',
+        type: 'classlib',
+      });
+      const conditionalMauiBlazorPath = tmpProjPath(
+        'ConditionalMauiBlazor/ConditionalMauiBlazor.csproj'
+      );
+      const conditionalMauiBlazor = readFile(conditionalMauiBlazorPath)
+        .replace(
+          /<TargetFramework>.*?<\/TargetFramework>/,
+          '<TargetFrameworks>net8.0;net9.0</TargetFrameworks>'
+        )
+        .replace(
+          '</PropertyGroup>',
+          `  <UseMaui>true</UseMaui>
+  </PropertyGroup>`
+        )
+        .replace(
+          '</Project>',
+          `  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.0" />
+  </ItemGroup>
+</Project>`
+        );
+      updateFile(
+        'ConditionalMauiBlazor/ConditionalMauiBlazor.csproj',
+        conditionalMauiBlazor
+      );
     });
 
     it('should detect multi-targeting configuration', () => {
@@ -183,6 +212,21 @@ describe('.NET Plugin - Advanced MSBuild Features', () => {
       const details = JSON.parse(projectDetails);
 
       expect(details.projectType).toBeUndefined();
+    });
+
+    it('should aggregate technology packages across target frameworks', () => {
+      const projectDetails = runCLI(
+        `show project ConditionalMauiBlazor --json`
+      );
+      const details = JSON.parse(projectDetails);
+
+      expect(details.metadata.technologies).toEqual([
+        'dotnet',
+        'C#',
+        '.NET MAUI',
+        'Blazor',
+        'Blazor Hybrid',
+      ]);
     });
 
     it('should build for all target frameworks', () => {

--- a/e2e/dotnet/src/dotnet.test.ts
+++ b/e2e/dotnet/src/dotnet.test.ts
@@ -39,6 +39,8 @@ describe('.NET Plugin', () => {
       const projectDetails = runCLI(`show project MyApp --json`);
       const details = JSON.parse(projectDetails);
 
+      expect(details.projectType).toBe('application');
+      expect(details.metadata.technologies).toEqual(['dotnet', 'C#']);
       expect(details.targets).toHaveProperty('build');
       expect(details.targets).toHaveProperty('clean');
       expect(details.targets).toHaveProperty('restore');
@@ -54,6 +56,8 @@ describe('.NET Plugin', () => {
       const projectDetails = runCLI(`show project MyLibrary --json`);
       const details = JSON.parse(projectDetails);
 
+      expect(details.projectType).toBe('library');
+      expect(details.metadata.technologies).toEqual(['dotnet', 'C#']);
       expect(details.targets).toHaveProperty('build');
       expect(details.targets).toHaveProperty('clean');
       expect(details.targets).toHaveProperty('restore');
@@ -65,6 +69,8 @@ describe('.NET Plugin', () => {
       const projectDetails = runCLI(`show project MyApp.Tests --json`);
       const details = JSON.parse(projectDetails);
 
+      expect(details.projectType).toBe('library');
+      expect(details.metadata.technologies).toEqual(['dotnet', 'C#']);
       expect(details.targets).toHaveProperty('build');
       expect(details.targets).toHaveProperty('test');
     });
@@ -139,6 +145,18 @@ describe('.NET Plugin', () => {
       expect(projectsData).toContain('Core');
       expect(projectsData).toContain('Core.Tests');
       expect(projectsData).toContain('WebApi.Tests');
+    });
+
+    it('should expose web application metadata', () => {
+      const projectDetails = runCLI(`show project WebApi --json`);
+      const details = JSON.parse(projectDetails);
+
+      expect(details.projectType).toBe('application');
+      expect(details.metadata.technologies).toEqual([
+        'dotnet',
+        'C#',
+        'ASP.NET Core',
+      ]);
     });
 
     it('should build projects in dependency order', () => {

--- a/e2e/dotnet/src/dotnet.test.ts
+++ b/e2e/dotnet/src/dotnet.test.ts
@@ -12,6 +12,8 @@ import {
   createSimpleDotNetWorkspace,
   createWebApiWorkspace,
   addProjectReference,
+  createDotNetProject,
+  updateProjectFile,
 } from './utils/create-dotnet-project';
 
 describe('.NET Plugin', () => {
@@ -19,6 +21,13 @@ describe('.NET Plugin', () => {
     newProject({ packages: [] });
     runCLI(`add @nx/dotnet`);
     createSimpleDotNetWorkspace();
+    createDotNetProject({ name: 'Executable.Tests', type: 'xunit' });
+    updateProjectFile('Executable.Tests', (content) =>
+      content.replace(
+        '</PropertyGroup>',
+        '  <OutputType>Exe</OutputType>\n</PropertyGroup>'
+      )
+    );
   });
 
   afterAll(() => cleanupProject());
@@ -33,6 +42,7 @@ describe('.NET Plugin', () => {
       expect(projectsData).toContain('MyApp');
       expect(projectsData).toContain('MyLibrary');
       expect(projectsData).toContain('MyApp.Tests');
+      expect(projectsData).toContain('Executable.Tests');
     });
 
     it('should show project details with .NET targets', () => {
@@ -72,6 +82,14 @@ describe('.NET Plugin', () => {
       expect(details.projectType).toBe('library');
       expect(details.metadata.technologies).toEqual(['dotnet', 'C#']);
       expect(details.targets).toHaveProperty('build');
+      expect(details.targets).toHaveProperty('test');
+    });
+
+    it('should leave executable test projects unclassified', () => {
+      const projectDetails = runCLI(`show project Executable.Tests --json`);
+      const details = JSON.parse(projectDetails);
+
+      expect(details.projectType).toBeUndefined();
       expect(details.targets).toHaveProperty('test');
     });
   });

--- a/e2e/dotnet/src/dotnet.test.ts
+++ b/e2e/dotnet/src/dotnet.test.ts
@@ -21,6 +21,7 @@ describe('.NET Plugin', () => {
     newProject({ packages: [] });
     runCLI(`add @nx/dotnet`);
     createSimpleDotNetWorkspace();
+    createDotNetProject({ name: 'BlazorWasm', type: 'blazorwasm' });
     createDotNetProject({ name: 'Executable.Tests', type: 'xunit' });
     updateProjectFile('Executable.Tests', (content) =>
       content.replace(
@@ -42,6 +43,7 @@ describe('.NET Plugin', () => {
       expect(projectsData).toContain('MyApp');
       expect(projectsData).toContain('MyLibrary');
       expect(projectsData).toContain('MyApp.Tests');
+      expect(projectsData).toContain('BlazorWasm');
       expect(projectsData).toContain('Executable.Tests');
     });
 
@@ -91,6 +93,19 @@ describe('.NET Plugin', () => {
 
       expect(details.projectType).toBeUndefined();
       expect(details.targets).toHaveProperty('test');
+    });
+
+    it('should expose Blazor WebAssembly technologies', () => {
+      const projectDetails = runCLI(`show project BlazorWasm --json`);
+      const details = JSON.parse(projectDetails);
+
+      expect(details.metadata.technologies).toEqual([
+        'dotnet',
+        'C#',
+        'Blazor',
+        'Blazor WebAssembly',
+        'WebAssembly',
+      ]);
     });
   });
 

--- a/e2e/dotnet/src/utils/create-dotnet-project.ts
+++ b/e2e/dotnet/src/utils/create-dotnet-project.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 
 export interface DotNetProjectOptions {
   name: string;
-  type: 'console' | 'classlib' | 'xunit' | 'webapi';
+  type: 'console' | 'classlib' | 'xunit' | 'webapi' | 'blazorwasm';
   cwd?: string;
 }
 

--- a/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
+++ b/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
@@ -168,6 +168,26 @@ public class ProjectMetadataTests
     }
 
     [Fact]
+    public void AggregatesDistinctPackageReferencesAcrossTargetFrameworks()
+    {
+        var webViewMaui = new PackageReference
+        {
+            Include = "Microsoft.AspNetCore.Components.WebView.Maui",
+            Version = "9.0.0"
+        };
+
+        var packageReferences = Analyzer.AggregatePackageReferences(
+            new[]
+            {
+                Array.Empty<PackageReference>(),
+                new[] { webViewMaui },
+                new[] { webViewMaui }
+            });
+
+        Assert.Equal(new[] { webViewMaui }, packageReferences);
+    }
+
+    [Fact]
     public void DoesNotInferBlazorFromRazorSdk()
     {
         var technologies = ProjectUtilities.GetTechnologies(

--- a/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
+++ b/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
@@ -17,6 +17,19 @@ public class ProjectMetadataTests
     }
 
     [Fact]
+    public void InfersApplicationsWhenTargetFrameworkOutputTypesAgree()
+    {
+        var projectType = ProjectUtilities.InferProjectType(
+            new[]
+            {
+                Properties(("OutputType", "Exe")),
+                Properties(("OutputType", "WinExe"))
+            });
+
+        Assert.Equal("application", projectType);
+    }
+
+    [Fact]
     public void InfersLibrariesFromLibraryOutputType()
     {
         var projectType = ProjectUtilities.InferProjectType(

--- a/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
+++ b/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
@@ -1,0 +1,115 @@
+using MsbuildAnalyzer.Utilities;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+public class ProjectMetadataTests
+{
+    [Theory]
+    [InlineData("Exe")]
+    [InlineData("WinExe")]
+    public void InfersApplicationsFromExecutableOutputTypes(string outputType)
+    {
+        var projectType = ProjectUtilities.InferProjectType(
+            new[] { Properties(("OutputType", outputType)) });
+
+        Assert.Equal("application", projectType);
+    }
+
+    [Fact]
+    public void InfersLibrariesFromLibraryOutputType()
+    {
+        var projectType = ProjectUtilities.InferProjectType(
+            new[] { Properties(("OutputType", "Library")) });
+
+        Assert.Equal("library", projectType);
+    }
+
+    [Fact]
+    public void DoesNotTreatCapabilitiesAsProjectTypes()
+    {
+        var projectType = ProjectUtilities.InferProjectType(
+            new[]
+            {
+                Properties(
+                    ("OutputType", "Library"),
+                    ("IsTestProject", "true"),
+                    ("IsPackable", "true"),
+                    ("PackAsTool", "true"))
+            });
+
+        Assert.Equal("library", projectType);
+    }
+
+    [Fact]
+    public void LeavesConflictingTargetFrameworksUnclassified()
+    {
+        var projectType = ProjectUtilities.InferProjectType(
+            new[]
+            {
+                Properties(("OutputType", "Exe")),
+                Properties(("OutputType", "Library"))
+            });
+
+        Assert.Null(projectType);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("AppContainerExe")]
+    public void LeavesUnknownOutputTypesUnclassified(string outputType)
+    {
+        var projectType = ProjectUtilities.InferProjectType(
+            new[] { Properties(("OutputType", outputType)) });
+
+        Assert.Null(projectType);
+    }
+
+    [Fact]
+    public void LeavesMissingOutputTypesUnclassified()
+    {
+        var projectType = ProjectUtilities.InferProjectType(
+            new[] { Properties(("IsTestProject", "true")) });
+
+        Assert.Null(projectType);
+    }
+
+    [Fact]
+    public void AddsStableEvaluatedSdkTechnologies()
+    {
+        var technologies = ProjectUtilities.GetTechnologies(
+            "apps/MyApp/MyApp.csproj",
+            new[]
+            {
+                Properties(
+                    ("UsingMicrosoftNETSdkWeb", "true"),
+                    ("UseMaui", "True"))
+            });
+
+        Assert.Equal(
+            new[] { "dotnet", "C#", "ASP.NET Core", ".NET MAUI" },
+            technologies);
+    }
+
+    [Fact]
+    public void DoesNotTreatOtherCapabilitiesAsTechnologies()
+    {
+        var technologies = ProjectUtilities.GetTechnologies(
+            "libs/MyLibrary/MyLibrary.fsproj",
+            new[]
+            {
+                Properties(
+                    ("IsTestProject", "true"),
+                    ("IsPackable", "true"),
+                    ("PackAsTool", "true"))
+            });
+
+        Assert.Equal(new[] { "dotnet", "F#" }, technologies);
+    }
+
+    private static IReadOnlyDictionary<string, string> Properties(
+        params (string Name, string Value)[] properties)
+    {
+        return properties.ToDictionary(property => property.Name, property => property.Value);
+    }
+}

--- a/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
+++ b/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
@@ -39,7 +39,7 @@ public class ProjectMetadataTests
     }
 
     [Fact]
-    public void DoesNotTreatCapabilitiesAsProjectTypes()
+    public void KeepsLibraryOutputTestProjectsClassifiedAsLibraries()
     {
         var projectType = ProjectUtilities.InferProjectType(
             new[]
@@ -49,9 +49,22 @@ public class ProjectMetadataTests
                     ("IsTestProject", "true"),
                     ("IsPackable", "true"),
                     ("PackAsTool", "true"))
-            });
+            },
+            isTestProject: true);
 
         Assert.Equal("library", projectType);
+    }
+
+    [Theory]
+    [InlineData("Exe")]
+    [InlineData("WinExe")]
+    public void LeavesExecutableTestProjectsUnclassified(string outputType)
+    {
+        var projectType = ProjectUtilities.InferProjectType(
+            new[] { Properties(("OutputType", outputType)) },
+            isTestProject: true);
+
+        Assert.Null(projectType);
     }
 
     [Fact]

--- a/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
+++ b/packages/dotnet/analyzer.Tests/ProjectMetadataTests.cs
@@ -1,3 +1,4 @@
+using MsbuildAnalyzer.Models;
 using MsbuildAnalyzer.Utilities;
 using Xunit;
 
@@ -115,6 +116,70 @@ public class ProjectMetadataTests
         Assert.Equal(
             new[] { "dotnet", "C#", "ASP.NET Core", ".NET MAUI" },
             technologies);
+    }
+
+    [Fact]
+    public void AddsWebAssemblyTechnology()
+    {
+        var technologies = ProjectUtilities.GetTechnologies(
+            "apps/MyApp/MyApp.csproj",
+            new[]
+            {
+                Properties(("UsingMicrosoftNETSdkWebAssembly", "true"))
+            });
+
+        Assert.Equal(new[] { "dotnet", "C#", "WebAssembly" }, technologies);
+    }
+
+    [Fact]
+    public void AddsBlazorWebAssemblyTechnologies()
+    {
+        var technologies = ProjectUtilities.GetTechnologies(
+            "apps/MyApp/MyApp.csproj",
+            new[]
+            {
+                Properties(
+                    ("UsingMicrosoftNETSdkBlazorWebAssembly", "true"),
+                    ("UsingMicrosoftNETSdkWebAssembly", "true"))
+            });
+
+        Assert.Equal(
+            new[] { "dotnet", "C#", "Blazor", "Blazor WebAssembly", "WebAssembly" },
+            technologies);
+    }
+
+    [Fact]
+    public void AddsMauiBlazorHybridTechnologies()
+    {
+        var technologies = ProjectUtilities.GetTechnologies(
+            "apps/MyApp/MyApp.csproj",
+            new[] { Properties(("UseMaui", "true")) },
+            new[]
+            {
+                new PackageReference
+                {
+                    Include = "Microsoft.AspNetCore.Components.WebView.Maui"
+                }
+            });
+
+        Assert.Equal(
+            new[] { "dotnet", "C#", ".NET MAUI", "Blazor", "Blazor Hybrid" },
+            technologies);
+    }
+
+    [Fact]
+    public void DoesNotInferBlazorFromRazorSdk()
+    {
+        var technologies = ProjectUtilities.GetTechnologies(
+            "apps/MyApp/MyApp.csproj",
+            new[]
+            {
+                Properties(
+                    ("UsingMicrosoftNETSdkWeb", "true"),
+                    ("UsingMicrosoftNETSdkRazor", "true"))
+            });
+
+        Assert.Equal(new[] { "dotnet", "C#", "ASP.NET Core" }, technologies);
     }
 
     [Fact]

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -127,15 +127,15 @@ public static class Analyzer
                         throw new InvalidOperationException("ProjectInstance is null.");
                     }
 
-                    var configurationNodes = nodes
+                    var targetFrameworkNodes = nodes
                         .Where(n => !string.IsNullOrEmpty(n.ProjectInstance?.GetPropertyValue("TargetFramework")))
                         .ToList();
-                    if (configurationNodes.Count == 0)
+                    if (targetFrameworkNodes.Count == 0)
                     {
-                        configurationNodes = nodes;
+                        targetFrameworkNodes = nodes;
                     }
 
-                    var evaluatedProperties = configurationNodes
+                    var evaluatedProperties = targetFrameworkNodes
                         .Where(n => n.ProjectInstance is not null)
                         .Select(n => CollectProperties(n.ProjectInstance!))
                         .ToList();
@@ -189,7 +189,7 @@ public static class Analyzer
                     {
                         Name = projectName,
                         Root = projectRoot,
-                        ProjectType = ProjectUtilities.InferProjectType(evaluatedProperties),
+                        ProjectType = ProjectUtilities.InferProjectType(evaluatedProperties, isTest),
                         Targets = targets,
                         Metadata = new Models.ProjectMetadata
                         {

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -193,7 +193,10 @@ public static class Analyzer
                         Targets = targets,
                         Metadata = new Models.ProjectMetadata
                         {
-                            Technologies = ProjectUtilities.GetTechnologies(projectPath, evaluatedProperties)
+                            Technologies = ProjectUtilities.GetTechnologies(
+                                projectPath,
+                                evaluatedProperties,
+                                packageRefs)
                         }
                     };
 
@@ -282,6 +285,8 @@ public static class Analyzer
             "AssemblyName",
             "IsTestProject",
             "UsingMicrosoftNETSdkWeb",
+            "UsingMicrosoftNETSdkBlazorWebAssembly",
+            "UsingMicrosoftNETSdkWebAssembly",
             "UseMaui",
 
             // Build configuration

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -127,6 +127,19 @@ public static class Analyzer
                         throw new InvalidOperationException("ProjectInstance is null.");
                     }
 
+                    var configurationNodes = nodes
+                        .Where(n => !string.IsNullOrEmpty(n.ProjectInstance?.GetPropertyValue("TargetFramework")))
+                        .ToList();
+                    if (configurationNodes.Count == 0)
+                    {
+                        configurationNodes = nodes;
+                    }
+
+                    var evaluatedProperties = configurationNodes
+                        .Where(n => n.ProjectInstance is not null)
+                        .Select(n => CollectProperties(n.ProjectInstance!))
+                        .ToList();
+
                     var projectRoot = ProjectUtilities.GetRelativeProjectRoot(projectPath, workspaceRoot);
                     var relativeProjectFile = ProjectUtilities.GetRelativeProjectFile(projectPath, workspaceRoot);
 
@@ -176,10 +189,11 @@ public static class Analyzer
                     {
                         Name = projectName,
                         Root = projectRoot,
+                        ProjectType = ProjectUtilities.InferProjectType(evaluatedProperties),
                         Targets = targets,
                         Metadata = new Models.ProjectMetadata
                         {
-                            Technologies = ProjectUtilities.GetTechnologies(projectPath)
+                            Technologies = ProjectUtilities.GetTechnologies(projectPath, evaluatedProperties)
                         }
                     };
 
@@ -267,6 +281,8 @@ public static class Analyzer
             "OutputType",
             "AssemblyName",
             "IsTestProject",
+            "UsingMicrosoftNETSdkWeb",
+            "UseMaui",
 
             // Build configuration
             "Configuration",

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -139,6 +139,10 @@ public static class Analyzer
                         .Where(n => n.ProjectInstance is not null)
                         .Select(n => CollectProperties(n.ProjectInstance!))
                         .ToList();
+                    var technologyPackageRefs = AggregatePackageReferences(
+                        targetFrameworkNodes
+                            .Where(n => n.ProjectInstance is not null)
+                            .Select(n => CollectPackageReferences(n.ProjectInstance!)));
 
                     var projectRoot = ProjectUtilities.GetRelativeProjectRoot(projectPath, workspaceRoot);
                     var relativeProjectFile = ProjectUtilities.GetRelativeProjectFile(projectPath, workspaceRoot);
@@ -196,7 +200,7 @@ public static class Analyzer
                             Technologies = ProjectUtilities.GetTechnologies(
                                 projectPath,
                                 evaluatedProperties,
-                                packageRefs)
+                                technologyPackageRefs)
                         }
                     };
 
@@ -237,6 +241,15 @@ public static class Analyzer
         }
 
         return packageRefs;
+    }
+
+    internal static List<PackageReference> AggregatePackageReferences(
+        IEnumerable<IEnumerable<PackageReference>> packageReferencesByTargetFramework)
+    {
+        return packageReferencesByTargetFramework
+            .SelectMany(packageReferences => packageReferences)
+            .Distinct()
+            .ToList();
     }
 
     /// <summary>

--- a/packages/dotnet/analyzer/Models/ProjectNode.cs
+++ b/packages/dotnet/analyzer/Models/ProjectNode.cs
@@ -16,6 +16,11 @@ public record NxProjectGraphNode
     public string Root { get; init; } = string.Empty;
 
     /// <summary>
+    /// The Nx project type when it can be inferred consistently across evaluated configurations.
+    /// </summary>
+    public string? ProjectType { get; init; }
+
+    /// <summary>
     /// Nx targets available for this project.
     /// </summary>
     public Dictionary<string, Target> Targets { get; init; } = new();

--- a/packages/dotnet/analyzer/Models/ProjectNode.cs
+++ b/packages/dotnet/analyzer/Models/ProjectNode.cs
@@ -16,7 +16,7 @@ public record NxProjectGraphNode
     public string Root { get; init; } = string.Empty;
 
     /// <summary>
-    /// The Nx project type when it can be inferred consistently across evaluated configurations.
+    /// The Nx project type when it can be inferred consistently across evaluated target frameworks.
     /// </summary>
     public string? ProjectType { get; init; }
 

--- a/packages/dotnet/analyzer/MsbuildAnalyzer.csproj
+++ b/packages/dotnet/analyzer/MsbuildAnalyzer.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.8.1" />
   </ItemGroup>
 
-  <PropertyGroup>
-    
-  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="MsbuildAnalyzer.Tests" />
+  </ItemGroup>
 
 </Project>

--- a/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
+++ b/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
@@ -210,7 +210,8 @@ public static class ProjectUtilities
     }
 
     public static string? InferProjectType(
-        IEnumerable<IReadOnlyDictionary<string, string>> evaluatedProperties)
+        IEnumerable<IReadOnlyDictionary<string, string>> evaluatedProperties,
+        bool isTestProject = false)
     {
         string? inferredType = null;
         var hasConfiguration = false;
@@ -231,6 +232,11 @@ public static class ProjectUtilities
             };
 
             if (currentType is null)
+            {
+                return null;
+            }
+
+            if (isTestProject && currentType == "application")
             {
                 return null;
             }

--- a/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
+++ b/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
@@ -1,4 +1,5 @@
 using Microsoft.Build.Execution;
+using MsbuildAnalyzer.Models;
 
 namespace MsbuildAnalyzer.Utilities;
 
@@ -172,12 +173,14 @@ public static class ProjectUtilities
     {
         return GetTechnologies(
             projectPath,
-            Array.Empty<IReadOnlyDictionary<string, string>>());
+            Array.Empty<IReadOnlyDictionary<string, string>>(),
+            Array.Empty<PackageReference>());
     }
 
     public static List<string> GetTechnologies(
         string projectPath,
-        IEnumerable<IReadOnlyDictionary<string, string>> evaluatedProperties)
+        IEnumerable<IReadOnlyDictionary<string, string>> evaluatedProperties,
+        IEnumerable<PackageReference>? packageReferences = null)
     {
         var techs = new List<string> { "dotnet" };
 
@@ -204,6 +207,35 @@ public static class ProjectUtilities
         if (properties.Any(p => HasTrueProperty(p, "UseMaui")))
         {
             techs.Add(".NET MAUI");
+        }
+
+        var packages = packageReferences ?? Array.Empty<PackageReference>();
+        var isBlazorWebAssembly = properties.Any(
+            p => HasTrueProperty(p, "UsingMicrosoftNETSdkBlazorWebAssembly"));
+        var isBlazorHybrid = properties.Any(p => HasTrueProperty(p, "UseMaui"))
+            && packages.Any(p =>
+                p.Include.Equals(
+                    "Microsoft.AspNetCore.Components.WebView.Maui",
+                    StringComparison.OrdinalIgnoreCase));
+
+        if (isBlazorWebAssembly || isBlazorHybrid)
+        {
+            techs.Add("Blazor");
+        }
+
+        if (isBlazorWebAssembly)
+        {
+            techs.Add("Blazor WebAssembly");
+        }
+
+        if (properties.Any(p => HasTrueProperty(p, "UsingMicrosoftNETSdkWebAssembly")))
+        {
+            techs.Add("WebAssembly");
+        }
+
+        if (isBlazorHybrid)
+        {
+            techs.Add("Blazor Hybrid");
         }
 
         return techs;

--- a/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
+++ b/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
@@ -166,9 +166,18 @@ public static class ProjectUtilities
     }
 
     /// <summary>
-    /// Gets the list of technologies for a project based on its file type and characteristics.
+    /// Gets the list of technologies for a project based on its file type and evaluated properties.
     /// </summary>
     public static List<string> GetTechnologies(string projectPath)
+    {
+        return GetTechnologies(
+            projectPath,
+            Array.Empty<IReadOnlyDictionary<string, string>>());
+    }
+
+    public static List<string> GetTechnologies(
+        string projectPath,
+        IEnumerable<IReadOnlyDictionary<string, string>> evaluatedProperties)
     {
         var techs = new List<string> { "dotnet" };
 
@@ -186,7 +195,62 @@ public static class ProjectUtilities
             techs.Add("VB");
         }
 
+        var properties = evaluatedProperties.ToList();
+        if (properties.Any(p => HasTrueProperty(p, "UsingMicrosoftNETSdkWeb")))
+        {
+            techs.Add("ASP.NET Core");
+        }
+
+        if (properties.Any(p => HasTrueProperty(p, "UseMaui")))
+        {
+            techs.Add(".NET MAUI");
+        }
 
         return techs;
+    }
+
+    public static string? InferProjectType(
+        IEnumerable<IReadOnlyDictionary<string, string>> evaluatedProperties)
+    {
+        string? inferredType = null;
+        var hasConfiguration = false;
+
+        foreach (var properties in evaluatedProperties)
+        {
+            hasConfiguration = true;
+            if (!properties.TryGetValue("OutputType", out var outputType))
+            {
+                return null;
+            }
+
+            var currentType = outputType.ToLowerInvariant() switch
+            {
+                "exe" or "winexe" => "application",
+                "library" => "library",
+                _ => null
+            };
+
+            if (currentType is null)
+            {
+                return null;
+            }
+
+            inferredType ??= currentType;
+            if (inferredType != currentType)
+            {
+                return null;
+            }
+        }
+
+        return hasConfiguration ? inferredType : null;
+    }
+
+    private static bool HasTrueProperty(
+        IReadOnlyDictionary<string, string> properties,
+        string propertyName)
+    {
+        return properties.TryGetValue(propertyName, out var value)
+            && bool.TryParse(value, out var result)
+            && result;
     }
 }

--- a/packages/dotnet/readme-template.md
+++ b/packages/dotnet/readme-template.md
@@ -47,6 +47,7 @@ dotnet new xunit -n MyApp.Tests
 ```
 
 The plugin will automatically detect your .NET projects and configure appropriate Nx targets.
+It also classifies projects as applications or libraries when evaluated MSBuild output types support a consistent inference, and reports the project language plus stable SDK technologies such as ASP.NET Core and .NET MAUI in project metadata.
 
 #### Step 4: Run Build, Test, and other commands
 

--- a/packages/dotnet/readme-template.md
+++ b/packages/dotnet/readme-template.md
@@ -47,7 +47,7 @@ dotnet new xunit -n MyApp.Tests
 ```
 
 The plugin will automatically detect your .NET projects and configure appropriate Nx targets.
-It also classifies projects as applications or libraries when evaluated MSBuild output types support a consistent inference, and reports the project language plus stable SDK technologies such as ASP.NET Core and .NET MAUI in project metadata.
+It also classifies projects as applications or libraries when evaluated MSBuild output types support a consistent inference, and reports the project language plus stable SDK technologies such as ASP.NET Core, .NET MAUI, Blazor, and WebAssembly in project metadata.
 
 #### Step 4: Run Build, Test, and other commands
 


### PR DESCRIPTION
## Current Behavior

`@nx/dotnet` does not set the native Nx `projectType` for evaluated MSBuild projects. Project metadata reports only `.NET` and the project language, even when evaluated SDK properties provide a stable broad technology identity.

## Expected Behavior

The MSBuild analyzer classifies projects as `application` for consistent `Exe`/`WinExe` output types and `library` for consistent `Library` output types across evaluated target frameworks. Unknown or conflicting output types remain unset rather than flattening multi-target ambiguity.

Existing test detection also participates in classification: executable test projects remain unclassified instead of becoming applications, while library-output test projects remain libraries. Test, pack, and tool capabilities do not become additional project types or technologies.

Project metadata reports broad technologies from high-confidence evaluated MSBuild signals:

- `ASP.NET Core` for the Web SDK
- `.NET MAUI` for MAUI projects
- `WebAssembly` for the WebAssembly SDK
- `Blazor` and `Blazor WebAssembly` for the Blazor WebAssembly SDK
- `Blazor` and `Blazor Hybrid` when a MAUI project references `Microsoft.AspNetCore.Components.WebView.Maui`

Technology inference aggregates evaluated package references across all target frameworks, so conditional references are not lost based on which inner build is selected as primary. Primary-node references remain unchanged for target generation.

Ordinary Web/Razor SDK projects are not labeled `Blazor` because those signals also describe non-Blazor projects.

## Validation

- `dotnet test packages/dotnet/analyzer.Tests/MsbuildAnalyzer.Tests.csproj --no-restore` (47 passed)
- `dotnet format` verification for the analyzer and analyzer tests
- Prettier verification for the changed TypeScript e2e tests and README template
- Real analyzer probes for console, class library, Web SDK, multi-target MAUI, executable xUnit, Blazor WebAssembly, and MAUI Blazor Hybrid projects, including a WebView.Maui reference conditioned on a non-primary target framework
- Negative real analyzer probe confirming an ordinary Blazor Web App receives `ASP.NET Core` but no generic `Blazor` label without a distinct evaluated signal

The Nx e2e target could not run locally because the current `master` lockfile references unpublished `23.2.0-beta.7` package tarballs, which return 404 during the pinned workspace restore. The focused e2e assertions are included for CI.

## Related Issue(s)

Discussion: https://github.com/nrwl/nx/discussions/36676
