### PR TITLE
docs(misc): fix broken mf-examples repository link

### DIFF
--- a/astro-docs/src/content/docs/kb/angular-micro-frontends.mdoc
+++ b/astro-docs/src/content/docs/kb/angular-micro-frontends.mdoc
@@ -26,7 +26,7 @@ standards (ES modules and import maps) instead of bundler-specific machinery.
 Native Federation apps are regular Angular applications in your workspace.
 Follow the package's documentation to configure the federation host and remotes, and a worked
 Angular Native Federation example lives in the
-[mf-examples repository](https://github.com/nrwl/mf-examples).
+[mf-examples repository](https://github.com/jaysoo/mf-examples).
 
 ## Nx still orchestrates the apps
 

--- a/astro-docs/src/content/docs/kb/consumer-and-provider.mdoc
+++ b/astro-docs/src/content/docs/kb/consumer-and-provider.mdoc
@@ -190,4 +190,4 @@ SSR is not first-classed in the new generators. The deprecated `module-federatio
 
 ## Reference
 
-A worked reference workspace covering all three bundlers, dynamic federation, and Angular Native Federation lives at the [mf-examples repository](https://github.com/nrwl/mf-examples) (see `apps/nx-react-vite/` for the canonical Nx-wired setup).
+A worked reference workspace covering all three bundlers, dynamic federation, and Angular Native Federation lives at the [mf-examples repository](https://github.com/jaysoo/mf-examples) (see `apps/nx-react-vite/` for the canonical Nx-wired setup).

--- a/astro-docs/src/content/docs/kb/micro-frontend-architecture.mdoc
+++ b/astro-docs/src/content/docs/kb/micro-frontend-architecture.mdoc
@@ -130,7 +130,7 @@ Start with a small set of singletons and expand it when duplication becomes meas
 For a complete walkthrough of this plugin setup, see
 [Vite Module Federation](/docs/kb/vite-module-federation).
 A worked reference workspace covering Vite, Rsbuild, and Rspack lives in the
-[mf-examples repository](https://github.com/nrwl/mf-examples).
+[mf-examples repository](https://github.com/jaysoo/mf-examples).
 
 ## Why build micro frontends in a monorepo?
 

--- a/astro-docs/src/content/docs/kb/react-micro-frontends.mdoc
+++ b/astro-docs/src/content/docs/kb/react-micro-frontends.mdoc
@@ -90,4 +90,4 @@ consumer skeleton.
 ## Reference
 
 A worked reference workspace covering Vite, Rsbuild, Rspack, and dynamic federation lives in the
-[mf-examples repository](https://github.com/nrwl/mf-examples).
+[mf-examples repository](https://github.com/jaysoo/mf-examples).


### PR DESCRIPTION
## Current Behavior

Several knowledge base pages link to `https://github.com/nrwl/mf-examples`, which no longer exists (404).

- [angular-micro-frontends.mdoc](https://github.com/nrwl/nx/blob/master/astro-docs/src/content/docs/kb/angular-micro-frontends.mdoc)
- [react-micro-frontends.mdoc](https://github.com/nrwl/nx/blob/master/astro-docs/src/content/docs/kb/react-micro-frontends.mdoc)
- [consumer-and-provider.mdoc](https://github.com/nrwl/nx/blob/master/astro-docs/src/content/docs/kb/consumer-and-provider.mdoc)
- [micro-frontend-architecture.mdoc](https://github.com/nrwl/nx/blob/master/astro-docs/src/content/docs/kb/micro-frontend-architecture.mdoc)

## Expected Behavior

The links point to the relocated repository at `https://github.com/jaysoo/mf-examples`, which contains the same worked reference workspace (including `apps/angular-native-fed` and `apps/nx-react-vite` referenced by the docs).

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #36631