### PR TITLE
fix(js): avoid duplicate node start without watch

### DIFF
--- a/e2e/js/src/js-executor-node.test.ts
+++ b/e2e/js/src/js-executor-node.test.ts
@@ -104,7 +104,7 @@ describe('js:node executor', () => {
     });
 
     const output = runCLI(`run ${tscLib}:run-node`);
-    expect(output).toContain('Hello from my tsc library!');
+    expect(output.match(/Hello from my tsc library!/g)).toHaveLength(1);
   }, 240_000);
 
   it('should execute library compiled with swc', async () => {

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -378,9 +378,15 @@ export async function* nodeExecutor(
       );
       while (true) {
         const event = await output.next();
+
+        if (event.done) {
+          break;
+        }
+
         await addToQueue(null, Promise.resolve(event.value));
         await debouncedProcessQueue.trigger();
-        if (event.done && !options.watch) {
+
+        if (!options.watch) {
           break;
         }
       }


### PR DESCRIPTION
## Current Behavior

When `@nx/js:node` runs with `watch: false` and its build target uses `@nx/js:tsc`, the application can start twice sequentially.

The node executor currently passes the terminal async-iterator event (`done: true`, `value: undefined`) to `addToQueue()` before checking whether iteration has completed. In non-watch mode, this schedules a second process after the successful build result.

## Expected Behavior

Terminal iterator events should not schedule node processes, and `watch: false` should consume only the first real build result needed to start the application once.

This change checks `event.done` before queueing the build result and restores the original non-watch behavior of exiting after the first real build event.

The existing `@nx/js:node` + `@nx/js:tsc` E2E coverage is strengthened to assert that the application startup message is emitted exactly once.

## Related Issue(s)

Fixes #36694
