### PR TITLE
fix(gradle): emit valid Groovy when applying the plugin to an existing allprojects block

### DIFF
--- a/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.spec.ts
+++ b/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.spec.ts
@@ -185,10 +185,34 @@ allprojects {
         expect(content).toMatch(
           /plugins\s*{\s*id\s*['"]dev\.nx\.gradle\.project-graph['"]\s*version\s*['"][^'"]+['"]/
         );
+        // Groovy's named-argument colon is required; `apply plugin "x"` is a syntax error.
         expect(content).toMatch(
-          /allprojects\s*{\s*apply\s*plugin\s*['"]dev\.nx\.gradle\.project-graph['"]/
+          /allprojects\s*{\s*apply\s*plugin:\s*['"]dev\.nx\.gradle\.project-graph['"]/
         );
         expect(content).toContain('repositories {');
+      });
+
+      it('should not re-apply the plugin to an allprojects block that already has it', async () => {
+        await tempFs.createFiles({
+          'proj/settings.gradle': '',
+          'proj/build.gradle': `plugins {
+    id "java"
+}
+
+allprojects {
+    apply plugin: "dev.nx.gradle.project-graph"
+    repositories {
+        mavenCentral()
+    }
+}`,
+        });
+
+        await addNxProjectGraphPlugin(tree);
+
+        const content = tree.read('proj/build.gradle', 'utf-8');
+        expect(
+          content.match(/apply\s+plugin:\s*['"]dev\.nx\.gradle\.project-graph['"]/g)
+        ).toHaveLength(1);
       });
     });
 

--- a/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.spec.ts
+++ b/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.spec.ts
@@ -210,7 +210,9 @@ allprojects {
 
         const content = tree.read('proj/build.gradle', 'utf-8');
         expect(
-          content.match(/apply\s+plugin:\s*['"]dev\.nx\.gradle\.project-graph['"]/g)
+          content.match(
+            /apply\s+plugin:\s*['"]dev\.nx\.gradle\.project-graph['"]/g
+          )
         ).toHaveLength(1);
       });
     });

--- a/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.spec.ts
+++ b/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.spec.ts
@@ -185,7 +185,6 @@ allprojects {
         expect(content).toMatch(
           /plugins\s*{\s*id\s*['"]dev\.nx\.gradle\.project-graph['"]\s*version\s*['"][^'"]+['"]/
         );
-        // Groovy's named-argument colon is required; `apply plugin "x"` is a syntax error.
         expect(content).toMatch(
           /allprojects\s*{\s*apply\s*plugin:\s*['"]dev\.nx\.gradle\.project-graph['"]/
         );

--- a/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.ts
+++ b/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.ts
@@ -290,7 +290,14 @@ async function addNxProjectGraphPluginToBuildGradle(
             '\\.'
           )}\\)`
         )
-      : new RegExp(`\\s*plugin\\(["']${gradleProjectGraphPluginName}["']\\)`);
+      : // Matches the Kotlin `plugin("x")` and Groovy `plugin: "x"` forms alike, so a second
+        // run of the generator doesn't append a duplicate apply.
+        new RegExp(
+          `\\s*plugin\\s*[:(]\\s*["']${gradleProjectGraphPluginName.replace(
+            /\./g,
+            '\\.'
+          )}["']`
+        );
 
     if (buildGradleContent.includes('allprojects {')) {
       if (!applyPluginPattern.test(buildGradleContent)) {
@@ -298,7 +305,9 @@ async function addNxProjectGraphPluginToBuildGradle(
           ? `plugin(${versionCatalogPluginAccessor})`
           : isKotlinDsl
             ? `plugin("${gradleProjectGraphPluginName}")`
-            : `plugin "${gradleProjectGraphPluginName}"`;
+            : // Groovy needs the named-argument colon: `apply plugin: "x"`. Without it Groovy
+              // reads `plugin` as a property and fails with "Could not get unknown property".
+              `plugin: "${gradleProjectGraphPluginName}"`;
 
         buildGradleContent = buildGradleContent.replace(
           /allprojects\s*\{/,

--- a/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.ts
+++ b/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.ts
@@ -290,8 +290,7 @@ async function addNxProjectGraphPluginToBuildGradle(
             '\\.'
           )}\\)`
         )
-      : // Matches the Kotlin `plugin("x")` and Groovy `plugin: "x"` forms alike, so a second
-        // run of the generator doesn't append a duplicate apply.
+      : // Both DSL forms, so a re-run doesn't append a duplicate apply.
         new RegExp(
           `\\s*plugin\\s*[:(]\\s*["']${gradleProjectGraphPluginName.replace(
             /\./g,
@@ -305,8 +304,7 @@ async function addNxProjectGraphPluginToBuildGradle(
           ? `plugin(${versionCatalogPluginAccessor})`
           : isKotlinDsl
             ? `plugin("${gradleProjectGraphPluginName}")`
-            : // Groovy needs the named-argument colon: `apply plugin: "x"`. Without it Groovy
-              // reads `plugin` as a property and fails with "Could not get unknown property".
+            : // Groovy named argument; without the colon `plugin` parses as a property.
               `plugin: "${gradleProjectGraphPluginName}"`;
 
         buildGradleContent = buildGradleContent.replace(

--- a/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.ts
+++ b/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.ts
@@ -304,8 +304,7 @@ async function addNxProjectGraphPluginToBuildGradle(
           ? `plugin(${versionCatalogPluginAccessor})`
           : isKotlinDsl
             ? `plugin("${gradleProjectGraphPluginName}")`
-            : // Groovy named argument; without the colon `plugin` parses as a property.
-              `plugin: "${gradleProjectGraphPluginName}"`;
+            : `plugin: "${gradleProjectGraphPluginName}"`;
 
         buildGradleContent = buildGradleContent.replace(
           /allprojects\s*\{/,


### PR DESCRIPTION
Split out of #36693 so it can be reviewed on its own — it is unrelated to the plugin changes there.

## Current Behavior

When a **Groovy** build file already contains an `allprojects {}` block, `@nx/gradle:init` writes:

```groovy
allprojects {
    apply plugin "dev.nx.gradle.project-graph"
    …
}
```

The named-argument colon is missing. `apply plugin: "x"` is sugar for `apply(plugin: "x")` — a `Map` passed to `Project.apply(Map)`. Without the colon, `plugin` is no longer a map key but an identifier, so Groovy resolves it as a property and the build fails during configuration, before anything else can run:

```
* What went wrong:
A problem occurred evaluating project ':x'.
> Could not get unknown property 'plugin' for project ':x' of type org.gradle.api.Project.
```

Only this one branch is affected. When there is no existing `allprojects {}` block the generator appends `allprojects { apply { plugin("…") } }`, which is valid in both DSLs, and the Kotlin branch emits `apply plugin("…")`, also valid.

Hit in practice running `@nx/gradle:init` against [apache/kafka](https://github.com/apache/kafka), whose root build file already has an `allprojects {}` block. The result is unusable until the colon is added by hand.

## Expected Behavior

The Groovy branch emits `apply plugin: "dev.nx.gradle.project-graph"`.

The already-applied check needed widening too: it only recognised the Kotlin `plugin("x")` form, so once the Groovy output gained its colon, a second `init` run would no longer detect the existing apply and would append a duplicate. It now matches both forms. The plugin name is also escaped before interpolation into the regex — previously its dots were live regex metacharacters.

## Why this was not caught

Worth flagging, because the gap is structural rather than a missing assertion.

**The unit test asserted the broken output.** `gradle-project-graph-plugin-utils.spec.ts` covered this exact branch with:

```js
/allprojects\s*{\s*apply\s*plugin\s*['"]dev\.nx\.gradle\.project-graph['"]/
```

Note `\s*` between `plugin` and the quote: that matches the colon-less output and would **fail** on the correct form. So the branch had coverage, but the expectation pinned the bug in place — anyone fixing the generator would have been met with a red test. It is corrected here, and a regression test covers the idempotent re-run, whose failure mode (duplicate `apply` lines) is otherwise silent.

**No e2e fixture can reach the branch.** Every Gradle e2e fixture is generated by `gradle init --type <dsl>-application --split-project` (`e2e/gradle/src/utils/create-gradle-project.ts`), and that template has no `allprojects {}` block — so the generator always takes the path that appends a fresh one, in both the Kotlin and Groovy variants. The only e2e that writes an `allprojects` block is `gradle-plugin-v1.test.ts`, which is the deprecated v1 path: it writes the block itself as setup and applies `project-report`, never going through this generator.

Had a fixture had that shape, e2e would have caught this immediately and loudly — the build fails at configuration time. I have not added such a fixture here because I could not run the Gradle e2e suite locally and would rather not land a test I have not seen pass; a follow-up adding a fixture whose build file already contains an `allprojects {}` block would close the gap properly.

## Testing

`gradle-project-graph-plugin-utils.spec.ts`: 35 tests pass, including the corrected assertion and the new idempotency test.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-nx-gradle-project-graph-failure-on-Kafka-6be88540">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->