### PR TITLE
feat(dotnet): opt-in per-runtime-identifier target variants for multi-targeted executables

### DIFF
--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -228,6 +228,35 @@ nx build my-app --configuration release
 nx build my-app --configuration debug
 ```
 
+## Multi-targeted projects
+
+A project that declares `<TargetFrameworks>` (plural) builds more than one target framework. An unqualified `nx build` builds them all, but a single host often cannot — an iOS + Windows project has no machine that can build every framework at once. The `frameworkVariants` option lets you opt in to per-target-framework target variants so you can build, cache, and route one framework in isolation.
+
+```json {% meta="{6}" %}
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/dotnet",
+      "options": {
+        "frameworkVariants": true
+      }
+    }
+  ]
+}
+```
+
+With the option enabled, a project declaring `<TargetFrameworks>net10.0;net10.0-ios</TargetFrameworks>` gets these additional targets alongside the unqualified ones:
+
+- `build-net10.0`, `build-net10.0-ios` - build a single framework
+- `build-net10.0-release`, `build-net10.0-ios-release` - the Release build that publish depends on
+- `publish-net10.0-ios` - publish a single framework (executable projects)
+- `test-net10.0-ios` - test a single framework (test projects)
+
+Each variant passes `--framework` to the .NET CLI, scopes its outputs and cache identity to that framework, and records the framework in its target metadata. The framework is joined to the target name with a hyphen (never a colon), so `nx run my-app:build-net10.0-ios` is unambiguous.
+
+This option is off by default and never changes the unqualified targets. Single-targeted projects are unaffected.
+
 ## Set up CI for your .NET monorepo
 
 In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.

--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -259,6 +259,26 @@ Any configuration you set on the `build` target is applied to its variants too, 
 
 This option is off by default and never changes the unqualified targets. Single-targeted projects are unaffected.
 
+### Runtime identifier variants
+
+When an executable framework also declares runtime identifiers, the same `frameworkVariants` option additionally generates per-RID variants for each declared RID:
+
+```xml
+<PropertyGroup>
+  <TargetFrameworks>net10.0;net10.0-ios</TargetFrameworks>
+  <RuntimeIdentifiers>ios-arm64</RuntimeIdentifiers>
+</PropertyGroup>
+```
+
+- `build-net10.0-ios-ios-arm64-release` - the RID-specific Release build
+- `publish-net10.0-ios-ios-arm64` - publish for that framework and RID
+
+The RID publish passes both `--framework` and `--runtime`, scopes its outputs to the runtime-specific output folder, and depends on the RID-specific build so a `--no-build` publish finds the correct output. The RID Release build is self-contained on the same terms as the framework build variants.
+
+Whether a framework is an executable is evaluated per framework (via `OutputType`), so in a project whose frameworks mix application and library, only the executable frameworks get RID variants. RID variants are only generated where the project explicitly declares runtime identifiers.
+
+RID variants require the standard appended output layout, where the framework and runtime identifier are output-path segments. To avoid declaring cache outputs the build won't write, they are skipped (with a warning) for projects that use `UseArtifactsOutput`, or that set `AppendTargetFrameworkToOutputPath` or `AppendRuntimeIdentifierToOutputPath` to `false`.
+
 ## Set up CI for your .NET monorepo
 
 In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.

--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -261,23 +261,32 @@ This option is off by default and never changes the unqualified targets. Single-
 
 ### Runtime identifier variants
 
-When an executable framework also declares runtime identifiers, the same `frameworkVariants` option additionally generates per-RID variants for each declared RID:
+Enable the separate `runtimeVariants` option to additionally generate per-RID variants for multi-targeted executables that have runtime identifiers. It is a distinct opt-in from `frameworkVariants` — turning on per-framework build variants does not, on its own, expand the graph with RID variants — and enabling it implies `frameworkVariants`:
 
-```xml
-<PropertyGroup>
-  <TargetFrameworks>net10.0;net10.0-ios</TargetFrameworks>
-  <RuntimeIdentifiers>ios-arm64</RuntimeIdentifiers>
-</PropertyGroup>
+```json {% meta="{6}" %}
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/dotnet",
+      "options": {
+        "runtimeVariants": true
+      }
+    }
+  ]
+}
 ```
+
+For a project with `<TargetFrameworks>net10.0;net10.0-ios</TargetFrameworks>` and `<RuntimeIdentifiers>ios-arm64</RuntimeIdentifiers>` you get:
 
 - `build-net10.0-ios-ios-arm64-release` - the RID-specific Release build
 - `publish-net10.0-ios-ios-arm64` - publish for that framework and RID
 
 The RID publish passes both `--framework` and `--runtime`, scopes its outputs to the runtime-specific output folder, and depends on the RID-specific build so a `--no-build` publish finds the correct output. The RID Release build is self-contained on the same terms as the framework build variants.
 
-Whether a framework is an executable is evaluated per framework (via `OutputType`), so in a project whose frameworks mix application and library, only the executable frameworks get RID variants. RID variants are only generated where the project explicitly declares runtime identifiers.
+The runtime identifiers come from the evaluated build: the plural `RuntimeIdentifiers` is authoritative when set, otherwise the evaluated singular `RuntimeIdentifier` is used, which for a platform framework may be an SDK default rather than a value you authored. Whether a framework is an executable is evaluated per framework (via `OutputType`), so in a project whose frameworks mix application and library, only the executable frameworks get RID variants.
 
-RID variants require the standard appended output layout, where the framework and runtime identifier are output-path segments. To avoid declaring cache outputs the build won't write, they are skipped (with a warning) for projects that use `UseArtifactsOutput`, or that set `AppendTargetFrameworkToOutputPath` or `AppendRuntimeIdentifierToOutputPath` to `false`.
+RID variants require the standard appended output layout, where the framework and runtime identifier are output-path segments and the publish directory is `<OutputPath>/publish`. To avoid declaring cache outputs the build won't write, they are skipped (with a warning) for projects that use `UseArtifactsOutput`, that set `AppendTargetFrameworkToOutputPath` or `AppendRuntimeIdentifierToOutputPath` to `false`, or that set a custom `PublishDir`.
 
 ## Set up CI for your .NET monorepo
 

--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -246,14 +246,16 @@ A project that declares `<TargetFrameworks>` (plural) builds more than one targe
 }
 ```
 
-With the option enabled, a project declaring `<TargetFrameworks>net10.0;net10.0-ios</TargetFrameworks>` gets these additional targets alongside the unqualified ones:
+With the option enabled, a project declaring `<TargetFrameworks>net10.0;net10.0-ios</TargetFrameworks>` gets these additional build targets alongside the unqualified ones:
 
-- `build-net10.0`, `build-net10.0-ios` - build a single framework
-- `build-net10.0-release`, `build-net10.0-ios-release` - the Release build that publish depends on
-- `publish-net10.0-ios` - publish a single framework (executable projects)
-- `test-net10.0-ios` - test a single framework (test projects)
+- `build-net10.0`, `build-net10.0-ios` - build a single framework (Debug by default)
+- `build-net10.0-release`, `build-net10.0-ios-release` - build a single framework in Release
 
 Each variant passes `--framework` to the .NET CLI, scopes its outputs and cache identity to that framework, and records the framework in its target metadata. The framework is joined to the target name with a hyphen (never a colon), so `nx run my-app:build-net10.0-ios` is unambiguous.
+
+Variants are self-contained: they don't depend on the unqualified build and don't pass `--no-dependencies`, so building one framework lets MSBuild build each referenced project's compatible framework directly instead of triggering an all-framework build. The tradeoff is coarser task-level caching of dependencies; `^production` stays an input so a dependency's source change still invalidates the variant.
+
+Any configuration you set on the `build` target is applied to its variants too, and disabling `build` removes them.
 
 This option is off by default and never changes the unqualified targets. Single-targeted projects are unaffected.
 

--- a/e2e/dotnet/src/dotnet-framework-variants.test.ts
+++ b/e2e/dotnet/src/dotnet-framework-variants.test.ts
@@ -1,0 +1,133 @@
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  tmpProjPath,
+  updateJson,
+  checkFilesMatchingPatternExist,
+} from '@nx/e2e-utils';
+
+import {
+  createDotNetProject,
+  enableMultiTargeting,
+} from './utils/create-dotnet-project';
+
+/**
+ * Exercises the opt-in per-target-framework target variants for multi-targeted
+ * projects (https://github.com/nrwl/nx/discussions/36676).
+ *
+ * The graph assertions go through the real plugin + MSBuild analyzer, so they
+ * validate that a multi-targeted project produces correctly-named, correctly-wired
+ * framework variants while leaving the unqualified targets in place. Frameworks
+ * are chosen so evaluation does not require an extra workload.
+ */
+describe('.NET Plugin - Framework Variants', () => {
+  beforeAll(() => {
+    newProject({ packages: [] });
+    runCLI(`add @nx/dotnet`);
+
+    // Opt in to framework variants by configuring the plugin.
+    updateJson('nx.json', (nxJson) => {
+      nxJson.plugins = (nxJson.plugins ?? []).map((p: unknown) =>
+        p === '@nx/dotnet'
+          ? { plugin: '@nx/dotnet', options: { frameworkVariants: true } }
+          : p
+      );
+      return nxJson;
+    });
+
+    createDotNetProject({ name: 'MultiApp', type: 'console' });
+    enableMultiTargeting('MultiApp', ['net9.0', 'net10.0']);
+
+    createDotNetProject({ name: 'SingleApp', type: 'console' });
+
+    runCLI('run-many -t restore');
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('should generate a build variant per target framework', () => {
+    const details = JSON.parse(runCLI(`show project MultiApp --json`));
+
+    expect(details.targets['build-net9.0']).toBeDefined();
+    expect(details.targets['build-net10.0']).toBeDefined();
+
+    // Unqualified targets are preserved.
+    expect(details.targets.build).toBeDefined();
+    expect(details.targets['build:release']).toBeDefined();
+  });
+
+  it('should pass --framework to the variant command', () => {
+    const details = JSON.parse(runCLI(`show project MultiApp --json`));
+
+    const args = details.targets['build-net10.0'].options.args;
+    expect(args).toEqual(
+      expect.arrayContaining(['--framework', 'net10.0'])
+    );
+  });
+
+  it('should scope variant outputs to the framework', () => {
+    const details = JSON.parse(runCLI(`show project MultiApp --json`));
+
+    expect(details.targets['build-net10.0'].outputs).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/net10\.0/),
+      ])
+    );
+    // A different framework's directory must not appear in this variant.
+    for (const output of details.targets['build-net10.0'].outputs) {
+      expect(output).not.toMatch(/net9\.0/);
+    }
+  });
+
+  it('should generate a publish variant per framework for executables', () => {
+    const details = JSON.parse(runCLI(`show project MultiApp --json`));
+
+    expect(details.targets['publish-net10.0']).toBeDefined();
+    expect(details.targets['publish-net10.0'].dependsOn).toContain(
+      'build-net10.0-release'
+    );
+  });
+
+  it('should record the target framework in variant metadata', () => {
+    const details = JSON.parse(runCLI(`show project MultiApp --json`));
+
+    expect(details.targets['build-net10.0'].metadata.targetFramework).toBe(
+      'net10.0'
+    );
+  });
+
+  it('should never use a colon-ambiguous variant target name', () => {
+    const details = JSON.parse(runCLI(`show project MultiApp --json`));
+
+    const variantNames = Object.keys(details.targets).filter((name) =>
+      name.includes('net10.0')
+    );
+    expect(variantNames.length).toBeGreaterThan(0);
+    for (const name of variantNames) {
+      expect(name).not.toContain(':');
+    }
+  });
+
+  it('should not generate variants for single-targeted projects', () => {
+    const details = JSON.parse(runCLI(`show project SingleApp --json`));
+
+    const variantNames = Object.keys(details.targets).filter((name) =>
+      /^build-net/.test(name)
+    );
+    expect(variantNames).toEqual([]);
+  });
+
+  it('should build a single framework variant in isolation', () => {
+    const output = runCLI('build-net10.0 MultiApp', {
+      verbose: true,
+      env: { NX_DAEMON: 'false' },
+    });
+    expect(output).toContain('Build succeeded');
+
+    checkFilesMatchingPatternExist(
+      '.*/MultiApp.dll',
+      tmpProjPath('MultiApp/bin/Debug/net10.0')
+    );
+  });
+});

--- a/e2e/dotnet/src/dotnet-framework-variants.test.ts
+++ b/e2e/dotnet/src/dotnet-framework-variants.test.ts
@@ -80,13 +80,13 @@ describe('.NET Plugin - Framework Variants', () => {
     }
   });
 
-  it('should generate a publish variant per framework for executables', () => {
+  it('should generate a self-contained build variant (no aggregate build dependency)', () => {
     const details = JSON.parse(runCLI(`show project MultiApp --json`));
 
-    expect(details.targets['publish-net10.0']).toBeDefined();
-    expect(details.targets['publish-net10.0'].dependsOn).toContain(
-      'build-net10.0-release'
-    );
+    const variant = details.targets['build-net10.0'];
+    // Self-contained: no dependsOn on the aggregate build, and no --no-dependencies.
+    expect(variant.dependsOn ?? []).not.toContain('^build');
+    expect(variant.options.args).not.toContain('--no-dependencies');
   });
 
   it('should record the target framework in variant metadata', () => {
@@ -94,6 +94,9 @@ describe('.NET Plugin - Framework Variants', () => {
 
     expect(details.targets['build-net10.0'].metadata.targetFramework).toBe(
       'net10.0'
+    );
+    expect(details.targets['build-net10.0'].metadata.frameworkVariantOf).toBe(
+      'build'
     );
   });
 

--- a/e2e/dotnet/src/dotnet-runtime-variants.test.ts
+++ b/e2e/dotnet/src/dotnet-runtime-variants.test.ts
@@ -1,0 +1,110 @@
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  updateJson,
+} from '@nx/e2e-utils';
+
+import {
+  createDotNetProject,
+  enableMultiTargeting,
+  updateProjectFile,
+} from './utils/create-dotnet-project';
+
+/**
+ * Exercises the opt-in per-runtime-identifier target variants for multi-targeted
+ * executables that declare RIDs (https://github.com/nrwl/nx/discussions/36676,
+ * https://github.com/nrwl/nx/issues/33474).
+ *
+ * Assertions go through the real plugin + MSBuild analyzer via `show project`,
+ * so no RID runtime pack is required to validate the generated task graph.
+ */
+describe('.NET Plugin - Runtime (RID) Variants', () => {
+  beforeAll(() => {
+    newProject({ packages: [] });
+    runCLI(`add @nx/dotnet`);
+
+    updateJson('nx.json', (nxJson) => {
+      nxJson.plugins = (nxJson.plugins ?? []).map((p: unknown) =>
+        p === '@nx/dotnet'
+          ? { plugin: '@nx/dotnet', options: { frameworkVariants: true } }
+          : p
+      );
+      return nxJson;
+    });
+
+    createDotNetProject({ name: 'RidApp', type: 'console' });
+    enableMultiTargeting('RidApp', ['net9.0', 'net10.0']);
+    updateProjectFile('RidApp', (content) =>
+      content.replace(
+        '</PropertyGroup>',
+        `  <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>\n</PropertyGroup>`
+      )
+    );
+
+    createDotNetProject({ name: 'NoRidApp', type: 'console' });
+    enableMultiTargeting('NoRidApp', ['net9.0', 'net10.0']);
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('should generate a RID-specific release build and publish per declared RID', () => {
+    const details = JSON.parse(runCLI(`show project RidApp --json`));
+
+    expect(details.targets['build-net10.0-win-x64-release']).toBeDefined();
+    expect(details.targets['publish-net10.0-win-x64']).toBeDefined();
+    expect(details.targets['build-net10.0-linux-x64-release']).toBeDefined();
+    expect(details.targets['publish-net10.0-linux-x64']).toBeDefined();
+  });
+
+  it('should pass --runtime to the RID variant command', () => {
+    const details = JSON.parse(runCLI(`show project RidApp --json`));
+
+    expect(details.targets['publish-net10.0-win-x64'].options.args).toEqual(
+      expect.arrayContaining(['--runtime', 'win-x64', '--framework', 'net10.0'])
+    );
+  });
+
+  it('should make the RID publish depend on the RID-specific build', () => {
+    const details = JSON.parse(runCLI(`show project RidApp --json`));
+
+    expect(details.targets['publish-net10.0-win-x64'].dependsOn).toContain(
+      'build-net10.0-win-x64-release'
+    );
+  });
+
+  it('should keep the RID release build self-contained', () => {
+    const details = JSON.parse(runCLI(`show project RidApp --json`));
+
+    const build = details.targets['build-net10.0-win-x64-release'];
+    expect(build.dependsOn ?? []).not.toContain('^build');
+    expect(build.options.args).not.toContain('--no-dependencies');
+  });
+
+  it('should scope RID outputs to a runtime-specific folder', () => {
+    const details = JSON.parse(runCLI(`show project RidApp --json`));
+
+    expect(details.targets['build-net10.0-win-x64-release'].outputs).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/bin\/Release\/net10\.0\/win-x64/),
+      ])
+    );
+  });
+
+  it('should record framework and runtime in RID variant metadata', () => {
+    const details = JSON.parse(runCLI(`show project RidApp --json`));
+
+    const metadata = details.targets['publish-net10.0-win-x64'].metadata;
+    expect(metadata.targetFramework).toBe('net10.0');
+    expect(metadata.runtimeIdentifier).toBe('win-x64');
+  });
+
+  it('should not generate RID variants when no RIDs are declared', () => {
+    const details = JSON.parse(runCLI(`show project NoRidApp --json`));
+
+    const ridTargets = Object.keys(details.targets).filter(
+      (name) => name.includes('win-x64') || name.includes('linux-x64')
+    );
+    expect(ridTargets).toEqual([]);
+  });
+});

--- a/e2e/dotnet/src/dotnet-runtime-variants.test.ts
+++ b/e2e/dotnet/src/dotnet-runtime-variants.test.ts
@@ -27,7 +27,7 @@ describe('.NET Plugin - Runtime (RID) Variants', () => {
     updateJson('nx.json', (nxJson) => {
       nxJson.plugins = (nxJson.plugins ?? []).map((p: unknown) =>
         p === '@nx/dotnet'
-          ? { plugin: '@nx/dotnet', options: { frameworkVariants: true } }
+          ? { plugin: '@nx/dotnet', options: { runtimeVariants: true } }
           : p
       );
       return nxJson;
@@ -97,6 +97,13 @@ describe('.NET Plugin - Runtime (RID) Variants', () => {
     const metadata = details.targets['publish-net10.0-win-x64'].metadata;
     expect(metadata.targetFramework).toBe('net10.0');
     expect(metadata.runtimeIdentifier).toBe('win-x64');
+  });
+
+  it('should still generate framework build variants (runtime implies framework)', () => {
+    const details = JSON.parse(runCLI(`show project RidApp --json`));
+
+    expect(details.targets['build-net10.0']).toBeDefined();
+    expect(details.targets['build-net9.0']).toBeDefined();
   });
 
   it('should not generate RID variants when no RIDs are declared', () => {

--- a/packages/dotnet/analyzer.Tests/AnalyzerIntegrationTests.cs
+++ b/packages/dotnet/analyzer.Tests/AnalyzerIntegrationTests.cs
@@ -1,0 +1,141 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// Analyzer-level integration tests that run the real analyzer executable
+/// against a temporary multi-targeted project and assert on the public JSON it
+/// emits. Unlike the <c>TargetBuilder</c> unit tests, these exercise the full
+/// path — MSBuild registration, <c>ProjectGraph</c> inner-build enumeration in
+/// <see cref="Analyzer"/>, and serialization — proving the framework variants
+/// actually surface (and don't, when disabled) through the contract the Nx
+/// plugin consumes.
+/// </summary>
+public class AnalyzerIntegrationTests : IDisposable
+{
+    private readonly string _workspace;
+
+    public AnalyzerIntegrationTests()
+    {
+        _workspace = Path.Combine(Path.GetTempPath(), "nx-dotnet-it-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_workspace, "App"));
+        File.WriteAllText(
+            Path.Combine(_workspace, "App", "App.csproj"),
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(
+            Path.Combine(_workspace, "nx.json"),
+            """{ "namedInputs": { "default": ["{projectRoot}/**/*"], "production": ["default"] } }""");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_workspace, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static string AnalyzerDll =>
+        Path.Combine(AppContext.BaseDirectory, "MsbuildAnalyzer.dll");
+
+    private JsonElement RunAnalyzer(string? optionsJson)
+    {
+        Assert.True(File.Exists(AnalyzerDll), $"Analyzer not found at {AnalyzerDll}");
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = _workspace,
+        };
+        psi.ArgumentList.Add(AnalyzerDll);
+        psi.ArgumentList.Add(_workspace);
+        if (optionsJson is not null)
+        {
+            psi.ArgumentList.Add(optionsJson);
+        }
+
+        using var proc = Process.Start(psi)!;
+        proc.StandardInput.WriteLine("App/App.csproj");
+        proc.StandardInput.Close();
+
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(180_000), "Analyzer timed out");
+        Assert.True(proc.ExitCode == 0, $"Analyzer exited {proc.ExitCode}. stderr:\n{stderr}");
+
+        using var doc = JsonDocument.Parse(stdout);
+        return doc.RootElement
+            .GetProperty("nodesByFile")
+            .GetProperty("App/App.csproj")
+            .GetProperty("targets")
+            .Clone();
+    }
+
+    private static string[] TargetNames(JsonElement targets) =>
+        targets.EnumerateObject().Select(p => p.Name).ToArray();
+
+    [Fact]
+    public void Enabled_RealMultiTargetProject_EmitsBuildVariants()
+    {
+        var targets = RunAnalyzer("""{"frameworkVariants":true}""");
+        var names = TargetNames(targets);
+
+        Assert.Contains("build-net8.0", names);
+        Assert.Contains("build-net9.0", names);
+        Assert.Contains("build-net8.0-release", names);
+        Assert.Contains("build-net9.0-release", names);
+
+        // Unqualified targets are preserved.
+        Assert.Contains("build", names);
+        Assert.Contains("build:release", names);
+    }
+
+    [Fact]
+    public void Enabled_Variant_HasFrameworkArgsSelfContainedDepsAndScopedOutputs()
+    {
+        var targets = RunAnalyzer("""{"frameworkVariants":true}""");
+        var variant = targets.GetProperty("build-net8.0");
+
+        var args = variant.GetProperty("options").GetProperty("args")
+            .EnumerateArray().Select(a => a.GetString()).ToArray();
+        Assert.Contains("--framework", args);
+        Assert.Contains("net8.0", args);
+        Assert.DoesNotContain("--no-dependencies", args);
+
+        // Self-contained: no dependency on the aggregate build.
+        var dependsOn = variant.TryGetProperty("dependsOn", out var d)
+            ? d.EnumerateArray().Select(x => x.GetString()).ToArray()
+            : Array.Empty<string>();
+        Assert.DoesNotContain("^build", dependsOn);
+
+        // Outputs are scoped to this framework and no other.
+        var outputs = variant.GetProperty("outputs")
+            .EnumerateArray().Select(o => o.GetString()!).ToArray();
+        Assert.NotEmpty(outputs);
+        Assert.All(outputs, o => Assert.Contains("net8.0", o));
+        Assert.DoesNotContain(outputs, o => o.Contains("net9.0"));
+
+        Assert.Equal(
+            "net8.0",
+            variant.GetProperty("metadata").GetProperty("targetFramework").GetString());
+    }
+
+    [Fact]
+    public void Disabled_RealMultiTargetProject_EmitsNoVariants()
+    {
+        var targets = RunAnalyzer(optionsJson: null);
+        var names = TargetNames(targets);
+
+        Assert.DoesNotContain(names, n => n.StartsWith("build-net"));
+        Assert.Contains("build", names);
+    }
+}

--- a/packages/dotnet/analyzer.Tests/ProjectUtilitiesRuntimeTests.cs
+++ b/packages/dotnet/analyzer.Tests/ProjectUtilitiesRuntimeTests.cs
@@ -1,0 +1,67 @@
+using MsbuildAnalyzer.Utilities;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// Unit tests for the runtime-identifier and publish-directory resolution
+/// helpers that back the per-RID variants.
+/// </summary>
+public class ProjectUtilitiesRuntimeTests
+{
+    // --- ResolveRuntimeIdentifiers ---------------------------------------
+
+    [Fact]
+    public void ResolveRuntimeIdentifiers_PluralIsAuthoritative()
+    {
+        var rids = ProjectUtilities.ResolveRuntimeIdentifiers(null, "win-x64;linux-x64");
+        Assert.Equal(new[] { "linux-x64", "win-x64" }, rids);
+    }
+
+    [Fact]
+    public void ResolveRuntimeIdentifiers_PluralSuppressesImplicitSingular()
+    {
+        // A platform framework can evaluate an SDK-default singular RuntimeIdentifier;
+        // a declared plural list must not be polluted by it.
+        var rids = ProjectUtilities.ResolveRuntimeIdentifiers("iossimulator-arm64", "ios-arm64");
+        Assert.Equal(new[] { "ios-arm64" }, rids);
+    }
+
+    [Fact]
+    public void ResolveRuntimeIdentifiers_FallsBackToEvaluatedSingular()
+    {
+        var rids = ProjectUtilities.ResolveRuntimeIdentifiers("iossimulator-arm64", null);
+        Assert.Equal(new[] { "iossimulator-arm64" }, rids);
+    }
+
+    [Fact]
+    public void ResolveRuntimeIdentifiers_EmptyWhenNeitherSet()
+    {
+        Assert.Empty(ProjectUtilities.ResolveRuntimeIdentifiers(null, null));
+        Assert.Empty(ProjectUtilities.ResolveRuntimeIdentifiers("", "  "));
+    }
+
+    // --- IsPublishDirDerivable -------------------------------------------
+
+    [Fact]
+    public void IsPublishDirDerivable_EmptyPublishDir_IsDerivable()
+    {
+        Assert.True(ProjectUtilities.IsPublishDirDerivable(null, "bin/Debug/net10.0"));
+        Assert.True(ProjectUtilities.IsPublishDirDerivable("  ", "bin/Debug/net10.0"));
+    }
+
+    [Fact]
+    public void IsPublishDirDerivable_DefaultPublishUnderOutputPath_IsDerivable()
+    {
+        Assert.True(ProjectUtilities.IsPublishDirDerivable("bin/Debug/net10.0/publish/", "bin/Debug/net10.0/"));
+        // Backslashes normalize the same way.
+        Assert.True(ProjectUtilities.IsPublishDirDerivable(@"bin\Debug\net10.0\publish", @"bin\Debug\net10.0"));
+    }
+
+    [Fact]
+    public void IsPublishDirDerivable_CustomPublishDir_IsNotDerivable()
+    {
+        Assert.False(ProjectUtilities.IsPublishDirDerivable("dist/custompub", "bin/Debug/net10.0"));
+        Assert.False(ProjectUtilities.IsPublishDirDerivable("bin/Debug/net10.0/out", "bin/Debug/net10.0"));
+    }
+}

--- a/packages/dotnet/analyzer.Tests/RuntimeAnalyzerIntegrationTests.cs
+++ b/packages/dotnet/analyzer.Tests/RuntimeAnalyzerIntegrationTests.cs
@@ -38,7 +38,7 @@ public class RuntimeAnalyzerIntegrationTests : IDisposable
         try { Directory.Delete(_workspace, recursive: true); } catch { /* best effort */ }
     }
 
-    private JsonElement RunAnalyzer()
+    private JsonElement RunAnalyzer(string optionsJson)
     {
         var dll = Path.Combine(AppContext.BaseDirectory, "MsbuildAnalyzer.dll");
         Assert.True(File.Exists(dll), $"Analyzer not found at {dll}");
@@ -53,7 +53,7 @@ public class RuntimeAnalyzerIntegrationTests : IDisposable
         };
         psi.ArgumentList.Add(dll);
         psi.ArgumentList.Add(_workspace);
-        psi.ArgumentList.Add("""{"frameworkVariants":true}""");
+        psi.ArgumentList.Add(optionsJson);
 
         using var proc = Process.Start(psi)!;
         proc.StandardInput.WriteLine("App/App.csproj");
@@ -73,9 +73,21 @@ public class RuntimeAnalyzerIntegrationTests : IDisposable
     }
 
     [Fact]
+    public void FrameworkVariantsAlone_EmitsNoRuntimeVariants()
+    {
+        var targets = RunAnalyzer("""{"frameworkVariants":true}""");
+        var names = targets.EnumerateObject().Select(p => p.Name).ToArray();
+
+        // Framework build variants are present, but no RID variants without the
+        // separate runtimeVariants opt-in.
+        Assert.Contains("build-net10.0", names);
+        Assert.DoesNotContain(names, n => n.Contains("win-x64") || n.Contains("linux-x64"));
+    }
+
+    [Fact]
     public void Enabled_RealRidProject_EmitsRuntimeVariantsWithScopedOutputs()
     {
-        var targets = RunAnalyzer();
+        var targets = RunAnalyzer("""{"runtimeVariants":true}""");
 
         var publish = targets.GetProperty("publish-net10.0-win-x64");
 

--- a/packages/dotnet/analyzer.Tests/RuntimeAnalyzerIntegrationTests.cs
+++ b/packages/dotnet/analyzer.Tests/RuntimeAnalyzerIntegrationTests.cs
@@ -1,0 +1,99 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// Analyzer-level integration test that runs the real analyzer executable
+/// against a temporary multi-targeted executable declaring runtime identifiers
+/// (standard output layout) and asserts the per-RID variants surface through
+/// the public JSON — exercising Analyzer's inner-build enumeration, RID
+/// collection, layout gating, and serialization end to end.
+/// </summary>
+public class RuntimeAnalyzerIntegrationTests : IDisposable
+{
+    private readonly string _workspace;
+
+    public RuntimeAnalyzerIntegrationTests()
+    {
+        _workspace = Path.Combine(Path.GetTempPath(), "nx-dotnet-rid-it-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_workspace, "App"));
+        File.WriteAllText(
+            Path.Combine(_workspace, "App", "App.csproj"),
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+                <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(_workspace, "nx.json"), "{}");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_workspace, recursive: true); } catch { /* best effort */ }
+    }
+
+    private JsonElement RunAnalyzer()
+    {
+        var dll = Path.Combine(AppContext.BaseDirectory, "MsbuildAnalyzer.dll");
+        Assert.True(File.Exists(dll), $"Analyzer not found at {dll}");
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = _workspace,
+        };
+        psi.ArgumentList.Add(dll);
+        psi.ArgumentList.Add(_workspace);
+        psi.ArgumentList.Add("""{"frameworkVariants":true}""");
+
+        using var proc = Process.Start(psi)!;
+        proc.StandardInput.WriteLine("App/App.csproj");
+        proc.StandardInput.Close();
+
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(180_000), "Analyzer timed out");
+        Assert.True(proc.ExitCode == 0, $"Analyzer exited {proc.ExitCode}. stderr:\n{stderr}");
+
+        using var doc = JsonDocument.Parse(stdout);
+        return doc.RootElement
+            .GetProperty("nodesByFile")
+            .GetProperty("App/App.csproj")
+            .GetProperty("targets")
+            .Clone();
+    }
+
+    [Fact]
+    public void Enabled_RealRidProject_EmitsRuntimeVariantsWithScopedOutputs()
+    {
+        var targets = RunAnalyzer();
+
+        var publish = targets.GetProperty("publish-net10.0-win-x64");
+
+        var args = publish.GetProperty("options").GetProperty("args")
+            .EnumerateArray().Select(a => a.GetString()).ToArray();
+        Assert.Contains("--runtime", args);
+        Assert.Contains("win-x64", args);
+
+        var dependsOn = publish.GetProperty("dependsOn")
+            .EnumerateArray().Select(x => x.GetString()).ToArray();
+        Assert.Contains("build-net10.0-win-x64-release", dependsOn);
+
+        var outputs = targets.GetProperty("build-net10.0-win-x64-release")
+            .GetProperty("outputs").EnumerateArray().Select(o => o.GetString()!).ToArray();
+        Assert.Contains(outputs, o => o.Contains("Release/net10.0/win-x64"));
+
+        var meta = publish.GetProperty("metadata");
+        Assert.Equal("net10.0", meta.GetProperty("targetFramework").GetString());
+        Assert.Equal("win-x64", meta.GetProperty("runtimeIdentifier").GetString());
+    }
+}

--- a/packages/dotnet/analyzer.Tests/TargetBuilderFrameworkVariantsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderFrameworkVariantsTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace MsbuildAnalyzer.Tests;
 
 /// <summary>
-/// Unit tests for the opt-in per-target-framework target variants added for
+/// Unit tests for the opt-in per-target-framework build variants added for
 /// multi-targeted projects (https://github.com/nrwl/nx/discussions/36676).
 ///
 /// These drive the pure target-building logic with property dictionaries that
@@ -109,12 +109,49 @@ public class TargetBuilderFrameworkVariantsTests
     }
 
     [Fact]
+    public void OnlyBuildVariants_AreGenerated()
+    {
+        // Scope is build variants only; test/publish variants are a later design.
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"), isExe: true, isTest: true);
+
+        Assert.DoesNotContain(targets.Keys, k => k.StartsWith("test-net") || k.StartsWith("publish-net"));
+    }
+
+    [Fact]
     public void BuildVariant_PassesFrameworkArgument()
     {
         var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
 
         var args = targets["build-net10.0-ios"].Options!.Args!;
-        Assert.Equal(new[] { "--no-restore", "--no-dependencies", "--framework", "net10.0-ios" }, args);
+        Assert.Equal(new[] { "--no-restore", "--framework", "net10.0-ios" }, args);
+    }
+
+    [Fact]
+    public void BuildVariant_IsSelfContained()
+    {
+        // A self-contained variant must not depend on the aggregate build or pass
+        // --no-dependencies, or it would rebuild every framework of every dependency
+        // and reintroduce the host-compatibility problem it exists to solve.
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
+
+        var buildVariant = targets["build-net10.0-ios"];
+        Assert.True(buildVariant.DependsOn is null || buildVariant.DependsOn.Length == 0);
+        Assert.DoesNotContain("--no-dependencies", buildVariant.Options!.Args!);
+
+        var releaseVariant = targets["build-net10.0-ios-release"];
+        Assert.True(releaseVariant.DependsOn is null || releaseVariant.DependsOn.Length == 0);
+        Assert.DoesNotContain("--no-dependencies", releaseVariant.Options!.Args!);
+    }
+
+    [Fact]
+    public void BuildVariant_KeepsProductionInputForInvalidation()
+    {
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
+
+        // With no nx.json the production input resolves to "default"; the caret form
+        // keeps a self-contained variant invalidating on dependency source changes.
+        var inputs = targets["build-net10.0-ios"].Inputs!;
+        Assert.Contains("^default", inputs.OfType<string>());
     }
 
     [Fact]
@@ -148,33 +185,13 @@ public class TargetBuilderFrameworkVariantsTests
     }
 
     [Fact]
-    public void BuildVariant_RecordsFrameworkMetadata()
+    public void BuildVariant_RecordsFrameworkAndBaseTargetMetadata()
     {
         var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
 
-        Assert.Equal("net10.0-ios", targets["build-net10.0-ios"].Metadata!.TargetFramework);
-    }
-
-    [Fact]
-    public void PublishVariant_OnlyForExecutables_DependsOnReleaseBuild()
-    {
-        var exeTargets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"), isExe: true);
-        Assert.Contains("publish-net10.0-ios", exeTargets.Keys);
-        Assert.Equal(new[] { "build-net10.0-ios-release" }, exeTargets["publish-net10.0-ios"].DependsOn);
-
-        var libTargets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
-        Assert.DoesNotContain("publish-net10.0-ios", libTargets.Keys);
-    }
-
-    [Fact]
-    public void TestVariant_OnlyForTestProjects_DependsOnDebugBuild()
-    {
-        var testTargets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"), isTest: true);
-        Assert.Contains("test-net10.0-ios", testTargets.Keys);
-        Assert.Equal(new[] { "build-net10.0-ios" }, testTargets["test-net10.0-ios"].DependsOn);
-
-        var nonTestTargets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
-        Assert.DoesNotContain("test-net10.0-ios", nonTestTargets.Keys);
+        var metadata = targets["build-net10.0-ios"].Metadata!;
+        Assert.Equal("net10.0-ios", metadata.TargetFramework);
+        Assert.Equal("build", metadata.FrameworkVariantOf);
     }
 
     // --- Naming safety & collisions --------------------------------------
@@ -182,7 +199,7 @@ public class TargetBuilderFrameworkVariantsTests
     [Fact]
     public void VariantNames_NeverContainColon()
     {
-        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"), isExe: true);
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
 
         foreach (var name in targets.Keys.Where(k => k.Contains("net10.0")))
         {
@@ -199,6 +216,7 @@ public class TargetBuilderFrameworkVariantsTests
         Assert.Contains("compile-net10.0-ios", targets.Keys);
         Assert.Contains("compile-net10.0-ios-release", targets.Keys);
         Assert.DoesNotContain("build-net10.0-ios", targets.Keys);
+        Assert.Equal("compile", targets["compile-net10.0-ios"].Metadata!.FrameworkVariantOf);
     }
 
     [Fact]

--- a/packages/dotnet/analyzer.Tests/TargetBuilderFrameworkVariantsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderFrameworkVariantsTests.cs
@@ -1,0 +1,221 @@
+using MsbuildAnalyzer.Models;
+using MsbuildAnalyzer.Utilities;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// Unit tests for the opt-in per-target-framework target variants added for
+/// multi-targeted projects (https://github.com/nrwl/nx/discussions/36676).
+///
+/// These drive the pure target-building logic with property dictionaries that
+/// mirror what MSBuild hands back for each inner build, so no full MSBuild
+/// evaluation is needed.
+/// </summary>
+public class TargetBuilderFrameworkVariantsTests
+{
+    private static readonly string WorkspaceRoot = Path.Combine(Path.GetTempPath(), "nx-dotnet-ws");
+
+    private static string ProjectDir(params string[] segments) =>
+        Path.Combine(new[] { WorkspaceRoot }.Concat(segments).ToArray());
+
+    private static Dictionary<string, string> InnerProperties(string tfm) => new()
+    {
+        ["TargetFramework"] = tfm,
+        ["OutputPath"] = $"bin/Debug/{tfm}/",
+        ["IntermediateOutputPath"] = $"obj/Debug/{tfm}/",
+    };
+
+    private static Dictionary<string, Target> BuildTargets(
+        bool frameworkVariants,
+        List<FrameworkVariant>? variants,
+        bool isExe = false,
+        bool isTest = false,
+        PluginOptions? options = null)
+    {
+        options ??= new PluginOptions();
+        options.FrameworkVariants = frameworkVariants;
+
+        return TargetBuilder.BuildTargets(
+            projectName: "MyProj",
+            fileName: "MyProj.csproj",
+            isTest: isTest,
+            isExe: isExe,
+            packageRefs: new List<PackageReference>(),
+            properties: new Dictionary<string, string>
+            {
+                ["BaseOutputPath"] = "bin/",
+                ["BaseIntermediateOutputPath"] = "obj/",
+            },
+            projectDirectory: ProjectDir("MyProj"),
+            workspaceRoot: WorkspaceRoot,
+            options: options,
+            nxJson: null,
+            directoryBuildInputs: new List<string>(),
+            frameworkVariants: variants);
+    }
+
+    private static List<FrameworkVariant> Variants(params string[] tfms) =>
+        tfms.Select(t => new FrameworkVariant
+        {
+            TargetFramework = t,
+            Properties = InnerProperties(t),
+        }).ToList();
+
+    // --- Opt-in / disabled behavior --------------------------------------
+
+    [Fact]
+    public void Disabled_ByDefault_EmitsNoVariants()
+    {
+        var targets = BuildTargets(frameworkVariants: false, Variants("net10.0", "net10.0-ios"));
+
+        Assert.DoesNotContain(targets.Keys, k => k.StartsWith("build-net"));
+        Assert.Contains("build", targets.Keys);
+        Assert.Contains("build:release", targets.Keys);
+    }
+
+    [Fact]
+    public void Enabled_ButNullVariants_EmitsNoVariants()
+    {
+        var targets = BuildTargets(frameworkVariants: true, variants: null);
+
+        Assert.DoesNotContain(targets.Keys, k => k.Contains("-net"));
+    }
+
+    [Fact]
+    public void Enabled_WithSingleFramework_EmitsNoVariants()
+    {
+        // A single evaluated framework has nothing to disambiguate.
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0"));
+
+        Assert.DoesNotContain(targets.Keys, k => k.StartsWith("build-net"));
+    }
+
+    // --- Variant generation ----------------------------------------------
+
+    [Fact]
+    public void Enabled_WithMultipleFrameworks_EmitsBuildVariants()
+    {
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
+
+        Assert.Contains("build-net10.0", targets.Keys);
+        Assert.Contains("build-net10.0-release", targets.Keys);
+        Assert.Contains("build-net10.0-ios", targets.Keys);
+        Assert.Contains("build-net10.0-ios-release", targets.Keys);
+
+        // Unqualified targets remain untouched.
+        Assert.Contains("build", targets.Keys);
+        Assert.Contains("build:release", targets.Keys);
+    }
+
+    [Fact]
+    public void BuildVariant_PassesFrameworkArgument()
+    {
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
+
+        var args = targets["build-net10.0-ios"].Options!.Args!;
+        Assert.Equal(new[] { "--no-restore", "--no-dependencies", "--framework", "net10.0-ios" }, args);
+    }
+
+    [Fact]
+    public void BuildVariant_ScopesOutputsToFramework()
+    {
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
+
+        Assert.Equal(
+            new[]
+            {
+                "{projectRoot}/bin/Debug/net10.0-ios",
+                "{projectRoot}/bin/Release/net10.0-ios",
+                "{projectRoot}/obj/Debug/net10.0-ios",
+                "{projectRoot}/obj/Release/net10.0-ios",
+            },
+            targets["build-net10.0-ios"].Outputs);
+    }
+
+    [Fact]
+    public void BuildReleaseVariant_ScopesOutputsToReleaseFramework()
+    {
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
+
+        Assert.Equal(
+            new[]
+            {
+                "{projectRoot}/bin/Release/net10.0-ios",
+                "{projectRoot}/obj/Release/net10.0-ios",
+            },
+            targets["build-net10.0-ios-release"].Outputs);
+    }
+
+    [Fact]
+    public void BuildVariant_RecordsFrameworkMetadata()
+    {
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
+
+        Assert.Equal("net10.0-ios", targets["build-net10.0-ios"].Metadata!.TargetFramework);
+    }
+
+    [Fact]
+    public void PublishVariant_OnlyForExecutables_DependsOnReleaseBuild()
+    {
+        var exeTargets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"), isExe: true);
+        Assert.Contains("publish-net10.0-ios", exeTargets.Keys);
+        Assert.Equal(new[] { "build-net10.0-ios-release" }, exeTargets["publish-net10.0-ios"].DependsOn);
+
+        var libTargets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
+        Assert.DoesNotContain("publish-net10.0-ios", libTargets.Keys);
+    }
+
+    [Fact]
+    public void TestVariant_OnlyForTestProjects_DependsOnDebugBuild()
+    {
+        var testTargets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"), isTest: true);
+        Assert.Contains("test-net10.0-ios", testTargets.Keys);
+        Assert.Equal(new[] { "build-net10.0-ios" }, testTargets["test-net10.0-ios"].DependsOn);
+
+        var nonTestTargets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"));
+        Assert.DoesNotContain("test-net10.0-ios", nonTestTargets.Keys);
+    }
+
+    // --- Naming safety & collisions --------------------------------------
+
+    [Fact]
+    public void VariantNames_NeverContainColon()
+    {
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"), isExe: true);
+
+        foreach (var name in targets.Keys.Where(k => k.Contains("net10.0")))
+        {
+            Assert.DoesNotContain(':', name);
+        }
+    }
+
+    [Fact]
+    public void VariantNames_DeriveFromConfiguredTargetName()
+    {
+        var options = new PluginOptions { BuildTargetName = "compile" };
+        var targets = BuildTargets(frameworkVariants: true, Variants("net10.0", "net10.0-ios"), options: options);
+
+        Assert.Contains("compile-net10.0-ios", targets.Keys);
+        Assert.Contains("compile-net10.0-ios-release", targets.Keys);
+        Assert.DoesNotContain("build-net10.0-ios", targets.Keys);
+    }
+
+    [Fact]
+    public void CollidingNormalizedFrameworks_AreSkippedNotOverwritten()
+    {
+        // Two distinct evaluated frameworks whose names normalize to the same
+        // token must not silently overwrite each other.
+        var variants = new List<FrameworkVariant>
+        {
+            new() { TargetFramework = "net8.0", Properties = InnerProperties("net8.0") },
+            new() { TargetFramework = "NET8.0", Properties = InnerProperties("NET8.0") },
+        };
+
+        var targets = BuildTargets(frameworkVariants: true, variants);
+
+        Assert.Contains("build-net8.0", targets.Keys);
+        // Only the first wins; the collision is reported and skipped.
+        Assert.Single(targets.Keys, k => k == "build-net8.0");
+    }
+}

--- a/packages/dotnet/analyzer.Tests/TargetBuilderRuntimeVariantsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderRuntimeVariantsTests.cs
@@ -1,0 +1,297 @@
+using MsbuildAnalyzer.Models;
+using MsbuildAnalyzer.Utilities;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// Unit tests for the opt-in per-runtime-identifier target variants generated
+/// for multi-targeted executables that declare RIDs
+/// (https://github.com/nrwl/nx/discussions/36676, https://github.com/nrwl/nx/issues/33474).
+/// </summary>
+public class TargetBuilderRuntimeVariantsTests
+{
+    private static readonly string WorkspaceRoot = Path.Combine(Path.GetTempPath(), "nx-dotnet-ws");
+
+    private static string ProjectDir(params string[] segments) =>
+        Path.Combine(new[] { WorkspaceRoot }.Concat(segments).ToArray());
+
+    private static Dictionary<string, string> InnerProperties(
+        string tfm,
+        (string key, string value)[]? extra = null)
+    {
+        var props = new Dictionary<string, string>
+        {
+            ["TargetFramework"] = tfm,
+            ["OutputPath"] = $"bin/Debug/{tfm}/",
+            ["IntermediateOutputPath"] = $"obj/Debug/{tfm}/",
+            ["BaseOutputPath"] = "bin/",
+            ["BaseIntermediateOutputPath"] = "obj/",
+        };
+        foreach (var (k, v) in extra ?? Array.Empty<(string, string)>())
+        {
+            props[k] = v;
+        }
+        return props;
+    }
+
+    private static FrameworkVariant Variant(
+        string tfm,
+        string[] rids,
+        bool isExecutable = true,
+        (string key, string value)[]? extraProps = null) => new()
+    {
+        TargetFramework = tfm,
+        Properties = InnerProperties(tfm, extraProps),
+        IsExecutable = isExecutable,
+        RuntimeIdentifiers = rids.ToList(),
+    };
+
+    private static Dictionary<string, Target> BuildTargets(List<FrameworkVariant> variants)
+    {
+        var options = new PluginOptions { FrameworkVariants = true };
+        return TargetBuilder.BuildTargets(
+            projectName: "MyProj",
+            fileName: "MyProj.csproj",
+            isTest: false,
+            isExe: true,
+            packageRefs: new List<PackageReference>(),
+            properties: new Dictionary<string, string>
+            {
+                ["BaseOutputPath"] = "bin/",
+                ["BaseIntermediateOutputPath"] = "obj/",
+            },
+            projectDirectory: ProjectDir("MyProj"),
+            workspaceRoot: WorkspaceRoot,
+            options: options,
+            nxJson: null,
+            directoryBuildInputs: new List<string>(),
+            frameworkVariants: variants);
+    }
+
+    private static List<FrameworkVariant> WinAndIos() => new()
+    {
+        Variant("net10.0", new[] { "win-x64" }),
+        Variant("net10.0-ios", new[] { "ios-arm64" },
+            extraProps: new[]
+            {
+                // Platform frameworks default a RID into the evaluated output path.
+                ("RuntimeIdentifier", "iossimulator-arm64"),
+                ("OutputPath", "bin/Debug/net10.0-ios/iossimulator-arm64/"),
+                ("IntermediateOutputPath", "obj/Debug/net10.0-ios/iossimulator-arm64/"),
+            }),
+    };
+
+    // --- Gating -----------------------------------------------------------
+
+    [Fact]
+    public void NoRidsDeclared_EmitsNoRuntimeVariants()
+    {
+        var targets = BuildTargets(new List<FrameworkVariant>
+        {
+            Variant("net10.0", Array.Empty<string>()),
+            Variant("net10.0-ios", Array.Empty<string>()),
+        });
+
+        Assert.DoesNotContain(targets.Keys, k => k.Contains("-ios-arm64") || k.Contains("-win-x64"));
+        Assert.Contains("build-net10.0-ios", targets.Keys);
+    }
+
+    [Fact]
+    public void NonExecutableFramework_EmitsNoRuntimeVariants()
+    {
+        var targets = BuildTargets(new List<FrameworkVariant>
+        {
+            Variant("net10.0", new[] { "win-x64" }, isExecutable: false),
+            Variant("net10.0-ios", new[] { "ios-arm64" }, isExecutable: false),
+        });
+
+        Assert.DoesNotContain(targets.Keys, k => k.Contains("win-x64") || k.Contains("ios-arm64"));
+    }
+
+    [Fact]
+    public void MixedLibraryAndExecutable_OnlyExecutableFrameworkGetsRuntimeVariants()
+    {
+        // OutputType can be conditioned per framework: only the executable one
+        // should get publish/RID variants.
+        var targets = BuildTargets(new List<FrameworkVariant>
+        {
+            Variant("net9.0", new[] { "win-x64" }, isExecutable: false),
+            Variant("net10.0", new[] { "win-x64" }, isExecutable: true),
+        });
+
+        Assert.DoesNotContain("build-net9.0-win-x64-release", targets.Keys);
+        Assert.DoesNotContain("publish-net9.0-win-x64", targets.Keys);
+        Assert.Contains("build-net10.0-win-x64-release", targets.Keys);
+        Assert.Contains("publish-net10.0-win-x64", targets.Keys);
+    }
+
+    [Fact]
+    public void RidsDeclared_ForExecutable_EmitsBuildAndPublishRuntimeVariants()
+    {
+        var targets = BuildTargets(WinAndIos());
+
+        Assert.Contains("build-net10.0-win-x64-release", targets.Keys);
+        Assert.Contains("publish-net10.0-win-x64", targets.Keys);
+        Assert.Contains("build-net10.0-ios-ios-arm64-release", targets.Keys);
+        Assert.Contains("publish-net10.0-ios-ios-arm64", targets.Keys);
+    }
+
+    // --- Command & dependencies ------------------------------------------
+
+    [Fact]
+    public void RuntimeBuildVariant_PassesRuntimeArgument()
+    {
+        var targets = BuildTargets(WinAndIos());
+
+        Assert.Equal(
+            new[] { "--no-restore", "--framework", "net10.0", "--runtime", "win-x64", "--configuration", "Release" },
+            targets["build-net10.0-win-x64-release"].Options!.Args);
+    }
+
+    [Fact]
+    public void RuntimeBuildVariant_IsSelfContained()
+    {
+        var targets = BuildTargets(WinAndIos());
+
+        var build = targets["build-net10.0-win-x64-release"];
+        Assert.True(build.DependsOn is null || build.DependsOn.Length == 0);
+        Assert.DoesNotContain("--no-dependencies", build.Options!.Args!);
+    }
+
+    [Fact]
+    public void PublishRuntimeVariant_DependsOnRuntimeSpecificBuild()
+    {
+        var targets = BuildTargets(WinAndIos());
+
+        // The key correctness point behind #33474: the RID publish depends on a
+        // RID-specific build, not the framework-only Release build.
+        Assert.Equal(
+            new[] { "build-net10.0-win-x64-release" },
+            targets["publish-net10.0-win-x64"].DependsOn);
+    }
+
+    // --- Output-path derivation ------------------------------------------
+
+    [Fact]
+    public void RuntimeVariant_AppendsRidWhenNoImplicitRid()
+    {
+        var targets = BuildTargets(WinAndIos());
+
+        Assert.Equal(
+            new[]
+            {
+                "{projectRoot}/bin/Release/net10.0/win-x64",
+                "{projectRoot}/obj/Release/net10.0/win-x64",
+            },
+            targets["build-net10.0-win-x64-release"].Outputs);
+
+        Assert.Equal(
+            new[]
+            {
+                "{projectRoot}/bin/Release/net10.0/win-x64/publish",
+                "{projectRoot}/obj/Release/net10.0/win-x64",
+            },
+            targets["publish-net10.0-win-x64"].Outputs);
+    }
+
+    [Fact]
+    public void RuntimeVariant_ReplacesImplicitRidFromEvaluatedPath()
+    {
+        // net10.0-ios's inner build defaults iossimulator-arm64 into the path; the
+        // declared ios-arm64 replaces it rather than nesting under it.
+        var targets = BuildTargets(WinAndIos());
+
+        Assert.Equal(
+            new[]
+            {
+                "{projectRoot}/bin/Release/net10.0-ios/ios-arm64",
+                "{projectRoot}/obj/Release/net10.0-ios/ios-arm64",
+            },
+            targets["build-net10.0-ios-ios-arm64-release"].Outputs);
+    }
+
+    // --- Conservative skip for unsupported layouts -----------------------
+
+    [Fact]
+    public void ArtifactsLayout_SkipsRuntimeVariants()
+    {
+        var targets = BuildTargets(new List<FrameworkVariant>
+        {
+            Variant("net9.0", new[] { "win-x64" }, extraProps: new[] { ("UseArtifactsOutput", "true") }),
+            Variant("net10.0", new[] { "win-x64" }, extraProps: new[] { ("UseArtifactsOutput", "true") }),
+        });
+
+        Assert.DoesNotContain(targets.Keys, k => k.Contains("win-x64"));
+    }
+
+    [Fact]
+    public void AppendRuntimeIdentifierFalse_SkipsRuntimeVariants()
+    {
+        var targets = BuildTargets(new List<FrameworkVariant>
+        {
+            Variant("net9.0", new[] { "win-x64" }, extraProps: new[] { ("AppendRuntimeIdentifierToOutputPath", "false") }),
+            Variant("net10.0", new[] { "win-x64" }, extraProps: new[] { ("AppendRuntimeIdentifierToOutputPath", "false") }),
+        });
+
+        Assert.DoesNotContain(targets.Keys, k => k.Contains("win-x64"));
+    }
+
+    [Fact]
+    public void AppendTargetFrameworkFalse_SkipsRuntimeVariants()
+    {
+        var targets = BuildTargets(new List<FrameworkVariant>
+        {
+            Variant("net9.0", new[] { "win-x64" }, extraProps: new[] { ("AppendTargetFrameworkToOutputPath", "false") }),
+            Variant("net10.0", new[] { "win-x64" }, extraProps: new[] { ("AppendTargetFrameworkToOutputPath", "false") }),
+        });
+
+        Assert.DoesNotContain(targets.Keys, k => k.Contains("win-x64"));
+    }
+
+    // --- Metadata & naming -----------------------------------------------
+
+    [Fact]
+    public void RuntimeVariant_RecordsFrameworkRuntimeAndBaseTargetMetadata()
+    {
+        var targets = BuildTargets(WinAndIos());
+
+        var publishMeta = targets["publish-net10.0-win-x64"].Metadata!;
+        Assert.Equal("net10.0", publishMeta.TargetFramework);
+        Assert.Equal("win-x64", publishMeta.RuntimeIdentifier);
+        Assert.Equal("publish", publishMeta.FrameworkVariantOf);
+
+        Assert.Equal("build", targets["build-net10.0-win-x64-release"].Metadata!.FrameworkVariantOf);
+    }
+
+    [Fact]
+    public void RuntimeVariantNames_NeverContainColon()
+    {
+        var targets = BuildTargets(WinAndIos());
+
+        foreach (var name in targets.Keys.Where(k => k.Contains("win-x64") || k.Contains("ios-arm64")))
+        {
+            Assert.DoesNotContain(':', name);
+        }
+    }
+
+    [Fact]
+    public void MultipleRids_EmitVariantsForEach()
+    {
+        var targets = BuildTargets(new List<FrameworkVariant>
+        {
+            Variant("net10.0", new[] { "win-x64", "linux-x64" }),
+            Variant("net10.0-ios", new[] { "ios-arm64" },
+                extraProps: new[]
+                {
+                    ("RuntimeIdentifier", "iossimulator-arm64"),
+                    ("OutputPath", "bin/Debug/net10.0-ios/iossimulator-arm64/"),
+                    ("IntermediateOutputPath", "obj/Debug/net10.0-ios/iossimulator-arm64/"),
+                }),
+        });
+
+        Assert.Contains("publish-net10.0-win-x64", targets.Keys);
+        Assert.Contains("publish-net10.0-linux-x64", targets.Keys);
+        Assert.Contains("publish-net10.0-ios-ios-arm64", targets.Keys);
+    }
+}

--- a/packages/dotnet/analyzer.Tests/TargetBuilderRuntimeVariantsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderRuntimeVariantsTests.cs
@@ -47,9 +47,16 @@ public class TargetBuilderRuntimeVariantsTests
         RuntimeIdentifiers = rids.ToList(),
     };
 
-    private static Dictionary<string, Target> BuildTargets(List<FrameworkVariant> variants)
+    private static Dictionary<string, Target> BuildTargets(
+        List<FrameworkVariant> variants,
+        bool runtimeVariants = true,
+        bool frameworkVariants = false)
     {
-        var options = new PluginOptions { FrameworkVariants = true };
+        var options = new PluginOptions
+        {
+            FrameworkVariants = frameworkVariants,
+            RuntimeVariants = runtimeVariants,
+        };
         return TargetBuilder.BuildTargets(
             projectName: "MyProj",
             fileName: "MyProj.csproj",
@@ -83,6 +90,17 @@ public class TargetBuilderRuntimeVariantsTests
     };
 
     // --- Gating -----------------------------------------------------------
+
+    [Fact]
+    public void FrameworkVariantsWithoutRuntimeVariants_EmitsNoRuntimeVariants()
+    {
+        // Opting into per-framework build variants must not, on its own, expand
+        // the graph with RID variants — that needs the separate runtimeVariants flag.
+        var targets = BuildTargets(WinAndIos(), runtimeVariants: false, frameworkVariants: true);
+
+        Assert.Contains("build-net10.0", targets.Keys); // framework variants present
+        Assert.DoesNotContain(targets.Keys, k => k.Contains("win-x64") || k.Contains("ios-arm64"));
+    }
 
     [Fact]
     public void NoRidsDeclared_EmitsNoRuntimeVariants()
@@ -247,6 +265,33 @@ public class TargetBuilderRuntimeVariantsTests
         });
 
         Assert.DoesNotContain(targets.Keys, k => k.Contains("win-x64"));
+    }
+
+    [Fact]
+    public void CustomPublishDir_SkipsRuntimeVariants()
+    {
+        // A custom publish directory that isn't <OutputPath>/publish can't be modeled
+        // per-RID, so the variants are skipped rather than pointed at the wrong folder.
+        var targets = BuildTargets(new List<FrameworkVariant>
+        {
+            Variant("net9.0", new[] { "win-x64" }, extraProps: new[] { ("PublishDir", "dist/custompub") }),
+            Variant("net10.0", new[] { "win-x64" }, extraProps: new[] { ("PublishDir", "dist/custompub") }),
+        });
+
+        Assert.DoesNotContain(targets.Keys, k => k.Contains("win-x64"));
+    }
+
+    [Fact]
+    public void DefaultPublishDir_EmitsRuntimeVariants()
+    {
+        // PublishDir equal to <OutputPath>/publish is the derivable default.
+        var targets = BuildTargets(new List<FrameworkVariant>
+        {
+            Variant("net9.0", new[] { "win-x64" }, extraProps: new[] { ("PublishDir", "bin/Debug/net9.0/publish/") }),
+            Variant("net10.0", new[] { "win-x64" }, extraProps: new[] { ("PublishDir", "bin/Debug/net10.0/publish/") }),
+        });
+
+        Assert.Contains("publish-net10.0-win-x64", targets.Keys);
     }
 
     // --- Metadata & naming -----------------------------------------------

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -158,6 +158,11 @@ public static class Analyzer
                         directoryFilesByDir
                     );
 
+                    // For opt-in per-framework variants, collect the evaluated inner builds
+                    // (one MSBuild ProjectGraph node per target framework). Only multi-targeted
+                    // projects (more than one distinct framework) get variants.
+                    var frameworkVariants = CollectFrameworkVariants(nodes, pluginOptions);
+
                     var targets = TargetBuilder.BuildTargets(
                         projectName,
                         Path.GetFileName(projectPath),
@@ -169,7 +174,8 @@ public static class Analyzer
                         workspaceRoot,
                         pluginOptions,
                         nxJson,
-                        directoryBuildInputs
+                        directoryBuildInputs,
+                        frameworkVariants
                     );
 
                     nodesByFile[relativeProjectFile] = new NxProjectGraphNode
@@ -204,6 +210,39 @@ public static class Analyzer
             NodesByFile = nodesByFile,
             ReferencesByRoot = referencesByRoot
         };
+    }
+
+    /// <summary>
+    /// Collects the evaluated inner builds of a multi-targeted project as
+    /// <see cref="FrameworkVariant"/> descriptors. Returns null unless framework
+    /// variants are enabled and the project has more than one distinct target
+    /// framework, so single-targeted projects are never expanded.
+    /// </summary>
+    private static List<FrameworkVariant>? CollectFrameworkVariants(
+        List<ProjectGraphNode> nodes,
+        PluginOptions pluginOptions)
+    {
+        if (!pluginOptions.FrameworkVariants)
+        {
+            return null;
+        }
+
+        // Inner builds are the ProjectGraph nodes that carry an evaluated
+        // TargetFramework; the outer build of a multi-targeted project has none.
+        var variants = nodes
+            .Where(n => n.ProjectInstance is not null &&
+                        !string.IsNullOrEmpty(n.ProjectInstance.GetPropertyValue("TargetFramework")))
+            .Select(n => new FrameworkVariant
+            {
+                TargetFramework = n.ProjectInstance!.GetPropertyValue("TargetFramework"),
+                Properties = CollectProperties(n.ProjectInstance!)
+            })
+            .GroupBy(v => v.TargetFramework, StringComparer.Ordinal)
+            .Select(g => g.First())
+            .OrderBy(v => v.TargetFramework, StringComparer.Ordinal)
+            .ToList();
+
+        return variants.Count > 1 ? variants : null;
     }
 
     private static List<PackageReference> CollectPackageReferences(ProjectInstance project)

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -232,10 +232,16 @@ public static class Analyzer
         var variants = nodes
             .Where(n => n.ProjectInstance is not null &&
                         !string.IsNullOrEmpty(n.ProjectInstance.GetPropertyValue("TargetFramework")))
-            .Select(n => new FrameworkVariant
+            .Select(n =>
             {
-                TargetFramework = n.ProjectInstance!.GetPropertyValue("TargetFramework"),
-                Properties = CollectProperties(n.ProjectInstance!)
+                var props = CollectProperties(n.ProjectInstance!);
+                return new FrameworkVariant
+                {
+                    TargetFramework = n.ProjectInstance!.GetPropertyValue("TargetFramework"),
+                    Properties = props,
+                    IsExecutable = IsExecutableProject(props),
+                    RuntimeIdentifiers = CollectRuntimeIdentifiers(n.ProjectInstance!)
+                };
             })
             .GroupBy(v => v.TargetFramework, StringComparer.Ordinal)
             .Select(g => g.First())
@@ -243,6 +249,38 @@ public static class Analyzer
             .ToList();
 
         return variants.Count > 1 ? variants : null;
+    }
+
+    /// <summary>
+    /// Collects the explicitly-declared runtime identifiers for an inner build,
+    /// combining the singular <c>RuntimeIdentifier</c> and the plural
+    /// <c>RuntimeIdentifiers</c>. Returns an empty list when none are declared,
+    /// so RID variants are only generated where the project asks for them.
+    /// </summary>
+    private static List<string> CollectRuntimeIdentifiers(ProjectInstance project)
+    {
+        var rids = new List<string>();
+
+        void Add(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return;
+            }
+            foreach (var rid in raw.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (!rids.Contains(rid, StringComparer.Ordinal))
+                {
+                    rids.Add(rid);
+                }
+            }
+        }
+
+        Add(project.GetPropertyValue("RuntimeIdentifier"));
+        Add(project.GetPropertyValue("RuntimeIdentifiers"));
+
+        rids.Sort(StringComparer.Ordinal);
+        return rids;
     }
 
     private static List<PackageReference> CollectPackageReferences(ProjectInstance project)
@@ -316,6 +354,12 @@ public static class Analyzer
             "UseArtifactsOutput",
             "ArtifactsPath",
             "ArtifactsPivots",
+
+            // Output-layout switches that determine whether framework/runtime
+            // identifier segments are appended to the output path (RID variants
+            // rely on the standard appended layout).
+            "AppendTargetFrameworkToOutputPath",
+            "AppendRuntimeIdentifierToOutputPath",
 
             // Output paths
             "OutputPath",

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -222,7 +222,7 @@ public static class Analyzer
         List<ProjectGraphNode> nodes,
         PluginOptions pluginOptions)
     {
-        if (!pluginOptions.FrameworkVariants)
+        if (!pluginOptions.FrameworkVariants && !pluginOptions.RuntimeVariants)
         {
             return null;
         }
@@ -252,35 +252,16 @@ public static class Analyzer
     }
 
     /// <summary>
-    /// Collects the explicitly-declared runtime identifiers for an inner build,
-    /// combining the singular <c>RuntimeIdentifier</c> and the plural
-    /// <c>RuntimeIdentifiers</c>. Returns an empty list when none are declared,
-    /// so RID variants are only generated where the project asks for them.
+    /// Collects the runtime identifiers evaluated for an inner build. The plural
+    /// <c>RuntimeIdentifiers</c> is authoritative when non-empty; otherwise the
+    /// evaluated singular <c>RuntimeIdentifier</c> (which may be an SDK default) is
+    /// used. Returns an empty list when neither is set.
     /// </summary>
     private static List<string> CollectRuntimeIdentifiers(ProjectInstance project)
     {
-        var rids = new List<string>();
-
-        void Add(string? raw)
-        {
-            if (string.IsNullOrWhiteSpace(raw))
-            {
-                return;
-            }
-            foreach (var rid in raw.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            {
-                if (!rids.Contains(rid, StringComparer.Ordinal))
-                {
-                    rids.Add(rid);
-                }
-            }
-        }
-
-        Add(project.GetPropertyValue("RuntimeIdentifier"));
-        Add(project.GetPropertyValue("RuntimeIdentifiers"));
-
-        rids.Sort(StringComparer.Ordinal);
-        return rids;
+        return ProjectUtilities.ResolveRuntimeIdentifiers(
+            project.GetPropertyValue("RuntimeIdentifier"),
+            project.GetPropertyValue("RuntimeIdentifiers"));
     }
 
     private static List<PackageReference> CollectPackageReferences(ProjectInstance project)

--- a/packages/dotnet/analyzer/Models/FrameworkVariant.cs
+++ b/packages/dotnet/analyzer/Models/FrameworkVariant.cs
@@ -1,0 +1,24 @@
+namespace MsbuildAnalyzer.Models;
+
+/// <summary>
+/// Describes one evaluated inner build of a multi-targeted project. The
+/// analyzer builds one of these per target framework from the MSBuild
+/// <c>ProjectGraph</c> inner nodes, so <see cref="Properties"/> holds the
+/// framework-specific evaluated values (e.g. an <c>OutputPath</c> that already
+/// includes the framework segment) rather than the outer-build aggregate.
+/// </summary>
+public sealed record FrameworkVariant
+{
+    /// <summary>
+    /// The evaluated target framework short name (e.g. "net10.0-ios"). Passed
+    /// verbatim to <c>--framework</c>, so it must match the declared value.
+    /// </summary>
+    public required string TargetFramework { get; init; }
+
+    /// <summary>
+    /// MSBuild properties evaluated for this specific inner build. These are
+    /// framework-scoped, so output/intermediate paths already resolve to the
+    /// framework's subdirectory.
+    /// </summary>
+    public required Dictionary<string, string> Properties { get; init; }
+}

--- a/packages/dotnet/analyzer/Models/FrameworkVariant.cs
+++ b/packages/dotnet/analyzer/Models/FrameworkVariant.cs
@@ -23,19 +23,22 @@ public sealed record FrameworkVariant
     public required Dictionary<string, string> Properties { get; init; }
 
     /// <summary>
-    /// Whether this specific inner build is an executable (its evaluated
-    /// <c>OutputType</c> is Exe/WinExe). Evaluated per framework because
-    /// <c>OutputType</c> can be conditioned on <c>TargetFramework</c>, so one
-    /// framework of a project can be an app while another is a library. Gates
-    /// per-RID publish variants, which only make sense for executables.
+    /// Whether this specific inner build is an executable, per the plugin's
+    /// existing <c>IsExecutableProject</c> rule (evaluated <c>OutputType</c> equal
+    /// to <c>Exe</c>; <c>WinExe</c> is not recognized, matching the unqualified
+    /// publish/run targets). Evaluated per framework because <c>OutputType</c> can
+    /// be conditioned on <c>TargetFramework</c>, so one framework of a project can
+    /// be an app while another is a library. Gates per-RID publish variants, which
+    /// only make sense for executables.
     /// </summary>
     public bool IsExecutable { get; init; }
 
     /// <summary>
-    /// The runtime identifiers explicitly declared for this framework (from
-    /// <c>RuntimeIdentifier</c>/<c>RuntimeIdentifiers</c>). Empty when the
-    /// project declares none, so RID-specific variants are only generated
-    /// "where declared".
+    /// The runtime identifiers evaluated for this framework. The plural
+    /// <c>RuntimeIdentifiers</c> is authoritative when non-empty; otherwise the
+    /// evaluated singular <c>RuntimeIdentifier</c> is used, which for platform
+    /// frameworks may be an SDK default rather than an authored value. Empty when
+    /// neither is set.
     /// </summary>
     public List<string> RuntimeIdentifiers { get; init; } = new();
 }

--- a/packages/dotnet/analyzer/Models/FrameworkVariant.cs
+++ b/packages/dotnet/analyzer/Models/FrameworkVariant.cs
@@ -21,4 +21,21 @@ public sealed record FrameworkVariant
     /// framework's subdirectory.
     /// </summary>
     public required Dictionary<string, string> Properties { get; init; }
+
+    /// <summary>
+    /// Whether this specific inner build is an executable (its evaluated
+    /// <c>OutputType</c> is Exe/WinExe). Evaluated per framework because
+    /// <c>OutputType</c> can be conditioned on <c>TargetFramework</c>, so one
+    /// framework of a project can be an app while another is a library. Gates
+    /// per-RID publish variants, which only make sense for executables.
+    /// </summary>
+    public bool IsExecutable { get; init; }
+
+    /// <summary>
+    /// The runtime identifiers explicitly declared for this framework (from
+    /// <c>RuntimeIdentifier</c>/<c>RuntimeIdentifiers</c>). Empty when the
+    /// project declares none, so RID-specific variants are only generated
+    /// "where declared".
+    /// </summary>
+    public List<string> RuntimeIdentifiers { get; init; } = new();
 }

--- a/packages/dotnet/analyzer/Models/PluginOptions.cs
+++ b/packages/dotnet/analyzer/Models/PluginOptions.cs
@@ -44,4 +44,13 @@ public class PluginOptions
     /// The name of the run target. Defaults to "run".
     /// </summary>
     public string RunTargetName { get; set; } = "run";
+
+    /// <summary>
+    /// When true, multi-targeted projects additionally get per-target-framework
+    /// target variants (e.g. "build-net10.0-ios") alongside the unqualified
+    /// targets. Opt-in because expanding the task graph this way is only useful
+    /// for workspaces that need to invoke a single framework in isolation.
+    /// Defaults to false, leaving the generated targets unchanged.
+    /// </summary>
+    public bool FrameworkVariants { get; set; } = false;
 }

--- a/packages/dotnet/analyzer/Models/PluginOptions.cs
+++ b/packages/dotnet/analyzer/Models/PluginOptions.cs
@@ -53,4 +53,13 @@ public class PluginOptions
     /// Defaults to false, leaving the generated targets unchanged.
     /// </summary>
     public bool FrameworkVariants { get; set; } = false;
+
+    /// <summary>
+    /// When true, multi-targeted executables additionally get per-runtime-identifier
+    /// variants (e.g. "publish-net10.0-ios-ios-arm64"). Separate from
+    /// <see cref="FrameworkVariants"/> so opting into per-framework build variants
+    /// does not, on its own, expand the graph with RID variants. Enabling this
+    /// implies framework variants. Defaults to false.
+    /// </summary>
+    public bool RuntimeVariants { get; set; } = false;
 }

--- a/packages/dotnet/analyzer/Models/TargetMetadata.cs
+++ b/packages/dotnet/analyzer/Models/TargetMetadata.cs
@@ -14,4 +14,11 @@ public record TargetMetadata
     /// Technologies used by this target.
     /// </summary>
     public List<string>? Technologies { get; init; }
+
+    /// <summary>
+    /// The evaluated target framework this target invocation is scoped to
+    /// (e.g. "net10.0-ios"). Only set on framework-specific target variants;
+    /// left null (and omitted from JSON) for the unqualified targets.
+    /// </summary>
+    public string? TargetFramework { get; init; }
 }

--- a/packages/dotnet/analyzer/Models/TargetMetadata.cs
+++ b/packages/dotnet/analyzer/Models/TargetMetadata.cs
@@ -29,4 +29,11 @@ public record TargetMetadata
     /// set on framework-specific target variants.
     /// </summary>
     public string? FrameworkVariantOf { get; init; }
+
+    /// <summary>
+    /// The runtime identifier this target invocation is scoped to
+    /// (e.g. "ios-arm64"). Only set on RID-specific target variants; left null
+    /// (and omitted from JSON) otherwise.
+    /// </summary>
+    public string? RuntimeIdentifier { get; init; }
 }

--- a/packages/dotnet/analyzer/Models/TargetMetadata.cs
+++ b/packages/dotnet/analyzer/Models/TargetMetadata.cs
@@ -21,4 +21,12 @@ public record TargetMetadata
     /// left null (and omitted from JSON) for the unqualified targets.
     /// </summary>
     public string? TargetFramework { get; init; }
+
+    /// <summary>
+    /// The unqualified target this variant derives from (e.g. "build"). Lets the
+    /// plugin apply the user's configuration for that base target to its
+    /// variants, and remove the variants when the base target is disabled. Only
+    /// set on framework-specific target variants.
+    /// </summary>
+    public string? FrameworkVariantOf { get; init; }
 }

--- a/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
+++ b/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
@@ -166,6 +166,69 @@ public static class ProjectUtilities
     }
 
     /// <summary>
+    /// Resolves the runtime identifiers for an evaluated inner build. The plural
+    /// <c>RuntimeIdentifiers</c> is authoritative when it declares any value;
+    /// otherwise the evaluated singular <c>RuntimeIdentifier</c> is used (which may
+    /// be an SDK default for platform frameworks). Values are split on ';',
+    /// trimmed, de-duplicated, and sorted for stable output. Returns an empty list
+    /// when neither is set.
+    /// </summary>
+    public static List<string> ResolveRuntimeIdentifiers(string? singular, string? plural)
+    {
+        var rids = new List<string>();
+
+        void Add(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return;
+            }
+            foreach (var rid in raw.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (!rids.Contains(rid, StringComparer.Ordinal))
+                {
+                    rids.Add(rid);
+                }
+            }
+        }
+
+        // Plural wins outright when present: a declared RuntimeIdentifiers list must
+        // not be polluted by an unrelated SDK-implicit singular RuntimeIdentifier.
+        Add(plural);
+        if (rids.Count == 0)
+        {
+            Add(singular);
+        }
+
+        rids.Sort(StringComparer.Ordinal);
+        return rids;
+    }
+
+    /// <summary>
+    /// Whether the publish output directory can be derived as
+    /// <c>&lt;OutputPath&gt;/publish</c>. True when <paramref name="publishDir"/> is
+    /// empty (the SDK default) or normalizes to exactly that; false for a custom or
+    /// fixed publish directory, which the per-RID output derivation can't model and
+    /// might collide across RIDs.
+    /// </summary>
+    public static bool IsPublishDirDerivable(string? publishDir, string? outputPath)
+    {
+        if (string.IsNullOrWhiteSpace(publishDir))
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            return false;
+        }
+
+        var pub = publishDir.Replace('\\', '/').TrimEnd('/');
+        var expected = outputPath.Replace('\\', '/').TrimEnd('/') + "/publish";
+        return string.Equals(pub, expected, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Gets the list of technologies for a project based on its file type and characteristics.
     /// </summary>
     public static List<string> GetTechnologies(string projectPath)

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.RidVariants.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.RidVariants.cs
@@ -137,6 +137,14 @@ public static partial class TargetBuilder
             return false;
         }
 
+        if (!ProjectUtilities.IsPublishDirDerivable(
+                properties.GetValueOrDefault("PublishDir"),
+                properties.GetValueOrDefault("OutputPath")))
+        {
+            reason = "a custom PublishDir was set that doesn't match the default <OutputPath>/publish layout";
+            return false;
+        }
+
         reason = string.Empty;
         return true;
     }

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.RidVariants.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.RidVariants.cs
@@ -1,0 +1,195 @@
+using MsbuildAnalyzer.Models;
+
+namespace MsbuildAnalyzer.Utilities;
+
+/// <summary>
+/// Per-runtime-identifier target variants for multi-targeted executables that
+/// declare RIDs (https://github.com/nrwl/nx/discussions/36676).
+///
+/// A RID-specific publish needs a RID-specific build: <c>dotnet publish
+/// --no-build --runtime &lt;rid&gt;</c> looks for build output under a
+/// runtime-specific folder, so the publish variant depends on a dedicated
+/// <c>build-&lt;tfm&gt;-&lt;rid&gt;-release</c> target rather than the framework-only
+/// Release build. This models the RID dimension correctly by construction (see
+/// nrwl/nx#33474) instead of forwarding <c>--runtime</c> at run time.
+///
+/// Output paths are derived from each inner build's evaluated
+/// <c>OutputPath</c>/<c>IntermediateOutputPath</c> (configuration rewritten to
+/// Release, then the RID placed where the SDK's default layout puts it). This
+/// is only valid for the standard appended layout, so RID variants are skipped
+/// with a warning when <c>UseArtifactsOutput</c> is set, when
+/// <c>AppendTargetFrameworkToOutputPath</c> or <c>AppendRuntimeIdentifierToOutputPath</c>
+/// is explicitly false, or when a path can't be reliably derived — rather than
+/// emit an output path the build will never write.
+///
+/// The RID Release build is self-contained on the same terms as the framework
+/// build variants — it does not depend on the aggregate <c>^build</c> and does
+/// not pass <c>--no-dependencies</c>. Only generated where a project explicitly
+/// declares runtime identifiers.
+/// </summary>
+public static partial class TargetBuilder
+{
+    private static void AddRuntimeVariantTargets(
+        Dictionary<string, Target> targets,
+        HashSet<string> seenNames,
+        string tfm,
+        string tfmToken,
+        Dictionary<string, string> properties,
+        List<string> runtimeIdentifiers,
+        string projectDirectory,
+        string workspaceRoot,
+        PluginOptions options,
+        string productionInput,
+        List<string> directoryBuildInputs,
+        List<string> technologies)
+    {
+        if (!IsRuntimeLayoutSupported(properties, out var reason))
+        {
+            Console.Error.WriteLine(
+                $"Warning: skipping runtime-identifier variants for '{tfm}' because {reason}. " +
+                "RID variants require the standard appended output layout.");
+            return;
+        }
+
+        // Any RID already baked into the inner build's evaluated output path (platform
+        // frameworks such as net10.0-ios default one). It is replaced by the declared RID
+        // rather than appended, so we don't get bin/.../<implicit-rid>/<declared-rid>.
+        var innerRid = properties.GetValueOrDefault("RuntimeIdentifier");
+
+        foreach (var rid in runtimeIdentifiers)
+        {
+            if (string.IsNullOrWhiteSpace(rid))
+            {
+                continue;
+            }
+
+            var binDir = DeriveRuntimeOutput(properties.GetValueOrDefault("OutputPath"), innerRid, rid, projectDirectory, workspaceRoot);
+            var objDir = DeriveRuntimeOutput(properties.GetValueOrDefault("IntermediateOutputPath"), innerRid, rid, projectDirectory, workspaceRoot);
+
+            if (binDir is null || objDir is null)
+            {
+                Console.Error.WriteLine(
+                    $"Warning: skipping runtime-identifier variants for '{tfm}'/'{rid}' because the output path could not be derived from the evaluated build.");
+                continue;
+            }
+
+            var ridToken = NormalizeTargetNameSegment(rid);
+            var buildReleaseName = BuildVariantName(options.BuildTargetName, tfmToken, ridToken, "release");
+            var publishName = BuildVariantName(options.PublishTargetName, tfmToken, ridToken);
+
+            // build-<tfm>-<rid>-release — a self-contained Release build for the RID, which the
+            // RID publish depends on so its --no-build publish finds the runtime-specific output.
+            TryAddVariant(targets, seenNames, buildReleaseName, new Target
+            {
+                Command = "dotnet build",
+                Options = new TargetOptions
+                {
+                    Cwd = "{projectRoot}",
+                    Args = ["--no-restore", "--framework", tfm, "--runtime", rid, "--configuration", "Release"]
+                },
+                Cache = true,
+                Inputs = BuildVariantInputs(productionInput, directoryBuildInputs),
+                Outputs = DedupeOutputs(new[] { binDir, objDir }),
+                Metadata = VariantMetadata($"Build the {tfm} target framework for {rid} in Release configuration", technologies, tfm, rid, options.BuildTargetName)
+            });
+
+            // publish-<tfm>-<rid>
+            TryAddVariant(targets, seenNames, publishName, new Target
+            {
+                Command = "dotnet publish",
+                Options = new TargetOptions
+                {
+                    Cwd = "{projectRoot}",
+                    Args = ["--no-build", "--no-dependencies", "--no-restore", "--framework", tfm, "--runtime", rid, "--configuration", "Release"]
+                },
+                DependsOn = [buildReleaseName],
+                Cache = true,
+                Inputs = BuildVariantInputs(productionInput, directoryBuildInputs),
+                Outputs = DedupeOutputs(new[] { AppendSegment(binDir, "publish"), objDir }),
+                Metadata = VariantMetadata($"Publish the {tfm} target framework for {rid}", technologies, tfm, rid, options.PublishTargetName)
+            });
+        }
+    }
+
+    /// <summary>
+    /// RID variants can only place outputs correctly in the standard appended
+    /// layout, where the framework and runtime identifier are output-path
+    /// segments. Reject the artifacts layout and any project that turns off the
+    /// framework or runtime-identifier path segments.
+    /// </summary>
+    private static bool IsRuntimeLayoutSupported(Dictionary<string, string> properties, out string reason)
+    {
+        if (UsesArtifactsOutput(properties))
+        {
+            reason = "it uses the artifacts output layout (UseArtifactsOutput)";
+            return false;
+        }
+
+        if (IsExplicitlyFalse(properties, "AppendTargetFrameworkToOutputPath"))
+        {
+            reason = "AppendTargetFrameworkToOutputPath is false";
+            return false;
+        }
+
+        if (IsExplicitlyFalse(properties, "AppendRuntimeIdentifierToOutputPath"))
+        {
+            reason = "AppendRuntimeIdentifierToOutputPath is false";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    private static bool IsExplicitlyFalse(Dictionary<string, string> properties, string name)
+    {
+        return properties.TryGetValue(name, out var value)
+            && value.Equals("false", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Derives the Release output directory for a declared runtime identifier from
+    /// an inner build's evaluated output path: rewrite the configuration segment to
+    /// Release, then place the RID. When the inner build already baked a (default)
+    /// RID into its path, the trailing RID segment is replaced; otherwise the RID is
+    /// appended. Returns <c>null</c> when the path can't be derived so the caller can
+    /// skip rather than emit a wrong output.
+    /// </summary>
+    private static string? DeriveRuntimeOutput(
+        string? rawPath,
+        string? innerRid,
+        string declaredRid,
+        string projectDirectory,
+        string workspaceRoot)
+    {
+        if (string.IsNullOrEmpty(rawPath))
+        {
+            return null;
+        }
+
+        var resolved = ResolvePath(rawPath, projectDirectory, workspaceRoot);
+        var release = WithConfiguration(resolved, "Release");
+        if (string.IsNullOrEmpty(release))
+        {
+            return null;
+        }
+
+        var segments = release.Split('/');
+
+        if (!string.IsNullOrEmpty(innerRid))
+        {
+            // The inner build defaulted a RID into the path; replace that trailing
+            // segment with the declared RID. If the layout doesn't match that
+            // expectation, decline rather than guess.
+            if (segments.Length > 0 && segments[^1].Equals(innerRid, StringComparison.OrdinalIgnoreCase))
+            {
+                segments[^1] = declaredRid;
+                return string.Join('/', segments);
+            }
+
+            return null;
+        }
+
+        return $"{release.TrimEnd('/')}/{declaredRid}";
+    }
+}

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Variants.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Variants.cs
@@ -91,10 +91,11 @@ public static partial class TargetBuilder
                 Metadata = VariantMetadata($"Build the {tfm} target framework in Release configuration", technologies, tfm, options.BuildTargetName)
             });
 
-            // Per-RID variants are only generated where this framework's inner build both is an
-            // executable and explicitly declares runtime identifiers. IsExecutable is evaluated
-            // per framework, so a library framework of a mixed project gets no publish/RID variants.
-            if (variant.IsExecutable && variant.RuntimeIdentifiers.Count > 0)
+            // Per-RID variants require the separate runtimeVariants opt-in and are only
+            // generated where this framework's inner build is an executable and has runtime
+            // identifiers. IsExecutable is evaluated per framework, so a library framework of a
+            // mixed project gets no publish/RID variants.
+            if (options.RuntimeVariants && variant.IsExecutable && variant.RuntimeIdentifiers.Count > 0)
             {
                 AddRuntimeVariantTargets(
                     targets, seenNames, tfm, token, variant.Properties, variant.RuntimeIdentifiers,

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Variants.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Variants.cs
@@ -3,13 +3,21 @@ using MsbuildAnalyzer.Models;
 namespace MsbuildAnalyzer.Utilities;
 
 /// <summary>
-/// Per-target-framework target variants for multi-targeted projects.
+/// Per-target-framework build variants for multi-targeted projects.
 ///
 /// A project that declares <c>&lt;TargetFrameworks&gt;</c> has no single host
 /// that can necessarily run an unqualified <c>dotnet build</c> across every
 /// framework (an iOS + Windows project is the canonical case). These variants
-/// let a workspace invoke, cache, and route one framework in isolation while
-/// the unqualified targets keep building the whole project.
+/// let a workspace build and cache one framework in isolation while the
+/// unqualified targets keep building the whole project.
+///
+/// Each variant is <b>self-contained</b>: it does not depend on the unqualified
+/// build and does not pass <c>--no-dependencies</c>, so MSBuild builds each
+/// referenced project's framework-compatible inner build directly. Depending on
+/// the aggregate <c>^build</c> would rebuild every framework of every dependency
+/// and reintroduce the very host-compatibility problem these variants solve.
+/// The tradeoff is coarser task-level caching of dependencies; <c>^production</c>
+/// remains an input so a dependency source change still invalidates the variant.
 ///
 /// Variant target names avoid the ambiguous <c>project:target:configuration</c>
 /// colon delimiter — the framework is joined to the configured target name with
@@ -21,8 +29,6 @@ public static partial class TargetBuilder
     private static void AddFrameworkVariantTargets(
         Dictionary<string, Target> targets,
         string fileName,
-        bool isTest,
-        bool isExe,
         List<FrameworkVariant> frameworkVariants,
         string projectDirectory,
         string workspaceRoot,
@@ -58,72 +64,32 @@ public static partial class TargetBuilder
                 Options = new TargetOptions
                 {
                     Cwd = "{projectRoot}",
-                    Args = ["--no-restore", "--no-dependencies", "--framework", tfm]
+                    Args = ["--no-restore", "--framework", tfm]
                 },
                 Configurations = FrameworkBuildConfigurations(tfm),
-                DependsOn = [$"^{options.BuildTargetName}"],
                 Cache = true,
                 Inputs = inputs,
                 Outputs = buildOutputs,
-                Metadata = VariantMetadata($"Build the {tfm} target framework", technologies, tfm)
+                Metadata = VariantMetadata($"Build the {tfm} target framework", technologies, tfm, options.BuildTargetName)
             });
 
-            // build-<tfm>-release — the Release build that publish/pack variants depend on,
-            // mirroring the unqualified build:release target (Nx cannot depend on a specific
-            // configuration, so the Release build is its own target).
+            // build-<tfm>-release — a Release build of the framework, mirroring the unqualified
+            // build:release target (Nx cannot depend on a configuration, so Release is its own
+            // target that a Release-only consumer can depend on).
             TryAddVariant(targets, seenNames, buildReleaseName, new Target
             {
                 Command = "dotnet build",
                 Options = new TargetOptions
                 {
                     Cwd = "{projectRoot}",
-                    Args = ["--no-restore", "--no-dependencies", "--framework", tfm, "--configuration", "Release"]
+                    Args = ["--no-restore", "--framework", tfm, "--configuration", "Release"]
                 },
                 Configurations = FrameworkBuildConfigurations(tfm),
-                DependsOn = [$"^{options.BuildTargetName}"],
                 Cache = true,
                 Inputs = inputs,
                 Outputs = releaseOutputs.Length > 0 ? releaseOutputs : buildOutputs,
-                Metadata = VariantMetadata($"Build the {tfm} target framework in Release configuration", technologies, tfm)
+                Metadata = VariantMetadata($"Build the {tfm} target framework in Release configuration", technologies, tfm, options.BuildTargetName)
             });
-
-            if (isTest)
-            {
-                var testName = BuildVariantName(options.TestTargetName, token);
-                TryAddVariant(targets, seenNames, testName, new Target
-                {
-                    Command = "dotnet test",
-                    Options = new TargetOptions
-                    {
-                        Cwd = "{projectRoot}",
-                        Args = ["--no-build", "--no-restore", "--framework", tfm]
-                    },
-                    DependsOn = [buildName],
-                    Cache = true,
-                    Inputs = BuildVariantInputs(productionInput, directoryBuildInputs, firstInput: "default"),
-                    Outputs = GetVariantTestOutputs(variant.Properties, projectDirectory, workspaceRoot),
-                    Metadata = VariantMetadata($"Run .NET tests for the {tfm} target framework", technologies, tfm)
-                });
-            }
-
-            if (isExe)
-            {
-                var publishName = BuildVariantName(options.PublishTargetName, token);
-                TryAddVariant(targets, seenNames, publishName, new Target
-                {
-                    Command = "dotnet publish",
-                    Options = new TargetOptions
-                    {
-                        Cwd = "{projectRoot}",
-                        Args = ["--no-build", "--no-dependencies", "--no-restore", "--framework", tfm, "--configuration", "Release"]
-                    },
-                    DependsOn = [buildReleaseName],
-                    Cache = true,
-                    Inputs = BuildVariantInputs(productionInput, directoryBuildInputs, firstInput: "default"),
-                    Outputs = GetVariantPublishOutputs(variant.Properties, projectDirectory, workspaceRoot),
-                    Metadata = VariantMetadata($"Publish the {tfm} target framework", technologies, tfm)
-                });
-            }
         }
     }
 
@@ -192,35 +158,39 @@ public static partial class TargetBuilder
     {
         ["debug"] = new TargetConfiguration
         {
-            Args = ["--no-restore", "--no-dependencies", "--framework", tfm, "--configuration", "Debug"]
+            Args = ["--no-restore", "--framework", tfm, "--configuration", "Debug"]
         },
         ["release"] = new TargetConfiguration
         {
-            Args = ["--no-restore", "--no-dependencies", "--framework", tfm, "--configuration", "Release"]
+            Args = ["--no-restore", "--framework", tfm, "--configuration", "Release"]
         }
     };
 
-    private static TargetMetadata VariantMetadata(string description, List<string> technologies, string tfm) => new()
+    private static TargetMetadata VariantMetadata(
+        string description,
+        List<string> technologies,
+        string tfm,
+        string frameworkVariantOf) => new()
     {
         Description = description,
         Technologies = technologies,
-        TargetFramework = tfm
+        TargetFramework = tfm,
+        FrameworkVariantOf = frameworkVariantOf
     };
 
     private static object[] BuildVariantInputs(
         string productionInput,
-        List<string> directoryBuildInputs,
-        string? firstInput = null)
+        List<string> directoryBuildInputs)
     {
-        // Mirrors the input shape of the unqualified cacheable targets so a variant
-        // invalidates on the same evaluation-affecting files.
+        // Mirrors the unqualified build's inputs minus dependentTasksOutputFiles: a self-contained
+        // variant has no dependent Nx tasks, but ^production still invalidates it when a
+        // dependency's sources change.
         return
         [
-            firstInput ?? productionInput,
+            productionInput,
             $"^{productionInput}",
             "{workspaceRoot}/.editorconfig",
             new { workingDirectory = "absolute" },
-            new { dependentTasksOutputFiles = "**/*" },
             .. directoryBuildInputs
         ];
     }
@@ -257,42 +227,6 @@ public static partial class TargetBuilder
         }
 
         return DedupeOutputs(outputs);
-    }
-
-    private static string[] GetVariantTestOutputs(
-        Dictionary<string, string> properties,
-        string projectDirectory,
-        string workspaceRoot)
-    {
-        var testResultsDir = properties.TryGetValue("TestResultsDirectory", out var configured) && !string.IsNullOrEmpty(configured)
-            ? ResolvePath(configured, projectDirectory, workspaceRoot)
-            : "{projectRoot}/TestResults";
-
-        return testResultsDir is null ? [] : [testResultsDir];
-    }
-
-    private static string[] GetVariantPublishOutputs(
-        Dictionary<string, string> properties,
-        string projectDirectory,
-        string workspaceRoot)
-    {
-        var outputs = new List<string?>();
-
-        var publishDir = properties.TryGetValue("PublishDir", out var configuredPublish) && !string.IsNullOrEmpty(configuredPublish)
-            ? ResolvePath(configuredPublish, projectDirectory, workspaceRoot)
-            : AppendSegment(ResolvePath(properties.GetValueOrDefault("OutputPath") ?? "", projectDirectory, workspaceRoot), "publish");
-
-        outputs.Add(WithConfiguration(publishDir, "Release"));
-
-        var intermediatePath = ResolvePath(properties.GetValueOrDefault("IntermediateOutputPath") ?? "", projectDirectory, workspaceRoot);
-        outputs.Add(WithConfiguration(intermediatePath, "Release"));
-
-        return DedupeOutputs(outputs);
-    }
-
-    private static string? AppendSegment(string? path, string segment)
-    {
-        return path is null ? null : $"{path.TrimEnd('/')}/{segment}";
     }
 
     private static string[] DedupeOutputs(IEnumerable<string?> outputs)

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Variants.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Variants.cs
@@ -90,6 +90,16 @@ public static partial class TargetBuilder
                 Outputs = releaseOutputs.Length > 0 ? releaseOutputs : buildOutputs,
                 Metadata = VariantMetadata($"Build the {tfm} target framework in Release configuration", technologies, tfm, options.BuildTargetName)
             });
+
+            // Per-RID variants are only generated where this framework's inner build both is an
+            // executable and explicitly declares runtime identifiers. IsExecutable is evaluated
+            // per framework, so a library framework of a mixed project gets no publish/RID variants.
+            if (variant.IsExecutable && variant.RuntimeIdentifiers.Count > 0)
+            {
+                AddRuntimeVariantTargets(
+                    targets, seenNames, tfm, token, variant.Properties, variant.RuntimeIdentifiers,
+                    projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs, technologies);
+            }
         }
     }
 
@@ -178,6 +188,20 @@ public static partial class TargetBuilder
         FrameworkVariantOf = frameworkVariantOf
     };
 
+    private static TargetMetadata VariantMetadata(
+        string description,
+        List<string> technologies,
+        string tfm,
+        string rid,
+        string frameworkVariantOf) => new()
+    {
+        Description = description,
+        Technologies = technologies,
+        TargetFramework = tfm,
+        RuntimeIdentifier = rid,
+        FrameworkVariantOf = frameworkVariantOf
+    };
+
     private static object[] BuildVariantInputs(
         string productionInput,
         List<string> directoryBuildInputs)
@@ -241,6 +265,11 @@ public static partial class TargetBuilder
             }
         }
         return result.ToArray();
+    }
+
+    private static string? AppendSegment(string? path, string segment)
+    {
+        return path is null ? null : $"{path.TrimEnd('/')}/{segment}";
     }
 
     /// <summary>

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Variants.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Variants.cs
@@ -1,0 +1,352 @@
+using MsbuildAnalyzer.Models;
+
+namespace MsbuildAnalyzer.Utilities;
+
+/// <summary>
+/// Per-target-framework target variants for multi-targeted projects.
+///
+/// A project that declares <c>&lt;TargetFrameworks&gt;</c> has no single host
+/// that can necessarily run an unqualified <c>dotnet build</c> across every
+/// framework (an iOS + Windows project is the canonical case). These variants
+/// let a workspace invoke, cache, and route one framework in isolation while
+/// the unqualified targets keep building the whole project.
+///
+/// Variant target names avoid the ambiguous <c>project:target:configuration</c>
+/// colon delimiter — the framework is joined to the configured target name with
+/// a hyphen (e.g. <c>build-net10.0-ios</c>), so <c>nx run app:build-net10.0-ios</c>
+/// is unambiguous.
+/// </summary>
+public static partial class TargetBuilder
+{
+    private static void AddFrameworkVariantTargets(
+        Dictionary<string, Target> targets,
+        string fileName,
+        bool isTest,
+        bool isExe,
+        List<FrameworkVariant> frameworkVariants,
+        string projectDirectory,
+        string workspaceRoot,
+        PluginOptions options,
+        string productionInput,
+        List<string> directoryBuildInputs)
+    {
+        var technologies = ProjectUtilities.GetTechnologies(fileName);
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var variant in frameworkVariants)
+        {
+            var tfm = variant.TargetFramework;
+            if (string.IsNullOrWhiteSpace(tfm))
+            {
+                continue;
+            }
+
+            var token = NormalizeTargetNameSegment(tfm);
+
+            var buildName = BuildVariantName(options.BuildTargetName, token);
+            var buildReleaseName = BuildVariantName(options.BuildTargetName, token, "release");
+
+            var buildOutputs = GetVariantBuildOutputs(variant.Properties, projectDirectory, workspaceRoot);
+            var releaseOutputs = GetVariantBuildOutputs(variant.Properties, projectDirectory, workspaceRoot, releaseOnly: true);
+
+            var inputs = BuildVariantInputs(productionInput, directoryBuildInputs);
+
+            // build-<tfm> (Debug by default, mirroring the unqualified build)
+            TryAddVariant(targets, seenNames, buildName, new Target
+            {
+                Command = "dotnet build",
+                Options = new TargetOptions
+                {
+                    Cwd = "{projectRoot}",
+                    Args = ["--no-restore", "--no-dependencies", "--framework", tfm]
+                },
+                Configurations = FrameworkBuildConfigurations(tfm),
+                DependsOn = [$"^{options.BuildTargetName}"],
+                Cache = true,
+                Inputs = inputs,
+                Outputs = buildOutputs,
+                Metadata = VariantMetadata($"Build the {tfm} target framework", technologies, tfm)
+            });
+
+            // build-<tfm>-release — the Release build that publish/pack variants depend on,
+            // mirroring the unqualified build:release target (Nx cannot depend on a specific
+            // configuration, so the Release build is its own target).
+            TryAddVariant(targets, seenNames, buildReleaseName, new Target
+            {
+                Command = "dotnet build",
+                Options = new TargetOptions
+                {
+                    Cwd = "{projectRoot}",
+                    Args = ["--no-restore", "--no-dependencies", "--framework", tfm, "--configuration", "Release"]
+                },
+                Configurations = FrameworkBuildConfigurations(tfm),
+                DependsOn = [$"^{options.BuildTargetName}"],
+                Cache = true,
+                Inputs = inputs,
+                Outputs = releaseOutputs.Length > 0 ? releaseOutputs : buildOutputs,
+                Metadata = VariantMetadata($"Build the {tfm} target framework in Release configuration", technologies, tfm)
+            });
+
+            if (isTest)
+            {
+                var testName = BuildVariantName(options.TestTargetName, token);
+                TryAddVariant(targets, seenNames, testName, new Target
+                {
+                    Command = "dotnet test",
+                    Options = new TargetOptions
+                    {
+                        Cwd = "{projectRoot}",
+                        Args = ["--no-build", "--no-restore", "--framework", tfm]
+                    },
+                    DependsOn = [buildName],
+                    Cache = true,
+                    Inputs = BuildVariantInputs(productionInput, directoryBuildInputs, firstInput: "default"),
+                    Outputs = GetVariantTestOutputs(variant.Properties, projectDirectory, workspaceRoot),
+                    Metadata = VariantMetadata($"Run .NET tests for the {tfm} target framework", technologies, tfm)
+                });
+            }
+
+            if (isExe)
+            {
+                var publishName = BuildVariantName(options.PublishTargetName, token);
+                TryAddVariant(targets, seenNames, publishName, new Target
+                {
+                    Command = "dotnet publish",
+                    Options = new TargetOptions
+                    {
+                        Cwd = "{projectRoot}",
+                        Args = ["--no-build", "--no-dependencies", "--no-restore", "--framework", tfm, "--configuration", "Release"]
+                    },
+                    DependsOn = [buildReleaseName],
+                    Cache = true,
+                    Inputs = BuildVariantInputs(productionInput, directoryBuildInputs, firstInput: "default"),
+                    Outputs = GetVariantPublishOutputs(variant.Properties, projectDirectory, workspaceRoot),
+                    Metadata = VariantMetadata($"Publish the {tfm} target framework", technologies, tfm)
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Joins a configured target name and framework token(s) with a hyphen. The
+    /// result never contains a colon, so it can't be mistaken for a
+    /// configuration in Nx's <c>project:target:configuration</c> syntax.
+    /// </summary>
+    private static string BuildVariantName(string baseName, params string[] segments)
+    {
+        return $"{baseName}-{string.Join("-", segments)}";
+    }
+
+    /// <summary>
+    /// Deterministically normalizes a framework short name into a target-name
+    /// segment: lower-cased with any character outside <c>[a-z0-9.+-]</c>
+    /// replaced by a hyphen. Framework short names are already lower-case
+    /// (e.g. "net10.0-ios"), so this is usually a no-op, but it guarantees the
+    /// generated name is a stable, safe Nx target identifier.
+    /// </summary>
+    private static string NormalizeTargetNameSegment(string value)
+    {
+        var chars = value.Trim().ToLowerInvariant().ToCharArray();
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var c = chars[i];
+            var ok = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' || c == '+' || c == '-';
+            if (!ok)
+            {
+                chars[i] = '-';
+            }
+        }
+        return new string(chars);
+    }
+
+    /// <summary>
+    /// Inserts a variant target unless its name collides with an already-emitted
+    /// target (either an unqualified target or a previously-added variant). On a
+    /// collision the variant is skipped and a warning is written to stderr,
+    /// rather than silently overwriting a real target.
+    /// </summary>
+    private static void TryAddVariant(
+        Dictionary<string, Target> targets,
+        HashSet<string> seenNames,
+        string name,
+        Target target)
+    {
+        if (name.Contains(':'))
+        {
+            Console.Error.WriteLine(
+                $"Warning: skipping framework variant target '{name}' because its name contains ':', which is ambiguous with Nx configuration syntax.");
+            return;
+        }
+
+        if (targets.ContainsKey(name) || !seenNames.Add(name))
+        {
+            Console.Error.WriteLine(
+                $"Warning: skipping framework variant target '{name}' because a target with that name already exists.");
+            return;
+        }
+
+        targets[name] = target;
+    }
+
+    private static Dictionary<string, TargetConfiguration> FrameworkBuildConfigurations(string tfm) => new()
+    {
+        ["debug"] = new TargetConfiguration
+        {
+            Args = ["--no-restore", "--no-dependencies", "--framework", tfm, "--configuration", "Debug"]
+        },
+        ["release"] = new TargetConfiguration
+        {
+            Args = ["--no-restore", "--no-dependencies", "--framework", tfm, "--configuration", "Release"]
+        }
+    };
+
+    private static TargetMetadata VariantMetadata(string description, List<string> technologies, string tfm) => new()
+    {
+        Description = description,
+        Technologies = technologies,
+        TargetFramework = tfm
+    };
+
+    private static object[] BuildVariantInputs(
+        string productionInput,
+        List<string> directoryBuildInputs,
+        string? firstInput = null)
+    {
+        // Mirrors the input shape of the unqualified cacheable targets so a variant
+        // invalidates on the same evaluation-affecting files.
+        return
+        [
+            firstInput ?? productionInput,
+            $"^{productionInput}",
+            "{workspaceRoot}/.editorconfig",
+            new { workingDirectory = "absolute" },
+            new { dependentTasksOutputFiles = "**/*" },
+            .. directoryBuildInputs
+        ];
+    }
+
+    /// <summary>
+    /// Build/intermediate outputs scoped to a single framework. The inner build's
+    /// evaluated <c>OutputPath</c>/<c>IntermediateOutputPath</c> already include the
+    /// framework segment; both the Debug and Release forms are declared so the
+    /// variant's configurations are cached correctly.
+    /// </summary>
+    private static string[] GetVariantBuildOutputs(
+        Dictionary<string, string> properties,
+        string projectDirectory,
+        string workspaceRoot,
+        bool releaseOnly = false)
+    {
+        var outputs = new List<string?>();
+
+        var outputPath = ResolvePath(properties.GetValueOrDefault("OutputPath") ?? "", projectDirectory, workspaceRoot);
+        var intermediatePath = ResolvePath(properties.GetValueOrDefault("IntermediateOutputPath") ?? "", projectDirectory, workspaceRoot);
+
+        foreach (var basePath in new[] { outputPath, intermediatePath })
+        {
+            if (basePath is null)
+            {
+                continue;
+            }
+
+            if (!releaseOnly)
+            {
+                outputs.Add(WithConfiguration(basePath, "Debug"));
+            }
+            outputs.Add(WithConfiguration(basePath, "Release"));
+        }
+
+        return DedupeOutputs(outputs);
+    }
+
+    private static string[] GetVariantTestOutputs(
+        Dictionary<string, string> properties,
+        string projectDirectory,
+        string workspaceRoot)
+    {
+        var testResultsDir = properties.TryGetValue("TestResultsDirectory", out var configured) && !string.IsNullOrEmpty(configured)
+            ? ResolvePath(configured, projectDirectory, workspaceRoot)
+            : "{projectRoot}/TestResults";
+
+        return testResultsDir is null ? [] : [testResultsDir];
+    }
+
+    private static string[] GetVariantPublishOutputs(
+        Dictionary<string, string> properties,
+        string projectDirectory,
+        string workspaceRoot)
+    {
+        var outputs = new List<string?>();
+
+        var publishDir = properties.TryGetValue("PublishDir", out var configuredPublish) && !string.IsNullOrEmpty(configuredPublish)
+            ? ResolvePath(configuredPublish, projectDirectory, workspaceRoot)
+            : AppendSegment(ResolvePath(properties.GetValueOrDefault("OutputPath") ?? "", projectDirectory, workspaceRoot), "publish");
+
+        outputs.Add(WithConfiguration(publishDir, "Release"));
+
+        var intermediatePath = ResolvePath(properties.GetValueOrDefault("IntermediateOutputPath") ?? "", projectDirectory, workspaceRoot);
+        outputs.Add(WithConfiguration(intermediatePath, "Release"));
+
+        return DedupeOutputs(outputs);
+    }
+
+    private static string? AppendSegment(string? path, string segment)
+    {
+        return path is null ? null : $"{path.TrimEnd('/')}/{segment}";
+    }
+
+    private static string[] DedupeOutputs(IEnumerable<string?> outputs)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<string>();
+        foreach (var o in outputs)
+        {
+            if (o is not null && seen.Add(o))
+            {
+                result.Add(o);
+            }
+        }
+        return result.ToArray();
+    }
+
+    /// <summary>
+    /// Rewrites the configuration portion of an already-tokenized output path to
+    /// <paramref name="configuration"/>. Handles the traditional layout where the
+    /// configuration is its own path segment (e.g. <c>bin/Debug/net10.0</c>) and the
+    /// artifacts layout where it is the prefix of a combined pivot segment
+    /// (e.g. <c>artifacts/bin/app/debug_net10.0</c>). A no-op when no configuration
+    /// token is present.
+    /// </summary>
+    private static string? WithConfiguration(string? path, string configuration)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        var segments = path.Split('/');
+        for (var i = 0; i < segments.Length; i++)
+        {
+            var segment = segments[i];
+
+            if (segment.Equals("Debug", StringComparison.OrdinalIgnoreCase) ||
+                segment.Equals("Release", StringComparison.OrdinalIgnoreCase))
+            {
+                segments[i] = configuration;
+                continue;
+            }
+
+            // Artifacts-output pivots combine configuration and framework, e.g. "debug_net10.0".
+            if (segment.StartsWith("debug_", StringComparison.OrdinalIgnoreCase))
+            {
+                segments[i] = configuration.ToLowerInvariant() + segment.Substring("debug".Length);
+            }
+            else if (segment.StartsWith("release_", StringComparison.OrdinalIgnoreCase))
+            {
+                segments[i] = configuration.ToLowerInvariant() + segment.Substring("release".Length);
+            }
+        }
+
+        return string.Join('/', segments);
+    }
+}

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
@@ -60,7 +60,7 @@ public static partial class TargetBuilder
         if (options.FrameworkVariants && frameworkVariants is { Count: > 1 })
         {
             AddFrameworkVariantTargets(
-                targets, fileName, isTest, isExe, frameworkVariants,
+                targets, fileName, frameworkVariants,
                 projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs);
         }
 

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
@@ -21,7 +21,8 @@ public static partial class TargetBuilder
         string workspaceRoot,
         PluginOptions options,
         NxJsonConfig? nxJson,
-        List<string> directoryBuildInputs)
+        List<string> directoryBuildInputs,
+        List<FrameworkVariant>? frameworkVariants = null)
     {
         var targets = new Dictionary<string, Target>();
 
@@ -52,6 +53,15 @@ public static partial class TargetBuilder
         if (!isExe && !isTest)
         {
             AddPackTarget(targets, projectName, fileName, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs);
+        }
+
+        // Opt-in per-target-framework variants for multi-targeted projects. Added last so the
+        // unqualified targets above stay byte-for-byte identical whether or not this runs.
+        if (options.FrameworkVariants && frameworkVariants is { Count: > 1 })
+        {
+            AddFrameworkVariantTargets(
+                targets, fileName, isTest, isExe, frameworkVariants,
+                projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs);
         }
 
         return targets;

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
@@ -57,7 +57,9 @@ public static partial class TargetBuilder
 
         // Opt-in per-target-framework variants for multi-targeted projects. Added last so the
         // unqualified targets above stay byte-for-byte identical whether or not this runs.
-        if (options.FrameworkVariants && frameworkVariants is { Count: > 1 })
+        // Runtime variants imply framework variants, so either flag enables this pass; the RID
+        // hook inside is separately gated on RuntimeVariants.
+        if ((options.FrameworkVariants || options.RuntimeVariants) && frameworkVariants is { Count: > 1 })
         {
             AddFrameworkVariantTargets(
                 targets, fileName, frameworkVariants,

--- a/packages/dotnet/src/analyzer/analyzer-client.ts
+++ b/packages/dotnet/src/analyzer/analyzer-client.ts
@@ -35,6 +35,7 @@ export interface DotNetAnalyzerOptions {
   restoreTargetName?: string;
   publishTargetName?: string;
   packTargetName?: string;
+  frameworkVariants?: boolean;
 }
 
 interface AnalyzerCache {

--- a/packages/dotnet/src/analyzer/analyzer-client.ts
+++ b/packages/dotnet/src/analyzer/analyzer-client.ts
@@ -36,6 +36,7 @@ export interface DotNetAnalyzerOptions {
   publishTargetName?: string;
   packTargetName?: string;
   frameworkVariants?: boolean;
+  runtimeVariants?: boolean;
 }
 
 interface AnalyzerCache {

--- a/packages/dotnet/src/plugins/create-nodes.spec.ts
+++ b/packages/dotnet/src/plugins/create-nodes.spec.ts
@@ -614,4 +614,16 @@ describe('@nx/dotnet - createNodes', () => {
       expect(cleanTargetName).toBe('cleanup');
     });
   });
+
+  describe('frameworkVariants option', () => {
+    it('should default to false when not provided', () => {
+      const options: DotNetPluginOptions = {};
+      expect(options.frameworkVariants ?? false).toBe(false);
+    });
+
+    it('should pass through the opt-in value', () => {
+      const options: DotNetPluginOptions = { frameworkVariants: true };
+      expect(options.frameworkVariants ?? false).toBe(true);
+    });
+  });
 });

--- a/packages/dotnet/src/plugins/create-nodes.spec.ts
+++ b/packages/dotnet/src/plugins/create-nodes.spec.ts
@@ -37,10 +37,23 @@ function mergeUserTargetConfigurations(
 
   const mergedTargets = { ...node.targets };
 
+  const variantsOf = (baseName: string): string[] =>
+    Object.keys(mergedTargets).filter(
+      (name) =>
+        (
+          mergedTargets[name]?.metadata as
+            | { frameworkVariantOf?: string }
+            | undefined
+        )?.frameworkVariantOf === baseName
+    );
+
   for (const { targetOption, defaultTargetName } of targetMappings) {
     // Disabled target from user configuration
     if (targetOption === false) {
       delete mergedTargets[defaultTargetName];
+      for (const variantName of variantsOf(defaultTargetName)) {
+        delete mergedTargets[variantName];
+      }
       continue;
     }
 
@@ -73,6 +86,16 @@ function mergeUserTargetConfigurations(
     // If target was renamed, remove the old target name
     if (isRenamed && mergedTargets[defaultTargetName]) {
       delete mergedTargets[defaultTargetName];
+    }
+
+    // Keep the framework variants consistent with the base target.
+    if (hasUserConfig) {
+      for (const variantName of variantsOf(actualTargetName)) {
+        mergedTargets[variantName] = mergeTargetConfigurations(
+          userSpecifiedConfig as TargetConfiguration,
+          mergedTargets[variantName]
+        );
+      }
     }
   }
 
@@ -624,6 +647,63 @@ describe('@nx/dotnet - createNodes', () => {
     it('should pass through the opt-in value', () => {
       const options: DotNetPluginOptions = { frameworkVariants: true };
       expect(options.frameworkVariants ?? false).toBe(true);
+    });
+
+    it('should be disabled when the build target is disabled', () => {
+      const options: DotNetPluginOptions = {
+        frameworkVariants: true,
+        build: false,
+      };
+      expect(
+        (options.frameworkVariants ?? false) && options.build !== false
+      ).toBe(false);
+    });
+  });
+
+  describe('framework variant merging', () => {
+    const nodeWithVariant = (): ProjectConfiguration => ({
+      root: 'apps/my-app',
+      name: 'my-app',
+      targets: {
+        build: {
+          executor: 'nx:run-commands',
+          options: { command: 'dotnet build' },
+        },
+        'build-net10.0': {
+          executor: 'nx:run-commands',
+          options: { command: 'dotnet build --framework net10.0' },
+          metadata: { frameworkVariantOf: 'build' } as never,
+        },
+      },
+    });
+
+    it('should apply user build config to framework variants', () => {
+      const result = mergeUserTargetConfigurations(nodeWithVariant(), {
+        build: { options: { verbose: true } },
+      });
+
+      expect(result.targets?.['build-net10.0']?.options).toEqual({
+        command: 'dotnet build --framework net10.0',
+        verbose: true,
+      });
+    });
+
+    it('should remove framework variants when build is disabled', () => {
+      const result = mergeUserTargetConfigurations(nodeWithVariant(), {
+        build: false,
+      });
+
+      expect(result.targets?.build).toBeUndefined();
+      expect(result.targets?.['build-net10.0']).toBeUndefined();
+    });
+
+    it('should not touch variants of other base targets', () => {
+      const node = nodeWithVariant();
+      const result = mergeUserTargetConfigurations(node, {
+        test: { options: { logger: 'console' } },
+      });
+
+      expect(result.targets?.['build-net10.0']).toBeDefined();
     });
   });
 });

--- a/packages/dotnet/src/plugins/create-nodes.spec.ts
+++ b/packages/dotnet/src/plugins/create-nodes.spec.ts
@@ -660,6 +660,40 @@ describe('@nx/dotnet - createNodes', () => {
     });
   });
 
+  describe('runtimeVariants option', () => {
+    // Mirrors the analyzerOptions computation in create-nodes.ts.
+    const frameworkEnabled = (o: DotNetPluginOptions) =>
+      ((o.frameworkVariants ?? false) || (o.runtimeVariants ?? false)) &&
+      o.build !== false;
+    const runtimeEnabled = (o: DotNetPluginOptions) =>
+      (o.runtimeVariants ?? false) && o.build !== false;
+
+    it('should default to false', () => {
+      expect(runtimeEnabled({})).toBe(false);
+    });
+
+    it('should imply framework variants when enabled', () => {
+      const options: DotNetPluginOptions = { runtimeVariants: true };
+      expect(runtimeEnabled(options)).toBe(true);
+      expect(frameworkEnabled(options)).toBe(true);
+    });
+
+    it('should not enable runtime variants from frameworkVariants alone', () => {
+      const options: DotNetPluginOptions = { frameworkVariants: true };
+      expect(frameworkEnabled(options)).toBe(true);
+      expect(runtimeEnabled(options)).toBe(false);
+    });
+
+    it('should be disabled when the build target is disabled', () => {
+      const options: DotNetPluginOptions = {
+        runtimeVariants: true,
+        build: false,
+      };
+      expect(runtimeEnabled(options)).toBe(false);
+      expect(frameworkEnabled(options)).toBe(false);
+    });
+  });
+
   describe('framework variant merging', () => {
     const nodeWithVariant = (): ProjectConfiguration => ({
       root: 'apps/my-app',

--- a/packages/dotnet/src/plugins/create-nodes.ts
+++ b/packages/dotnet/src/plugins/create-nodes.ts
@@ -90,6 +90,19 @@ export interface DotNetPluginOptions {
    * Use `targetName` to rename the target, and provide additional options/configurations to merge with the generated target.
    */
   run?: TargetConfigurationWithName | false;
+  /**
+   * When enabled, multi-targeted projects (those declaring `<TargetFrameworks>`)
+   * additionally get per-target-framework target variants alongside the
+   * unqualified targets — for example `build-net10.0-ios`, `build-net10.0-ios-release`,
+   * `test-net10.0-ios`, and `publish-net10.0-ios`. Each variant passes `--framework`
+   * to the .NET CLI and scopes its outputs and cache identity to that framework.
+   *
+   * This is opt-in because it expands the task graph, and it never changes the
+   * unqualified targets. Single-targeted projects are unaffected.
+   *
+   * @default false
+   */
+  frameworkVariants?: boolean;
 }
 
 // MSBuild auto-imports Directory.Build.props/.targets from each ancestor of a project file,
@@ -208,6 +221,7 @@ export const createNodes: CreateNodes<DotNetPluginOptions> = [
           'watch',
         runTargetName:
           (normalizedOptions.run && normalizedOptions.run.targetName) || 'run',
+        frameworkVariants: normalizedOptions.frameworkVariants ?? false,
       };
 
       const result = await analyzeProjects(

--- a/packages/dotnet/src/plugins/create-nodes.ts
+++ b/packages/dotnet/src/plugins/create-nodes.ts
@@ -92,10 +92,15 @@ export interface DotNetPluginOptions {
   run?: TargetConfigurationWithName | false;
   /**
    * When enabled, multi-targeted projects (those declaring `<TargetFrameworks>`)
-   * additionally get per-target-framework target variants alongside the
-   * unqualified targets — for example `build-net10.0-ios`, `build-net10.0-ios-release`,
-   * `test-net10.0-ios`, and `publish-net10.0-ios`. Each variant passes `--framework`
-   * to the .NET CLI and scopes its outputs and cache identity to that framework.
+   * additionally get per-target-framework build variants alongside the
+   * unqualified targets — for example `build-net10.0-ios` and
+   * `build-net10.0-ios-release`. Each variant passes `--framework` to the .NET
+   * CLI and scopes its outputs and cache identity to that framework.
+   *
+   * Variants are self-contained: they do not depend on the unqualified build,
+   * so building one framework never triggers an all-framework build of the
+   * project or its dependencies. Any configuration you set on the `build`
+   * target is applied to its variants too, and disabling `build` removes them.
    *
    * This is opt-in because it expands the task graph, and it never changes the
    * unqualified targets. Single-targeted projects are unaffected.
@@ -143,10 +148,26 @@ function mergeUserTargetConfigurations(
 
   const mergedTargets = { ...node.targets };
 
+  // A framework variant's metadata records the unqualified target it derives
+  // from (e.g. `build`), so the same user configuration can be applied to the
+  // variants and they can be removed alongside a disabled base target.
+  const variantsOf = (baseName: string): string[] =>
+    Object.keys(mergedTargets).filter(
+      (name) =>
+        (
+          mergedTargets[name]?.metadata as
+            | { frameworkVariantOf?: string }
+            | undefined
+        )?.frameworkVariantOf === baseName
+    );
+
   for (const { targetOption, defaultTargetName } of targetMappings) {
     // Disabled target from user configuration
     if (targetOption === false) {
       delete mergedTargets[defaultTargetName];
+      for (const variantName of variantsOf(defaultTargetName)) {
+        delete mergedTargets[variantName];
+      }
       continue;
     }
 
@@ -179,6 +200,18 @@ function mergeUserTargetConfigurations(
     // If target was renamed, remove the old target name
     if (isRenamed && mergedTargets[defaultTargetName]) {
       delete mergedTargets[defaultTargetName];
+    }
+
+    // Keep the framework variants consistent with the base target: apply the
+    // same user configuration to each variant. The analyzer already names and
+    // stamps variants with the configured (possibly renamed) target name.
+    if (hasUserConfig) {
+      for (const variantName of variantsOf(actualTargetName)) {
+        mergedTargets[variantName] = mergeTargetConfigurations(
+          userSpecifiedConfig as TargetConfiguration,
+          mergedTargets[variantName]
+        );
+      }
     }
   }
 
@@ -221,7 +254,11 @@ export const createNodes: CreateNodes<DotNetPluginOptions> = [
           'watch',
         runTargetName:
           (normalizedOptions.run && normalizedOptions.run.targetName) || 'run',
-        frameworkVariants: normalizedOptions.frameworkVariants ?? false,
+        // Framework variants derive from the build target, so a disabled build
+        // means no variants to generate.
+        frameworkVariants:
+          (normalizedOptions.frameworkVariants ?? false) &&
+          normalizedOptions.build !== false,
       };
 
       const result = await analyzeProjects(

--- a/packages/dotnet/src/plugins/create-nodes.ts
+++ b/packages/dotnet/src/plugins/create-nodes.ts
@@ -108,6 +108,17 @@ export interface DotNetPluginOptions {
    * @default false
    */
   frameworkVariants?: boolean;
+  /**
+   * When enabled, multi-targeted executables that have runtime identifiers get
+   * per-RID variants — for example `build-net10.0-ios-ios-arm64-release` and
+   * `publish-net10.0-ios-ios-arm64`. This is a separate opt-in from
+   * {@link frameworkVariants}, so opting into per-framework build variants does
+   * not on its own expand the graph with RID variants. Enabling it implies
+   * `frameworkVariants`.
+   *
+   * @default false
+   */
+  runtimeVariants?: boolean;
 }
 
 // MSBuild auto-imports Directory.Build.props/.targets from each ancestor of a project file,
@@ -255,9 +266,15 @@ export const createNodes: CreateNodes<DotNetPluginOptions> = [
         runTargetName:
           (normalizedOptions.run && normalizedOptions.run.targetName) || 'run',
         // Framework variants derive from the build target, so a disabled build
-        // means no variants to generate.
+        // means no variants to generate. Runtime variants imply framework variants.
         frameworkVariants:
-          (normalizedOptions.frameworkVariants ?? false) &&
+          ((normalizedOptions.frameworkVariants ?? false) ||
+            (normalizedOptions.runtimeVariants ?? false)) &&
+          normalizedOptions.build !== false,
+        // RID variants additionally build/publish, so they're gated on the
+        // separate runtimeVariants opt-in (and a non-disabled build).
+        runtimeVariants:
+          (normalizedOptions.runtimeVariants ?? false) &&
           normalizedOptions.build !== false,
       };
 


### PR DESCRIPTION
> **Draft / exploratory** — PR 2 of a small stack for discussion [#36676](https://github.com/nrwl/nx/discussions/36676).
>
> **Stacked on #36680.** Built on top of `redth-dotnet-tfm-variants` (PR 1: per-TFM build variants). GitHub won't let an upstream PR use a fork branch as its base, so this targets `master` and its first commits are #36680's — **review #36680 first, then only the final commits here (the RID additions).** The per-branch diff `redth-dotnet-tfm-variants..redth-dotnet-tfm-rid-variants` is the true scope of this PR.

## Current Behavior

Even with the per-framework build variants from #36680, a multi-targeted executable that has runtime identifiers has no way to build or publish a single RID as its own cacheable task. Publishing a RID with the unqualified targets runs into the [#33474](https://github.com/nrwl/nx/issues/33474) class of failure: `--runtime` doesn't reach the dependent build, and outputs aren't placed in the runtime-specific folder a `--no-build` publish expects.

## Expected Behavior

A **separate** `runtimeVariants` opt-in (default false). It is distinct from `frameworkVariants` — turning on per-framework build variants does not, on its own, expand the graph with RID variants — and enabling it **implies** `frameworkVariants`. For each framework whose evaluated inner build is an executable and has runtime identifiers, the analyzer emits, per RID:

- `build-<tfm>-<rid>-release` — a self-contained RID-specific Release build
- `publish-<tfm>-<rid>` — publish for that framework and RID

Both pass `--framework` and `--runtime`. The RID publish **depends on the RID-specific Release build**, so a `--no-build` publish finds the runtime-specific output — modeling the RID dimension correctly **by construction** rather than forwarding `--runtime` at run time (contrast #33662).

### Design notes

- **Separate opt-in with correct gating.** RID variants require `runtimeVariants`; a disabled `build` suppresses everything, and a disabled `publish` removes the RID publish variants (via the `frameworkVariantOf` metadata marker). Wired through TS options, analyzer options, and C# `PluginOptions`.
- **Evaluated RIDs, not "authored".** `RuntimeIdentifier` can be SDK-implicit for platform frameworks, so the plural `RuntimeIdentifiers` is authoritative when set; otherwise the evaluated singular `RuntimeIdentifier` is used — documented as an evaluated RID that may be an SDK default. (Tested: a declared plural list suppresses an unrelated implicit singular.)
- **Per-framework executability.** `OutputType` can be conditioned on `TargetFramework`, so executability is evaluated per inner build (matching the plugin's existing `IsExecutableProject` rule: `Exe`; `WinExe` is not recognized). A mixed application/library project only gets RID variants on its executable frameworks.
- **Evaluated, layout-aware output paths + conservative skip.** RID outputs are derived from each inner build's evaluated `OutputPath`/`IntermediateOutputPath` (config → Release, then the RID placed where the SDK's default layout puts it: **replacing** an implicitly-defaulted RID such as a platform framework's, or **appending** when there is none). Because that only holds for the standard appended layout, RID variants are **skipped with a warning** — rather than declaring a cache output the build never writes — when `UseArtifactsOutput` is set, when `AppendTargetFrameworkToOutputPath`/`AppendRuntimeIdentifierToOutputPath` is `false`, or when a **custom `PublishDir`** (not `<OutputPath>/publish`) is set.
- **Self-contained**, same terms as the framework build variants (no `^build`, no `--no-dependencies`), with the same colon-free, collision-checked naming.

## Testing

- C# analyzer unit tests — `runtimeVariants` gating (framework-only emits no RID), per-framework executable gating incl. a mixed library/executable project, `--runtime` args, self-contained RID build, RID-publish→RID-build dependency, append-vs-implicit-RID-replace output derivation, layout-skip paths (artifacts, `Append*=false`, custom `PublishDir`), metadata, naming, multiple RIDs.
- Pure-helper unit tests — `ResolveRuntimeIdentifiers` (plural authoritative / suppresses implicit singular / singular fallback / empty) and `IsPublishDirDerivable` (empty / default / custom).
- Analyzer-level integration tests (run the real executable) — RID variants surface through the public JSON on a standard-layout project, and `frameworkVariants` alone surfaces none.
- e2e (`dotnet-runtime-variants.test.ts`) via the `runtimeVariants` opt-in; docs updated (runtime identifier variants subsection incl. the supported-layout rule).

> ⚠️ Same environment caveat as #36680: JS-side `nx build/lint/jest` + e2e could not run in my sandbox (`pnpm install` 404 for an unpublished Nx beta behind an auth-gated proxy). The C# analyzer builds and all **73** unit + integration tests pass, validated end-to-end against real multi-targeted executables (standard, artifacts, custom PublishDir, and mixed library/exe). CI should exercise the JS/e2e paths.

## Related Issue(s)

Refs discussion #36676. Related: #33474, #33662. Stacked on #36680.
