### PR TITLE
docs(core): update local generators video embed

### DIFF
--- a/astro-docs/src/content/docs/kb/local-generators.mdoc
+++ b/astro-docs/src/content/docs/kb/local-generators.mdoc
@@ -11,9 +11,9 @@ Local plugin generators provide a way to automate many tasks you regularly perfo
 Nx provides tooling around creating, and running custom generators from within your workspace. This guide shows you how to create, run, and customize generators within your Nx workspace.
 
 {% youtube
-src="https://www.youtube.com/embed/myqfGDWC2go"
-title="Scaffold new Pkgs in a PNPM Workspaces Monorepo"
-caption="Demoes how to use Nx generators in a PNPM workspace to automate the creation of libraries"
+src="https://www.youtube.com/embed/50FWA1oCaFQ"
+title="AI didn't kill code generators. It made them better."
+caption="Shows how AI coding agents and Nx generators work together to scaffold code consistently"
 /%}
 
 ## Creating a generator


### PR DESCRIPTION
## Current Behavior

The Local Generators knowledge base page embeds the older "Scaffold new Pkgs in a PNPM Workspaces Monorepo" video (`myqfGDWC2go`).

## Expected Behavior

The page embeds the newer video "AI didn't kill code generators. It made them better." (`50FWA1oCaFQ`), with title and caption updated to match.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/update-local-gen-video-15b70895">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->