### PR TITLE
docs(nx-cloud): document file:// and full-URL custom step references

### DIFF
--- a/astro-docs/src/content/docs/kb/custom-steps.mdoc
+++ b/astro-docs/src/content/docs/kb/custom-steps.mdoc
@@ -17,9 +17,9 @@ To create a custom step, follow these steps:
 1\. **Create a New YAML File**: Create a new YAML file in your `.nx/workflows` directory (e.g., `custom-step.yaml`)
 
 {% aside type="note" title="Custom step file location" %}
-Custom steps do not need to be in the `.nx/workflows` directory. However, they must be available on a public GitHub repository. You have a few options for organizing your custom steps:
+Custom steps do not need to be in the `.nx/workflows` directory. However, they must be reachable through one of the [step reference forms](#step-reference-forms). You have a few options for organizing your custom steps:
 
-- **Same Repository as your Nx Workspace**: Ideal for open-source projects where the Nx workspace is publicly accessible.
+- **Same Repository as your Nx Workspace**: Reference the step with a `file://` path, or with the GitHub shorthand if the repository is public on GitHub.
 - **Create a Dedicated Repository**: Create a separate repository to store a collection of custom steps. This is useful for sharing steps across multiple projects or teams, or if your main Nx workspace is not on GitHub or is private.
 
 {% /aside %}
@@ -103,6 +103,52 @@ launch-templates:
 {% aside type="note" title="Recommendation on Using Inputs vs. Env" %}
 While you can use both `env` and `inputs` to pass values to custom steps, it is recommended to use `inputs` as they offer validation support, whereas `env` does not.
 {% /aside %}
+
+### Step reference forms
+
+The `uses` field accepts three reference forms: the GitHub shorthand shown above, workspace-local `file://` paths, and full HTTPS URLs.
+The GitHub shorthand (`your-org/your-repo/main/path/to/step.yaml`) is fetched from `raw.githubusercontent.com` and requires a branch or tag.
+Vendoring steps into your repository or hosting them yourself means agent startup doesn't depend on that endpoint's availability, and works for workspaces not hosted on GitHub.
+
+#### Workspace-local files
+
+Reference a step file committed to your workspace with a `file://` URL.
+Note the triple slash. The path is resolved from the workspace root.
+
+```yaml
+// .nx/workflows/agents.yaml
+launch-templates:
+  custom-template:
+    resource-class: 'docker_linux_amd64/medium'
+    image: 'ubuntu22.04-node24.14-v1'
+    init-steps:
+      - uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
+      - name: Custom Step
+        uses: 'file:///.nx/workflows/custom-step.yaml'
+```
+
+At validation time, Nx Cloud reads the file from your repository at the triggering commit.
+At runtime, the agent reads it from the checked-out workspace.
+The file only exists after the repository checkout, so the checkout step itself can't use a `file://` reference.
+Keep checkout as a remote step or an inline `script`.
+
+#### Full URLs
+
+Reference a step file on any HTTPS endpoint that returns the raw YAML body, for example a GitLab raw file URL or an internal file server.
+The URL is fetched as-is with an HTTP GET.
+
+```yaml
+// .nx/workflows/agents.yaml
+launch-templates:
+  custom-template:
+    resource-class: 'docker_linux_amd64/medium'
+    image: 'ubuntu22.04-node24.14-v1'
+    init-steps:
+      - name: Custom Step
+        uses: 'https://your-host.example.com/steps/custom-step.yaml'
+```
+
+Whichever form you use, scripts referenced by a step file (such as `main` and `post`) resolve relative to the step file's own location: the same repository and ref for remote steps, workspace-relative for `file://` steps.
 
 ### Validating custom steps
 

--- a/astro-docs/src/content/docs/kb/launch-templates.mdoc
+++ b/astro-docs/src/content/docs/kb/launch-templates.mdoc
@@ -188,16 +188,21 @@ launch-templates:
 When defined, specifies an existing step file to be used. **Cannot be used when `script` is also defined**
 
 You can find the [list of Nx Cloud reusable steps here](https://github.com/nrwl/nx-cloud-workflows/tree/main/workflow-steps). If you cannot find a reusable step that suits your needs, [you can create your own custom steps](/docs/kb/custom-steps).
-Besides the GitHub shorthand shown below, `uses` accepts workspace-local `file://` paths and full HTTPS URLs, described in [step reference forms](/docs/kb/custom-steps#step-reference-forms).
+Besides the GitHub shorthand, `uses` accepts workspace-local `file://` paths and full HTTPS URLs from any host serving the raw YAML, not only GitHub. Both are described in [step reference forms](/docs/kb/custom-steps#step-reference-forms).
 
 ```yaml
 // .nx/workflows/agents.yaml
 launch-templates:
   template-one:
     init-steps:
+      # GitHub shorthand (checkout must stay remote, so no file:// here)
       - uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
+      # full URL form of the GitHub shorthand
       - name: 'Install Node Modules'
-        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
+        uses: 'https://raw.githubusercontent.com/nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
+      # workspace-local file, resolved from the workspace root
+      - name: 'Custom Step'
+        uses: 'file:///.nx/workflows/custom-step.yaml'
 ```
 
 ### `launch-templates.<template-name>.init-steps[*].script`

--- a/astro-docs/src/content/docs/kb/launch-templates.mdoc
+++ b/astro-docs/src/content/docs/kb/launch-templates.mdoc
@@ -188,6 +188,7 @@ launch-templates:
 When defined, specifies an existing step file to be used. **Cannot be used when `script` is also defined**
 
 You can find the [list of Nx Cloud reusable steps here](https://github.com/nrwl/nx-cloud-workflows/tree/main/workflow-steps). If you cannot find a reusable step that suits your needs, [you can create your own custom steps](/docs/kb/custom-steps).
+Besides the GitHub shorthand shown below, `uses` accepts workspace-local `file://` paths and full HTTPS URLs, described in [step reference forms](/docs/kb/custom-steps#step-reference-forms).
 
 ```yaml
 // .nx/workflows/agents.yaml


### PR DESCRIPTION
Documents two supported but previously undocumented `uses:` reference forms for workflow steps in Nx Agents launch templates, in `custom-steps.mdoc` (with a cross-reference from `launch-templates.mdoc`):

- **Workspace-local**: `uses: 'file:///.nx/workflows/custom-step.yaml'` (triple slash, resolved from the workspace root). The step template is vendored in the workspace repository. Includes the caveat that the file only exists after checkout, so the checkout step itself cannot use this form.
- **Full URL**: `uses: 'https://your-host.example.com/steps/custom-step.yaml'`. Any HTTPS endpoint that returns the raw YAML body, for example a GitLab raw file URL or an internal file server.

Also documents that step scripts (`main`, `post`) resolve relative to the step file's own location, and why these forms matter: vendored or self-hosted steps remove the agent-startup dependency on raw.githubusercontent.com availability and work for workspaces not hosted on GitHub.

Context: during the 2026-08-17 GitHub incident, agents failed at startup because step definitions could not be downloaded from raw.githubusercontent.com. These reference forms are the supported mitigation, but neither was documented.

Resolves DOC-590.

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/able-tiger-74257ec3">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->