### PR TITLE
fix(core): don't leave an unkillable nx process when a terminal closes

### DIFF
--- a/packages/nx/src/native/pseudo_terminal/command/unix.rs
+++ b/packages/nx/src/native/pseudo_terminal/command/unix.rs
@@ -47,18 +47,15 @@ pub fn write_to_pty(stdin: &mut Stdin, writer: WriterArc) -> anyhow::Result<()> 
                     // Read data from stdin
                     loop {
                         match stdin.read(&mut buffer) {
+                            Ok(0) => return Ok(()),
                             Ok(n) => {
                                 let mut writer = writer.lock();
                                 writer.write_all(&buffer[..n])?;
                                 writer.flush()?;
                             }
-                            Err(e) => {
-                                if e.kind() == std::io::ErrorKind::WouldBlock {
-                                    break;
-                                } else if e.kind() == std::io::ErrorKind::Interrupted {
-                                    continue;
-                                }
-                            }
+                            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                            Err(e) => return Err(e.into()),
                         }
                     }
                 }

--- a/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
+++ b/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
@@ -351,7 +351,11 @@ impl PseudoTerminal {
                 }
                 if should_control_raw_mode {
                     trace!("Disabling raw mode");
-                    disable_raw_mode().expect("Failed to restore non-raw terminal");
+                    // Must not panic: that would skip the exit notification below,
+                    // leaving every consumer of this task's exit waiting forever.
+                    if let Err(e) = disable_raw_mode() {
+                        trace!("Failed to restore non-raw terminal: {:?}", e);
+                    }
                 }
                 exit_to_process_tx.send(exit.to_string()).ok();
             } else {


### PR DESCRIPTION
## Current Behavior

Closing a terminal that is running a non-continuous task (for example a `serve` target using `@nx/js:node`) leaves the `bin/nx.js` orchestrator alive, reparented to PPID 1, spinning at ~100% CPU. It ignores SIGTERM, SIGHUP and SIGINT, so only SIGKILL removes it. Reproduces every time on macOS.

Two separate defects are involved.

**1. The orphan.** The thread that waits for a task to exit calls `disable_raw_mode().expect(...)`. When the terminal is destroyed the pty slave is revoked, `disable_raw_mode()` fails, and the `expect` panics one line before `exit_to_process_tx.send(...)`. The exit notification is never sent, so `ChildProcess::on_exit` never fires, `getResults()` never resolves, the task's `discreteTaskExitHandled` promise never resolves, and `performCleanup` blocks forever on its final await. `cleanup()` therefore never settles, `resolveStopPromise()` is never called, and the process never exits. `setupSignalHandlers` latched `stopRequested` on the first SIGHUP, so every later signal hits the early return and does nothing. The panic message goes to a revoked stderr, so nothing is logged anywhere.

**2. The 100% CPU.** `write_to_pty` treats `Ok(0)` (EOF) as a successful zero byte read, and any `ErrorKind` other than `WouldBlock` or `Interrupted` falls through the `if`/`else if` without breaking or returning. A revoked tty hits one of these, so the stdin forwarding thread spins.

Continuous tasks are unaffected: `performCleanup` completes those directly instead of waiting on `onExit`, which is the workaround its own comment describes. Non-continuous tasks take the unprotected path. A target inherits `continuous` from its executor schema, and `@nx/js:node` does not set it.

## Expected Behavior

The process exits when its terminal goes away, and no thread spins.

- A `disable_raw_mode()` failure is logged and ignored. There is no raw mode left to restore once the terminal is gone, and the exit notification on the following line must still be sent.
- `write_to_pty` returns on EOF and on unexpected read errors instead of looping.

Each row below is a real build of the native module run against the reproduction:

| build | result |
| --- | --- |
| before | orphan at ~99% CPU, ignores all signals |
| stdin loop fix only | orphan survives, sits at 0.0% CPU |
| raw mode fix only | no orphan, exits cleanly |
| both | no orphan, exits cleanly |

Removing the panic is what fixes the orphan. The stdin loop fix is included because an unbounded busy loop on EOF or an unexpected error should not be reachable regardless.

Reproduction, headless, on a target that is not continuous:

```sh
script -q /dev/null npx nx run <project>:serve &
SCRIPT_PID=$!
sleep 30                     # let the task come up
kill -9 $SCRIPT_PID          # destroys the pty master, same as closing the window
ps -Ao pid=,ppid=,pcpu=,command= | grep 'nx/dist/bin/nx\.js' | grep -v daemon
```

`script -q /dev/null` runs the task under a real pty, and SIGKILLing `script` tears the pty master down abruptly, which is what a terminal does on window close.

Notes for reviewers:

- The `if`/`else if` in `write_to_pty` is converted to match guards. That shape is what allowed the silent fallthrough, so exhaustiveness is now explicit.
- Behavior change: an unexpected stdin read error now ends stdin passthrough for that task rather than retrying. The alternative is the busy loop above.
- `enable_raw_mode().expect(...)` on the setup path is left as is, since the terminal still exists at that point. Can be included if preferred.
- No automated test. Exercising this needs a real pty plus a revoked descriptor, which does not fit the existing Rust unit tests. The script above is the practical regression check.

## Related Issue(s)

Fixes #36682
