### PR TITLE
fix(js): resolve override selectors in affected detection

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
@@ -1,6 +1,6 @@
 import { NxJsonConfiguration } from '../../../../config/nx-json';
 import { ProjectGraph } from '../../../../config/project-graph';
-import { JsonDiffType } from '../../../../utils/json-diff';
+import { jsonDiff, JsonDiffType } from '../../../../utils/json-diff';
 import { logger } from '../../../../utils/logger';
 import { WholeFileChange } from '../../../../project-graph/file-utils';
 import { getTouchedNpmPackages } from './npm-packages';
@@ -386,6 +386,181 @@ describe('getTouchedNpmPackages', () => {
       },
       projectGraph
     );
+    expect(result).toEqual(['npm:happy-nrwl']);
+  });
+
+  it('should mark every installed package version as affected for version-scoped overrides', () => {
+    projectGraph.externalNodes['npm:happy-nrwl@2'] = {
+      name: 'npm:happy-nrwl@2',
+      type: 'npm',
+      data: {
+        packageName: 'happy-nrwl',
+        version: '2',
+      },
+    };
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Added,
+              path: ['pnpm', 'overrides', 'happy-nrwl@>=1.0.0 <2.0.0'],
+              value: {
+                lhs: undefined,
+                rhs: '2.0.0',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      {
+        pnpm: {
+          overrides: {
+            'happy-nrwl@>=1.0.0 <2.0.0': '2.0.0',
+          },
+        },
+      },
+      projectGraph
+    );
+
+    expect(result).toEqual(['npm:happy-nrwl', 'npm:happy-nrwl@2']);
+  });
+
+  it('should scope affected packages when versioned override keys are replaced', () => {
+    for (const version of ['1.1.18', '2.1.4', '5.0.9']) {
+      const name = `npm:brace-expansion@${version}`;
+      projectGraph.externalNodes[name] = {
+        name,
+        type: 'npm',
+        data: {
+          packageName: 'brace-expansion',
+          version,
+        },
+      };
+    }
+
+    const basePackageJson = {
+      pnpm: {
+        overrides: {
+          'brace-expansion@>=5.0.0 <5.0.6': '5.0.6',
+        },
+      },
+    };
+    const headPackageJson = {
+      pnpm: {
+        overrides: {
+          'brace-expansion@<1.1.17': '1.1.18',
+          'brace-expansion@>=2.0.0 <2.1.3': '2.1.4',
+          'brace-expansion@>=5.0.0 <5.0.9': '5.0.9',
+        },
+      },
+    };
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => jsonDiff(basePackageJson, headPackageJson),
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      headPackageJson,
+      projectGraph
+    );
+
+    expect(result).toEqual([
+      'npm:brace-expansion@1.1.18',
+      'npm:brace-expansion@2.1.4',
+      'npm:brace-expansion@5.0.9',
+    ]);
+  });
+
+  it('should handle version-scoped overrides for scoped packages', () => {
+    projectGraph.externalNodes['npm:@scope/happy-nrwl'] = {
+      name: 'npm:@scope/happy-nrwl',
+      type: 'npm',
+      data: {
+        packageName: '@scope/happy-nrwl',
+        version: '2',
+      },
+    };
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Modified,
+              path: ['overrides', '@scope/happy-nrwl@>=1.0.0 <2.0.0'],
+              value: {
+                lhs: '1.0.0',
+                rhs: '2.0.0',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      {
+        overrides: {
+          '@scope/happy-nrwl@>=1.0.0 <2.0.0': '2.0.0',
+        },
+      },
+      projectGraph
+    );
+
+    expect(result).toEqual(['npm:@scope/happy-nrwl']);
+  });
+
+  it('should mark the child package as affected for parent-scoped pnpm overrides', () => {
+    projectGraph.externalNodes['npm:parent-nrwl'] = {
+      name: 'npm:parent-nrwl',
+      type: 'npm',
+      data: {
+        packageName: 'parent-nrwl',
+        version: '2',
+      },
+    };
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Modified,
+              path: [
+                'pnpm',
+                'overrides',
+                'parent-nrwl@>1.0.0>happy-nrwl@>=1.0.0',
+              ],
+              value: {
+                lhs: '1.0.0',
+                rhs: '2.0.0',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      {
+        pnpm: {
+          overrides: {
+            'parent-nrwl@>1.0.0>happy-nrwl@>=1.0.0': '2.0.0',
+          },
+        },
+      },
+      projectGraph
+    );
+
     expect(result).toEqual(['npm:happy-nrwl']);
   });
 

--- a/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
@@ -564,6 +564,78 @@ describe('getTouchedNpmPackages', () => {
     expect(result).toEqual(['npm:happy-nrwl']);
   });
 
+  it('should mark the child package as affected for nested npm overrides', () => {
+    projectGraph.externalNodes['npm:parent-nrwl'] = {
+      name: 'npm:parent-nrwl',
+      type: 'npm',
+      data: {
+        packageName: 'parent-nrwl',
+        version: '2',
+      },
+    };
+    const basePackageJson = {
+      overrides: {
+        'parent-nrwl@^2.0.0': {
+          'happy-nrwl': '1.0.0',
+        },
+      },
+    };
+    const headPackageJson = {
+      overrides: {
+        'parent-nrwl@^2.0.0': {
+          'happy-nrwl': '2.0.0',
+        },
+      },
+    };
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => jsonDiff(basePackageJson, headPackageJson),
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      headPackageJson,
+      projectGraph
+    );
+
+    expect(result).toEqual(['npm:happy-nrwl']);
+  });
+
+  it('should handle the self key in nested npm overrides', () => {
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Modified,
+              path: ['overrides', 'happy-nrwl@^1.0.0', '.'],
+              value: {
+                lhs: '1.0.0',
+                rhs: '1.1.0',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      {
+        overrides: {
+          'happy-nrwl@^1.0.0': {
+            '.': '1.1.0',
+          },
+        },
+      },
+      projectGraph
+    );
+
+    expect(result).toEqual(['npm:happy-nrwl']);
+  });
+
   it('should mark all projects as affected when resolutions are changed for unknown packages', () => {
     const result = getTouchedNpmPackages(
       [

--- a/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
@@ -389,6 +389,74 @@ describe('getTouchedNpmPackages', () => {
     expect(result).toEqual(['npm:happy-nrwl']);
   });
 
+  it('should preserve the original package when an override changes from a string to an object', () => {
+    projectGraph.externalNodes['npm:nested-nrwl'] = {
+      name: 'npm:nested-nrwl',
+      type: 'npm',
+      data: {
+        packageName: 'nested-nrwl',
+        version: '1',
+      },
+    };
+    const basePackageJson = {
+      overrides: {
+        'happy-nrwl': '1.0.0',
+      },
+    };
+    const headPackageJson = {
+      overrides: {
+        'happy-nrwl': {
+          'nested-nrwl': '1.0.0',
+        },
+      },
+    };
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => jsonDiff(basePackageJson, headPackageJson),
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      headPackageJson,
+      projectGraph
+    );
+
+    expect(result).toEqual(['npm:happy-nrwl', 'npm:nested-nrwl']);
+  });
+
+  it('should fall back to all projects when a scoped override target is missing', () => {
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Modified,
+              path: ['overrides', '@scope/happy-nrwl@^1'],
+              value: {
+                lhs: '1.0.0',
+                rhs: '2.0.0',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      {
+        overrides: {
+          '@scope/happy-nrwl@^1': '2.0.0',
+        },
+      },
+      projectGraph
+    );
+
+    expect(result).toEqual(['proj1', 'proj2']);
+  });
+
   it('should mark every installed package version as affected for version-scoped overrides', () => {
     projectGraph.externalNodes['npm:happy-nrwl@2'] = {
       name: 'npm:happy-nrwl@2',
@@ -564,6 +632,47 @@ describe('getTouchedNpmPackages', () => {
     expect(result).toEqual(['npm:happy-nrwl']);
   });
 
+  it('should fall back to all projects when a pnpm override target is missing', () => {
+    projectGraph.externalNodes['npm:parent-nrwl'] = {
+      name: 'npm:parent-nrwl',
+      type: 'npm',
+      data: {
+        packageName: 'parent-nrwl',
+        version: '1',
+      },
+    };
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Modified,
+              path: ['pnpm', 'overrides', 'parent-nrwl@1>unknown-child@1'],
+              value: {
+                lhs: '1.0.0',
+                rhs: '2.0.0',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      {
+        pnpm: {
+          overrides: {
+            'parent-nrwl@1>unknown-child@1': '2.0.0',
+          },
+        },
+      },
+      projectGraph
+    );
+
+    expect(result).toEqual(['proj1', 'proj2']);
+  });
+
   it('should mark the child package as affected for nested npm overrides', () => {
     projectGraph.externalNodes['npm:parent-nrwl'] = {
       name: 'npm:parent-nrwl',
@@ -636,6 +745,45 @@ describe('getTouchedNpmPackages', () => {
     expect(result).toEqual(['npm:happy-nrwl']);
   });
 
+  it('should fall back to all projects when a resolution path target is missing', () => {
+    projectGraph.externalNodes['npm:parent-nrwl'] = {
+      name: 'npm:parent-nrwl',
+      type: 'npm',
+      data: {
+        packageName: 'parent-nrwl',
+        version: '1',
+      },
+    };
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Modified,
+              path: ['resolutions', 'parent-nrwl@^1/unknown-child@^1'],
+              value: {
+                lhs: '1.0.0',
+                rhs: '2.0.0',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      {
+        resolutions: {
+          'parent-nrwl@^1/unknown-child@^1': '2.0.0',
+        },
+      },
+      projectGraph
+    );
+
+    expect(result).toEqual(['proj1', 'proj2']);
+  });
+
   it('should mark all projects as affected when resolutions are changed for unknown packages', () => {
     const result = getTouchedNpmPackages(
       [
@@ -666,6 +814,47 @@ describe('getTouchedNpmPackages', () => {
       projectGraph
     );
     expect(result).toEqual(['proj1', 'proj2']);
+  });
+
+  it('should not treat a pnpm greater-than range as a parent selector', () => {
+    projectGraph.externalNodes['npm:1'] = {
+      name: 'npm:1',
+      type: 'npm',
+      data: {
+        packageName: '1',
+        version: '1',
+      },
+    };
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Modified,
+              path: ['pnpm', 'overrides', 'happy-nrwl@>1'],
+              value: {
+                lhs: '1.0.0',
+                rhs: '2.0.0',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      {
+        pnpm: {
+          overrides: {
+            'happy-nrwl@>1': '2.0.0',
+          },
+        },
+      },
+      projectGraph
+    );
+
+    expect(result).toEqual(['npm:happy-nrwl']);
   });
 
   it('should mark specific package as affected when pnpm.overrides are changed for known packages', () => {

--- a/packages/nx/src/plugins/js/project-graph/affected/npm-packages.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/npm-packages.ts
@@ -28,6 +28,7 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
   const changes = packageJsonChange.getChanges();
 
   const npmPackages = Object.values(projectGraph.externalNodes);
+  let packagesByName: Map<string, ProjectGraphExternalNode[]> | undefined;
 
   const missingTouchedNpmPackages: string[] = [];
 
@@ -77,27 +78,29 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
         (c.path[0] === 'pnpm' && c.path[1] === 'overrides'))
     ) {
       const packageSelector = getPackageSelector(c);
+      if (!packageSelector) continue;
 
-      if (packageSelector) {
-        const matchingNpmPackages = findPackagesForSelector(
-          packageSelector,
-          npmPackages
-        );
+      packagesByName ??= groupPackagesByName(npmPackages);
+      const matchingNpmPackages = findPackagesForSelector(
+        packageSelector,
+        packagesByName
+      );
 
-        if (matchingNpmPackages.length) {
-          touched.push(...matchingNpmPackages.map((pkg) => pkg.name));
-
-          if (
-            matchingNpmPackages.some((pkg) =>
-              globalPackages.has(pkg.data.packageName)
-            )
-          ) {
-            return Object.keys(projectGraph.nodes);
-          }
-        } else {
-          return Object.keys(projectGraph.nodes);
-        }
+      // An unresolved selector can still target a transitive dependency,
+      // so fall back to marking every project affected.
+      if (!matchingNpmPackages.length) {
+        return Object.keys(projectGraph.nodes);
       }
+
+      if (
+        matchingNpmPackages.some((pkg) =>
+          globalPackages.has(pkg.data.packageName)
+        )
+      ) {
+        return Object.keys(projectGraph.nodes);
+      }
+
+      touched.push(...matchingNpmPackages.map((pkg) => pkg.name));
     } else if (isWholeFileChange(c)) {
       // Whole file was touched, so all npm packages are touched.
       touched = npmPackages.map((pkg) => pkg.name);
@@ -125,16 +128,30 @@ function getPackageSelector(change: JsonChange): string | undefined {
   return selector === '.' ? change.path[selectorIndex - 1] : selector;
 }
 
+function groupPackagesByName(
+  npmPackages: ProjectGraphExternalNode[]
+): Map<string, ProjectGraphExternalNode[]> {
+  const packagesByName = new Map<string, ProjectGraphExternalNode[]>();
+  for (const pkg of npmPackages) {
+    const packageName = pkg.data.packageName;
+    if (!packageName) continue;
+    const packages = packagesByName.get(packageName);
+    if (packages) {
+      packages.push(pkg);
+    } else {
+      packagesByName.set(packageName, [pkg]);
+    }
+  }
+  return packagesByName;
+}
+
 function findPackagesForSelector(
   selector: string,
-  npmPackages: ProjectGraphExternalNode[]
+  packagesByName: Map<string, ProjectGraphExternalNode[]>
 ): ProjectGraphExternalNode[] {
   let match: { packageName: string; end: number } | undefined;
-  const packageNames = new Set(
-    npmPackages.map((pkg) => pkg.data.packageName).filter(Boolean)
-  );
 
-  for (const packageName of packageNames) {
+  for (const packageName of packagesByName.keys()) {
     let index = selector.indexOf(packageName);
     while (index !== -1) {
       const end = index + packageName.length;
@@ -157,9 +174,7 @@ function findPackagesForSelector(
     }
   }
 
-  return match
-    ? npmPackages.filter((pkg) => pkg.data.packageName === match.packageName)
-    : [];
+  return match ? packagesByName.get(match.packageName) : [];
 }
 
 function getGlobalPackages(plugins: NxJsonConfiguration['plugins']) {

--- a/packages/nx/src/plugins/js/project-graph/affected/npm-packages.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/npm-packages.ts
@@ -83,7 +83,8 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
       packagesByName ??= groupPackagesByName(npmPackages);
       const matchingNpmPackages = findPackagesForSelector(
         packageSelector,
-        packagesByName
+        packagesByName,
+        c.path[0] === 'pnpm'
       );
 
       // An unresolved selector can still target a transitive dependency,
@@ -119,9 +120,12 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
 };
 
 function getPackageSelector(change: JsonChange): string | undefined {
-  const value =
-    change.type === JsonDiffType.Deleted ? change.value.lhs : change.value.rhs;
-  if (typeof value !== 'string') return;
+  if (
+    typeof change.value.lhs !== 'string' &&
+    typeof change.value.rhs !== 'string'
+  ) {
+    return;
+  }
 
   const selectorIndex = change.path[0] === 'pnpm' ? 2 : change.path.length - 1;
   const selector = change.path[selectorIndex];
@@ -147,34 +151,22 @@ function groupPackagesByName(
 
 function findPackagesForSelector(
   selector: string,
-  packagesByName: Map<string, ProjectGraphExternalNode[]>
+  packagesByName: Map<string, ProjectGraphExternalNode[]>,
+  isPnpmOverride: boolean
 ): ProjectGraphExternalNode[] {
-  let match: { packageName: string; end: number } | undefined;
-
-  for (const packageName of packagesByName.keys()) {
-    let index = selector.indexOf(packageName);
-    while (index !== -1) {
-      const end = index + packageName.length;
-      const validStart =
-        index === 0 ||
-        selector[index - 1] === '>' ||
-        selector[index - 1] === '/';
-      const validEnd = end === selector.length || selector[end] === '@';
-
-      if (
-        validStart &&
-        validEnd &&
-        (!match ||
-          end > match.end ||
-          (end === match.end && packageName.length > match.packageName.length))
-      ) {
-        match = { packageName, end };
-      }
-      index = selector.indexOf(packageName, index + 1);
+  if (isPnpmOverride) {
+    // Pnpm does not treat `>` as a parent delimiter when it starts a range.
+    const parentDelimiterIndex = selector.search(/[^ |@]>/);
+    if (parentDelimiterIndex !== -1) {
+      selector = selector.slice(parentDelimiterIndex + 2);
     }
   }
 
-  return match ? packagesByName.get(match.packageName) : [];
+  const packageName = selector.match(
+    /(?:^|\/)(@[^/@>\s]+\/[^/@>\s]+|[^/@>\s]+)(?:@[^/]*)?$/
+  )?.[1];
+
+  return packageName ? (packagesByName.get(packageName) ?? []) : [];
 }
 
 function getGlobalPackages(plugins: NxJsonConfiguration['plugins']) {

--- a/packages/nx/src/plugins/js/project-graph/affected/npm-packages.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/npm-packages.ts
@@ -76,28 +76,25 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
         c.path[0] === 'resolutions' ||
         (c.path[0] === 'pnpm' && c.path[1] === 'overrides'))
     ) {
-      // Changes to overrides, resolutions, or pnpm.overrides
-      // Find which package was changed and mark projects that depend on it as affected
-      const packageName = c.path[0] === 'pnpm' ? c.path[2] : c.path[1];
+      const packageSelector = getPackageSelector(c);
 
-      if (packageName) {
-        // Look for the npm package in external nodes
-        let npmPackage: ProjectGraphProjectNode | ProjectGraphExternalNode =
-          npmPackages.find((pkg) => pkg.data.packageName === packageName);
+      if (packageSelector) {
+        const matchingNpmPackages = findPackagesForSelector(
+          packageSelector,
+          npmPackages
+        );
 
-        if (npmPackage) {
-          touched.push(npmPackage.name);
+        if (matchingNpmPackages.length) {
+          touched.push(...matchingNpmPackages.map((pkg) => pkg.name));
 
-          // If it's a global package, all projects are affected
           if (
-            'packageName' in npmPackage.data &&
-            globalPackages.has(npmPackage.data.packageName)
+            matchingNpmPackages.some((pkg) =>
+              globalPackages.has(pkg.data.packageName)
+            )
           ) {
             return Object.keys(projectGraph.nodes);
           }
         } else {
-          // If the package isn't found in external nodes, it might affect all projects
-          // since overrides can affect transitive dependencies
           return Object.keys(projectGraph.nodes);
         }
       }
@@ -115,8 +112,55 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
       )} were not found. Please open an issue in GitHub including the package.json file.`
     );
   }
-  return touched;
+  return [...new Set(touched)];
 };
+
+function getPackageSelector(change: JsonChange): string | undefined {
+  const value =
+    change.type === JsonDiffType.Deleted ? change.value.lhs : change.value.rhs;
+  if (typeof value !== 'string') return;
+
+  const selectorIndex = change.path[0] === 'pnpm' ? 2 : change.path.length - 1;
+  const selector = change.path[selectorIndex];
+  return selector === '.' ? change.path[selectorIndex - 1] : selector;
+}
+
+function findPackagesForSelector(
+  selector: string,
+  npmPackages: ProjectGraphExternalNode[]
+): ProjectGraphExternalNode[] {
+  let match: { packageName: string; end: number } | undefined;
+  const packageNames = new Set(
+    npmPackages.map((pkg) => pkg.data.packageName).filter(Boolean)
+  );
+
+  for (const packageName of packageNames) {
+    let index = selector.indexOf(packageName);
+    while (index !== -1) {
+      const end = index + packageName.length;
+      const validStart =
+        index === 0 ||
+        selector[index - 1] === '>' ||
+        selector[index - 1] === '/';
+      const validEnd = end === selector.length || selector[end] === '@';
+
+      if (
+        validStart &&
+        validEnd &&
+        (!match ||
+          end > match.end ||
+          (end === match.end && packageName.length > match.packageName.length))
+      ) {
+        match = { packageName, end };
+      }
+      index = selector.indexOf(packageName, index + 1);
+    }
+  }
+
+  return match
+    ? npmPackages.filter((pkg) => pkg.data.packageName === match.packageName)
+    : [];
+}
 
 function getGlobalPackages(plugins: NxJsonConfiguration['plugins']) {
   return (plugins ?? [])

--- a/packages/nx/src/project-graph/affected/affected-project-graph.spec.ts
+++ b/packages/nx/src/project-graph/affected/affected-project-graph.spec.ts
@@ -73,4 +73,84 @@ describe('filterAffected()', () => {
 
     expect(Object.keys(result.nodes)).toEqual(['current-a']);
   });
+
+  it('includes dependents of every installed version for an override change', async () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        'uses-version-1': {
+          name: 'uses-version-1',
+          type: 'lib',
+          data: { root: 'libs/uses-version-1' },
+        },
+        'uses-version-2': {
+          name: 'uses-version-2',
+          type: 'lib',
+          data: { root: 'libs/uses-version-2' },
+        },
+        unrelated: {
+          name: 'unrelated',
+          type: 'lib',
+          data: { root: 'libs/unrelated' },
+        },
+      },
+      externalNodes: {
+        'npm:happy-nrwl@1': {
+          name: 'npm:happy-nrwl@1',
+          type: 'npm',
+          data: { packageName: 'happy-nrwl', version: '1' },
+        },
+        'npm:happy-nrwl@2': {
+          name: 'npm:happy-nrwl@2',
+          type: 'npm',
+          data: { packageName: 'happy-nrwl', version: '2' },
+        },
+      },
+      dependencies: {
+        'uses-version-1': [
+          {
+            source: 'uses-version-1',
+            target: 'npm:happy-nrwl@1',
+            type: 'static',
+          },
+        ],
+        'uses-version-2': [
+          {
+            source: 'uses-version-2',
+            target: 'npm:happy-nrwl@2',
+            type: 'static',
+          },
+        ],
+        unrelated: [],
+        'npm:happy-nrwl@1': [],
+        'npm:happy-nrwl@2': [],
+      },
+    };
+
+    const result = await filterAffected(
+      graph,
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: 'JsonPropertyModified',
+              path: ['overrides', 'happy-nrwl@^1'],
+              value: { lhs: '1.0.0', rhs: '2.0.0' },
+            },
+          ],
+        },
+      ],
+      nxJson,
+      { overrides: { 'happy-nrwl@^1': '2.0.0' } }
+    );
+
+    expect(Object.keys(result.nodes).sort()).toEqual([
+      'uses-version-1',
+      'uses-version-2',
+    ]);
+    expect(Object.keys(result.externalNodes).sort()).toEqual([
+      'npm:happy-nrwl@1',
+      'npm:happy-nrwl@2',
+    ]);
+  });
 });


### PR DESCRIPTION
## Current Behavior

Version-scoped override keys cannot equal the bare package names in the project graph. The unknown-package fallback then marks every project affected, even when the target package exists.

## Expected Behavior

Nx resolves version, scope, parent, and nested override selectors against graph package names. It seeds the normal reverse traversal with every installed version of the target package.

- Matching only the selector range is unsafe because a replacement version can fall outside that range.
- Unknown selectors still use the all-project fallback.

## Related Issue(s)

Fixes #36698
