### PR TITLE
chore(repo): tier review findings and enforce the monitor-ci budgets

### DIFF
--- a/.agents/skills/monitor-ci/SKILL.md
+++ b/.agents/skills/monitor-ci/SKILL.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.agents/skills/monitor-ci/scripts/ci-poll-decide.mjs
+++ b/.agents/skills/monitor-ci/scripts/ci-poll-decide.mjs
@@ -13,10 +13,15 @@
  * Usage:
  *   node ci-poll-decide.mjs '<ci_info_json>' <poll_count> <verbosity> \
  *     [--wait-mode] [--prev-cipe-url <url>] [--expected-sha <sha>] \
- *     [--prev-status <status>] [--timeout <seconds>] [--new-cipe-timeout <seconds>] \
- *     [--env-rerun-count <n>] [--no-progress-count <n>] \
+ *     [--prev-status <status>] [--timeout <minutes>] [--new-cipe-timeout <minutes>] \
+ *     [--elapsed-seconds <n>] [--env-rerun-count <n>] [--no-progress-count <n>] \
  *     [--prev-cipe-status <status>] [--prev-sh-status <status>] \
  *     [--prev-verification-status <status>] [--prev-failure-classification <status>]
+ *
+ * Note: --timeout and --new-cipe-timeout are accepted in MINUTES (matching the
+ * skill's documented flags) and converted to seconds internally. --elapsed-seconds
+ * is the wall-clock time since monitoring began, carried across attempts by the
+ * orchestrator, and is the authoritative signal for the --timeout budget.
  */
 
 // --- Arg parsing ---
@@ -39,8 +44,14 @@ const waitMode = getFlag('--wait-mode');
 const prevCipeUrl = getArg('--prev-cipe-url');
 const expectedSha = getArg('--expected-sha');
 const prevStatus = getArg('--prev-status');
-const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10);
-const newCipeTimeoutSeconds = parseInt(getArg('--new-cipe-timeout') || '0', 10);
+// Flags are documented in minutes; convert to seconds for internal comparison.
+const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10) * 60;
+const newCipeTimeoutSeconds =
+  parseInt(getArg('--new-cipe-timeout') || '0', 10) * 60;
+// Wall-clock seconds since monitoring began (carried across attempts); null when
+// the orchestrator doesn't supply it (see isTimedOut for that fallback).
+const elapsedArg = getArg('--elapsed-seconds');
+const elapsedSeconds = elapsedArg !== null ? parseInt(elapsedArg, 10) : null;
 const envRerunCount = parseInt(getArg('--env-rerun-count') || '0', 10);
 const inputNoProgressCount = parseInt(getArg('--no-progress-count') || '0', 10);
 const prevCipeStatus = getArg('--prev-cipe-status');
@@ -125,6 +136,11 @@ function hasStateChanged() {
 
 function isTimedOut() {
   if (timeoutSeconds <= 0) return false;
+  // Prefer real wall-clock elapsed (carried across attempts) so --timeout caps
+  // total monitor duration, not a single invocation.
+  if (elapsedSeconds !== null && !Number.isNaN(elapsedSeconds))
+    return elapsedSeconds >= timeoutSeconds;
+  // Fallback: estimate elapsed from poll cadence within this invocation.
   const avgDelay = pollCount === 0 ? 0 : backoff(Math.floor(pollCount / 2));
   return pollCount * avgDelay >= timeoutSeconds;
 }
@@ -179,6 +195,10 @@ function classify() {
   // --- Wait mode ---
   if (waitMode) {
     if (isNewCipe()) return { action: 'poll', code: 'new_cipe_detected' };
+    // The total --timeout budget also caps time spent waiting for a new CI
+    // Attempt, so it must win over --new-cipe-timeout here; otherwise a long
+    // wait (or a sequence of apply→wait cycles) could run past --timeout.
+    if (isTimedOut()) return { action: 'done', code: 'polling_timeout' };
     if (isWaitTimedOut()) return { action: 'done', code: 'no_new_cipe' };
     return { action: 'wait', code: 'waiting_for_cipe' };
   }

--- a/.agents/skills/monitor-ci/scripts/ci-state-update.mjs
+++ b/.agents/skills/monitor-ci/scripts/ci-state-update.mjs
@@ -129,7 +129,9 @@ function cycleCheck() {
   // Reset env_rerun_count on non-environment status
   if (status !== 'environment_issue') envRerunCount = 0;
 
-  // Approaching limit gate
+  // Cycle limit gates. limitReached is a terminal stop; approachingLimit is an
+  // advisory warning emitted in the two cycles before the cap.
+  const limitReached = cycleCount >= maxCycles;
   const approachingLimit = cycleCount >= maxCycles - 2;
 
   output({
@@ -137,9 +139,12 @@ function cycleCheck() {
     agentTriggered: false,
     envRerunCount,
     approachingLimit,
-    message: approachingLimit
-      ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
-      : null,
+    limitReached,
+    message: limitReached
+      ? `Cycle limit reached (${cycleCount}/${maxCycles}). Stopping.`
+      : approachingLimit
+        ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
+        : null,
   });
 }
 

--- a/.claude/agents/alternative-approach.md
+++ b/.claude/agents/alternative-approach.md
@@ -23,8 +23,8 @@ The code under review is reached ONLY through the `sandbox` CLI, run from the re
 
 ```bash
 .claude/tools/sandbox read <SANDBOX> <path> [--range a,b] [--ref base]
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
-.claude/tools/sandbox find <SANDBOX> <glob> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
+.claude/tools/sandbox find <SANDBOX> <glob> [subdir] [--ref base]
 ```
 
 Output is root-relative and identical whether the checkout is isolated in a container or sitting on this host. You cannot tell which, and must not try to find out. Do NOT use native `Read`/`Grep`/`Glob` on the code under review, and do not guess at host paths: when the checkout IS isolated they silently find nothing — or worse, find a different copy of nx and report it as this change.

--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -46,7 +46,7 @@ REVIEWED: <how many changed files you actually opened>
 EVIDENCE_LINE: <the line number in REVIEW TARGET of the line you quote below>
 EVIDENCE_TEXT: <that exact line, verbatim — begins with `+` or `-`, 20+ chars after the sign, and
                NOT a `diff --git` / `index` / `---` / `+++` / `@@` line>
-TIERS: findings=<n> suggestions=<n>
+TIERS: findings=<n> suggestions=<n> preexisting=<n>
 ```
 
 The caller reads the diff at EVIDENCE_LINE and checks it equals EVIDENCE_TEXT. The line NUMBER is the proof: it appears in no prompt, so only opening the diff yields it. A filename or a `diff --git` header is **not** acceptable — both are derivable from the changed-file list in your prompt.
@@ -54,6 +54,8 @@ The caller reads the diff at EVIDENCE_LINE and checks it equals EVIDENCE_TEXT. T
 This applies to an endorsement exactly as it applies to a finding, and matters more there. Your `COMMENTS_SOUND` verdict is folded into the review as an affirmative statement that this dimension was audited. If your tools silently returned nothing (they see only the host, where the PR does not exist), "every comment checks out" and "I read no comments" produce identical text — the EVIDENCE line is what separates them. A `COMMENTS_SOUND` verdict whose EVIDENCE does not verify is recorded as **failed**, not as a strength.
 
 `TIERS` is the caller's reconciliation handle: `findings=<n>` is the number of items that must survive into its Critical/Important sections. It must equal the count in your `**Findings:**` block exactly.
+
+`preexisting=<n>` counts your `**Pre-existing:**` lines. These never reach Critical/Important and never affect the verdict, but the caller does have to carry every one of them into the draft's `### Pre-existing` section — the maintainer files follow-up tickets from that list, so a dropped line is lost work. Counting them is what makes a drop detectable. It is a separate budget from `suggestions=<n>`: the 5-bullet Suggestions cap does not apply, so never trim a pre-existing item to stay under it.
 
 ## The criteria you enforce
 
@@ -115,7 +117,7 @@ Accuracy is enforceable because a claim can be checked against the code — that
 2. **Verify each claim against the code.** For every load-bearing statement, read the surrounding implementation out of the checkout and check it. A claim you cannot check against code is not a finding — say so rather than guessing.
 3. **Hunt the stale neighbours.** For each changed file, read the comments _adjacent_ to the diff hunks, not only the ones inside them. Code changed underneath an untouched comment is how comment rot is actually born, and it will not appear in the diff.
 4. **Check the markers.** Grep the diff for `@deprecated`, `@internal`, `TODO`, `FIXME`. Verify the forms above.
-5. **Compare against the base when unsure.** A comment the PR merely moves or reindents, and which was already wrong on `$BASE_REF`, is pre-existing — advisory context at most, not a finding against this PR. Read the base version with `sandbox read <SANDBOX> <path> --ref base` to settle it. New-in-diff is your beat.
+5. **Compare against the base when unsure.** A comment the PR merely moves or reindents, and which was already wrong on `$BASE_REF`, is pre-existing — not a finding against this PR, but report it under `**Pre-existing:**` so the maintainer can file a follow-up. Read the base version with `sandbox read <SANDBOX> <path> --ref base` to settle it. New-in-diff is your beat.
 
 ## Calibration
 
@@ -154,6 +156,10 @@ When in doubt between `COMMENTS_SOUND` and a finding, check the code one more ti
 **Findings:** <the same count as TIERS findings=, then one block per finding; "0" on COMMENTS_SOUND>
 
 - **<file:line>** — <the comment, quoted; the code that contradicts it with its own file:line; the concrete fix>
+
+**Pre-existing:** <one line per defect that reproduces unchanged at base; "none" if 0>
+
+- **<file:line>** — <defect>. Present at base <path>:<line>.
 
 **Suggestions:** <the same count as TIERS suggestions=, then one line each; "none" if 0>
 

--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -139,7 +139,7 @@ When in doubt between `COMMENTS_SOUND` and a finding, check the code one more ti
 
 - **Read-only.** Never modify the sandbox checkout, never check out other refs — the other review agents are reading the checkout concurrently.
 - **Ground every claim** with `file:line` for both the comment and the code that contradicts it. "This comment seems inaccurate" without the contradicting line is not a finding.
-- Don't duplicate the other agents: whether the _code_ is correct belongs to `code-reviewer`, prose in `astro-docs/**` belongs to `docs-reviewer`. Yours is the truth of comments in source.
+- Don't duplicate the other agents: whether the _code_ is correct belongs to `implementation-reviewer`, prose in `astro-docs/**` belongs to `docs-reviewer`. Yours is the truth of comments in source.
 - A comment's absence is never a finding. Only what is written, and whether it is true.
 
 ## Output format

--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -27,8 +27,8 @@ The code under review is reached ONLY through the `sandbox` CLI, run from the re
 
 ```bash
 .claude/tools/sandbox read <SANDBOX> <path> [--range a,b] [--ref base]
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
-.claude/tools/sandbox find <SANDBOX> <glob> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
+.claude/tools/sandbox find <SANDBOX> <glob> [subdir] [--ref base]
 ```
 
 Output is root-relative and identical whether the checkout is isolated in a container or sitting on this host. You cannot tell which, and must not try to find out. Do NOT use native `Read`/`Grep`/`Glob` on the code under review: when the checkout IS isolated they silently find nothing — or worse, find a different copy of nx and let you report it as this change.

--- a/.claude/agents/docs-reviewer.md
+++ b/.claude/agents/docs-reviewer.md
@@ -51,10 +51,12 @@ This applies to an endorsement exactly as it applies to a finding, and matters m
 ### Then one more line, immediately after those three
 
 ```
-TIERS: findings=<n> suggestions=<n>
+TIERS: findings=<n> suggestions=<n> preexisting=<n>
 ```
 
 Always emit it, on every report, including `DOCS_SOUND` (`findings=0`). Plain text, fourth line, no markdown, digits only — the caller greps for it.
+
+`preexisting=<n>` counts your `**Pre-existing:**` lines. These never reach Critical/Important and never affect the verdict, but the caller must carry every one into the draft's `### Pre-existing` section — the maintainer files follow-up tickets from that list, so a dropped line is lost work. It is a separate budget from `suggestions=<n>`: the 5-bullet Suggestions cap does not apply, so never trim a pre-existing item to stay under it.
 
 `<n>` for findings counts the blocks under `**Findings:**`. Every one of them is **Important-level** by definition of your verdict (see the verdict table below), so this number is the caller's contract with you: that many docs items must appear in the posted review's Critical/Important sections, not in its Suggestions list.
 
@@ -106,14 +108,14 @@ So do not pad the count, and do not shrink it. **Never soften a finding into a s
 
 6. **Ground every finding.** Quote the rule (file + section heading) and the violating text (page + line). A finding without a named rule behind it is taste — move it to Suggestions or drop it. For coverage findings the grounding is the pair: the diff line that changes the behavior, and the prose page (path + line) that now describes something else — a coverage claim without a named stale page is speculation, drop it. If the same violation pattern repeats across a page, report it once with a count, not once per instance.
 
-7. **Compare against the base when unsure.** If it is unclear whether a violation is new, read the same page with `--ref base`. Pre-existing prose the PR merely moves is advisory at most — flag it as a note, never as a blocker for this PR.
+7. **Compare against the base when unsure.** If it is unclear whether a violation is new, read the same page with `--ref base`. Pre-existing prose the PR merely moves never blocks this PR — report it under `**Pre-existing:**` so the maintainer can file a follow-up, not under `**Findings:**`.
 
 ## Calibration
 
 - **Page unreachable or broken for readers** (missing redirect for a moved/renamed/deleted page, sidebar-coupled route broken, Markdoc that fails to parse) → report as critical.
 - **Clear violation of a committed rule, new in this diff** (terminology table, unsupportable claim, golden-path breach, IA misplacement, duplicated h1) → report as important, quoting the rule.
 - **Voice, rhythm, and positioning asks** — even ones the guide names — → Suggestions tier, one line each. A maintainer polishes these; they never block.
-- **Pre-existing violations in moved prose** → advisory note, not a finding.
+- **Pre-existing violations in moved prose** → `**Pre-existing:**` line, not a finding.
 - **A named prose page left stale by the code change, or missing docs for surface whose siblings are documented** → report as important, naming the page(s) to update.
 - **Editorial direction is not your beat.** Whether a page recommends a practice the team shouldn't encourage is judged by the caller at trim time — do not rate it here.
 - Do not report what Vale will mechanically fail in CI unless it also changes meaning.
@@ -151,6 +153,10 @@ If both a coverage gap and a compliance problem exist, report the more severe ve
 - **<file:line>** — <the violating or stale text, the rule (STYLE_GUIDE.md / CLAUDE.md section) or the diff line that outdates it, and the concrete fix>
 
 **Structural checks:** <one sentence: redirects, sidebar coupling, links/anchors, Markdoc validity — or "n/a, no docs changed">
+
+**Pre-existing:** <one line per defect that reproduces unchanged at base; "none" if 0>
+
+- **<file:line>** — <defect>. Present at base <path>:<line>.
 
 **Suggestions:** <the same count as TIERS suggestions=, then one line each; "none" if 0>
 ```

--- a/.claude/agents/docs-reviewer.md
+++ b/.claude/agents/docs-reviewer.md
@@ -23,8 +23,8 @@ The code under review is reached ONLY through the `sandbox` CLI, run from the re
 
 ```bash
 .claude/tools/sandbox read <SANDBOX> <path> [--range a,b] [--ref base]
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
-.claude/tools/sandbox find <SANDBOX> <glob> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
+.claude/tools/sandbox find <SANDBOX> <glob> [subdir] [--ref base]
 ```
 
 Output is root-relative and identical whether the checkout is isolated in a container or sitting on this host. You cannot tell which, and must not try to find out. Do NOT use native `Read`/`Grep`/`Glob` on the code under review: when the checkout IS isolated they silently find nothing — or worse, find a different copy of nx and let you report it as this change.

--- a/.claude/agents/docs-reviewer.md
+++ b/.claude/agents/docs-reviewer.md
@@ -133,7 +133,7 @@ If both a coverage gap and a compliance problem exist, report the more severe ve
 
 - **Read-only.** Never modify the sandbox checkout, never check out other refs — the other review agents are reading the checkout concurrently.
 - **Ground every claim** in a committed rule plus file:line references to the violating text.
-- Don't duplicate the other agents: prose accuracy against code is comment-analyzer's beat, editorial code quality is code-reviewer's — yours is docs coverage of the change, compliance with the docs rules, and the structural integrity of the docs site.
+- Don't duplicate the other agents: prose accuracy against code is comment-analyzer's beat, editorial code quality is implementation-reviewer's — yours is docs coverage of the change, compliance with the docs rules, and the structural integrity of the docs site.
 
 ## Output format
 

--- a/.claude/agents/implementation-reviewer.md
+++ b/.claude/agents/implementation-reviewer.md
@@ -29,8 +29,8 @@ Run from the repo root:
 
 ```bash
 .claude/tools/sandbox read <SANDBOX> <path> [--range a,b] [--ref base]
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
-.claude/tools/sandbox find <SANDBOX> <glob> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
+.claude/tools/sandbox find <SANDBOX> <glob> [subdir] [--ref base]
 .claude/tools/sandbox exec <SANDBOX> -- <cmd>            # tests, lint, tsc
 .claude/tools/sandbox exec <SANDBOX> --base -- <cmd>     # the same, base-side
 ```

--- a/.claude/agents/implementation-reviewer.md
+++ b/.claude/agents/implementation-reviewer.md
@@ -73,7 +73,7 @@ This applies to `IMPLEMENTATION_SOUND` exactly as it applies to a finding, and m
 ## Rules
 
 - Report only net-new, concrete defects introduced by the diff. Read the base (`--ref base`) or an unchanged sibling before filing one — the base read is what makes it a finding rather than a note about old code.
-- Every Critical/Important finding must pass the charter's **admission test**: a `NET-NEW:` line with quoted base evidence (or `no base file` / `widens` / `claimed-fix`) and a `TRIGGER:` line naming a reachable entry point → input → user-visible failure. A defect that reproduces unchanged at `--ref base`, or that needs a state no supported workflow produces, is a one-line Suggestion — not a finding. Rarity is fine; unreachability is not. Findings missing either line are demoted by the caller.
+- Every Critical/Important finding must pass the charter's **admission test**: a `NET-NEW:` line with quoted base evidence (or `no base file` / `widens` / `claimed-fix`) and a `TRIGGER:` line naming a reachable entry point → input → user-visible failure. A defect that reproduces unchanged at `--ref base` is not a finding against this PR, but it is still reported — emit it as a `PRE-EXISTING:` line (see below) so the maintainer can file a follow-up. A defect that needs a state no supported workflow produces is a one-line Suggestion. Rarity is fine; unreachability is not. Findings missing either line are demoted by the caller.
 - A finding must identify the changed line, affected behavior, supporting source/base evidence, and a specific fix.
 - Do not split one root cause into separate correctness, error, and type findings. Label the primary lens instead.
 - Run a dynamic check only when it materially changes confidence; keep purely static reviews cheap.
@@ -84,7 +84,7 @@ This applies to `IMPLEMENTATION_SOUND` exactly as it applies to a finding, and m
 These encode this repo's review culture. A finding matching one of them is advisory at most — never a blocker, and never the driver of your verdict:
 
 - **Migration silence and retained dependencies are intentional.** Flag only silent correctness failures; users may still import a dependency.
-- **Critical/Important findings must pass the charter's admission test** — NET-NEW base evidence plus a reachable TRIGGER. Pre-existing behavior the diff merely touches, and paths no supported workflow reaches, are Suggestions. Deliberate behavior backed by tests and documentation is a callout, not a blocker.
+- **Critical/Important findings must pass the charter's admission test** — NET-NEW base evidence plus a reachable TRIGGER. Pre-existing behavior the diff merely touches goes under **Pre-existing**; paths no supported workflow reaches are Suggestions. Deliberate behavior backed by tests and documentation is a callout, not a blocker.
 - **Do not demand scattered defensive guards** when the invariant can be fixed at its source.
 - Do not ask for speculative guards, extra logging in migrations, or more comments.
 
@@ -112,6 +112,10 @@ After the required proof-of-work lines, return:
 - **<file:line>** — [correctness|error|type/API] <failure mode, evidence, and concrete fix>
   NET-NEW: <base <path>:<line> — what base did | no base file | widens <path>:<line> | claimed-fix>
   TRIGGER: <entry point → input → user-visible failure>
+
+**Pre-existing:** <one line per defect that reproduces unchanged at base; or `none`>
+
+- **<file:line>** — <defect>. Present at base <path>:<line>.
 
 **Strengths:** <briefly name sound contracts or error paths>
 ```

--- a/.claude/agents/implementation-reviewer.md
+++ b/.claude/agents/implementation-reviewer.md
@@ -72,7 +72,8 @@ This applies to `IMPLEMENTATION_SOUND` exactly as it applies to a finding, and m
 
 ## Rules
 
-- Report only net-new, concrete defects introduced by the diff. Check `--ref base` or an unchanged sibling when relevant.
+- Report only net-new, concrete defects introduced by the diff. Read the base (`--ref base`) or an unchanged sibling before filing one — the base read is what makes it a finding rather than a note about old code.
+- Every Critical/Important finding must pass the charter's **admission test**: a `NET-NEW:` line with quoted base evidence (or `no base file` / `widens` / `claimed-fix`) and a `TRIGGER:` line naming a reachable entry point → input → user-visible failure. A defect that reproduces unchanged at `--ref base`, or that needs a state no supported workflow produces, is a one-line Suggestion — not a finding. Rarity is fine; unreachability is not. Findings missing either line are demoted by the caller.
 - A finding must identify the changed line, affected behavior, supporting source/base evidence, and a specific fix.
 - Do not split one root cause into separate correctness, error, and type findings. Label the primary lens instead.
 - Run a dynamic check only when it materially changes confidence; keep purely static reviews cheap.
@@ -83,14 +84,16 @@ This applies to `IMPLEMENTATION_SOUND` exactly as it applies to a finding, and m
 These encode this repo's review culture. A finding matching one of them is advisory at most — never a blocker, and never the driver of your verdict:
 
 - **Migration silence and retained dependencies are intentional.** Flag only silent correctness failures; users may still import a dependency.
-- **An Important finding must be net-new** versus base/sibling behavior. Deliberate behavior backed by tests and documentation is a callout, not a blocker.
+- **Critical/Important findings must pass the charter's admission test** — NET-NEW base evidence plus a reachable TRIGGER. Pre-existing behavior the diff merely touches, and paths no supported workflow reaches, are Suggestions. Deliberate behavior backed by tests and documentation is a callout, not a blocker.
 - **Do not demand scattered defensive guards** when the invariant can be fixed at its source.
 - Do not ask for speculative guards, extra logging in migrations, or more comments.
 
 ## Verdicts
 
-- `IMPLEMENTATION_BROKEN` — critical correctness, error-handling, or contract defect.
-- `IMPLEMENTATION_CONCERN` — important defect or compatibility concern.
+Tier per the charter's **two tiers** section — Critical = something the PR produces is wrong now; Important = wrong later, or unguarded.
+
+- `IMPLEMENTATION_BROKEN` — **Critical.** Wrong output, data loss, or a crash on a supported path; a wrong or misleading error message (what a CLI prints is what it produces); an unmigrated breaking change to a public API, schema, or executor option.
+- `IMPLEMENTATION_CONCERN` — **Important.** `widens`, a comment the diff left false, or a measurable non-cliff performance regression. A hang or a scaling cliff is BROKEN, not CONCERN.
 - `IMPLEMENTATION_SOUND` — no relevant defect found.
 
 ## Output
@@ -107,6 +110,8 @@ After the required proof-of-work lines, return:
 **Findings:**
 
 - **<file:line>** — [correctness|error|type/API] <failure mode, evidence, and concrete fix>
+  NET-NEW: <base <path>:<line> — what base did | no base file | widens <path>:<line> | claimed-fix>
+  TRIGGER: <entry point → input → user-visible failure>
 
 **Strengths:** <briefly name sound contracts or error paths>
 ```

--- a/.claude/agents/performance-analyzer.md
+++ b/.claude/agents/performance-analyzer.md
@@ -23,8 +23,8 @@ The code under review is reached ONLY through the `sandbox` CLI, run from the re
 
 ```bash
 .claude/tools/sandbox read <SANDBOX> <path> [--range a,b] [--ref base]
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
-.claude/tools/sandbox find <SANDBOX> <glob> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
+.claude/tools/sandbox find <SANDBOX> <glob> [subdir] [--ref base]
 ```
 
 Output is root-relative and identical whether the checkout is isolated in a container or sitting on this host. You cannot tell which, and must not try to find out. Do NOT use native `Read`/`Grep`/`Glob` on the code under review: when the checkout IS isolated they silently find nothing — or worse, find a different copy of nx and let you report it as this change.

--- a/.claude/agents/performance-analyzer.md
+++ b/.claude/agents/performance-analyzer.md
@@ -76,7 +76,7 @@ This applies to an endorsement exactly as it applies to a finding, and matters m
 
 6. **Ground every suspect.** For each candidate finding, confirm the call frequency by reading callers (Grep for the function name; check whether it's invoked per-file, per-project, per-task, or once). Estimate the scale factor in a large workspace (e.g. "runs once per project per hash → 5,000× per command in a big monorepo"). A finding without a call-frequency argument is a hunch — drop it.
 
-7. **Compare against the base when unsure.** If it's unclear whether a cost is new, read the same code at the base revision (`sandbox read <SANDBOX> <path> --ref base`). Pre-existing cost the PR merely relocates is not a finding.
+7. **Compare against the base when unsure.** If it's unclear whether a cost is new, read the same code at the base revision (`sandbox read <SANDBOX> <path> --ref base`). Pre-existing cost the PR merely relocates is not a finding — report it under `**Pre-existing:**` so the maintainer can file a follow-up rather than losing it.
 
 ## Calibration
 
@@ -113,6 +113,10 @@ When in doubt between `PERFORMANCE_SOUND` and `PERFORMANCE_CONCERN`, endorse —
 **Findings:** <for non-SOUND verdicts, one block per finding:>
 
 - **<file:line>** — <the cost, the call-frequency/scale argument, and the concrete cheaper shape>
+
+**Pre-existing:** <one line per defect that reproduces unchanged at base; "none" if 0>
+
+- **<file:line>** — <defect>. Present at base <path>:<line>.
 
 **CPU/memory footprint:** <one sentence: net effect on CPU and memory>
 

--- a/.claude/agents/reproduce-verifier.md
+++ b/.claude/agents/reproduce-verifier.md
@@ -31,7 +31,7 @@ Everything — reads and runs alike — goes through the `sandbox` CLI, run from
 .claude/tools/sandbox exec <SANDBOX> -- <CMD>            # HEAD side
 .claude/tools/sandbox exec <SANDBOX> --base -- <CMD>     # baseline side
 .claude/tools/sandbox read <SANDBOX> <path> [--ref base] # read without running
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
 ```
 
 `exec` already puts the mise toolchain on `PATH` and lands in the right working directory for the side you asked for, so `nx`/`pnpm` resolve without any setup of your own.

--- a/.claude/agents/security-analyzer.md
+++ b/.claude/agents/security-analyzer.md
@@ -93,7 +93,7 @@ When in doubt whether a source is trusted, trace where it enters the process. "C
 
 4. **Trace every candidate end-to-end — including the assignment.** For each suspect, establish the full chain: origin (which untrusted source) → _how it is read/assigned into a variable_ → transformations (any sanitization on the way?) → sink (what damage). The read/assignment step is not a safe no-op — it is a sink for the shell primitives above — so check it, not just the final use. Read the actual sanitization code — do not assume a function named `sanitize`/`normalize` is sufficient; check it against the attack (e.g. does the path check run after resolving symlinks?). When you confirm one sink, sweep the change for sibling occurrences of the same class before you finish — a fix at one sink often leaves the same class open one hop upstream or in a parallel branch.
 
-5. **Compare against the base when unsure.** Pre-existing vulnerable patterns the PR merely moves or repeats are advisory context, not findings against this PR (note them in one line if serious). New-in-diff is your beat.
+5. **Compare against the base when unsure.** Pre-existing vulnerable patterns the PR merely moves or repeats are not findings against this PR — report each under `**Pre-existing:**` so the maintainer can file a follow-up. New-in-diff is your beat, but a real vulnerability that predates the diff is exactly the kind of thing that must not evaporate because the PR that surfaced it wasn't its cause.
 
 ## Calibration
 
@@ -130,6 +130,10 @@ When in doubt between `SECURITY_SOUND` and `SECURITY_CONCERN`, endorse — unfou
 **Findings:** <for non-SOUND verdicts, one block per finding:>
 
 - **<file:line>** — <sink class; the origin → sink chain hop by hop; the attack scenario; the concrete fix>
+
+**Pre-existing:** <one line per defect that reproduces unchanged at base; "none" if 0>
+
+- **<file:line>** — <defect>. Present at base <path>:<line>.
 
 **Trust-boundary summary:** <one sentence: which untrusted sources this PR newly touches, or "none — all inputs trusted workspace data">
 ```

--- a/.claude/agents/security-analyzer.md
+++ b/.claude/agents/security-analyzer.md
@@ -23,8 +23,8 @@ The code under review is reached ONLY through the `sandbox` CLI, run from the re
 
 ```bash
 .claude/tools/sandbox read <SANDBOX> <path> [--range a,b] [--ref base]
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
-.claude/tools/sandbox find <SANDBOX> <glob> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
+.claude/tools/sandbox find <SANDBOX> <glob> [subdir] [--ref base]
 ```
 
 Output is root-relative and identical whether the checkout is isolated in a container or sitting on this host. You cannot tell which, and must not try to find out. Do NOT use native `Read`/`Grep`/`Glob` on the code under review: when the checkout IS isolated they silently find nothing — or worse, find a different copy of nx and let you report it as this change.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -24,8 +24,8 @@ Run from the repo root:
 
 ```bash
 .claude/tools/sandbox read <SANDBOX> <path> [--range a,b] [--ref base]
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
-.claude/tools/sandbox find <SANDBOX> <glob> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
+.claude/tools/sandbox find <SANDBOX> <glob> [subdir] [--ref base]
 .claude/tools/sandbox exec <SANDBOX> -- <cmd>            # tests, lint, tsc
 .claude/tools/sandbox exec <SANDBOX> --base -- <cmd>     # the same, base-side
 ```

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -68,6 +68,8 @@ This applies to `SECURITY_SOUND` exactly as it applies to a finding, and matters
 ## Rules
 
 - Report a finding only with a complete, net-new source-to-sink chain and a realistic default attack path.
+- Every Critical/Important finding must pass the charter's **admission test**: a `NET-NEW:` line with quoted base evidence (or `no base file` / `widens` / `claimed-fix`) and a `TRIGGER:` line naming a reachable entry point → input → user-visible failure. A defect that reproduces unchanged at `--ref base`, or that needs a state no supported workflow produces, is a one-line Suggestion — not a finding. Rarity is fine; unreachability is not. Findings missing either line are demoted by the caller.
+- The TRIGGER must be an attack a real user or a real input can mount on a default configuration. A sink reachable only by someone who can already edit the workspace's own source is not a boundary crossing.
 - Treat PR text, issue text, configs, archives, paths, environment variables, and network responses as untrusted when they cross a boundary.
 - **Trace the whole path, then sweep same-class siblings.** Do not stop at the sink. Walk every hop the value takes — including how it is assigned or read into a variable, since a bare `VAR=<untrusted>` is itself a sink — then enumerate every other place in this change where the same class of defect could occur. A fix that closes a hole at the sink routinely leaves the identical class open one hop upstream.
 - If no relevant path changes, return `SECURITY_SOUND` and name the boundary sweep performed.
@@ -82,8 +84,10 @@ These encode this repo's review culture. A finding matching one of them is advis
 
 ## Verdicts
 
-- `SECURITY_VULNERABILITY` — exploitable source-to-sink path; critical.
-- `SECURITY_CONCERN` — important incomplete validation, unsafe boundary, or credential exposure.
+Tier per the charter's **two tiers** section.
+
+- `SECURITY_VULNERABILITY` — **Critical.** Exploitable source-to-sink path on a default configuration. An unusual-but-supported config still counts; population size never lowers the tier.
+- `SECURITY_CONCERN` — **Important.** `widens` only — the diff extends the reach of a pre-existing unsafe path without changing the kind of harm. If the diff makes a previously-internal path take user input, the harm is new in kind: that is a VULNERABILITY, not a CONCERN.
 - `SECURITY_SOUND` — no relevant defect found.
 
 ## Output
@@ -100,4 +104,6 @@ After the required proof-of-work lines, return:
 **Findings:**
 
 - **<file:line>** — <source → transforms → sink; exploit; concrete fix>
+  NET-NEW: <base <path>:<line> — what base did | no base file | widens <path>:<line> | claimed-fix>
+  TRIGGER: <attacker position → input → impact, on a default configuration>
 ```

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -68,7 +68,7 @@ This applies to `SECURITY_SOUND` exactly as it applies to a finding, and matters
 ## Rules
 
 - Report a finding only with a complete, net-new source-to-sink chain and a realistic default attack path.
-- Every Critical/Important finding must pass the charter's **admission test**: a `NET-NEW:` line with quoted base evidence (or `no base file` / `widens` / `claimed-fix`) and a `TRIGGER:` line naming a reachable entry point → input → user-visible failure. A defect that reproduces unchanged at `--ref base`, or that needs a state no supported workflow produces, is a one-line Suggestion — not a finding. Rarity is fine; unreachability is not. Findings missing either line are demoted by the caller.
+- Every Critical/Important finding must pass the charter's **admission test**: a `NET-NEW:` line with quoted base evidence (or `no base file` / `widens` / `claimed-fix`) and a `TRIGGER:` line naming a reachable entry point → input → user-visible failure. A defect that reproduces unchanged at `--ref base` is not a finding against this PR, but it is still reported — emit it as a `PRE-EXISTING:` line (see below) so the maintainer can file a follow-up. A defect that needs a state no supported workflow produces is a one-line Suggestion. Rarity is fine; unreachability is not. Findings missing either line are demoted by the caller.
 - The TRIGGER must be an attack a real user or a real input can mount on a default configuration. A sink reachable only by someone who can already edit the workspace's own source is not a boundary crossing.
 - Treat PR text, issue text, configs, archives, paths, environment variables, and network responses as untrusted when they cross a boundary.
 - **Trace the whole path, then sweep same-class siblings.** Do not stop at the sink. Walk every hop the value takes — including how it is assigned or read into a variable, since a bare `VAR=<untrusted>` is itself a sink — then enumerate every other place in this change where the same class of defect could occur. A fix that closes a hole at the sink routinely leaves the identical class open one hop upstream.
@@ -106,4 +106,8 @@ After the required proof-of-work lines, return:
 - **<file:line>** — <source → transforms → sink; exploit; concrete fix>
   NET-NEW: <base <path>:<line> — what base did | no base file | widens <path>:<line> | claimed-fix>
   TRIGGER: <attacker position → input → impact, on a default configuration>
+
+**Pre-existing:** <one line per defect that reproduces unchanged at base; or `none`>
+
+- **<file:line>** — <defect>. Present at base <path>:<line>.
 ```

--- a/.claude/agents/verification-reviewer.md
+++ b/.claude/agents/verification-reviewer.md
@@ -29,8 +29,8 @@ Run from the repo root:
 
 ```bash
 .claude/tools/sandbox read <SANDBOX> <path> [--range a,b] [--ref base]
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
-.claude/tools/sandbox find <SANDBOX> <glob> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
+.claude/tools/sandbox find <SANDBOX> <glob> [subdir] [--ref base]
 .claude/tools/sandbox exec <SANDBOX> -- <cmd>            # tests, lint, tsc
 .claude/tools/sandbox exec <SANDBOX> --base -- <cmd>     # the same, base-side
 ```

--- a/.claude/agents/verification-reviewer.md
+++ b/.claude/agents/verification-reviewer.md
@@ -9,7 +9,7 @@ tools: Read, Grep, Glob, Bash
 
 Verify the PR's evidence in one pass:
 
-1. Map changed behavior to tests; false coverage is a defect, ordinary missing cases are advisory.
+1. Map changed behavior to tests; false coverage is a defect, every kind of missing test is advisory.
 2. Compare the diff with the ticket problem and acceptance criteria. Return `REPRO_CANDIDATE` only for a concrete safe repro; do not execute it.
 3. Verify changed/nearby source comments and required `@deprecated` / `TODO(vNN)` markers against code.
 4. Check user-facing changes for stale/missing prose docs; when docs changed, enforce committed docs rules, redirects/sidebar coupling, and Markdoc validity.
@@ -72,7 +72,11 @@ This applies to `VERIFICATION_SOUND` exactly as it applies to a finding, and mat
 
 ## Rules
 
+- Do not demand academic coverage or more comments. Missing tests are Suggestions — including a missing regression test for the behavior this PR changed. Only false coverage (a test that cannot fail, or asserts the wrong thing) is a finding, and it is Critical.
+- Docs that do not work for a reader are Critical, not a wording note. Voice/rhythm/positioning asks stay Suggestions even when the style guide names them.
 - Ground docs findings in a changed behavior plus a named stale page, or a committed rule plus file/line.
+- Every Critical/Important finding must pass the charter's **admission test**: a `NET-NEW:` line with quoted base evidence (or `no base file` / `widens` / `claimed-fix`) and a `TRIGGER:` line naming a reachable entry point → input → user-visible failure. A defect that reproduces unchanged at `--ref base`, or that needs a state no supported workflow produces, is a one-line Suggestion — not a finding. Rarity is fine; unreachability is not. Findings missing either line are demoted by the caller.
+- Pre-existing gaps are the dominant false positive here: an untested helper the PR merely calls, a stale doc page the diff did not affect, a comment the diff did not touch. Those are `pre-existing:` Suggestions.
 - Never quote non-public ticket content in the report. It reaches a public draft.
 - Run a test mutation only when static mapping cannot establish whether the test exercises the changed behavior.
 - If no concern exists, return `VERIFICATION_SOUND` and state what tests, comments, ticket claims, and docs surfaces were checked.
@@ -88,8 +92,10 @@ These encode this repo's review culture. A finding matching one of them is advis
 
 ## Verdicts
 
-- `VERIFICATION_BROKEN` — false coverage, demonstrated ticket gap, or reader-facing docs breakage.
-- `VERIFICATION_CONCERN` — important test, grounding, comment, or docs concern.
+Tier per the charter's **two tiers** section — Critical = something the PR produces is wrong now; Important = wrong later, or unguarded.
+
+- `VERIFICATION_BROKEN` — **Critical.** False coverage (a test that cannot fail or asserts the wrong thing); docs that tell a reader to do something that does not work; `claimed-fix` — the PR does not fix what the ticket says it fixes.
+- `VERIFICATION_CONCERN` — **Important.** New user-facing surface with no docs; a comment the diff left false. A missing test is never CONCERN — put it in Suggestions.
 - `VERIFICATION_SOUND` — evidence is credible.
 
 ## Output
@@ -108,6 +114,8 @@ After the required proof-of-work lines, return:
 **Findings:**
 
 - **<file:line>** — [test|ticket|comment|docs] <evidence and concrete fix>
+  NET-NEW: <base <path>:<line> — what base did | no base file | widens <path>:<line> | claimed-fix>
+  TRIGGER: <entry point → input → user-visible failure>
 
 **Suggestions:** <non-blocking coverage or wording ideas; or `none`>
 ```

--- a/.claude/agents/verification-reviewer.md
+++ b/.claude/agents/verification-reviewer.md
@@ -75,8 +75,8 @@ This applies to `VERIFICATION_SOUND` exactly as it applies to a finding, and mat
 - Do not demand academic coverage or more comments. Missing tests are Suggestions — including a missing regression test for the behavior this PR changed. Only false coverage (a test that cannot fail, or asserts the wrong thing) is a finding, and it is Critical.
 - Docs that do not work for a reader are Critical, not a wording note. Voice/rhythm/positioning asks stay Suggestions even when the style guide names them.
 - Ground docs findings in a changed behavior plus a named stale page, or a committed rule plus file/line.
-- Every Critical/Important finding must pass the charter's **admission test**: a `NET-NEW:` line with quoted base evidence (or `no base file` / `widens` / `claimed-fix`) and a `TRIGGER:` line naming a reachable entry point → input → user-visible failure. A defect that reproduces unchanged at `--ref base`, or that needs a state no supported workflow produces, is a one-line Suggestion — not a finding. Rarity is fine; unreachability is not. Findings missing either line are demoted by the caller.
-- Pre-existing gaps are the dominant false positive here: an untested helper the PR merely calls, a stale doc page the diff did not affect, a comment the diff did not touch. Those are `pre-existing:` Suggestions.
+- Every Critical/Important finding must pass the charter's **admission test**: a `NET-NEW:` line with quoted base evidence (or `no base file` / `widens` / `claimed-fix`) and a `TRIGGER:` line naming a reachable entry point → input → user-visible failure. A defect that reproduces unchanged at `--ref base` is not a finding against this PR, but it is still reported — emit it as a `PRE-EXISTING:` line (see below) so the maintainer can file a follow-up. A defect that needs a state no supported workflow produces is a one-line Suggestion. Rarity is fine; unreachability is not. Findings missing either line are demoted by the caller.
+- Pre-existing gaps are the dominant false positive here: an untested helper the PR merely calls, a stale doc page the diff did not affect, a comment the diff did not touch. Those go under **Pre-existing**, not Findings — reported, never blocking.
 - Never quote non-public ticket content in the report. It reaches a public draft.
 - Run a test mutation only when static mapping cannot establish whether the test exercises the changed behavior.
 - If no concern exists, return `VERIFICATION_SOUND` and state what tests, comments, ticket claims, and docs surfaces were checked.
@@ -116,6 +116,10 @@ After the required proof-of-work lines, return:
 - **<file:line>** — [test|ticket|comment|docs] <evidence and concrete fix>
   NET-NEW: <base <path>:<line> — what base did | no base file | widens <path>:<line> | claimed-fix>
   TRIGGER: <entry point → input → user-visible failure>
+
+**Pre-existing:** <one line per defect that reproduces unchanged at base; or `none`>
+
+- **<file:line>** — <defect>. Present at base <path>:<line>.
 
 **Suggestions:** <non-blocking coverage or wording ideas; or `none`>
 ```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,11 @@
   "env": {
     "BASH_MAX_TIMEOUT_MS": "1800000"
   },
+  "sandbox": {
+    "filesystem": {
+      "allowWrite": ["~/.nx-pr-reviews", "~/.nx-sandboxes"]
+    }
+  },
   "extraKnownMarketplaces": {
     "nx-claude-plugins": {
       "source": {
@@ -41,7 +46,6 @@
     }
   },
   "enabledPlugins": {
-    "nx@nx-claude-plugins": true,
-    "pr-review-toolkit@claude-plugins-official": true
+    "nx@nx-claude-plugins": true
   }
 }

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: grill-me
+description: Grill the user relentlessly about a plan, design, decision, or set of review findings — working the decision tree in rounds until nothing is left silently assumed. Use when the user wants to stress-test their thinking, says "grill me", or when another skill (for example /review-pr) delegates its evaluation pass here.
+allowed-tools: Read, Grep, Glob, Bash(git -C *), Bash(git log *), Bash(git diff *), Bash(git show *), Bash(gh pr view *), Bash(gh issue view *), Agent, AskUserQuestion, Edit(*), Write(*)
+---
+
+Interview the user relentlessly until you reach a shared understanding. Map the subject as a **design tree**: every decision branches into the decisions that hang off it.
+
+Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled — the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round.
+
+Format each question like so:
+
+```
+❓ **Q1** - **<question title>**: <question body, may be several paragraphs, including any choices>
+
+➡️ <your recommended answer>
+```
+
+Each round of answers reshapes the tree — settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a _later_ round, not this one.
+
+Finding _facts_ is your job, never the user's. When a frontier question needs a fact from the environment, dispatch a sub-agent to find it — never ask the user for something you could look up. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait: ask the rest of the frontier now. The _decisions_ are the user's — put each to them and wait.
+
+The session is done when the frontier is empty: every branch visited, nothing left silently assumed. Do not act on the outcome until the user confirms you have reached shared understanding.
+
+## Two rules that hold regardless of caller
+
+- **Never answer your own questions.** If a round goes unanswered, stop and leave the subject exactly as it was. A grill that supplies the user's answers manufactures agreement that was never given, and every downstream step that trusts the result inherits the fabrication. Silence means stop, not proceed with the obvious answer.
+- **Skip what is already settled.** A question the caller's own material answers is noise. The point is resolving genuine uncertainty, not walking a checklist.
+
+## When a caller delegates a set of findings
+
+Review findings are mostly independent of each other, so the tree is shallow and wide rather than deep. Round it anyway — the dependencies are real, they just sit between _tiers_ rather than between individual items:
+
+1. **Round 1 — the blocking findings.** They gate the verdict, and they are independent of one another, so the whole tier is one frontier.
+2. **Round 2 — the rest, plus what round 1 unblocked.** Dropping one finding as pre-existing usually implicates its siblings in the same file or pattern; those questions could not be asked until round 1 landed.
+3. **Round 3 — the consequences.** The verdict that follows from what survived, and anything the user's reasoning generalized into a standing rule.
+
+Apply each round's answers before asking the next, rather than collecting everything and acting at the end — the user should be able to stop after any round and keep the value of what is already decided.
+
+---
+
+The round/frontier method above is adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (`skills/productivity/grilling`), MIT-licensed, © 2026 Matt Pocock.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -39,6 +39,8 @@ Review findings are mostly independent of each other, so the tree is shallow and
 
 Apply each round's answers before asking the next, rather than collecting everything and acting at the end — the user should be able to stop after any round and keep the value of what is already decided.
 
+**Close by briefing again.** When the frontier is empty, re-render the opening inventory against the post-grill state, showing what moved — dropped, re-tiered, kept — and ask whether it matches what the user decided. Answers are given one round at a time against one item at a time, so nobody tracks the cumulative effect in their head, and the material has been mutating the whole way. This is a confirmation, not another round: do not reopen a settled item or raise something the grill never asked about. If the user's reply opens something genuinely new, that is a new round — grill it properly.
+
 ---
 
 The round/frontier method above is adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (`skills/productivity/grilling`), MIT-licensed, © 2026 Matt Pocock.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -29,6 +29,8 @@ The session is done when the frontier is empty: every branch visited, nothing le
 
 ## When a caller delegates a set of findings
 
+**Brief the user before the first question.** Unlike a plan they wrote themselves, findings arrive from agents the user has not read — so state, up front, what was reviewed and the one-line inventory of findings by tier. Then have every question restate the finding it is about, inline, rather than referring to it by number. A question about a defect the user has never seen is unanswerable, and rule one below turns an unanswered question into a full stop — so opening cold does not make the grill cautious, it makes it produce nothing.
+
 Review findings are mostly independent of each other, so the tree is shallow and wide rather than deep. Round it anyway — the dependencies are real, they just sit between _tiers_ rather than between individual items:
 
 1. **Round 1 — the blocking findings.** They gate the verdict, and they are independent of one another, so the whole tier is one frontier.

--- a/.claude/skills/review-local-branch/SKILL.md
+++ b/.claude/skills/review-local-branch/SKILL.md
@@ -125,6 +125,11 @@ Report **critical** and **important** findings, plus **strengths**. Concrete, ac
 nice-to-haves may go in a terse **Suggestions** list. When you endorse a debatable design decision,
 say so in a **Maintainer calls** line rather than folding it into an endorsement.
 
+A defect that reproduces unchanged at `--ref base` does not block this branch, but report it under
+**Pre-existing** — one line per defect, no cap, naming the base line that proves it predates the
+work. That list is what follow-up tickets get filed from; dropping it loses work nobody else is
+positioned to redo.
+
 Your own definition carries the calibrations that bind your dimension, and the proof-of-work
 contract. Both still apply.
 ```
@@ -207,7 +212,7 @@ verdict: <clean|concerns|failed>
 
 `dirty: true` matters on re-review: unlike a PR head SHA, a dirty tree has no stable identity, so a draft against one can never be deduped. Always re-review a dirty branch rather than reporting `ALREADY_REVIEWED`.
 
-Sections: `## Summary`, `## Critical`, `## Important`, `## Strengths`, `## Suggestions`, `## Maintainer calls`, `## Not reviewed` (untracked files), `## Failures` (agents whose EVIDENCE never verified).
+Sections: `## Summary`, `## Critical`, `## Important`, `## Maintainer calls`, `## Suggestions`, `## Pre-existing` (defects that reproduce at base — follow-up material, never blocking; omit when empty), `## Strengths`, `## Not reviewed` (untracked files), `## Failures` (agents whose EVIDENCE never verified).
 
 ## Step 7: Clean up, then offer the rest
 

--- a/.claude/skills/review-pending-pr-reviews/SKILL.md
+++ b/.claude/skills/review-pending-pr-reviews/SKILL.md
@@ -121,6 +121,29 @@ Apply each round's answers before asking the next — drop, re-tier, or keep —
 `/review-pr` Step 7's rule: **only Critical blocks**, at any quantity. Dropping the last Critical
 moves a PR from `needs-changes` to `lgtm`.
 
+**When the frontier is empty, brief again** — the same inventory the grill opened with, re-rendered
+against the post-grill draft, showing what moved rather than only where it landed:
+
+```text
+Grill complete — PR #<N>
+
+Verdict: <before> → <after>          (or "unchanged: <verdict>")
+
+Dropped (<n>)
+  <file:line> — <claim, one clause> — <the maintainer's reason, in their words>
+Re-tiered (<n>)
+  <file:line> — <claim, one clause> — critical→important: <reason>
+Kept (<n>)
+  <file:line> — <claim, one clause>
+```
+
+The maintainer answered one round at a time, against one finding at a time; nobody holds the
+cumulative effect of six answers in their head. Ask whether it matches what they decided, and fix it
+here if not — this is the last point before Step 4 offers to post it to a public PR.
+
+**This is a confirmation, not another round.** Do not reopen a settled finding or raise a concern the
+grill did not. If the maintainer's reply opens something genuinely new, grill it as a new round.
+
 Record every drop and re-tier under `## Grill` in the draft file, one line each:
 
 ```markdown

--- a/.claude/skills/review-pending-pr-reviews/SKILL.md
+++ b/.claude/skills/review-pending-pr-reviews/SKILL.md
@@ -67,6 +67,32 @@ Flag before the action prompt:
 entirely when the draft's frontmatter shows a `## Grill` section already — `/review-pr` Step 8.5
 grilled it interactively and re-grilling wastes the maintainer's time. Say so and go to Step 4.
 
+**Brief the maintainer before the first question — it is not optional, and it matters more here than
+in `/review-pr`.** That skill's grill follows a review the maintainer just watched run; this one
+opens on a draft a cron produced days ago, about a PR they have likely never opened. Asking "does
+this hold?" cold makes the question unanswerable, and silence is defined below as _stop_ — so a cold
+grill yields no evaluation at all, on the very drafts this skill calls the real gate.
+
+```text
+PR #<N>: <title> — <author>, <age>, reviewed <date> at <head_sha>
+<one or two sentences: what the PR actually changes, in plain terms>
+
+Draft verdict: <verdict> — <what drives it>
+
+Critical (<n>) — these gate the verdict
+  1. <file:line> — <the claim in one clause>
+
+Important (<n>)
+  2. <file:line> — <the claim in one clause>
+
+Pre-existing (<n>), Suggestions (<n>) — not grilled, listed so you know they exist
+```
+
+One line per finding. The detail arrives with the question that needs it, and every question
+restates its own finding inline — the claim, its `NET-NEW` line, its `TRIGGER` line, and one sentence
+on what specifically is uncertain about it. Never refer to a finding by number alone, and never make
+the maintainer open the draft to answer.
+
 Invoke `/grill-me`, scoped to findings rather than to a plan. It works in **rounds over a frontier** —
 round 1 is every Critical finding, round 2 is Important plus whatever round 1 unblocked, round 3 is
 the consequences. Skip Suggestions; they never move the verdict.

--- a/.claude/skills/review-pending-pr-reviews/SKILL.md
+++ b/.claude/skills/review-pending-pr-reviews/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: review-pending-pr-reviews
+description: Review, grill, edit, and post pending PR review drafts saved by /review-pr (or its batch/cron runners). Lists drafts that have not yet been posted, walks the maintainer through each finding, then posts, closes, or discards. Use when the user says "post my pending reviews", "what reviews are waiting", "go through the review outbox", or invokes /review-pending-pr-reviews.
+allowed-tools: Bash(gh pr review *), Bash(gh pr view *), Bash(gh pr comment *), Bash(gh pr close *), Bash(ls ~/.nx-pr-reviews*), Bash(ls $TRIAGE_DIR*), Bash(git -C ~/.nx-pr-reviews *), Bash(git -C $TRIAGE_DIR *), Bash(open *), Bash(cat > /tmp/gh-pr-review*), Bash(cat > /tmp/gh-pr-close*), Read, Edit(~/.nx-pr-reviews/*), Write(~/.nx-pr-reviews/*), Write(/tmp/gh-pr-review*), Write(/tmp/gh-pr-close*), Grep, Glob, Skill
+---
+
+# Review Pending PR Reviews
+
+The outbox for `/review-pr`. Nothing reaches GitHub until the maintainer approves it here.
+
+This skill is where a **human is guaranteed to be present**. `/review-pr` runs headless most of the
+time — `review-prs` drives it across tmux panes, and a cron runs it overnight — so its own Step 8.5
+grill is skipped on the majority of reviews. This skill is therefore the real evaluation gate: it
+grills the findings first (Step 3) and only then offers to post.
+
+## Configuration
+
+- `TRIAGE_DIR` — where drafts live. Default: **`~/.nx-pr-reviews`**, matching `/review-pr`'s own
+  default. Override with the same value if the maintainer has repointed it.
+
+**Do not read `~/.claude/triage/prs/`.** That is the store of the retired `review-pr-deep` pipeline.
+Its drafts predate the current review criteria (pre-`PIPELINE_VERSION` tiers), so posting one would
+publish findings the current calibrations would have dropped. If the maintainer wants those, they
+must be re-reviewed by `/review-pr`, not posted from the old store.
+
+Each draft has YAML frontmatter (`pr`, `verdict`, `head_sha`, `pipeline_version`, `posted_at`, ...)
+and a `## Review draft` section holding the body that will be posted.
+
+A draft is **pending** iff `posted_at:` is empty. Once posted or discarded, `posted_at` is set and
+the file is kept as the historical record — it feeds `/review-pr`'s re-review dedup, so never delete
+one.
+
+## 1. Find pending drafts
+
+```bash
+ls $TRIAGE_DIR
+```
+
+Read each file's frontmatter; pending iff `posted_at:` is empty. Sort oldest-first by
+`last_reviewed_at` so the longest-waiting review goes first.
+
+For each, display: PR number and title, `verdict`, `attempt`, `last_reviewed_at`, URL, and the first
+3 lines of `## Review draft`.
+
+## 2. Check for drift before presenting
+
+```bash
+gh pr view PR_NUMBER --repo nrwl/nx --json headRefOid,state,isDraft -q '{head: .headRefOid, state: .state, isDraft: .isDraft}'
+```
+
+IMPORTANT: every Bash command must be a single, standalone command. Do not chain with `&&`, `||`, or
+`;`, and do not append redirects or backgrounding — these break permission matching. Use separate
+Bash calls.
+
+Flag before the action prompt:
+
+- **Stale** — current head differs from frontmatter `head_sha`. Recommend `skip` and re-running
+  `/review-pr PR_NUMBER`.
+- **Closed/merged** — `state != OPEN`. Recommend `discard`.
+- **Draft PR** — `isDraft == true`. The maintainer may not want to post yet.
+- **Old pipeline** — `pipeline_version` is missing or below `/review-pr`'s current constant. The
+  draft was produced by weaker criteria. Recommend `skip` + re-review rather than posting.
+
+## 3. Grill the findings before offering to post
+
+**Do this before showing the action prompt, and only for drafts that survived Step 2.** Skip it
+entirely when the draft's frontmatter shows a `## Grill` section already — `/review-pr` Step 8.5
+grilled it interactively and re-grilling wastes the maintainer's time. Say so and go to Step 4.
+
+Invoke `/grill-me`, scoped to findings rather than to a plan. It works in **rounds over a frontier** —
+round 1 is every Critical finding, round 2 is Important plus whatever round 1 unblocked, round 3 is
+the consequences. Skip Suggestions; they never move the verdict.
+
+For each finding, state your recommendation up front, then ask the three questions the tiers turn on:
+
+1. **Does it hold?** Is the defect real as described, not merely plausible?
+2. **Is it this PR's?** Does the `NET-NEW` line's base evidence support it, or is it pre-existing /
+   `widens`?
+3. **Is the tier right?** Critical = something the PR produces is wrong _now_. Important = wrong
+   _later_, or left unguarded.
+
+Skip any question the draft already answers. The goal is resolving genuine uncertainty, not making
+the maintainer re-read their own review.
+
+**Never answer your own questions.** If a question goes unanswered, stop and leave the draft exactly
+as it is. A grill that supplies the maintainer's answers launders agent output into apparent human
+review — which is precisely what this skill exists to prevent.
+
+**The sandbox is long gone by now.** Unlike `/review-pr` Step 8.5, this skill cannot re-read
+`--ref base` to settle a factual dispute — the checkout was destroyed when that review finished. If a
+round turns on a fact rather than a judgment, say so and recommend `skip` + a fresh `/review-pr` run
+rather than guessing. Do not drop a finding on an unverified hunch.
+
+Apply each round's answers before asking the next — drop, re-tier, or keep — then **recompute the verdict** with
+`/review-pr` Step 7's rule: **only Critical blocks**, at any quantity. Dropping the last Critical
+moves a PR from `needs-changes` to `lgtm`.
+
+Record every drop and re-tier under `## Grill` in the draft file, one line each:
+
+```markdown
+## Grill
+
+- <file:line> — <finding, one clause> — DROPPED: <maintainer's reason, in their words>
+- <file:line> — <finding, one clause> — RETIERED critical→important: <reason>
+```
+
+That section is the tuning data for `/review-pr`'s criteria. A reason that recurs across PRs is a
+missing calibration — add it to that skill's "Nx-specific calibration" list instead of re-litigating
+it every review.
+
+## 4. Present for review
+
+Open the PR alongside the draft:
+
+```bash
+gh pr view PR_NUMBER --repo nrwl/nx --web
+```
+
+```
+## Pending PR Review: #PR_NUMBER — TITLE
+**Verdict:** needs-changes          ← post-grill verdict; note it if the grill changed it
+**Attempt:** 1
+**HEAD:** 438fa5a1 (stored) — 438fa5a1 (current)  ← or ⚠ DRIFT if different
+**State:** OPEN (draft)
+**Reviewed:** 2026-04-24
+
+### Summary
+<First Summary paragraph from the Review draft — 2-5 lines.>
+
+### Counts
+Critical: N · Important: N · Suggestions: N        (after the grill)
+Dropped in grill: N
+
+---
+<first ~15 lines of the Review draft>
+... (full body is in $TRIAGE_DIR/PR_NUMBER.md)
+---
+
+Actions: [post] [edit] [skip] [discard] [open-file]
+```
+
+**If `verdict: superseded`** — posting a review on a dead PR is noise. The draft already names the
+superseding PR in its `### Close-without-merge check` section.
+
+```
+Actions: [close-with-pointer] [edit] [skip] [discard] [open-file]
+```
+
+**If `verdict: unnecessary`** — the PR shouldn't merge but there's no specific replacement to point
+at (no real bug / abandoned / duplicate of rejected work).
+
+```
+Actions: [close-with-reason] [edit] [skip] [discard] [open-file]
+```
+
+Wait for the maintainer to choose an action for each draft.
+
+## 5. Actions
+
+- **post** — Post to GitHub. Extract ONLY the `## Review draft` body (from the first `###` under it
+  through the last line before `## Prior reviews`); never the frontmatter, `## Grill`, or trailing
+  sections.
+
+  Verdict → `gh pr review` flag:
+  - `lgtm` / `approve` → `--approve`
+  - `needs-changes` → `--request-changes`
+  - `blocked` / `comment` / anything else → `--comment`
+  - `superseded` / `unnecessary` do NOT use `post` — see the close flows below.
+
+  Always use `--body-file` to avoid shell quoting issues:
+
+  ```bash
+  cat > /tmp/gh-pr-review-PR_NUMBER.md << 'REVIEW_EOF'
+  REVIEW_BODY
+  REVIEW_EOF
+  ```
+
+  ```bash
+  gh pr review PR_NUMBER --repo nrwl/nx --request-changes --body-file /tmp/gh-pr-review-PR_NUMBER.md
+  ```
+
+  Then update frontmatter with Edit: `posted_at: <ISO-8601 local timestamp>`, `posted_url: <URL>`.
+  Append to `## Posted`: `- attempt N posted YYYY-MM-DD as <verdict> → <posted_url>`. Commit
+  (see below). Never delete the file.
+
+- **close-with-pointer** (only for `superseded`) — Close with a short comment pointing at the
+  superseding work. Do NOT post a review.
+  1. Extract the superseding PR number(s) from `### Close-without-merge check`. Prompt if unclear.
+  2. Draft a short comment, let the maintainer edit before posting:
+     ```
+     Thanks for the PR! This has been superseded by #<SUPERSEDING_PR>, which <one-line reason>. Closing this one — appreciate the work.
+     ```
+  3. `gh pr comment` with `--body-file`.
+  4. `gh pr close <NUMBER> --repo nrwl/nx`.
+  5. Frontmatter: `posted_at: <timestamp> (closed as superseded)`, `posted_url: <comment URL>`.
+  6. `## Posted`: `- attempt N closed-as-superseded YYYY-MM-DD → <comment_url>`. Commit.
+
+- **close-with-reason** (only for `unnecessary`) — Close with a short comment explaining why, with no
+  specific replacement. Do NOT post a review.
+  1. Extract the reason and evidence from `### Close-without-merge check` (which signals fired,
+     linked issue with no thumbs-up, last activity date, prior closed PR number).
+  2. Draft a short, kind comment tailored to the reason. **Always** show it for edit before posting —
+     these need a human touch. Templates by primary reason:
+     - **Bug not reproduced:**
+       ```
+       Thanks for the PR! Before reviewing in depth, we tried to reproduce the issue from #<ISSUE> on master and weren't able to — the behavior described doesn't appear to be a bug we can confirm. Could you share a minimal repro repo so we can verify there's something to fix here? In the meantime I'm closing this; happy to reopen once we can confirm the underlying issue. Appreciate the contribution.
+       ```
+     - **Abandoned (stale + conflicted + unanswered):**
+       ```
+       Thanks for the PR! This branch has been inactive for <N> months and now has merge conflicts plus open reviewer questions. Closing for now to keep the queue tidy — please feel free to reopen with a rebase and answers to the prior review when you're able. Appreciate the work.
+       ```
+     - **Duplicate of recently-closed PR:**
+       ```
+       Thanks for the PR! This looks similar in scope to #<PRIOR_CLOSED_PR>, which we closed previously — the same concerns likely apply here. Closing to avoid re-litigating; if you think the situation has changed, the best next step is a comment on #<PRIOR_CLOSED_PR> or a fresh issue laying out the new context. Appreciate the contribution.
+       ```
+     - **Other / mixed:** one paragraph pulling the strongest signal(s). Always thank the contributor.
+
+  3. Stage via `--body-file`:
+     ```bash
+     cat > /tmp/gh-pr-close-PR_NUMBER.md << 'CLOSE_EOF'
+     <comment body>
+     CLOSE_EOF
+     ```
+  4. `gh pr comment <NUMBER> --repo nrwl/nx --body-file /tmp/gh-pr-close-PR_NUMBER.md`
+  5. `gh pr close <NUMBER> --repo nrwl/nx`
+  6. Frontmatter: `posted_at: <timestamp> (closed as unnecessary)`, `posted_url: <comment URL>`.
+  7. `## Posted`: `- attempt N closed-as-unnecessary YYYY-MM-DD → <comment_url>`. Commit.
+
+  **Be cautious.** Closing without a pointer feels worse to a contributor than "superseded by". If
+  the maintainer is unsure, prefer `skip`, or fall back to `post` with `--comment` so the contributor
+  can respond before the PR is closed.
+
+- **edit** — Modify the `## Review draft` body in place via Edit, then show it again for approval.
+
+- **skip** — Leave it pending. Move on. Right answer for stale drafts and old `pipeline_version`.
+
+- **discard** — Set `posted_at: <timestamp> (discarded)`. Append to `## Posted`:
+  `- attempt N discarded YYYY-MM-DD (<reason>)`. Never delete the file. Commit.
+
+- **open-file** — `open $TRIAGE_DIR/PR_NUMBER.md`, then re-prompt for an action.
+
+- **post all** — Post every remaining pending draft, mapping each verdict to its flag. **Grill each
+  one first** (Step 3) unless it already carries a `## Grill` section — `post all` is a shortcut past
+  the action prompt, not past the evaluation. Update each file, commit once, show a summary. Skip
+  `superseded` and `unnecessary` drafts (they need per-PR comments) and list them at the end.
+
+## Commit after changes
+
+Only when `TRIAGE_DIR` is actually a git repo and the file is not ignored — same guard as
+`/review-pr` Step 10. The default `~/.nx-pr-reviews` is typically **not** a repo, in which case the
+file on disk is the record and this step is a silent no-op:
+
+```bash
+git -C $TRIAGE_DIR rev-parse --is-inside-work-tree
+```
+
+```bash
+git -C $TRIAGE_DIR add PR_NUMBER.md
+```
+
+```bash
+git -C $TRIAGE_DIR commit -m "triage: posted review for PR #PR_NUMBER"
+```
+
+Use `discarded` for discards; `triage: update pending PR reviews (posted/discarded)` for `post all`.
+
+## 6. Summary
+
+```
+## PR Review Queue Complete
+- Posted: X reviews
+- Skipped: X drafts (still pending)
+- Discarded: X drafts
+- Findings dropped in grill: X across Y drafts
+- Remaining: X drafts in $TRIAGE_DIR
+```
+
+## Empty queue
+
+If every file has a non-empty `posted_at`: **"No pending PR reviews to post. The outbox is empty."**

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -41,6 +41,7 @@ Consequences that the rest of this skill depends on:
 - `SANDBOX_IMAGE` — the toolchain image the checkout runs in. Default: `nx-review-sandbox:latest` (built by the `setup-review-sandbox` skill). Claude runs on the host, not in this image.
 - `SANDBOX` — the sandbox id, returned by `sandbox start` in Step 3. There is no default and no name to guess: it is minted per run.
 - `TRIAGE_DIR` — where drafts live. Default: `~/.nx-pr-reviews` (outside the repo — so `git clean` never touches drafts and re-review history survives — and outside `~/.claude`, so the skill never writes into Claude Code's own config dir)
+- `REVIEW_NONINTERACTIVE` — set by headless callers (`review-prs`, the review cron) to skip Step 8.5's grill. Unset in a normal session. Default: unset.
 - `NX_REPO_PATH` — path to the local clone of nrwl/nx this skill ships inside. Default: `git rev-parse --show-toplevel`. Used **only** by the Step 4.5 close-signal checks, which may run before the sandbox exists, and always with a fresh `git fetch` first. It is never used for the PR checkout and is never passed to an agent — agents read base state with `sandbox read --ref base`, which is fetched fresh every run and cannot be stale.
 
 ## Step 1: Pre-flight
@@ -522,7 +523,7 @@ once, deliberately, before the first `Agent` call.
    SHA. If prior needs its own worktree, fetch it into `/work/repo.git`, add a uniquely named
    the prior SHA, then run `sandbox worktree "$SANDBOX" orchestrator-prior base`; it
    runs both required setup commands before returning. A number without its baseline cannot answer
-   "is this net-new?", which is calibration 7's question.
+   "is this net-new?", which is the admission test's first question.
 5. **Measure the corollaries each dimension will ask for, not just the headline conclusion.** This is
    what decides whether the step actually suppresses duplication. An agent whose own question sits
    one hop from your conclusion will rebuild the whole harness to answer that hop, and the
@@ -687,6 +688,110 @@ installed, an extracted tarball, a `/snap` snapshot.>
 Report **critical** and **important** findings, plus **strengths**. Concrete,
 actionable nice-to-haves (a rename, a restructure, a missing cross-link) may go
 in a terse **Suggestions** list — one line each; vague polish will be discarded.
+
+### The two tiers
+
+    Critical   — something this PR produces is WRONG, now.
+    Important  — nothing is wrong now, but the PR leaves something that
+                 will be wrong later, or unguarded against becoming wrong.
+
+Severity is **what happens to an affected user, never how many are affected.**
+Windows-only, large-workspaces-only, one-rare-flag-only — name the condition in
+the TRIGGER line and keep the tier. A Windows user hitting wrong output is
+fully broken, and Windows is a supported platform, not an edge case.
+
+**Critical** — any of:
+
+1. **Wrong output, data loss, or a crash** on a supported path.
+2. **A wrong or misleading error message.** Nx is a CLI: what it prints IS what
+   it produces. A message that routes someone to the wrong cause is wrong
+   output, not a wording problem.
+3. **Docs that tell a reader to do something that does not work.** Same
+   argument — a page is a product surface.
+4. **False coverage** — a test that cannot fail, or asserts the wrong thing.
+   Worse than no test: it certifies the bug as fixed and survives refactors.
+5. **An exploitable source-to-sink path** on a default configuration.
+6. **A breaking change** to a public API, generator schema, or executor option
+   with no migration.
+7. **`claimed-fix`** — the PR does not fix what it says it fixes. The finding is
+   not the bug; it is that merging _closes the issue_, so the bug becomes
+   invisible and untracked.
+
+There is no bounded version of wrong. If something the PR produces is wrong on a
+reachable path, it is Critical — do not soften it because the path is narrow.
+
+**Important** — any of:
+
+1. **`widens`** — a real defect that predates the PR, whose reach the diff
+   extends. Important because the author did not cause it, not because the harm
+   is smaller. Holding a PR for a bug it did not write is contributor-hostile;
+   the root-cause fix belongs in its own PR.
+2. **New user-facing surface with no docs** — a flag or option that works but is
+   undiscoverable.
+3. **A comment the diff left false.** The misleading-error argument aimed at the
+   next maintainer instead of the user.
+4. **A measurable, non-cliff performance regression.** A hang or a scaling cliff
+   is Critical; slower is Important.
+
+**Missing tests are never a finding — Suggestions at most, including for the
+behavior this PR changed.** Absence of a test is not a defect; a test that lies
+is (Critical #4). Ask for the regression test in a one-line Suggestion and let
+the maintainer decide whether to hold the PR for it.
+
+Important still requires a **named mechanism** — the undocumented flag, the
+comment that is now false, the number that regressed. "This feels risky" is
+not an Important finding; it is not a finding.
+
+**Widening that changes the KIND of harm is not `widens` — it is Critical.** If a
+path that only ever saw internal values now takes user config, or a removed guard
+makes an unreachable branch reachable, the buggy line is unchanged but the harm
+is new. File it as a new defect and put the base evidence on the _reachability_,
+not on the bug.
+
+### Admission test (every Critical/Important finding)
+
+Two failure modes dominate this pipeline's false positives: defects that were
+already there before the PR, and defects nothing a real user does can reach.
+Both read as legitimate findings, because both describe real code. So every
+Critical/Important finding MUST carry these two lines, immediately under it:
+
+    NET-NEW: <base evidence — see below>
+    TRIGGER: <entry point → input → user-visible failure>
+
+**NET-NEW** must be one of:
+
+- `base <path>:<line> — <what the base did instead>` — you read the base file
+  and the behavior differs. Quote it; a bare assertion is not evidence.
+- `no base file` — the file is added by this PR.
+- `widens <path>:<line>` — the defect predates the PR but the diff materially
+  extends it (new call site, new caller passing untrusted input, a guard
+  removed). Say what the diff changed about its reach.
+- `claimed-fix` — the PR's stated purpose is to fix this exact behavior and it
+  does not. Name the ticket/PR-body claim.
+
+If the same defect reproduces unchanged at `--ref base`, it is **pre-existing**
+and it is not a finding. At most one Suggestions line prefixed `pre-existing:`.
+The reviewer is deciding whether to merge _this diff_, not whether the file is
+perfect. "The PR touched this function, so its old bugs are in scope" is the
+specific mistake — touching a function does not adopt it.
+
+**TRIGGER** must name a path a supported Nx workflow actually reaches: the
+command or public API entry point, the input/config that gets there, and what
+the user sees fail. Not a finding at Critical/Important if reaching it needs a
+state the codebase never produces — an argument no caller passes, an env var no
+supported flow sets, a dependency version outside the supported range, a
+hand-edited internal file, or a `null` that every call site already excludes.
+"A future caller might" is not a trigger; neither is "in theory". Demote those
+to Suggestions, one line, and say what the unreachable precondition is.
+
+Rarity is not the same as unreachability. A path a real user hits only on
+Windows, only in a monorepo above some size, or only with a rarely-used flag
+IS a trigger — name the condition. Cut the ones nothing reaches, not the ones
+few people reach.
+
+Both lines are checked by the caller at trim time. A Critical/Important finding
+that omits either, or whose NET-NEW cites no base evidence, is demoted to
+Suggestions — so a real defect written up without them loses its weight.
 When you endorse a debatable design decision (fail-open vs fail-closed,
 normalization, escape hatches, compat trade-offs), say so explicitly in a
 **Maintainer calls** line rather than folding it into an endorsement.
@@ -874,7 +979,8 @@ Aggregate the surviving agents' output into Critical / Important / Strengths you
 
 "Keep in full" is the load-bearing half of that paragraph, and it is the half this step actually fails. Four rules make it enforceable:
 
-- **Never re-tier an agent's finding downward on your own judgment.** The only sanctioned downgrade is a named calibration from the list below; when you apply one, say which calibration and why in the draft. "It feels minor", "that's just style", "the fix is one character" are not calibrations. An agent that filed something as a finding did so against a rule it was required to name. You are re-checking it against the calibrations, not re-scoring it by taste, and you are not the tier the agent's contract already assigned.
+- **Enforce the admission test first.** Before anything else, check every Critical/Important finding for its `NET-NEW` and `TRIGGER` lines. Missing either, or a `NET-NEW` that asserts novelty without quoting base evidence ⇒ demote to Suggestions and record one line in `## Failures` naming the agent and the finding. Do not repair it for them by reading `--ref base` yourself — an agent that filed a finding without checking the base did not establish the defect is the PR's, and confirming it here converts your read into their evidence. The one exception: a `widens` or `claimed-fix` NET-NEW that names the base line but reads thin — verify that one in the sandbox and keep it if it holds. This gate is what stops pre-existing and unreachable findings from reaching the maintainer, and it is the only downgrade you perform without a numbered calibration.
+- **Never re-tier an agent's finding downward on your own judgment.** Apart from the admission-test gate above, the only sanctioned downgrade is a named calibration from the list below; when you apply one, say which calibration and why in the draft. "It feels minor", "that's just style", "the fix is one character" are not calibrations. An agent that filed something as a finding did so against a rule it was required to name. You are re-checking it against the calibrations, not re-scoring it by taste, and you are not the tier the agent's contract already assigned.
 - **Severity comes from the rule violated, not the size of the fix.** A one-character punctuation change that breaks a committed `STYLE_GUIDE.md` rule vale has no rule for is Important. A three-paragraph rewrite that violates nothing is a Suggestion. Judging by surface form is the specific way this step goes wrong: docs, comment, and naming findings all have tiny diffs, so they read as polish and get swept into a tier that cannot move the verdict.
 - **The 5-bullet cap binds the Suggestions tier only.** It is never a reason to move anything out of Critical or Important, and it never licenses a silent merge or drop. If you cut to the cap, name in one line what you cut and why. A reader must never mistake a trimmed list for a complete one.
 - **Reconcile per reviewer before writing the draft.** Preserve every Critical/Important finding, or record the named calibration that downgraded it in `## Failures`.
@@ -897,14 +1003,15 @@ This direction check is yours at trim time. Documentation coverage, committed do
 
 These standing maintainer calibrations encode this repo's review culture. The charter (Step 5) hands them to the agents up front; re-check the surviving findings against them here — anything that slipped through gets downgraded now. A finding matching one of these is at most a compact one-line advisory note in the draft and **never drives the verdict**:
 
-1. **Coverage gaps are advisory.** Missing branches/fixtures never block alone; false coverage (wrong assertion or a test that cannot fail) is a defect.
+1. **Coverage gaps are advisory.** Missing branches, fixtures, and a missing regression test for the changed behavior itself are all Suggestions — they never block. False coverage — a wrong assertion, or a test that cannot fail — is Critical.
 2. Do not demand tests for deprecation warnings, legacy paths, telemetry wiring, or never-throw wrappers; testable logic inside them remains in scope.
 3. Migration silence and retained dependencies are intentional. Flag only silent correctness failures; users may still import a dependency.
 4. `migrations.json` is already inside the migration trust boundary. Flag it only when data crosses a new boundary (for example HTTP or runtime input).
 5. `nx migrate` and `nx release` temp directories are intentional post-mortem artifacts, not leaks.
-6. An Important finding must be net-new versus base/sibling behavior. Deliberate behavior backed by tests and documentation is a callout, not a blocker.
+6. Critical/Important findings must pass the charter's **admission test** — a NET-NEW line with base evidence and a TRIGGER line naming a reachable path. Pre-existing behavior the diff merely touches, and paths no supported workflow reaches, are Suggestions at most. Deliberate behavior backed by tests and documentation is a callout, not a blocker.
 7. Do not demand scattered defensive guards when the invariant can be fixed at its source.
 8. Comment-volume asks are Suggestions. Inaccurate/stale comments and required `@deprecated` / `TODO(vNN)` markers remain blocking.
+9. **Severity ignores population size.** Rarity never demotes a finding; unreachability disqualifies it. Windows-only, large-workspace-only, and rare-flag defects keep their tier — name the condition in TRIGGER. Windows is a supported platform, not an edge case.
 
 ## Step 5a: Run the alternative-approach agent
 
@@ -1220,12 +1327,19 @@ Check in this order (first match wins):
 - **Any reviewer recorded as failed** (EVIDENCE line unverifiable after a retry, or the reviewer errored) → `verdict: failed`. This outranks everything below: a review missing a standing dimension is not clean. Name failed reviewers in `## Failures`.
 - Close-without-merge check emitted "Likely superseded" with strong evidence (see Step 4.5) → `verdict: superseded`
 - Close-without-merge check emitted "Likely unnecessary" with strong evidence (see Step 4.5) → `verdict: unnecessary`
-- Has any **Still concerning** or **New concerns** items rated critical → `verdict: needs-changes`
-- Has 3+ items across Still concerning + New concerns → `verdict: needs-changes`
+- Has any **Still concerning** or **New concerns** items rated **critical** → `verdict: needs-changes`
 - Couldn't reach a clear conclusion → `verdict: blocked`
 - Otherwise → `verdict: lgtm`
 
-(For first reviews with no prior context, fall back to the toolkit's Critical/Important categories.)
+(For first reviews with no prior context, fall back to the Critical/Important categories.)
+
+**Only Critical blocks.** There is deliberately no count threshold: Important and
+Suggestions never drive the verdict at any quantity. The old "3+ items" rule was a proxy
+for "lots of noise probably means something is wrong" — it was tuned against an Important
+tier that had no definition, and it let three bounded observations block a PR nobody would
+actually hold. The admission test now does that job at the source. A PR with eight
+Important findings and no Critical is `lgtm` with a long list of follow-ups, which is the
+honest answer.
 
 **Verdict values:** `lgtm | needs-changes | blocked | superseded | unnecessary | failed`.
 
@@ -1286,6 +1400,12 @@ HEAD: `<HEAD_SHA_SHORT>` · base: `<BASE_REF>`
 de-identified — this file is host-side, so embargoed context may be named here, and
 must not be copied into the posted body)
 
+## Grill
+
+(omit until Step 8.5 — or `/review-pending-pr-reviews` — walks the maintainer through the
+findings. One line per drop or re-tier, in the maintainer's own words. Its presence is what
+tells the outbox skill this draft has already been evaluated by a human.)
+
 ## Posted
 
 (none yet, or whatever was already there)
@@ -1296,6 +1416,66 @@ must not be copied into the posted body)
 ```
 
 Carry `## Author follow-ups (not for the PR)` forward verbatim on re-review, alongside `## Posted` and `## Failures` — an unanswered question stays open across attempts.
+
+## Step 8.5: Grill the maintainer on the findings (interactive sessions only)
+
+**Skip this step entirely when `$REVIEW_NONINTERACTIVE` is set** — `review-prs` and the review cron
+set it, because nobody is there to answer. Step 8 has already written the draft, so a skipped grill
+costs nothing; this step only ever _refines_ a draft that is already on disk.
+
+**It runs here, before Step 9, because the sandbox must still be alive.** The grill's central
+question — "is this actually pre-existing?" — is answered by reading `--ref base`, and Step 9
+destroys the only copy of the checkout. A grill placed after cleanup can only re-read the host diff,
+which is precisely the evidence the finding already cited. Sub-agent fact-finding depends on this
+too. The cost is that the sandbox lives for the length of the interview: if the maintainer walks
+away mid-grill, stop and run Step 9 anyway rather than leaking a multi-GB sandbox — the draft on
+disk is already valid, and `.claude/tools/sandbox prune` sweeps anything left behind.
+
+**Never answer your own questions.** If a question goes unanswered, stop and leave the draft exactly
+as written. A grill that invents the maintainer's answers is worse than no grill: it edits the draft
+on fabricated authority and launders agent output into apparent human review. Silence means stop, not
+proceed with the obvious answer.
+
+Invoke `/grill-me`, scoped to the findings rather than to a plan. It works the tree in **rounds over
+a frontier** — round 1 is every Critical finding (they gate the verdict and are independent of each
+other), round 2 is Important plus whatever round 1 unblocked, round 3 is the consequences. Each
+question carries your recommended answer.
+
+Per finding, ask the three questions the tiers actually turn on:
+
+1. **Does it hold?** Is the defect real as described — not merely plausible.
+2. **Is it this PR's?** Does the `NET-NEW` evidence support it, or is this pre-existing / `widens`?
+3. **Is the tier right?** Critical means something the PR produces is wrong now. Important means
+   wrong later, or unguarded.
+
+Skip a question the draft already answers — the point is to resolve what is genuinely uncertain, not
+to make the maintainer re-read their own review. Do not grill Suggestions; they never affect the
+verdict and are not worth the maintainer's attention.
+
+**Answer factual questions yourself, from the live sandbox.** If a round turns on whether the base
+really behaved differently, read `--ref base` — or dispatch a sub-agent to — rather than asking the
+maintainer to remember. Their answers are for _decisions_; facts are your job, and this is the last
+step where the checkout still exists to settle them.
+
+Apply each round's answers to the draft before asking the next — the maintainer should be able to
+stop after any round and keep what is already decided. Drop the finding, re-tier it, or keep it.
+Then **recompute the verdict** with Step 7's rules — dropping the last Critical moves a PR from `needs-changes` to
+`lgtm`, and that is the whole point of the step.
+
+Record every drop and re-tier under `## Grill` in the triage file, one line each:
+
+```markdown
+## Grill
+
+- <file:line> — <finding, one clause> — DROPPED: <maintainer's reason, in their words>
+- <file:line> — <finding, one clause> — RETIERED critical→important: <reason>
+```
+
+That section is the tuning data for the criteria in this skill. A reason that recurs across PRs is a
+missing calibration; add it to the "Nx-specific calibration" list rather than re-litigating it every
+review. Rewrite the frontmatter `verdict` and the `## Review draft` body if they changed, then continue to
+Step 9. Step 10's commit and the final "Returning the draft" line then carry the post-grill state,
+so nothing needs re-committing here.
 
 ## Step 9: Cleanup
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -190,8 +190,8 @@ Each agent already carries this protocol in its own definition; what follows is 
 
 ```bash
 .claude/tools/sandbox read <SANDBOX> <path> [--range a,b] [--ref base]
-.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir]
-.claude/tools/sandbox find <SANDBOX> <glob> [subdir]
+.claude/tools/sandbox grep <SANDBOX> <pattern> [subdir] [--ref base]
+.claude/tools/sandbox find <SANDBOX> <glob> [subdir] [--ref base]
 .claude/tools/sandbox exec <SANDBOX> [--base] -- <CMD>
 ```
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1520,6 +1520,40 @@ stop after any round and keep what is already decided. Drop the finding, re-tier
 Then **recompute the verdict** with Step 7's rules — dropping the last Critical moves a PR from `needs-changes` to
 `lgtm`, and that is the whole point of the step.
 
+### Brief again when the frontier is empty
+
+**The grill closes with the same briefing it opened with, re-rendered against the post-grill draft.**
+Symmetry is the point: the opening brief is what the maintainer judged _from_, so the closing brief
+is the only way they can check that what got applied is what they meant. Answers are given one round
+at a time, against one finding at a time — nobody tracks the cumulative effect of six answers in
+their head, and the draft has been silently mutating the whole way.
+
+Show what moved, not just where it landed:
+
+```text
+Grill complete — PR #<N>
+
+Verdict: <before> → <after>          (or "unchanged: <verdict>")
+
+Dropped (<n>)
+  <file:line> — <claim, one clause> — <the maintainer's reason, in their words>
+Re-tiered (<n>)
+  <file:line> — <claim, one clause> — critical→important: <reason>
+Kept (<n>)
+  <file:line> — <claim, one clause>
+
+Draft: <TRIAGE_DIR>/<N>.md
+```
+
+Then ask one closing question: does this match what they decided? A correction here is cheap and
+costs one edit; the same correction after Step 9 costs a whole re-review, because the sandbox that
+could settle it is gone.
+
+**This is a confirmation, not another round.** Do not reopen a settled finding, argue a drop, or
+introduce a concern the grill did not raise — the frontier is empty, and the closing brief has no
+license to refill it. If the maintainer's answer to the closing question opens something genuinely
+new, that is a new round: go back and grill it properly.
+
 Record every drop and re-tier under `## Grill` in the triage file, one line each:
 
 ```markdown

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1456,6 +1456,44 @@ as written. A grill that invents the maintainer's answers is worse than no grill
 on fabricated authority and launders agent output into apparent human review. Silence means stop, not
 proceed with the obvious answer.
 
+### Brief the maintainer before the first question
+
+**Print this briefing before invoking `/grill-me`. It is not optional.** The maintainer has not read
+the draft — Step 8 wrote it to disk, and nothing has shown it to them. Asking "does this finding
+hold?" about a defect they have never seen makes the question unanswerable, and the honest response
+to an unanswerable question is silence, which this step treats as _stop_. A grill that opens cold
+therefore does not produce a cautious review; it produces no review at all.
+
+```text
+Reviewed PR #<N>: <title>
+<one or two sentences: what the PR actually changes, in plain terms>
+
+Draft verdict: <verdict> — <what drives it: "1 Critical", "no Critical, 6 Important">
+Full draft: <TRIAGE_DIR>/<N>.md
+
+Critical (<n>) — these gate the verdict
+  1. <file:line> — <the claim in one clause>
+  2. …
+
+Important (<n>)
+  3. <file:line> — <the claim in one clause>
+
+Pre-existing (<n>), Suggestions (<n>) — not grilled, listed so you know they exist
+```
+
+Keep it to one line per finding; the detail arrives with the question that needs it. Some drafts run
+to hundreds of KB, and a briefing that reprints the draft is the same failure as no briefing.
+
+### Each question carries its own evidence
+
+A numbered finding in the briefing is a map, not enough to judge by. So every question restates,
+inline, the finding it is about: **the claim**, its `NET-NEW` line, its `TRIGGER` line, and one
+sentence on _why this one is uncertain_ — the specific thing you could not settle from the sandbox.
+Never make the maintainer open the draft to answer, and never refer to a finding by number alone.
+
+If you cannot say what is uncertain about a finding, you have no question — that finding is settled
+and belongs in neither the grill nor its rounds.
+
 Invoke `/grill-me`, scoped to the findings rather than to a plan. It works the tree in **rounds over
 a frontier** — round 1 is every Critical finding (they gate the verdict and are independent of each
 other), round 2 is Important plus whatever round 1 unblocked, round 3 is the consequences. Each

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -770,10 +770,22 @@ Critical/Important finding MUST carry these two lines, immediately under it:
   does not. Name the ticket/PR-body claim.
 
 If the same defect reproduces unchanged at `--ref base`, it is **pre-existing**
-and it is not a finding. At most one Suggestions line prefixed `pre-existing:`.
-The reviewer is deciding whether to merge _this diff_, not whether the file is
-perfect. "The PR touched this function, so its old bugs are in scope" is the
-specific mistake — touching a function does not adopt it.
+and it does not block this PR. The reviewer is deciding whether to merge _this
+diff_, not whether the file is perfect. "The PR touched this function, so its
+old bugs are in scope" is the specific mistake — touching a function does not
+adopt it.
+
+**It is still reported.** Emit it under a `PRE-EXISTING:` line instead of
+dropping it — one per defect, no cap, in the same `file:line — defect` shape
+plus the base evidence that proves it predates the diff:
+
+    PRE-EXISTING: <path>:<line> — <defect>. Present at base <path>:<line>.
+
+The maintainer files follow-up tickets from these, so a bare "this is old" is
+useless: the line must stand on its own once separated from the PR that
+surfaced it. This is the one place a defect you are forbidden to block on still
+reaches the reviewer intact — silently discarding it loses work nobody else is
+positioned to redo.
 
 **TRIGGER** must name a path a supported Nx workflow actually reaches: the
 command or public API entry point, the input/config that gets there, and what
@@ -977,12 +989,16 @@ Aggregate the surviving agents' output into Critical / Important / Strengths you
 
 **Only critical and important findings drive the verdict.** Keep **Critical**, **Important**, and **Strengths** in full. Suggestions are no longer discarded: distill any **Suggestions** / nice-to-have material into a `### Suggestions` section of at most 5 one-line bullets (`file:line — ask`), keeping only concrete, actionable asks (a rename, a restructure, a doc cross-link) and dropping vague polish. This tier NEVER influences the verdict — it exists because the maintainer's own reviews are largely made of it. The trimmed text is what flows into the steps below (reconciliation in Step 5b, formatting in Step 6).
 
+**Pre-existing defects get their own section, and it is uncapped.** Collect every agent's `PRE-EXISTING:` lines into a `### Pre-existing` section, verbatim, deduped by `file:line`. It never influences the verdict, and it does **not** draw from the Suggestions 5-bullet cap — the two are separate budgets. Suggestions is taste (a rename, a doc cross-link); this is real defects that predate the diff and exist to be turned into follow-up tickets. Capping them, or folding them into Suggestions where they compete with polish for slots, is how they get silently dropped — which is the whole failure this section exists to stop. Omit the section only when there are none.
+
+Agents that emit a `TIERS` line carry a `preexisting=<n>` count; reconcile the section against it exactly as you do `findings=<n>`, and record any shortfall in `## Failures`. The count is the only mechanical check that a pre-existing item survived the trim.
+
 "Keep in full" is the load-bearing half of that paragraph, and it is the half this step actually fails. Four rules make it enforceable:
 
-- **Enforce the admission test first.** Before anything else, check every Critical/Important finding for its `NET-NEW` and `TRIGGER` lines. Missing either, or a `NET-NEW` that asserts novelty without quoting base evidence ⇒ demote to Suggestions and record one line in `## Failures` naming the agent and the finding. Do not repair it for them by reading `--ref base` yourself — an agent that filed a finding without checking the base did not establish the defect is the PR's, and confirming it here converts your read into their evidence. The one exception: a `widens` or `claimed-fix` NET-NEW that names the base line but reads thin — verify that one in the sandbox and keep it if it holds. This gate is what stops pre-existing and unreachable findings from reaching the maintainer, and it is the only downgrade you perform without a numbered calibration.
+- **Enforce the admission test first.** Before anything else, check every Critical/Important finding for its `NET-NEW` and `TRIGGER` lines. Missing either, or a `NET-NEW` that asserts novelty without quoting base evidence ⇒ demote and record one line in `## Failures` naming the agent and the finding. **Demote by reason, not to one bucket:** a finding whose `NET-NEW` shows the defect reproduces at base goes to `### Pre-existing` (it is a real defect, just not this PR's — the maintainer still wants it); one whose `TRIGGER` names an unreachable path, or which is missing either line outright, goes to Suggestions. Dropping a demoted-as-pre-existing finding on the floor is the failure mode here, not mis-tiering it. Do not repair it for them by reading `--ref base` yourself — an agent that filed a finding without checking the base did not establish the defect is the PR's, and confirming it here converts your read into their evidence. The one exception: a `widens` or `claimed-fix` NET-NEW that names the base line but reads thin — verify that one in the sandbox and keep it if it holds. This gate is what stops pre-existing and unreachable findings from reaching the maintainer, and it is the only downgrade you perform without a numbered calibration.
 - **Never re-tier an agent's finding downward on your own judgment.** Apart from the admission-test gate above, the only sanctioned downgrade is a named calibration from the list below; when you apply one, say which calibration and why in the draft. "It feels minor", "that's just style", "the fix is one character" are not calibrations. An agent that filed something as a finding did so against a rule it was required to name. You are re-checking it against the calibrations, not re-scoring it by taste, and you are not the tier the agent's contract already assigned.
 - **Severity comes from the rule violated, not the size of the fix.** A one-character punctuation change that breaks a committed `STYLE_GUIDE.md` rule vale has no rule for is Important. A three-paragraph rewrite that violates nothing is a Suggestion. Judging by surface form is the specific way this step goes wrong: docs, comment, and naming findings all have tiny diffs, so they read as polish and get swept into a tier that cannot move the verdict.
-- **The 5-bullet cap binds the Suggestions tier only.** It is never a reason to move anything out of Critical or Important, and it never licenses a silent merge or drop. If you cut to the cap, name in one line what you cut and why. A reader must never mistake a trimmed list for a complete one.
+- **The 5-bullet cap binds the Suggestions tier only.** It is never a reason to move anything out of Critical, Important, or `### Pre-existing`, and it never licenses a silent merge or drop. If you cut to the cap, name in one line what you cut and why. A reader must never mistake a trimmed list for a complete one.
 - **Reconcile per reviewer before writing the draft.** Preserve every Critical/Important finding, or record the named calibration that downgraded it in `## Failures`.
 
 Keep findings distinct from Suggestions: a committed-rule violation is not polish merely because the diff is small.
@@ -1008,7 +1024,7 @@ These standing maintainer calibrations encode this repo's review culture. The ch
 3. Migration silence and retained dependencies are intentional. Flag only silent correctness failures; users may still import a dependency.
 4. `migrations.json` is already inside the migration trust boundary. Flag it only when data crosses a new boundary (for example HTTP or runtime input).
 5. `nx migrate` and `nx release` temp directories are intentional post-mortem artifacts, not leaks.
-6. Critical/Important findings must pass the charter's **admission test** — a NET-NEW line with base evidence and a TRIGGER line naming a reachable path. Pre-existing behavior the diff merely touches, and paths no supported workflow reaches, are Suggestions at most. Deliberate behavior backed by tests and documentation is a callout, not a blocker.
+6. Critical/Important findings must pass the charter's **admission test** — a NET-NEW line with base evidence and a TRIGGER line naming a reachable path. Pre-existing behavior the diff merely touches goes to `### Pre-existing` — reported for follow-up, never blocking. Paths no supported workflow reaches are Suggestions at most. Deliberate behavior backed by tests and documentation is a callout, not a blocker.
 7. Do not demand scattered defensive guards when the invariant can be fixed at its source.
 8. Comment-volume asks are Suggestions. Inaccurate/stale comments and required `@deprecated` / `TODO(vNN)` markers remain blocking.
 9. **Severity ignores population size.** Rarity never demotes a finding; unreachability disqualifies it. Windows-only, large-workspace-only, and rare-flag defects keep their tier — name the condition in TRIGGER. Windows is a supported platform, not an edge case.
@@ -1320,6 +1336,8 @@ The adjusted text becomes the final `$REVIEW_BODY`.
 
 `$REVIEW_BODY` is posted as-is — no header, footer, or tool attribution. It should read like a review a maintainer wrote. The review metadata (commit, date, attempt) lives in the triage file's frontmatter, not in the posted body.
 
+**Section order.** Grounding first, then what blocks, then what doesn't: `### Close-without-merge check`, `### Reproduction verification`, `### Approach analysis`, `### Security review`, `### Critical`, `### Important`, `### Maintainer calls`, `### Questions for the author`, `### Suggestions`, `### Pre-existing`, `### Strengths`. `### Pre-existing` sits below everything actionable on this PR and carries a one-line preamble saying it is follow-up material that does not affect the verdict — otherwise a reader skimming headers counts it against the author.
+
 ## Step 7: Determine verdict
 
 Check in this order (first match wins):
@@ -1333,8 +1351,10 @@ Check in this order (first match wins):
 
 (For first reviews with no prior context, fall back to the Critical/Important categories.)
 
-**Only Critical blocks.** There is deliberately no count threshold: Important and
-Suggestions never drive the verdict at any quantity. The old "3+ items" rule was a proxy
+**Only Critical blocks.** There is deliberately no count threshold: Important,
+Suggestions, and `### Pre-existing` never drive the verdict at any quantity. A long
+`### Pre-existing` list is not evidence against the PR — it is evidence the file was
+already in poor shape, which is the author's problem only if their diff caused it. The old "3+ items" rule was a proxy
 for "lots of noise probably means something is wrong" — it was tuned against an Important
 tier that had no definition, and it let three bounded observations block a PR nobody would
 actually hold. The admission test now does that job at the source. A PR with eight

--- a/.claude/tools/sandbox
+++ b/.claude/tools/sandbox
@@ -290,8 +290,8 @@ function cmdStart(argv) {
       `mode=${sb.mode} isolation=${sb.isolation} exec=${sb.exec}\n` +
       `Read source ONLY through this CLI:\n` +
       `  .claude/tools/sandbox read ${id} <path> [--range a,b] [--ref <sha>]\n` +
-      `  .claude/tools/sandbox grep ${id} <pattern> [subdir]\n` +
-      `  .claude/tools/sandbox find ${id} <glob>\n` +
+      `  .claude/tools/sandbox grep ${id} <pattern> [subdir] [--ref <sha>]\n` +
+      `  .claude/tools/sandbox find ${id} <glob> [subdir] [--ref <sha>]\n` +
       (sb.exec !== 'none'
         ? `  .claude/tools/sandbox exec ${id} -- <cmd>` +
           (sb.exec === 'screened' ? '   (obvious writes are rejected)' : '') +
@@ -359,26 +359,78 @@ function relOut(stdout) {
 }
 
 function cmdGrep(argv) {
-  const [id, pattern, subdir] = argv;
-  if (!id || !pattern) die('usage: sandbox grep <id> <pattern> [subdir]');
+  const { positional, opts } = parseArgs(argv, { ref: 'string' });
+  const [id, pattern, subdir] = positional;
+  if (!id || !pattern)
+    die('usage: sandbox grep <id> <pattern> [subdir] [--ref <sha>]');
   const sb = getSandbox(id);
   const where = relInRoot(sb.root, subdir || '.');
-  const r = execRaw(sb, ['grep', '-rn', '--', pattern, where], {
-    cwd: sb.root,
-  });
-  process.stdout.write(relOut(r.stdout));
+
+  const r = opts.ref
+    ? gitRawIn(sb, [
+        'grep',
+        '-n',
+        '-e',
+        pattern,
+        resolveRef(sb, opts.ref),
+        '--',
+        where,
+      ])
+    : execRaw(sb, ['grep', '-rn', '--', pattern, where], { cwd: sb.root });
+
+  // `git grep <ref>` prefixes every hit with `<ref>:`; strip it so a base search
+  // and a working-tree search are indistinguishable in shape.
+  const prefix = opts.ref ? `${resolveRef(sb, opts.ref)}:` : '';
+  const stdout = prefix
+    ? (r.stdout || '')
+        .split('\n')
+        .map((l) => (l.startsWith(prefix) ? l.slice(prefix.length) : l))
+        .join('\n')
+    : r.stdout;
+
+  process.stdout.write(relOut(stdout));
   // grep exits 1 on "no matches", which is not an error for a search verb.
   process.exit(r.status === 0 || r.status === 1 ? 0 : r.status);
 }
 
 function cmdFind(argv) {
-  const [id, glob, subdir] = argv;
-  if (!id || !glob) die('usage: sandbox find <id> <glob> [subdir]');
+  const { positional, opts } = parseArgs(argv, { ref: 'string' });
+  const [id, glob, subdir] = positional;
+  if (!id || !glob)
+    die('usage: sandbox find <id> <glob> [subdir] [--ref <sha>]');
   const sb = getSandbox(id);
   const where = relInRoot(sb.root, subdir || '.');
+
+  if (opts.ref) {
+    // ls-tree lists the ref's tree; match the basename so the glob means what
+    // it means for `find -name`.
+    const r = gitRawIn(sb, [
+      'ls-tree',
+      '-r',
+      '--name-only',
+      resolveRef(sb, opts.ref),
+      '--',
+      where,
+    ]);
+    const re = globToRegExp(glob);
+    const hits = readOut(r)
+      .split('\n')
+      .filter((p) => p && re.test(path.posix.basename(p)));
+    process.stdout.write(hits.length ? hits.join('\n') + '\n' : '');
+    return;
+  }
+
   const r = execRaw(sb, ['find', where, '-name', glob], { cwd: sb.root });
   process.stdout.write(relOut(r.stdout));
   process.exit(r.status || 0);
+}
+
+/** `find -name` glob semantics: `*` and `?` match within a single name component. */
+function globToRegExp(glob) {
+  const body = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/[*?]/g, (c) => (c === '*' ? '.*' : '.'));
+  return new RegExp(`^${body}$`);
 }
 
 // ---------------------------------------------------------------- exec screen
@@ -1079,16 +1131,46 @@ function nowIso() {
   return new Date().toISOString();
 }
 
-function parseFlags(argv, spec) {
-  const out = {};
+/**
+ * Split argv into positionals and flags in one pass. The verbs that take an
+ * optional trailing positional need this: parsing flags separately let
+ * `grep <id> <pat> --ref base` bind `--ref` as the subdir and drop `base`,
+ * so the search silently ran against the working tree instead of the ref.
+ * An unknown flag is fatal for the same reason — a silently ignored `--ref`
+ * returns HEAD content under a base-shaped command.
+ */
+function parseArgs(argv, spec) {
+  const positional = [];
+  const opts = {};
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (!a.startsWith('-')) continue;
+    if (!a.startsWith('-')) {
+      positional.push(a);
+      continue;
+    }
     const key = a.replace(/^--?/, '');
-    if (!(key in spec)) continue;
-    out[key] = spec[key] === 'boolean' ? true : argv[++i];
+    if (!(key in spec)) die(`unknown flag '${a}'`);
+    opts[key] = spec[key] === 'boolean' ? true : argv[++i];
   }
-  return out;
+  return { positional, opts };
+}
+
+function parseFlags(argv, spec) {
+  return parseArgs(argv, spec).opts;
+}
+
+/** `--ref base` is an alias for the base the sandbox was started with. */
+function resolveRef(sb, ref) {
+  const r = ref === 'base' ? sb.baseRef : ref;
+  if (!r) die('this sandbox was not started with a --base ref');
+  return r;
+}
+
+/** Like gitIn, but hands back the raw result so search verbs can tolerate "no matches". */
+function gitRawIn(sb, args) {
+  return sb.mode === 'local'
+    ? run('git', ['-C', sb.root, ...args])
+    : execRaw(sb, ['git', '-C', sb.root, ...args]);
 }
 
 // ---------------------------------------------------------------- main
@@ -1098,8 +1180,8 @@ const USAGE = `sandbox — uniform access to a checkout, isolated or local
   start  --local <path> [--allow-exec]         register a host dir; exec=screened unless --allow-exec
   start  --image <img> [--checkout <url> --ref <r> [--base <r>]]
   read   <id> <path> [--range a,b] [--ref <sha>] [-n]
-  grep   <id> <pattern> [subdir]
-  find   <id> <glob> [subdir]
+  grep   <id> <pattern> [subdir] [--ref <sha>]
+  find   <id> <glob> [subdir] [--ref <sha>]
   exec   <id> [--base] -- <cmd...>             --base runs base-side (installs it on first use)
   install <id> [--base]                        idempotent; head is the caller's to do up front
   view   <id> [--exec screened|none]           second id onto the same checkout, narrowed

--- a/.gemini/commands/monitor-ci.toml
+++ b/.gemini/commands/monitor-ci.toml
@@ -140,7 +140,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -177,8 +177,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \\
   [--expected-sha <expected_commit_sha>] \\
   [--prev-status <prev_status>] \\
-  [--timeout <timeout_seconds>] \\
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \\
+  [--timeout <timeout_minutes>] \\
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \\
+  [--elapsed-seconds <seconds_since_start_time>] \\
   [--env-rerun-count <env_rerun_count>] \\
   [--no-progress-count <no_progress_count>] \\
   [--prev-cipe-status <prev_cipe_status>] \\
@@ -186,6 +187,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \\
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -259,9 +262,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \\
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.github/prompts/monitor-ci.prompt.md
+++ b/.github/prompts/monitor-ci.prompt.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.github/skills/monitor-ci/SKILL.md
+++ b/.github/skills/monitor-ci/SKILL.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.github/skills/monitor-ci/scripts/ci-poll-decide.mjs
+++ b/.github/skills/monitor-ci/scripts/ci-poll-decide.mjs
@@ -13,10 +13,15 @@
  * Usage:
  *   node ci-poll-decide.mjs '<ci_info_json>' <poll_count> <verbosity> \
  *     [--wait-mode] [--prev-cipe-url <url>] [--expected-sha <sha>] \
- *     [--prev-status <status>] [--timeout <seconds>] [--new-cipe-timeout <seconds>] \
- *     [--env-rerun-count <n>] [--no-progress-count <n>] \
+ *     [--prev-status <status>] [--timeout <minutes>] [--new-cipe-timeout <minutes>] \
+ *     [--elapsed-seconds <n>] [--env-rerun-count <n>] [--no-progress-count <n>] \
  *     [--prev-cipe-status <status>] [--prev-sh-status <status>] \
  *     [--prev-verification-status <status>] [--prev-failure-classification <status>]
+ *
+ * Note: --timeout and --new-cipe-timeout are accepted in MINUTES (matching the
+ * skill's documented flags) and converted to seconds internally. --elapsed-seconds
+ * is the wall-clock time since monitoring began, carried across attempts by the
+ * orchestrator, and is the authoritative signal for the --timeout budget.
  */
 
 // --- Arg parsing ---
@@ -39,8 +44,14 @@ const waitMode = getFlag('--wait-mode');
 const prevCipeUrl = getArg('--prev-cipe-url');
 const expectedSha = getArg('--expected-sha');
 const prevStatus = getArg('--prev-status');
-const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10);
-const newCipeTimeoutSeconds = parseInt(getArg('--new-cipe-timeout') || '0', 10);
+// Flags are documented in minutes; convert to seconds for internal comparison.
+const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10) * 60;
+const newCipeTimeoutSeconds =
+  parseInt(getArg('--new-cipe-timeout') || '0', 10) * 60;
+// Wall-clock seconds since monitoring began (carried across attempts); null when
+// the orchestrator doesn't supply it (see isTimedOut for that fallback).
+const elapsedArg = getArg('--elapsed-seconds');
+const elapsedSeconds = elapsedArg !== null ? parseInt(elapsedArg, 10) : null;
 const envRerunCount = parseInt(getArg('--env-rerun-count') || '0', 10);
 const inputNoProgressCount = parseInt(getArg('--no-progress-count') || '0', 10);
 const prevCipeStatus = getArg('--prev-cipe-status');
@@ -125,6 +136,11 @@ function hasStateChanged() {
 
 function isTimedOut() {
   if (timeoutSeconds <= 0) return false;
+  // Prefer real wall-clock elapsed (carried across attempts) so --timeout caps
+  // total monitor duration, not a single invocation.
+  if (elapsedSeconds !== null && !Number.isNaN(elapsedSeconds))
+    return elapsedSeconds >= timeoutSeconds;
+  // Fallback: estimate elapsed from poll cadence within this invocation.
   const avgDelay = pollCount === 0 ? 0 : backoff(Math.floor(pollCount / 2));
   return pollCount * avgDelay >= timeoutSeconds;
 }
@@ -179,6 +195,10 @@ function classify() {
   // --- Wait mode ---
   if (waitMode) {
     if (isNewCipe()) return { action: 'poll', code: 'new_cipe_detected' };
+    // The total --timeout budget also caps time spent waiting for a new CI
+    // Attempt, so it must win over --new-cipe-timeout here; otherwise a long
+    // wait (or a sequence of apply→wait cycles) could run past --timeout.
+    if (isTimedOut()) return { action: 'done', code: 'polling_timeout' };
     if (isWaitTimedOut()) return { action: 'done', code: 'no_new_cipe' };
     return { action: 'wait', code: 'waiting_for_cipe' };
   }

--- a/.github/skills/monitor-ci/scripts/ci-state-update.mjs
+++ b/.github/skills/monitor-ci/scripts/ci-state-update.mjs
@@ -129,7 +129,9 @@ function cycleCheck() {
   // Reset env_rerun_count on non-environment status
   if (status !== 'environment_issue') envRerunCount = 0;
 
-  // Approaching limit gate
+  // Cycle limit gates. limitReached is a terminal stop; approachingLimit is an
+  // advisory warning emitted in the two cycles before the cap.
+  const limitReached = cycleCount >= maxCycles;
   const approachingLimit = cycleCount >= maxCycles - 2;
 
   output({
@@ -137,9 +139,12 @@ function cycleCheck() {
     agentTriggered: false,
     envRerunCount,
     approachingLimit,
-    message: approachingLimit
-      ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
-      : null,
+    limitReached,
+    message: limitReached
+      ? `Cycle limit reached (${cycleCount}/${maxCycles}). Stopping.`
+      : approachingLimit
+        ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
+        : null,
   });
 }
 

--- a/.opencode/commands/monitor-ci.md
+++ b/.opencode/commands/monitor-ci.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.opencode/skills/monitor-ci/SKILL.md
+++ b/.opencode/skills/monitor-ci/SKILL.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.opencode/skills/monitor-ci/scripts/ci-poll-decide.mjs
+++ b/.opencode/skills/monitor-ci/scripts/ci-poll-decide.mjs
@@ -13,10 +13,15 @@
  * Usage:
  *   node ci-poll-decide.mjs '<ci_info_json>' <poll_count> <verbosity> \
  *     [--wait-mode] [--prev-cipe-url <url>] [--expected-sha <sha>] \
- *     [--prev-status <status>] [--timeout <seconds>] [--new-cipe-timeout <seconds>] \
- *     [--env-rerun-count <n>] [--no-progress-count <n>] \
+ *     [--prev-status <status>] [--timeout <minutes>] [--new-cipe-timeout <minutes>] \
+ *     [--elapsed-seconds <n>] [--env-rerun-count <n>] [--no-progress-count <n>] \
  *     [--prev-cipe-status <status>] [--prev-sh-status <status>] \
  *     [--prev-verification-status <status>] [--prev-failure-classification <status>]
+ *
+ * Note: --timeout and --new-cipe-timeout are accepted in MINUTES (matching the
+ * skill's documented flags) and converted to seconds internally. --elapsed-seconds
+ * is the wall-clock time since monitoring began, carried across attempts by the
+ * orchestrator, and is the authoritative signal for the --timeout budget.
  */
 
 // --- Arg parsing ---
@@ -39,8 +44,14 @@ const waitMode = getFlag('--wait-mode');
 const prevCipeUrl = getArg('--prev-cipe-url');
 const expectedSha = getArg('--expected-sha');
 const prevStatus = getArg('--prev-status');
-const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10);
-const newCipeTimeoutSeconds = parseInt(getArg('--new-cipe-timeout') || '0', 10);
+// Flags are documented in minutes; convert to seconds for internal comparison.
+const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10) * 60;
+const newCipeTimeoutSeconds =
+  parseInt(getArg('--new-cipe-timeout') || '0', 10) * 60;
+// Wall-clock seconds since monitoring began (carried across attempts); null when
+// the orchestrator doesn't supply it (see isTimedOut for that fallback).
+const elapsedArg = getArg('--elapsed-seconds');
+const elapsedSeconds = elapsedArg !== null ? parseInt(elapsedArg, 10) : null;
 const envRerunCount = parseInt(getArg('--env-rerun-count') || '0', 10);
 const inputNoProgressCount = parseInt(getArg('--no-progress-count') || '0', 10);
 const prevCipeStatus = getArg('--prev-cipe-status');
@@ -125,6 +136,11 @@ function hasStateChanged() {
 
 function isTimedOut() {
   if (timeoutSeconds <= 0) return false;
+  // Prefer real wall-clock elapsed (carried across attempts) so --timeout caps
+  // total monitor duration, not a single invocation.
+  if (elapsedSeconds !== null && !Number.isNaN(elapsedSeconds))
+    return elapsedSeconds >= timeoutSeconds;
+  // Fallback: estimate elapsed from poll cadence within this invocation.
   const avgDelay = pollCount === 0 ? 0 : backoff(Math.floor(pollCount / 2));
   return pollCount * avgDelay >= timeoutSeconds;
 }
@@ -179,6 +195,10 @@ function classify() {
   // --- Wait mode ---
   if (waitMode) {
     if (isNewCipe()) return { action: 'poll', code: 'new_cipe_detected' };
+    // The total --timeout budget also caps time spent waiting for a new CI
+    // Attempt, so it must win over --new-cipe-timeout here; otherwise a long
+    // wait (or a sequence of apply→wait cycles) could run past --timeout.
+    if (isTimedOut()) return { action: 'done', code: 'polling_timeout' };
     if (isWaitTimedOut()) return { action: 'done', code: 'no_new_cipe' };
     return { action: 'wait', code: 'waiting_for_cipe' };
   }

--- a/.opencode/skills/monitor-ci/scripts/ci-state-update.mjs
+++ b/.opencode/skills/monitor-ci/scripts/ci-state-update.mjs
@@ -129,7 +129,9 @@ function cycleCheck() {
   // Reset env_rerun_count on non-environment status
   if (status !== 'environment_issue') envRerunCount = 0;
 
-  // Approaching limit gate
+  // Cycle limit gates. limitReached is a terminal stop; approachingLimit is an
+  // advisory warning emitted in the two cycles before the cap.
+  const limitReached = cycleCount >= maxCycles;
   const approachingLimit = cycleCount >= maxCycles - 2;
 
   output({
@@ -137,9 +139,12 @@ function cycleCheck() {
     agentTriggered: false,
     envRerunCount,
     approachingLimit,
-    message: approachingLimit
-      ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
-      : null,
+    limitReached,
+    message: limitReached
+      ? `Cycle limit reached (${cycleCount}/${maxCycles}). Stopping.`
+      : approachingLimit
+        ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
+        : null,
   });
 }
 


### PR DESCRIPTION
## Current Behavior

**Review findings had no admission bar and no severity definition.** Nothing required a finding to be net-new to the PR or reachable in practice, so pre-existing and unreachable defects reached drafts at a tier that could block. The tiers themselves were undefined, and a "3+ items" count rule let three bounded observations force `needs-changes` on a PR nobody would actually hold.

**Pre-existing defects were disposed of rather than reported.** The charter allowed "at most one Suggestions line prefixed `pre-existing:`", and Suggestions are capped at 5 bullets total — so a real defect predating the diff competed with renames and doc-link asks for a slot, and usually lost. The analyzers were worse: they routed these to an "advisory note" that no draft section collected at all. The maintainer never saw them, so no follow-up ticket was ever filed and the agent's work was thrown away.

**`monitor-ci`'s two budgets were both unenforceable.** `--timeout` and `--new-cipe-timeout` were documented in minutes but parsed as seconds, so every run used a budget 60x smaller than intended. Elapsed time was estimated from poll cadence within a single invocation, so the budget silently reset on every attempt rather than capping the monitor as a whole. `--max-cycles` only ever emitted an advisory "approaching limit" — nothing stopped at the cap.

**The `pr-review-toolkit` plugin had no live caller.** `review-pr-deep` and `setup-review-prs-cron` are both disabled, and `/review-pr` and `/review-local-branch` dispatch only to the agents in `.claude/agents`. Leaving it enabled collided on two names, `/review-pr` and `comment-analyzer` — and since CLAUDE.md makes the local `comment-analyzer` mandatory reading, a dispatch to the plugin's copy swapped the comment rules silently.

## Expected Behavior

**Review findings are tiered against a defined bar.**

- Every Critical/Important finding requires NET-NEW base evidence and a reachable TRIGGER; the orchestrator demotes findings missing either.
- Critical is "wrong now", Important is "wrong later". Severity comes from the rule violated, not the size of the fix, and ignores how many users are affected — so Windows-only keeps its tier.
- Only Critical drives the verdict. The 3+ count rule is gone: a PR with eight Important findings and no Critical is `lgtm` with a long list of follow-ups, which is the honest answer. The admission test now does that job at the source.
- New Step 8.5 grills the maintainer over the findings interactively, placed before sandbox cleanup so "is this pre-existing?" can still be settled against the `--ref` base rather than guessed.
- `grill-me` and `review-pending-pr-reviews` are vendored into the repo; committed skills already depended on both while they existed on only one machine.

**Pre-existing defects are reported, never blocking.**

- Agents emit `PRE-EXISTING: <path>:<line> — <defect>. Present at base <path>:<line>.`
- The orchestrator collects them into an uncapped `### Pre-existing` section on a budget separate from the 5-bullet Suggestions cap, ordered below everything actionable and prefaced as follow-up material that does not affect the verdict.
- The admission-test gate now demotes **by reason**: reproduces-at-base goes to Pre-existing, an unreachable TRIGGER goes to Suggestions.
- `docs-reviewer` and `comment-analyzer` carry `preexisting=<n>` in their `TIERS` line, so a dropped item is mechanically detectable exactly like `findings=<n>`.
- `review-local-branch` gains the same section.

This matters beyond bookkeeping: given only "block it or lose it", an agent holding a real pre-existing defect had an incentive to over-tier it into Critical/Important. A third destination is what lets the admission bar actually bite.

**`monitor-ci` enforces both budgets.**

- `--timeout` and `--new-cipe-timeout` parse as minutes, converting internally.
- New `--elapsed-seconds`, carried across attempts by the orchestrator, is the authoritative signal; the poll-cadence estimate remains as a fallback.
- The total timeout wins over `--new-cipe-timeout` in wait mode, so a run of apply-then-wait cycles cannot outlive the budget.
- `cycle-check` returns `limitReached` as a terminal stop, distinct from the advisory `approachingLimit`.

**The plugin is gone.** Dropped from `enabledPlugins`, the stale `code-reviewer` references in `comment-analyzer` and `docs-reviewer` retargeted to `implementation-reviewer`, and sandbox writes allowed to `~/.nx-pr-reviews` and `~/.nx-sandboxes`.

All three `monitor-ci` mirrors (`.agents/`, `.github/`, `.opencode/`) plus the `.gemini` and `.opencode` command files stay byte-identical.

## Related Issue(s)

N/A — repo tooling and agent configuration.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Tier-review-findings-and-enforce-the-monitor-ci-budgets-68a19415">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->