### PR TITLE
docs(misc): make the language plugin guide work from a pure-language repo

### DIFF
--- a/astro-docs/src/content/docs/kb/add-language-support.mdoc
+++ b/astro-docs/src/content/docs/kb/add-language-support.mdoc
@@ -16,13 +16,13 @@ Build an Nx plugin that adds support for my toolchain to this workspace, followi
    - Which targets to infer, and the command behind each one.
    - How manifests declare dependencies on each other, by package name, by relative path, or both.
    - Roughly how many projects the workspace has.
-   - Whether lower-stability Nx APIs are acceptable in exchange for faster graph computation.
-2. Check for a root `package.json` and create one with `npm init -y` plus a dev dependency on `nx` if it is missing, because the plugin generator needs it.
+   - Which Nx versions the plugin has to support, since the disk caching helpers live in a lower-stability entry point.
+2. Check for a root `package.json`. The plugin is a Node package, so the generator has nothing to write to without one. If it is missing, initialize it with whichever package manager the repository already uses, or with `npm init -y` if there is no JavaScript in the repository at all. Do not run `npm init` against a manifest that already exists, because it rewrites fields such as `type` and `license`. Once the manifest is there, `nx init` installs Nx through the detected package manager, so no separate install step is needed.
 3. Generate the plugin with `npx nx add @nx/plugin` and `npx nx g plugin packages/<plugin-name>`, in a directory the toolchain does not treat as a workspace member.
 4. Export `createNodes` from the plugin entry point: glob the manifest, and for each match return a project with cacheable targets that run the toolchain's own commands. Return `{}` for a manifest that describes an aggregate root rather than a package, and infer only the targets each project can run.
 5. Export `createDependencies`: map dependency declarations in the manifests to workspace projects and emit static dependencies.
 6. Register the plugin in `nx.json`, then verify with `NX_DAEMON=false NX_CACHE_PROJECT_GRAPH=false nx show project <project-name> --json`, `nx graph --file=graph.json`, and one real run of every target you inferred.
-7. Measure graph creation with `NX_PERF_LOGGING=true` and work through the checklist under "Tune graph performance" if my plugin accounts for a meaningful share of the time. Reach for the lower-stability disk caching helpers only if I approved them in step 1.
+7. Once the graph is correct, move on to the second phase and optimize it. Measure with `NX_PERF_LOGGING=true`, then work through the performant project graph plugins guide, including disk caching through `@nx/devkit/internal`. Tell me if the Nx version range from step 1 rules those helpers out.
 
 Page: {pageUrl}
 {% /llm_copy_prompt %}
@@ -60,8 +60,9 @@ npx nx g plugin packages/nx-uv
 {% tabitem label="In a repository without Nx" %}
 
 ```shell
+# Only if there is no root package.json yet.
 npm init -y
-npm install --save-dev nx
+
 npx nx init
 npx nx add @nx/plugin
 npx nx g plugin packages/nx-uv
@@ -77,12 +78,11 @@ npx create-nx-plugin nx-uv
 {% /tabitem %}
 {% /tabs %}
 
-In a repository that holds no JavaScript, `nx init` installs Nx under `.nx` and writes no `package.json`, which
-makes the plugin generator fail with `Cannot find package.json`.
-
-Generate the plugin outside any directory your toolchain treats as a workspace member.
-A uv root that globs `packages/*` for members reports `missing a pyproject.toml` as soon as a TypeScript plugin
-lands in `packages/nx-uv`, so exclude that path from the glob or put the plugin somewhere else.
+{% aside type="note" title="Watch for your toolchain's workspace globs" %}
+Some toolchains claim directories through a member glob, and a TypeScript plugin dropped inside one breaks them.
+A uv root that globs `packages/*` reports `missing a pyproject.toml` once the plugin lands in `packages/nx-uv`.
+Exclude that path from the glob, or generate the plugin where the glob doesn't reach.
+{% /aside %}
 
 The plugin entry point exports the two functions, each tied to the glob and options you'll fill in over the next sections:
 
@@ -366,38 +366,25 @@ it('creates a project for each pyproject.toml', async () => {
 The first-party plugins that spawn an external tool mock that step in unit tests and feed in a recorded report fixture, so the tests stay fast and deterministic.
 Plugins scaffolded with `create-nx-plugin` also include an e2e setup that publishes the plugin to a local registry, installs it into a fresh workspace, and asserts on `nx show project --json` output.
 
-## Tune graph performance
+## Optimize graph creation
 
-`createNodes` runs before every task, including the ones Nx restores from cache.
-Reading one small manifest per project, as the example above does, is fast enough for most workspaces.
-Measure before changing anything:
+A correct plugin is the first half of the job.
+`createNodes` runs before every task, including the ones Nx restores from cache, so whatever it costs is charged
+to every command in the workspace.
+Measure that cost once the graph is right:
 
 ```shell
-# Cold: your plugin recomputes everything.
 NX_PERF_LOGGING=true NX_DAEMON=false NX_CACHE_PROJECT_GRAPH=false npx nx graph --file=graph.json
-
-# Warm: Nx reuses the cached graph.
-NX_PERF_LOGGING=true NX_DAEMON=false npx nx graph --file=graph.json
 ```
 
-Nx prints a timing per step, including `<plugin-name>:createNodes`, `<plugin-name>:createDependencies`, and
-`Load Nx Plugin: <plugin-name>`.
-That last one is the cost of importing your entry point, and it is paid on warm runs too.
-When your plugin accounts for a meaningful share of graph creation, work through this list:
+Nx prints a timing per step, including `<plugin-name>:createNodes` and `Load Nx Plugin: <plugin-name>`.
+Loading the entry point is frequently the larger of the two, and it is paid even when Nx reuses a cached graph.
 
-- Read and parse the manifests concurrently, in the single batch `createNodes` hands you.
-- Parse each manifest once and share the result with `createDependencies`.
-- Sort arrays before returning them, so the same input hashes the same way on every machine.
-- Keep top-level imports light and move heavy dependencies behind `await import(...)` in the path that needs them.
-- Replace any per-file child process with a single invocation for the whole workspace.
-- Cache results to disk once reparsing unchanged manifests dominates the remaining time.
+The patterns that bring those numbers down are caching computed targets to disk, loading manifests in one parallel
+batch, keeping returned output deterministic, and keeping top-level imports light.
+Disk caching uses a handful of helpers from `@nx/devkit/internal`, which nearly every first-party plugin depends
+on.
+They sit at a lower stability tier than the main `@nx/devkit` entry point and can change between versions, and
+some will be promoted to the public API later.
 
-Every API shown above comes from the public `@nx/devkit` entry point, which supports one major version of `nx`
-in either direction.
-Disk caching is the exception.
-First-party plugins use a few lower-stability helpers from `@nx/devkit/internal` for it, and those are subject to
-change between versions.
-Some will be promoted to the public API later.
-Until then you can write the equivalent yourself, which amounts to a content hash plus a JSON file on disk.
-
-For the code behind each of these, see [write a performant project graph plugin](/docs/kb/performant-project-graph-plugins).
+[Write a performant project graph plugin](/docs/kb/performant-project-graph-plugins) has the code for each pattern.

--- a/astro-docs/src/content/docs/kb/add-language-support.mdoc
+++ b/astro-docs/src/content/docs/kb/add-language-support.mdoc
@@ -11,11 +11,18 @@ topics:
 {% llm_copy_prompt title="Let an AI agent build the plugin" %}
 Build an Nx plugin that adds support for my toolchain to this workspace, following the structure below.
 
-1. Ask me which toolchain to support and which manifest file marks a project (for example `pyproject.toml`, `go.mod`, `Cargo.toml`).
-2. Generate the plugin with `npx nx add @nx/plugin` and `npx nx g plugin packages/<plugin-name>`.
-3. Export `createNodes` from the plugin entry point: glob the manifest, and for each match return a project with cacheable targets that run the toolchain's own commands.
-4. Export `createDependencies`: map dependency declarations in the manifests to workspace projects and emit static dependencies.
-5. Register the plugin in `nx.json`, then verify with `NX_DAEMON=false NX_CACHE_PROJECT_GRAPH=false nx show project <project-name> --json` and `nx graph`.
+1. Ask me the following before writing any code:
+   - Which toolchain to support, and which manifest file marks a project (for example `pyproject.toml`, `go.mod`, `Cargo.toml`).
+   - Which targets to infer, and the command behind each one.
+   - How manifests declare dependencies on each other, by package name, by relative path, or both.
+   - Roughly how many projects the workspace has.
+   - Whether lower-stability Nx APIs are acceptable in exchange for faster graph computation.
+2. Check for a root `package.json` and create one with `npm init -y` plus a dev dependency on `nx` if it is missing, because the plugin generator needs it.
+3. Generate the plugin with `npx nx add @nx/plugin` and `npx nx g plugin packages/<plugin-name>`, in a directory the toolchain does not treat as a workspace member.
+4. Export `createNodes` from the plugin entry point: glob the manifest, and for each match return a project with cacheable targets that run the toolchain's own commands. Return `{}` for a manifest that describes an aggregate root rather than a package, and infer only the targets each project can run.
+5. Export `createDependencies`: map dependency declarations in the manifests to workspace projects and emit static dependencies.
+6. Register the plugin in `nx.json`, then verify with `NX_DAEMON=false NX_CACHE_PROJECT_GRAPH=false nx show project <project-name> --json`, `nx graph --file=graph.json`, and one real run of every target you inferred.
+7. Measure graph creation with `NX_PERF_LOGGING=true` and work through the checklist under "Tune graph performance" if my plugin accounts for a meaningful share of the time. Reach for the lower-stability disk caching helpers only if I approved them in step 1.
 
 Page: {pageUrl}
 {% /llm_copy_prompt %}
@@ -38,10 +45,11 @@ The examples below use Python projects managed with [uv](https://docs.astral.sh/
 ## Set up a plugin
 
 A plugin is a module that exports `createNodes` and, optionally, `createDependencies`.
-Scaffold one with:
+It ships as a Node package, so the workspace needs a root `package.json` first.
+Scaffold the plugin with:
 
 {% tabs %}
-{% tabitem label="In an existing workspace" %}
+{% tabitem label="In an existing Nx workspace" %}
 
 ```shell
 npx nx add @nx/plugin
@@ -49,7 +57,18 @@ npx nx g plugin packages/nx-uv
 ```
 
 {% /tabitem %}
-{% tabitem label="In a new workspace" %}
+{% tabitem label="In a repository without Nx" %}
+
+```shell
+npm init -y
+npm install --save-dev nx
+npx nx init
+npx nx add @nx/plugin
+npx nx g plugin packages/nx-uv
+```
+
+{% /tabitem %}
+{% tabitem label="In a new plugin workspace" %}
 
 ```shell
 npx create-nx-plugin nx-uv
@@ -57,6 +76,13 @@ npx create-nx-plugin nx-uv
 
 {% /tabitem %}
 {% /tabs %}
+
+In a repository that holds no JavaScript, `nx init` installs Nx under `.nx` and writes no `package.json`, which
+makes the plugin generator fail with `Cannot find package.json`.
+
+Generate the plugin outside any directory your toolchain treats as a workspace member.
+A uv root that globs `packages/*` for members reports `missing a pyproject.toml` as soon as a TypeScript plugin
+lands in `packages/nx-uv`, so exclude that path from the glob or put the plugin somewhere else.
 
 The plugin entry point exports the two functions, each tied to the glob and options you'll fill in over the next sections:
 
@@ -66,6 +92,7 @@ import { CreateDependencies, CreateNodes } from '@nx/devkit';
 
 // Options users can set in nx.json
 export interface UvPluginOptions {
+  buildTargetName?: string;
   testTargetName?: string;
 }
 
@@ -95,6 +122,7 @@ Register the plugin in `nx.json` so Nx calls it when computing the project graph
     {
       "plugin": "nx-uv",
       "options": {
+        "buildTargetName": "build",
         "testTargetName": "test",
       },
     },
@@ -163,6 +191,13 @@ function createNodesInternal(
     readFileSync(join(context.workspaceRoot, configFilePath), 'utf-8')
   );
 
+  // A uv workspace root lists its members without declaring a package of its own.
+  const name = pyproject.project?.name;
+  if (!name) {
+    return {};
+  }
+
+  const buildTargetName = options?.buildTargetName ?? 'build';
   const testTargetName = options?.testTargetName ?? 'test';
 
   const testTarget: TargetConfiguration = {
@@ -180,24 +215,36 @@ function createNodesInternal(
     },
   };
 
-  return {
-    projects: {
-      [projectRoot]: {
-        name: pyproject.project.name,
-        targets: {
-          [testTargetName]: testTarget,
-        },
-      },
-    },
+  const targets: Record<string, TargetConfiguration> = {
+    [testTargetName]: testTarget,
   };
+
+  // Only a project that declares a build backend can produce a distribution.
+  if (pyproject['build-system']) {
+    targets[buildTargetName] = {
+      command: 'uv build --out-dir dist',
+      options: { cwd: projectRoot },
+      cache: true,
+      inputs: ['{projectRoot}/**/*.py', '{projectRoot}/pyproject.toml'],
+      outputs: ['{projectRoot}/dist'],
+      metadata: {
+        technologies: ['python'],
+        description: 'Build a wheel and source distribution via uv',
+      },
+    };
+  }
+
+  return { projects: { [projectRoot]: { name, targets } } };
 }
 ```
 
 With this in place, `nx test <project-name>` runs pytest for any project that has a `pyproject.toml`, with caching configured once in the plugin instead of per project.
+`nx build <project-name>` works the same way for the projects that declare a build backend.
 
 A few things to know about the returned configuration:
 
-- **The config file is the project marker.** For language plugins, the manifest marks the project, so there's no need to check for `project.json` or `package.json` the way JS tooling plugins do. Return `{}` to skip creating a project for a matched file.
+- **The config file is the project marker.** For language plugins, the manifest marks the project, so there's no need to check for `project.json` or `package.json` the way JS tooling plugins do.
+- **Read the manifest before inferring.** Manifests within one workspace are not uniform. A root that only aggregates members is not a project at all, plenty of projects have no build backend, and the project name can live in a toolchain-specific table rather than the standard one.
 - **Targets are regular Nx targets.** `command`, `cache`, `inputs`, `outputs`, and `dependsOn` behave exactly as they do in `project.json`. Paths must start with `{projectRoot}` or `{workspaceRoot}`, and set `outputs` for tasks that produce files so Nx can restore them from cache. See the [inputs reference](/docs/reference/inputs) for details.
 - **Consider the lockfile in `inputs`.** Hashing the lockfile (`uv.lock`, `go.sum`, `Cargo.lock`) re-runs tasks when dependency versions change, but any lockfile change busts the cache for every project. The built-in JS support avoids this by hashing only the external packages each project uses, which is worth copying if your lockfile churns often.
 - **Returned configuration is merged, not final.** Users can override anything your plugin infers by adding a `project.json` file to the project or `targetDefaults` in `nx.json`. Plugin-inferred values have the lowest priority.
@@ -246,6 +293,9 @@ export const createDependencies: CreateDependencies<UvPluginOptions> = (
     const config = parse(
       readFileSync(join(context.workspaceRoot, pyprojectPath), 'utf-8')
     );
+    if (!config.project?.name) {
+      continue;
+    }
     packageToProject.set(config.project.name, projectName);
     projectPyprojects.set(projectName, { config, path: pyprojectPath });
   }
@@ -269,6 +319,9 @@ export const createDependencies: CreateDependencies<UvPluginOptions> = (
 };
 ```
 
+Some toolchains point at a sibling directory instead of naming a package, as a Poetry path dependency does.
+Resolve those against the directory of the manifest that declares them, then match the result to a project root.
+
 Manifest files like `pyproject.toml`, `go.mod`, or `Cargo.toml` cover most toolchains, since the dependency information is already written down in one place per project.
 If your language only expresses dependencies through import statements in source code, parse those files instead, and use `context.filesToProcess` to limit the work to files that changed since the last graph computation.
 
@@ -276,7 +329,7 @@ Accurate parsing is often easier in the language itself than in TypeScript.
 The first-party Gradle, Maven, and .NET plugins all spawn the toolchain once for the whole workspace, have it write a JSON report of projects and dependencies, and build both nodes and dependencies from that report.
 Nx always calls `createNodes` before `createDependencies`, so the report can be produced once and shared between the two.
 
-## Test your plugin
+## Verify your plugin
 
 While developing, two environment variables matter:
 
@@ -288,7 +341,8 @@ NX_DAEMON=false NX_CACHE_PROJECT_GRAPH=false npx nx show projects
 Check the results of your plugin directly:
 
 - `nx show project <project-name> --json` prints the full inferred configuration, including targets your plugin created.
-- `nx graph` renders the projects and the dependencies you emitted.
+- `nx graph --file=graph.json` writes the projects and the dependencies you emitted to a file rather than opening a browser, which works over SSH and in CI. Pass an `.html` path for the interactive view.
+- `nx <target> <project-name>` runs a target you inferred. Run one of every kind you created, because a target that reads correctly in `nx show project` can still fail the moment its command executes.
 
 For automated coverage, call your functions directly in a unit test with a fixture directory as the workspace root, and snapshot the returned projects and dependencies:
 
@@ -312,11 +366,38 @@ it('creates a project for each pyproject.toml', async () => {
 The first-party plugins that spawn an external tool mock that step in unit tests and feed in a recorded report fixture, so the tests stay fast and deterministic.
 Plugins scaffolded with `create-nx-plugin` also include an e2e setup that publishes the plugin to a local registry, installs it into a fresh workspace, and asserts on `nx show project --json` output.
 
-## A note on internal APIs
+## Tune graph performance
 
-Everything shown above comes from the public `@nx/devkit` entry point, which is stable and supports one major version of `nx` in either direction.
-First-party plugins also use a few lower-stability helpers from `@nx/devkit/internal`, mainly for caching computed targets to disk so graph computation stays fast in large workspaces.
-Some of these utilities will be promoted to the public API in the future, but for now they are subject to change between versions.
-If you need the behavior today, implement it yourself, which amounts to a content hash plus a JSON file on disk.
+`createNodes` runs before every task, including the ones Nx restores from cache.
+Reading one small manifest per project, as the example above does, is fast enough for most workspaces.
+Measure before changing anything:
 
-Once your plugin works, continue with [write a performant project graph plugin](/docs/kb/performant-project-graph-plugins) for the disk caching and batching patterns first-party plugins use.
+```shell
+# Cold: your plugin recomputes everything.
+NX_PERF_LOGGING=true NX_DAEMON=false NX_CACHE_PROJECT_GRAPH=false npx nx graph --file=graph.json
+
+# Warm: Nx reuses the cached graph.
+NX_PERF_LOGGING=true NX_DAEMON=false npx nx graph --file=graph.json
+```
+
+Nx prints a timing per step, including `<plugin-name>:createNodes`, `<plugin-name>:createDependencies`, and
+`Load Nx Plugin: <plugin-name>`.
+That last one is the cost of importing your entry point, and it is paid on warm runs too.
+When your plugin accounts for a meaningful share of graph creation, work through this list:
+
+- Read and parse the manifests concurrently, in the single batch `createNodes` hands you.
+- Parse each manifest once and share the result with `createDependencies`.
+- Sort arrays before returning them, so the same input hashes the same way on every machine.
+- Keep top-level imports light and move heavy dependencies behind `await import(...)` in the path that needs them.
+- Replace any per-file child process with a single invocation for the whole workspace.
+- Cache results to disk once reparsing unchanged manifests dominates the remaining time.
+
+Every API shown above comes from the public `@nx/devkit` entry point, which supports one major version of `nx`
+in either direction.
+Disk caching is the exception.
+First-party plugins use a few lower-stability helpers from `@nx/devkit/internal` for it, and those are subject to
+change between versions.
+Some will be promoted to the public API later.
+Until then you can write the equivalent yourself, which amounts to a content hash plus a JSON file on disk.
+
+For the code behind each of these, see [write a performant project graph plugin](/docs/kb/performant-project-graph-plugins).

--- a/astro-docs/src/content/docs/kb/add-language-support.mdoc
+++ b/astro-docs/src/content/docs/kb/add-language-support.mdoc
@@ -374,11 +374,12 @@ to every command in the workspace.
 Measure that cost once the graph is right:
 
 ```shell
-NX_PERF_LOGGING=true NX_DAEMON=false NX_CACHE_PROJECT_GRAPH=false npx nx graph --file=graph.json
+NX_PERF_LOGGING=true NX_DAEMON=false npx nx show projects
 ```
 
 Nx prints a timing per step, including `<plugin-name>:createNodes` and `Load Nx Plugin: <plugin-name>`.
 Loading the entry point is frequently the larger of the two, and it is paid even when Nx reuses a cached graph.
+Keep the daemon off, or the plugin timings never reach your terminal.
 
 The patterns that bring those numbers down are caching computed targets to disk, loading manifests in one parallel
 batch, keeping returned output deterministic, and keeping top-level imports light.

--- a/astro-docs/src/content/docs/kb/add-language-support.mdoc
+++ b/astro-docs/src/content/docs/kb/add-language-support.mdoc
@@ -319,8 +319,10 @@ export const createDependencies: CreateDependencies<UvPluginOptions> = (
 };
 ```
 
+{% aside type="note" title="Dependencies declared by path" %}
 Some toolchains point at a sibling directory instead of naming a package, as a Poetry path dependency does.
 Resolve those against the directory of the manifest that declares them, then match the result to a project root.
+{% /aside %}
 
 Manifest files like `pyproject.toml`, `go.mod`, or `Cargo.toml` cover most toolchains, since the dependency information is already written down in one place per project.
 If your language only expresses dependencies through import statements in source code, parse those files instead, and use `context.filesToProcess` to limit the work to files that changed since the last graph computation.
@@ -368,24 +370,22 @@ Plugins scaffolded with `create-nx-plugin` also include an e2e setup that publis
 
 ## Optimize graph creation
 
-A correct plugin is the first half of the job.
-`createNodes` runs before every task, including the ones Nx restores from cache, so whatever it costs is charged
-to every command in the workspace.
-Measure that cost once the graph is right:
+`createNodes` runs before every task, so measure what your plugin costs once the graph is correct:
 
 ```shell
 NX_PERF_LOGGING=true NX_DAEMON=false npx nx show projects
 ```
 
 Nx prints a timing per step, including `<plugin-name>:createNodes` and `Load Nx Plugin: <plugin-name>`.
-Loading the entry point is frequently the larger of the two, and it is paid even when Nx reuses a cached graph.
 Keep the daemon off, or the plugin timings never reach your terminal.
 
-The patterns that bring those numbers down are caching computed targets to disk, loading manifests in one parallel
-batch, keeping returned output deterministic, and keeping top-level imports light.
-Disk caching uses a handful of helpers from `@nx/devkit/internal`, which nearly every first-party plugin depends
-on.
-They sit at a lower stability tier than the main `@nx/devkit` entry point and can change between versions, and
-some will be promoted to the public API later.
+From there, work through the patterns that bring those numbers down:
 
-[Write a performant project graph plugin](/docs/kb/performant-project-graph-plugins) has the code for each pattern.
+- Cache computed targets to disk. This uses a handful of helpers from `@nx/devkit/internal`, which nearly every
+  first-party plugin depends on. They sit at a lower stability tier than `@nx/devkit` and can change between
+  versions, and some will be promoted to the public API later.
+- Load and parse the manifests in one parallel batch.
+- Keep the configuration you return deterministic.
+- Keep top-level imports light.
+
+[Write a performant project graph plugin](/docs/kb/performant-project-graph-plugins) has the code for each.


### PR DESCRIPTION
## Current Behavior

The guide assumes a Node-backed Nx workspace. In a pure-language repository `nx init` installs Nx under `.nx` and writes no `package.json`, so the plugin generator fails with `Cannot find package.json`. The copyable prompt asks only for toolchain and manifest, stops at `nx graph`, and never runs an inferred target.

## Expected Behavior

A bootstrap tab covers repositories without Nx, the prompt asks for targets, dependency forms, scale, and internal-API tolerance, `createNodes` handles manifests that mark an aggregate root rather than a package, verification runs a real target, and a new `Tune graph performance` section replaces `A note on internal APIs`.

Every command and code sample was executed in a disposable pure-Python uv fixture.

Preview: https://deploy-preview-36702--nx-docs.netlify.app/docs/kb/add-language-support

## Related Issue(s)

DOC-597

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/quiet-otter-4a73b56a">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->