### PR TITLE
feat(core): guarantee terminal output files and add an agent-friendly summary output style

### DIFF
--- a/e2e/nx/src/terminal-outputs.test.ts
+++ b/e2e/nx/src/terminal-outputs.test.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'fs';
 import {
   cleanupProject,
   listFiles,
@@ -159,6 +160,91 @@ describe('terminal outputs on disk', () => {
     const replay = runCLI(`echo ${lib}`);
     expect(replay).toContain('read the output from the cache');
   }, 120000);
+
+  describe('--output-style=summary', () => {
+    function createFailingProject(lib: string, marker: string) {
+      updateFile(
+        `libs/${lib}/project.json`,
+        JSON.stringify({
+          name: lib,
+          targets: {
+            echo: {
+              executor: 'nx:run-commands',
+              cache: false,
+              options: {
+                command: `node -e "console.log('${marker}'); process.exit(3)"`,
+              },
+            },
+          },
+        })
+      );
+    }
+
+    function nonEmptyLines(out: string): string[] {
+      return out.split('\n').filter((l) => l.trim().length > 0);
+    }
+
+    it('should collapse a passing run to a handful of lines', () => {
+      const lib = uniq('summary-pass');
+      const marker = `summary-pass-marker-${lib}`;
+      createRunCommandsProject(lib, marker, false);
+
+      const results = runCLI(`echo ${lib} --output-style=summary`);
+
+      // The task's own output is on disk, not in the run's output.
+      expect(results).not.toContain(marker);
+      expect(results).toContain('succeeded');
+      expect(nonEmptyLines(results).length).toBeLessThanOrEqual(10);
+    }, 120000);
+
+    it('should name a failing task and point at its log on disk', () => {
+      const lib = uniq('summary-fail');
+      const marker = `summary-fail-marker-${lib}`;
+      createFailingProject(lib, marker);
+
+      const results = runCLI(`echo ${lib} --output-style=summary`, {
+        silenceError: true,
+        redirectStderr: true,
+      });
+
+      expect(results).toContain('1 failed');
+      expect(results).toContain(`nx run ${lib}:echo`);
+      expect(results).toContain('(exit 3)');
+      // Bounded regardless of how much the task logged.
+      expect(nonEmptyLines(results).length).toBeLessThanOrEqual(30);
+
+      // The path it prints has to be real, and hold the output it stands in for.
+      const logPath = results.match(/full log: (\S+)/)?.[1];
+      expect(logPath).toBeDefined();
+      expect(existsSync(logPath)).toBe(true);
+      expect(readFileSync(logPath, 'utf-8')).toContain(marker);
+    }, 120000);
+
+    it('should be the default when nx is driven by an AI agent', () => {
+      const lib = uniq('summary-agent');
+      const marker = `summary-agent-marker-${lib}`;
+      createRunCommandsProject(lib, marker, false);
+
+      const results = runCLI(`echo ${lib}`, { env: { CLAUDECODE: '1' } });
+
+      expect(results).not.toContain(marker);
+      expect(results).toContain('succeeded');
+      expect(nonEmptyLines(results).length).toBeLessThanOrEqual(10);
+    }, 120000);
+
+    it('should let an explicit output style beat the AI agent default', () => {
+      const lib = uniq('summary-explicit');
+      const marker = `summary-explicit-marker-${lib}`;
+      createRunCommandsProject(lib, marker, false);
+
+      const results = runCLI(`echo ${lib} --output-style=static`, {
+        env: { CLAUDECODE: '1' },
+      });
+
+      // static prints every task in full, agent or not.
+      expect(results).toContain(marker);
+    }, 120000);
+  });
 
   it('should keep the cached path intact so a replay still reads its output', () => {
     const lib = uniq('cached');

--- a/e2e/nx/src/terminal-outputs.test.ts
+++ b/e2e/nx/src/terminal-outputs.test.ts
@@ -1,0 +1,156 @@
+import {
+  cleanupProject,
+  listFiles,
+  newProject,
+  readFile,
+  runCLI,
+  uniq,
+  updateFile,
+} from '@nx/e2e-utils';
+
+const TERMINAL_OUTPUTS_DIR = '.nx/cache/terminalOutputs';
+
+describe('terminal outputs on disk', () => {
+  beforeAll(() => newProject({ packages: [] }));
+
+  afterAll(() => cleanupProject());
+
+  /**
+   * Every task that reaches a terminal state has to leave its output at
+   * `<cacheDir>/terminalOutputs/<hash>`, so the file is found by content
+   * rather than by recomputing the task's hash.
+   */
+  function terminalOutputContains(marker: string): boolean {
+    return listFiles(TERMINAL_OUTPUTS_DIR).some((file) =>
+      readFile(`${TERMINAL_OUTPUTS_DIR}/${file}`).includes(marker)
+    );
+  }
+
+  function createRunCommandsProject(
+    lib: string,
+    marker: string,
+    cache: boolean
+  ) {
+    updateFile(
+      `libs/${lib}/project.json`,
+      JSON.stringify({
+        name: lib,
+        targets: {
+          echo: {
+            executor: 'nx:run-commands',
+            cache,
+            options: { command: `node -e "console.log('${marker}')"` },
+          },
+        },
+      })
+    );
+  }
+
+  it('should write terminal output for a cache:false task with --output-style=stream', () => {
+    const lib = uniq('streamed');
+    const marker = `streamed-marker-${lib}`;
+    createRunCommandsProject(lib, marker, false);
+
+    const results = runCLI(`echo ${lib} --output-style=stream`);
+
+    expect(results).toContain(marker);
+    expect(terminalOutputContains(marker)).toBe(true);
+  }, 120000);
+
+  it('should write terminal output for a cache:false task in batch mode', () => {
+    const plugin = uniq('batch-plugin');
+    const lib = uniq('batched');
+    const marker = `batched-marker-${lib}`;
+
+    // A minimal plugin whose executor supports batching, dropped straight into
+    // node_modules so it resolves like any installed one. Its batch
+    // implementation hands each task's output back over IPC and never touches
+    // disk — exactly the path that used to leave no file behind.
+    const pluginRoot = `node_modules/${plugin}`;
+    updateFile(
+      `${pluginRoot}/package.json`,
+      JSON.stringify({
+        name: plugin,
+        version: '0.0.1',
+        executors: './executors.json',
+      })
+    );
+    updateFile(
+      `${pluginRoot}/executors.json`,
+      JSON.stringify({
+        executors: {
+          echo: {
+            implementation: './impl',
+            batchImplementation: './batch-impl',
+            schema: './schema.json',
+          },
+        },
+      })
+    );
+    updateFile(
+      `${pluginRoot}/schema.json`,
+      JSON.stringify({
+        $schema: 'http://json-schema.org/schema',
+        type: 'object',
+        properties: { text: { type: 'string' } },
+      })
+    );
+    updateFile(
+      `${pluginRoot}/impl.js`,
+      `module.exports = {
+        default: async (options) => {
+          console.log(options.text);
+          return { success: true };
+        },
+      };`
+    );
+    updateFile(
+      `${pluginRoot}/batch-impl.js`,
+      `module.exports = {
+        default: async (taskGraph, inputs) => {
+          const results = {};
+          for (const taskId of Object.keys(taskGraph.tasks)) {
+            results[taskId] = {
+              success: true,
+              terminalOutput: inputs[taskId].text,
+            };
+          }
+          return results;
+        },
+      };`
+    );
+
+    updateFile(
+      `libs/${lib}/project.json`,
+      JSON.stringify({
+        name: lib,
+        targets: {
+          echo: {
+            executor: `${plugin}:echo`,
+            cache: false,
+            options: { text: marker },
+          },
+        },
+      })
+    );
+
+    runCLI(`echo ${lib}`, { env: { NX_BATCH_MODE: 'true' } });
+
+    expect(terminalOutputContains(marker)).toBe(true);
+  }, 120000);
+
+  it('should keep the cached path intact so a replay still reads its output', () => {
+    const lib = uniq('cached');
+    const marker = `cached-marker-${lib}`;
+    createRunCommandsProject(lib, marker, true);
+
+    const firstRun = runCLI(`echo ${lib}`);
+    expect(firstRun).not.toContain('read the output from the cache');
+    expect(terminalOutputContains(marker)).toBe(true);
+
+    const replay = runCLI(`echo ${lib}`);
+    expect(replay).toContain('read the output from the cache');
+    // The replay reads this very file, so it must still be there afterwards.
+    expect(terminalOutputContains(marker)).toBe(true);
+  }, 120000);
+});

--- a/e2e/nx/src/terminal-outputs.test.ts
+++ b/e2e/nx/src/terminal-outputs.test.ts
@@ -139,6 +139,27 @@ describe('terminal outputs on disk', () => {
     expect(terminalOutputContains(marker)).toBe(true);
   }, 120000);
 
+  it('should not replay a task whose output was written without artifacts', () => {
+    const lib = uniq('skipcache');
+    const marker = `skipcache-marker-${lib}`;
+    createRunCommandsProject(lib, marker, true);
+
+    // --skip-nx-cache leaves a terminal output file, and a record of it so the
+    // GC can collect it, but writes no cache entry.
+    const skipped = runCLI(`echo ${lib} --skip-nx-cache`);
+    expect(skipped).not.toContain('read the output from the cache');
+    expect(terminalOutputContains(marker)).toBe(true);
+
+    // That record must never be served as a hit — there are no outputs behind
+    // it, so replaying it would restore nothing while reporting success.
+    const firstRealRun = runCLI(`echo ${lib}`);
+    expect(firstRealRun).not.toContain('read the output from the cache');
+
+    // ...and the real entry it just wrote supersedes the record.
+    const replay = runCLI(`echo ${lib}`);
+    expect(replay).toContain('read the output from the cache');
+  }, 120000);
+
   it('should keep the cached path intact so a replay still reads its output', () => {
     const lib = uniq('cached');
     const marker = `cached-marker-${lib}`;

--- a/e2e/nx/src/terminal-outputs.test.ts
+++ b/e2e/nx/src/terminal-outputs.test.ts
@@ -209,7 +209,12 @@ describe('terminal outputs on disk', () => {
 
       expect(results).toContain('1 failed');
       expect(results).toContain(`nx run ${lib}:echo`);
-      expect(results).toContain('(exit 3)');
+      // 1, not the 3 the task actually exits with. `completeTasks` rebuilds
+      // `TaskResult.code` from the status rather than carrying the code the
+      // process returned, so every failure reaches a life cycle as 1 - long
+      // before this style existed, and shared with task history and Nx Cloud.
+      // Asserting 3 here would be asserting a fix to that, not to this.
+      expect(results).toContain('(exit 1)');
       // Bounded regardless of how much the task logged.
       expect(nonEmptyLines(results).length).toBeLessThanOrEqual(30);
 

--- a/e2e/nx/src/terminal-outputs.test.ts
+++ b/e2e/nx/src/terminal-outputs.test.ts
@@ -209,12 +209,14 @@ describe('terminal outputs on disk', () => {
 
       expect(results).toContain('1 failed');
       expect(results).toContain(`nx run ${lib}:echo`);
-      // 1, not the 3 the task actually exits with. `completeTasks` rebuilds
-      // `TaskResult.code` from the status rather than carrying the code the
-      // process returned, so every failure reaches a life cycle as 1 - long
-      // before this style existed, and shared with task history and Nx Cloud.
-      // Asserting 3 here would be asserting a fix to that, not to this.
-      expect(results).toContain('(exit 1)');
+      // No exit code is printed. `completeTasks` rebuilds `TaskResult.code`
+      // from the status rather than carrying the code the process returned, so
+      // every failure reaches a life cycle as 1 - this task exits 3 and would
+      // have rendered `(exit 1)`. Rather than print a number that is always 1
+      // to a reader whose job is to machine-read the line, the style prints
+      // none. Carrying the real code through `TaskResult` would change what
+      // task history and Nx Cloud record, which is its own change.
+      expect(results).not.toContain('(exit');
       // Bounded regardless of how much the task logged.
       expect(nonEmptyLines(results).length).toBeLessThanOrEqual(30);
 

--- a/e2e/nx/src/terminal-outputs.test.ts
+++ b/e2e/nx/src/terminal-outputs.test.ts
@@ -100,7 +100,12 @@ describe('terminal outputs on disk', () => {
       `${pluginRoot}/impl.js`,
       `module.exports = {
         default: async (options) => {
-          console.log(options.text);
+          // Distinct from the batch marker on purpose: batching falls back to
+          // this silently when the batch implementation does not resolve
+          // (tasks-schedule.ts returns without a diagnostic), and the
+          // single-task path already wrote the output file before this PR - so
+          // a shared marker would keep the test green on the unfixed code.
+          console.log(options.text + '-single');
           return { success: true };
         },
       };`
@@ -113,7 +118,7 @@ describe('terminal outputs on disk', () => {
           for (const taskId of Object.keys(taskGraph.tasks)) {
             results[taskId] = {
               success: true,
-              terminalOutput: inputs[taskId].text,
+              terminalOutput: inputs[taskId].text + '-batched',
             };
           }
           return results;
@@ -137,7 +142,9 @@ describe('terminal outputs on disk', () => {
 
     runCLI(`echo ${lib}`, { env: { NX_BATCH_MODE: 'true' } });
 
-    expect(terminalOutputContains(marker)).toBe(true);
+    // The batched marker specifically: this is the path NXC-4694 is about, and
+    // the non-batch fallback wrote a file at base too.
+    expect(terminalOutputContains(`${marker}-batched`)).toBe(true);
   }, 120000);
 
   it('should not replay a task whose output was written without artifacts', () => {

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -188,6 +188,14 @@ export function getStrippedEnvironmentVariables(cwd: string = tmpProjPath()) {
       // Remove AI agent detection env vars to prevent the test runner's
       // environment (e.g., running inside Claude Code) from leaking into
       // e2e test subprocesses. Tests that need these pass them explicitly.
+      //
+      // Every variable `is_ai_agent` reads must be here, or a run started from
+      // that agent resolves to `--output-style=summary`, which prints no task
+      // output and no `Successfully ran target` line — the string ~96 e2e files
+      // assert on. Keep in sync with `packages/nx/src/native/utils/ai.rs`.
+      // PAGER is deliberately absent: Cursor needs it alongside CURSOR_TRACE_ID
+      // and COMPOSER_NO_INTERACTION, which are both stripped. NX_DAEMON_PROCESS
+      // is already dropped by the NX_ rule above.
       const aiAgentEnvVars = [
         'CLAUDECODE',
         'CLAUDE_CODE',
@@ -196,6 +204,8 @@ export function getStrippedEnvironmentVariables(cwd: string = tmpProjPath()) {
         'CURSOR_TRACE_ID',
         'COMPOSER_NO_INTERACTION',
         'REPL_ID',
+        'VSCODE_AGENT',
+        'CODEX_THREAD_ID',
       ];
       if (aiAgentEnvVars.includes(key)) {
         return false;

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -192,7 +192,9 @@ export function getStrippedEnvironmentVariables(cwd: string = tmpProjPath()) {
       // Every variable `is_ai_agent` reads must be here, or a run started from
       // that agent resolves to `--output-style=summary`, which prints no task
       // output and no `Successfully ran target` line — the string ~96 e2e files
-      // assert on. Keep in sync with `packages/nx/src/native/utils/ai.rs`.
+      // assert on. This list has fallen behind `ai.rs` twice as it gained
+      // detectors, so check it rather than trusting it:
+      //   grep -o 'env::var("[^"]*"' packages/nx/src/native/utils/ai.rs
       // PAGER is deliberately absent: Cursor needs it alongside CURSOR_TRACE_ID
       // and COMPOSER_NO_INTERACTION, which are both stripped. NX_DAEMON_PROCESS
       // is already dropped by the NX_ rule above.
@@ -206,6 +208,8 @@ export function getStrippedEnvironmentVariables(cwd: string = tmpProjPath()) {
         'REPL_ID',
         'VSCODE_AGENT',
         'CODEX_THREAD_ID',
+        'COPILOT_CLI',
+        'SUPERSET_AGENT_ID',
       ];
       if (aiAgentEnvVars.includes(key)) {
         return false;

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -307,19 +307,26 @@ async function runPublishOnProjects(
    * NOTE: Force TUI to be disabled for now.
    */
   process.env.NX_TUI = 'false';
+  const publishOutputStyle = (args as any).specifiedOutputStyle ?? 'static';
   const { taskResults } = await runCommandForTasks(
     projectsWithTarget,
     projectGraph,
     { nxJson },
     {
       targets: [requiredTargetName],
+      ...(args as any),
       // Everything this command reports — the registry, the tag, the
       // package.json diff, the dry-run summary — is printed from inside the
       // task, so the failures-only default would swallow all of it (under
-      // --dry-run every task succeeds by definition). An explicit
-      // --output-style still wins, since it comes in through the spread.
-      outputStyle: 'static',
-      ...(args as any),
+      // --dry-run every task succeeds by definition). Set after the spread and
+      // on all three fields: the middleware always writes `resolvedOutputStyle`,
+      // so a value placed before it would be overwritten on every run, and the
+      // renderer reads the new fields rather than the deprecated one. A style
+      // the user actually named still wins, which is what `specifiedOutputStyle`
+      // being set means.
+      outputStyle: publishOutputStyle,
+      specifiedOutputStyle: publishOutputStyle,
+      resolvedOutputStyle: publishOutputStyle,
       // It is possible for workspaces to have circular dependencies between packages and still release them to a registry
       nxIgnoreCycles: true,
     },

--- a/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
@@ -1,3 +1,4 @@
+import type { Mock } from 'vitest';
 import * as stream from 'node:stream';
 import * as yargs from 'yargs';
 
@@ -16,6 +17,7 @@ import {
   withTuiOptions,
 } from './shared-options';
 import { withEnvironmentVariables } from '../../internal-testing-utils/with-environment';
+import { isAiAgent } from '../../native';
 
 const argv = yargs.default([]);
 
@@ -248,8 +250,7 @@ describe('shared-options', () => {
       ));
 
     it('should default to summary when driven by an AI agent', async () => {
-      const { isAiAgent } = require('../../native');
-      (isAiAgent as jest.Mock).mockReturnValue(true);
+      (isAiAgent as Mock).mockReturnValue(true);
       try {
         await withEnvironmentVariables(
           { NX_TUI: false, CI: 'false', NX_TUI_SKIP_CAPABILITY_CHECK: 'true' },
@@ -264,13 +265,12 @@ describe('shared-options', () => {
           }
         );
       } finally {
-        (isAiAgent as jest.Mock).mockReturnValue(false);
+        (isAiAgent as Mock).mockReturnValue(false);
       }
     });
 
     it('should let an explicit style beat the AI agent default', async () => {
-      const { isAiAgent } = require('../../native');
-      (isAiAgent as jest.Mock).mockReturnValue(true);
+      (isAiAgent as Mock).mockReturnValue(true);
       try {
         await withEnvironmentVariables(
           { NX_TUI: false, CI: 'false', NX_TUI_SKIP_CAPABILITY_CHECK: 'true' },
@@ -281,7 +281,7 @@ describe('shared-options', () => {
           }
         );
       } finally {
-        (isAiAgent as jest.Mock).mockReturnValue(false);
+        (isAiAgent as Mock).mockReturnValue(false);
       }
     });
 

--- a/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
@@ -247,6 +247,50 @@ describe('shared-options', () => {
         }
       ));
 
+    it('should default to summary when driven by an AI agent', async () => {
+      const { isAiAgent } = require('../../native');
+      (isAiAgent as jest.Mock).mockReturnValue(true);
+      try {
+        await withEnvironmentVariables(
+          { NX_TUI: false, CI: 'false', NX_TUI_SKIP_CAPABILITY_CHECK: 'true' },
+          async () => {
+            const command = withOutputStyleOption(argv);
+            const result = await command.parseAsync([]);
+            expect(result.outputStyle).toEqual('summary');
+          }
+        );
+      } finally {
+        (isAiAgent as jest.Mock).mockReturnValue(false);
+      }
+    });
+
+    it('should let an explicit style beat the AI agent default', async () => {
+      const { isAiAgent } = require('../../native');
+      (isAiAgent as jest.Mock).mockReturnValue(true);
+      try {
+        await withEnvironmentVariables(
+          { NX_TUI: false, CI: 'false', NX_TUI_SKIP_CAPABILITY_CHECK: 'true' },
+          async () => {
+            const command = withOutputStyleOption(argv);
+            const result = await command.parseAsync(['--output-style=static']);
+            expect(result.outputStyle).toEqual('static');
+          }
+        );
+      } finally {
+        (isAiAgent as jest.Mock).mockReturnValue(false);
+      }
+    });
+
+    it('should not default to summary when not an AI agent', async () =>
+      withEnvironmentVariables(
+        { NX_TUI: false, CI: 'false', NX_TUI_SKIP_CAPABILITY_CHECK: 'true' },
+        async () => {
+          const command = withOutputStyleOption(argv);
+          const result = await command.parseAsync([]);
+          expect(result.outputStyle).not.toEqual('summary');
+        }
+      ));
+
     it('should use NX_DEFAULT_OUTPUT_STYLE if not set', async () =>
       withEnvironmentVariables(
         {

--- a/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
@@ -277,6 +277,11 @@ describe('shared-options', () => {
           async () => {
             const command = withOutputStyleOption(argv);
             const result = await command.parseAsync(['--output-style=static']);
+            // Assert the field the run renders with: `outputStyle` holds what
+            // yargs parsed, so it reads 'static' whether or not the agent
+            // default overrode it.
+            expect(result.resolvedOutputStyle).toEqual('static');
+            expect(result.specifiedOutputStyle).toEqual('static');
             expect(result.outputStyle).toEqual('static');
           }
         );
@@ -286,11 +291,17 @@ describe('shared-options', () => {
     });
 
     it('should not default to summary when not an AI agent', async () =>
+      // NX_TUI is the string 'false', not the boolean: a boolean unsets the
+      // variable, and `shouldUseTui` then falls through to defaulting ON, so
+      // this would resolve to 'tui' and never exercise the non-agent default.
       withEnvironmentVariables(
-        { NX_TUI: false, CI: 'false', NX_TUI_SKIP_CAPABILITY_CHECK: 'true' },
+        { NX_TUI: 'false', CI: 'false', NX_TUI_SKIP_CAPABILITY_CHECK: 'true' },
         async () => {
           const command = withOutputStyleOption(argv);
           const result = await command.parseAsync([]);
+          // `outputStyle` is never written by resolution, so asserting on it
+          // alone passes even if summary became the default for everyone.
+          expect(result.resolvedOutputStyle).toEqual('static-failures-only');
           expect(result.outputStyle).not.toEqual('summary');
         }
       ));

--- a/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
@@ -256,7 +256,11 @@ describe('shared-options', () => {
           async () => {
             const command = withOutputStyleOption(argv);
             const result = await command.parseAsync([]);
-            expect(result.outputStyle).toEqual('summary');
+            // The agent default is inferred, not named: it resolves the render
+            // style without claiming the user asked for it, which is what keeps
+            // the streaming decision reading absence.
+            expect(result.resolvedOutputStyle).toEqual('summary');
+            expect(result.specifiedOutputStyle).toBeUndefined();
           }
         );
       } finally {

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -372,7 +372,19 @@ export function withOutputStyleOption<T>(
         // renderer built for that. Assigning here is what selects the summary
         // life cycle; the failures-only default is resolved at render time
         // instead, so it never reaches the orchestrator's streaming decision.
-        if (!args.outputStyle && isAiAgent() && choices.includes('summary')) {
+        //
+        // `NX_TUI=true` is checked because this runs BEFORE the TUI middleware,
+        // and naming a style makes `shouldUseTui` return false on the style
+        // list before it ever reads that variable - so without this, an
+        // explicit opt-in to the TUI would be discarded silently. Agent
+        // detection is ambient (`REPL_ID` is exported into a human's shell),
+        // so the human asking for a renderer has to outrank it.
+        if (
+          !args.outputStyle &&
+          process.env.NX_TUI !== 'true' &&
+          isAiAgent() &&
+          choices.includes('summary')
+        ) {
           args.outputStyle = 'summary';
         }
       },

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -366,37 +366,38 @@ export function withOutputStyleOption<T>(
         ) {
           args.outputStyle = process.env.NX_DEFAULT_OUTPUT_STYLE;
         }
+        // Everything above this line is the user naming a style; everything
+        // below infers one. Splitting them here is what lets the rest of the
+        // codebase ask either question without re-deriving it from a single
+        // overloaded field.
+        (args as any).specifiedOutputStyle = args.outputStyle;
       },
       (args) => {
-        // An agent reads output to find the one failure, so default it to the
-        // renderer built for that. Assigning here is what selects the summary
-        // life cycle; the failures-only default is resolved at render time
-        // instead, so it never reaches the orchestrator's streaming decision.
-        //
-        // `NX_TUI=true` is checked because this runs BEFORE the TUI middleware,
-        // and naming a style makes `shouldUseTui` return false on the style
-        // list before it ever reads that variable - so without this, an
-        // explicit opt-in to the TUI would be discarded silently. Agent
-        // detection is ambient (`REPL_ID` is exported into a human's shell),
-        // so the human asking for a renderer has to outrank it.
-        if (
-          !args.outputStyle &&
-          process.env.NX_TUI !== 'true' &&
-          isAiAgent() &&
-          choices.includes('summary')
-        ) {
-          args.outputStyle = 'summary';
-        }
-      },
-      (args) => {
+        // Resolution, in precedence order. `shouldUseTui` reads
+        // `specifiedOutputStyle`, so it sees only what the user named and is
+        // not fed a value inferred here - which is what used to make this
+        // ordering circular. It also reads `NX_TUI` before its own agent check,
+        // so an explicit opt-in beats the agent default without needing a
+        // special case: agent detection is ambient (`REPL_ID` is exported into
+        // a human's shell), and a human asking for a renderer outranks it.
         const useTui = shouldUseTui(readNxJson(), args as NxArgs);
+        process.env.NX_TUI = useTui.toString();
+
+        const resolved: OutputStyle =
+          (args.outputStyle as OutputStyle) ??
+          (useTui
+            ? 'tui'
+            : isAiAgent() && choices.includes('summary')
+              ? 'summary'
+              : 'static-failures-only');
+        (args as any).resolvedOutputStyle = resolved;
+
+        // `outputStyle` stays what yargs parsed, except for the TUI, whose
+        // `check` runs after kebab-case normalization and needs both spellings.
         if (useTui) {
-          // We have to set both of these because `check` runs after the normalization that
-          // handles the kebab-case'd args -> camelCase'd args translation.
           (args as any)['output-style'] = 'tui';
           (args as any).outputStyle = 'tui';
         }
-        process.env.NX_TUI = useTui.toString();
       },
     ]) as Argv<T & { outputStyle: OutputStyle }>;
 }

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -385,11 +385,7 @@ export function withOutputStyleOption<T>(
 
         const resolved: OutputStyle =
           (args.outputStyle as OutputStyle) ??
-          (useTui
-            ? 'tui'
-            : isAiAgent() && choices.includes('summary')
-              ? 'summary'
-              : 'static-failures-only');
+          (useTui ? 'tui' : isAiAgent() ? 'summary' : 'static-failures-only');
         (args as any).resolvedOutputStyle = resolved;
 
         // `outputStyle` stays what yargs parsed, except for the TUI, whose

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -1,4 +1,5 @@
 import { readNxJson } from '../../config/nx-json';
+import { isAiAgent } from '../../native';
 import { shouldUseTui } from '../../tasks-runner/is-tui-enabled';
 import { NxArgs } from '../../utils/command-line-utils';
 import type { Argv, ParserConfigurationOptions } from 'yargs';
@@ -330,6 +331,7 @@ const allOutputStyles = [
   'dynamic-legacy',
   'static',
   'static-failures-only',
+  'summary',
   'stream',
   'stream-without-prefixes',
 ] as const;
@@ -344,13 +346,14 @@ export function withOutputStyleOption<T>(
     'tui',
     'static',
     'static-failures-only',
+    'summary',
     'stream',
     'stream-without-prefixes',
   ]
 ) {
   return yargs
     .option('outputStyle', {
-      describe: `Defines how Nx emits outputs tasks logs. **tui**: enables the Nx Terminal UI, recommended for local development environments. **dynamic-legacy**: use dynamic-legacy output life cycle, previous content is overwritten or modified as new outputs are added, display minimal logs by default, always show errors. This output format is recommended for local development environments where tui is not supported. **static**: uses static output life cycle, no previous content is rewritten or modified as new outputs are added, and every task prints its full output regardless of status. **static-failures-only**: same as **static**, but successful and cached tasks collapse to a single line, so only failing tasks (and, for a single-project run, the project you asked for) print their full output. This is what Nx uses by default in CI and other non-interactive environments. **stream**: nx by default logs output to an internal output stream, enable this option to stream logs to stdout / stderr. **stream-without-prefixes**: nx prefixes the project name the target is running on, use this option remove the project name prefix from output.`,
+      describe: `Defines how Nx emits outputs tasks logs. **tui**: enables the Nx Terminal UI, recommended for local development environments. **dynamic-legacy**: use dynamic-legacy output life cycle, previous content is overwritten or modified as new outputs are added, display minimal logs by default, always show errors. This output format is recommended for local development environments where tui is not supported. **static**: uses static output life cycle, no previous content is rewritten or modified as new outputs are added, and every task prints its full output regardless of status. **static-failures-only**: same as **static**, but successful and cached tasks collapse to a single line, so only failing tasks (and, for a single-project run, the project you asked for) print their full output. This is what Nx uses by default in CI and other non-interactive environments. **summary**: prints only run counts and one line per failing task, naming the file on disk that holds its full output. No task output is printed inline, so the size of a run's output does not depend on how much its tasks logged. This is the default when Nx detects it is being driven by an AI agent. **stream**: nx by default logs output to an internal output stream, enable this option to stream logs to stdout / stderr. **stream-without-prefixes**: nx prefixes the project name the target is running on, use this option remove the project name prefix from output.`,
       type: 'string',
       choices,
     })
@@ -362,6 +365,15 @@ export function withOutputStyleOption<T>(
           choices.includes(process.env.NX_DEFAULT_OUTPUT_STYLE as OutputStyle)
         ) {
           args.outputStyle = process.env.NX_DEFAULT_OUTPUT_STYLE;
+        }
+      },
+      (args) => {
+        // An agent reads output to find the one failure, so default it to the
+        // renderer built for that. Assigning here is what selects the summary
+        // life cycle; the failures-only default is resolved at render time
+        // instead, so it never reaches the orchestrator's streaming decision.
+        if (!args.outputStyle && isAiAgent() && choices.includes('summary')) {
+          args.outputStyle = 'summary';
         }
       },
       (args) => {

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -345,9 +345,16 @@ impl NxCache {
                     // `code` is meaningless for a row that can't be replayed;
                     // the reads all filter it out before it could be read.
                     conn.execute(
+                        // `size` is refreshed only for a row that is still
+                        // output-only: a task rerun with a longer log would
+                        // otherwise keep its first size forever and undercount
+                        // against maxCacheSize. A row with artifacts is owned by
+                        // `record_to_cache`, whose size covers the whole entry.
                         "INSERT INTO cache_outputs (hash, code, size, has_artifacts)
                          VALUES (?1, 0, ?2, 0)
-                         ON CONFLICT(hash) DO UPDATE SET accessed_at = CURRENT_TIMESTAMP",
+                         ON CONFLICT(hash) DO UPDATE SET
+                             accessed_at = CURRENT_TIMESTAMP,
+                             size = CASE WHEN has_artifacts = 0 THEN excluded.size ELSE size END",
                         params![record.hash, record.size],
                     )?;
                 }

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -322,12 +322,14 @@ impl NxCache {
     /// would accumulate forever. The row carries `has_artifacts = 0` so it can
     /// never be served as a cache hit.
     ///
-    /// On conflict only `accessed_at` moves. Nothing else ever touches these
-    /// rows — the reads filter them out, so they would otherwise age from the
-    /// first write and be collected out from under a task that is still being
-    /// run daily. Leaving `has_artifacts` and `size` alone keeps a rewrite
-    /// from demoting a real entry written by `put`, or from replacing its size
-    /// (which covers artifacts) with the size of the terminal output alone.
+    /// On conflict `accessed_at` always moves: the reads filter these rows out,
+    /// so they would otherwise age from the first write and be collected out
+    /// from under a task that is still being run daily. `size` moves only while
+    /// the row is still output-only (`has_artifacts = 0`), so a task rerun with
+    /// a longer log stops undercounting against `maxCacheSize`. `has_artifacts`
+    /// is never touched, and a row that already has artifacts keeps the size
+    /// `put` recorded, so a rewrite can neither demote a real entry nor replace
+    /// its whole-entry size with the terminal output's.
     #[napi]
     pub fn record_terminal_outputs(
         &mut self,

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -18,6 +18,15 @@ use napi::bindgen_prelude::External;
 use std::sync::{Arc, Mutex};
 
 #[napi(object)]
+#[derive(Clone, Debug)]
+pub struct TerminalOutputRecord {
+    pub hash: String,
+    /// Byte length of the terminal output written for this hash, so these
+    /// files are counted against `maxCacheSize` like any other cache content.
+    pub size: i64,
+}
+
+#[napi(object)]
 #[derive(Default, Clone, Debug)]
 pub struct CachedResult {
     pub code: i16,
@@ -71,11 +80,16 @@ impl NxCache {
     }
 
     fn setup(&self) -> anyhow::Result<()> {
+        // `has_artifacts` distinguishes a real cache entry, which owns a
+        // `<cacheDir>/<hash>` directory, from a row that exists only so the
+        // terminal output of an uncacheable run is reachable by the GC. Only
+        // the former may be served as a cache hit — see `get`/`fetch_cache_rows`.
         let query = if self.link_task_details {
             "CREATE TABLE IF NOT EXISTS cache_outputs (
                 hash    TEXT PRIMARY KEY NOT NULL,
                 code   INTEGER NOT NULL,
                 size   INTEGER NOT NULL,
+                has_artifacts INTEGER NOT NULL DEFAULT 1,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (hash) REFERENCES task_details (hash)
@@ -86,6 +100,7 @@ impl NxCache {
                 hash    TEXT PRIMARY KEY NOT NULL,
                 code   INTEGER NOT NULL,
                 size   INTEGER NOT NULL,
+                has_artifacts INTEGER NOT NULL DEFAULT 1,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
@@ -114,7 +129,7 @@ impl NxCache {
             .query_row(
                 "UPDATE cache_outputs
                     SET accessed_at = CURRENT_TIMESTAMP
-                    WHERE hash = ?1
+                    WHERE hash = ?1 AND has_artifacts = 1
                     RETURNING code, size",
                 params![hash],
                 |row| Ok((row.get::<_, i16>(0)?, row.get::<_, i64>(1)?)),
@@ -183,7 +198,7 @@ impl NxCache {
             .unwrap()
             .query_map(
                 "UPDATE cache_outputs SET accessed_at = CURRENT_TIMESTAMP
-                 WHERE hash IN rarray(?1)
+                 WHERE hash IN rarray(?1) AND has_artifacts = 1
                  RETURNING hash, code, size",
                 [values],
                 |row| {
@@ -299,6 +314,53 @@ impl NxCache {
         Ok(())
     }
 
+    /// Register terminal outputs that were written without a cache entry —
+    /// uncacheable tasks, and cacheable ones run with `--skip-nx-cache`.
+    ///
+    /// Without a row the file is invisible to `remove_old_cache_records`,
+    /// which only ever walks hashes it finds in the database, so these files
+    /// would accumulate forever. The row carries `has_artifacts = 0` so it can
+    /// never be served as a cache hit.
+    ///
+    /// On conflict only `accessed_at` moves. Nothing else ever touches these
+    /// rows — the reads filter them out, so they would otherwise age from the
+    /// first write and be collected out from under a task that is still being
+    /// run daily. Leaving `has_artifacts` and `size` alone keeps a rewrite
+    /// from demoting a real entry written by `put`, or from replacing its size
+    /// (which covers artifacts) with the size of the terminal output alone.
+    #[napi]
+    pub fn record_terminal_outputs(
+        &mut self,
+        records: Vec<TerminalOutputRecord>,
+    ) -> anyhow::Result<()> {
+        if records.is_empty() {
+            return Ok(());
+        }
+        trace!("RECORD_TERMINAL_OUTPUTS {}", records.len());
+
+        {
+            let mut db = self.db.lock().unwrap();
+            db.transaction(|conn| {
+                for record in records.iter() {
+                    // `code` is meaningless for a row that can't be replayed;
+                    // the reads all filter it out before it could be read.
+                    conn.execute(
+                        "INSERT INTO cache_outputs (hash, code, size, has_artifacts)
+                         VALUES (?1, 0, ?2, 0)
+                         ON CONFLICT(hash) DO UPDATE SET accessed_at = CURRENT_TIMESTAMP",
+                        params![record.hash, record.size],
+                    )?;
+                }
+                Ok(())
+            })?;
+        }
+
+        if self.max_cache_size != 0 {
+            self.ensure_cache_size_within_limit()?;
+        }
+        Ok(())
+    }
+
     fn get_task_outputs_path_internal(&self, hash: &str) -> PathBuf {
         self.cache_path.join("terminalOutputs").join(hash)
     }
@@ -311,9 +373,12 @@ impl NxCache {
 
     fn record_to_cache(&self, hash: String, code: i16, size: i64) -> anyhow::Result<()> {
         trace!("Recording to cache: {}, {}, {}", &hash, code, size);
+        // `has_artifacts` is forced back to 1 on conflict: an earlier
+        // uncacheable run of the same hash (`--skip-nx-cache`) may have left a
+        // terminal-output-only row, and this run did write the artifacts.
         self.db.lock().unwrap().execute(
-            "INSERT INTO cache_outputs (hash, code, size) VALUES (?1, ?2, ?3)
-             ON CONFLICT(hash) DO UPDATE SET code = excluded.code, size = excluded.size, created_at = CURRENT_TIMESTAMP, accessed_at = CURRENT_TIMESTAMP",
+            "INSERT INTO cache_outputs (hash, code, size, has_artifacts) VALUES (?1, ?2, ?3, 1)
+             ON CONFLICT(hash) DO UPDATE SET code = excluded.code, size = excluded.size, has_artifacts = 1, created_at = CURRENT_TIMESTAMP, accessed_at = CURRENT_TIMESTAMP",
             params![hash, code, size],
         )?;
         if self.max_cache_size != 0 {
@@ -369,7 +434,13 @@ impl NxCache {
                     if let Ok((hash, size)) = row {
                         cache_size -= size;
                         db.execute("DELETE FROM cache_outputs WHERE hash = ?1", params![hash])?;
-                        remove_items(&[self.cache_path.join(&hash)])?;
+                        // Both paths, matching remove_old_cache_records. Dropping
+                        // the row without the terminal output file would strand
+                        // that file with nothing left to point the GC at it.
+                        remove_items(&[
+                            self.cache_path.join(&hash),
+                            self.get_task_outputs_path_internal(&hash),
+                        ])?;
                     }
                     // We've deleted enough cache entries to be under the
                     // target cache size, stop looking for more.
@@ -437,10 +508,16 @@ impl NxCache {
             .db
             .lock()
             .unwrap()
-            .query_row("SELECT EXISTS (SELECT 1 FROM cache_outputs)", [], |row| {
-                let exists: bool = row.get(0)?;
-                Ok(exists)
-            })?
+            .query_row(
+                // Only real cache entries own a `<hash>` directory, so only
+                // those can be out of sync with the filesystem.
+                "SELECT EXISTS (SELECT 1 FROM cache_outputs WHERE has_artifacts = 1)",
+                [],
+                |row| {
+                    let exists: bool = row.get(0)?;
+                    Ok(exists)
+                },
+            )?
             .unwrap_or(false);
 
         if !cache_records_exist {

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -1,4 +1,4 @@
-use std::fs::{create_dir_all, read_dir, read_to_string, remove_file, write};
+use std::fs::{create_dir_all, read_dir, read_to_string, remove_file, symlink_metadata, write};
 use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
 use std::time::{Duration, Instant, SystemTime};
@@ -74,6 +74,16 @@ fn sweep_batch_outputs_with(
     max_bytes: u64,
     min_eviction_age: Duration,
 ) -> anyhow::Result<()> {
+    // `read_dir` opens through `opendir(2)`, which follows a symlink on the
+    // directory itself - so without this a `batchOutputs` symlinked elsewhere
+    // would have that directory's aged files deleted instead. The per-entry
+    // handling below already refuses to follow a link; this is the one hop it
+    // cannot see. `~/.nx` is writable by anything sharing our uid, which is why
+    // `probeWritable` opens with `wx` for the same reason.
+    if symlink_metadata(dir).map(|m| !m.is_dir()).unwrap_or(true) {
+        return Ok(());
+    }
+
     let entries = match read_dir(dir) {
         Ok(entries) => entries,
         // Nothing has captured a batch log yet.
@@ -830,6 +840,26 @@ mod test {
 
         assert!(live.exists(), "a log written within the hour is off limits");
         assert!(!stale.exists(), "an older one over budget still goes");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sweep_batch_outputs_will_not_follow_a_symlinked_directory() {
+        let temp = TempDir::new().unwrap();
+        // What an agent confined to `~/.nx` can plant: `batchOutputs` pointing
+        // somewhere it was never granted. Following it would delete that
+        // directory's aged files instead of our own.
+        let victim = temp.path().join("victim");
+        let aged = write_log(&victim, "secrets.env", 16, 8 * 24 * HOUR);
+        let link = temp.path().join("batchOutputs");
+        std::os::unix::fs::symlink(&victim, &link).unwrap();
+
+        sweep(&link, u64::MAX);
+
+        assert!(
+            aged.exists(),
+            "a symlinked sweep root must be refused, not walked"
+        );
     }
 
     #[cfg(unix)]

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -24,6 +24,91 @@ const BATCH_OUTPUT_MAX_BYTES: u64 = 1024 * 1024 * 1024;
 /// How recently a log must have been written to count as live.
 const BATCH_OUTPUT_MIN_EVICTION_AGE: Duration = Duration::from_secs(60 * 60);
 
+/// One directory, one file per batch — keyed by the batch rather than a
+/// task hash, since one worker produces one log and the hash of any task in
+/// it is still preliminary while it runs. Mirrored by
+/// `batchOutputPathForKey` in tasks-runner/cache.ts, which writes them.
+fn batch_outputs_path(cache_path: &str) -> PathBuf {
+    PathBuf::from(cache_path).join("batchOutputs")
+}
+
+/// A free function, not a method: `BatchProcess` writes these logs whichever
+/// cache implementation is active, so the sweep must not be reachable only
+/// through the DB-backed one.
+///
+/// Deletes batch logs by age, then oldest-first while the directory is over
+/// budget.
+///
+/// No database rows: nothing looks a batch log up by key, so a row would be
+/// write-only bookkeeping that a hard-killed process could skip, orphaning
+/// the file forever. The filesystem cannot drift from itself, and the file
+/// is appended to for the life of its batch, so a size recorded anywhere
+/// else is wrong until that batch ends.
+///
+/// The budget is separate from `maxCacheSize` on purpose: these are debug
+/// artifacts, and sharing a budget would let one evict a replayable cache
+/// entry — trading a rebuild for a text file.
+///
+/// The age sweep deletes at `BATCH_OUTPUT_MAX_AGE`; the eviction skips
+/// anything written within `BATCH_OUTPUT_MIN_EVICTION_AGE`. That is
+/// last-write, not creation, so a batch silent through a long quiet phase is
+/// not protected.
+#[napi]
+pub fn sweep_batch_outputs(cache_path: String) -> anyhow::Result<()> {
+    let dir = batch_outputs_path(&cache_path);
+    let entries = match read_dir(&dir) {
+        Ok(entries) => entries,
+        // Nothing has captured a batch log yet.
+        Err(_) => return Ok(()),
+    };
+
+    let now = SystemTime::now();
+    let mut files: Vec<(PathBuf, u64, SystemTime)> = Vec::new();
+    for entry in entries.flatten() {
+        // From the dirent, so a symlink is neither followed for its age nor
+        // counted as a file.
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+        let age = now.duration_since(modified).unwrap_or(Duration::ZERO);
+        if age > BATCH_OUTPUT_MAX_AGE {
+            // Racing another Nx process sweeping the same directory is fine.
+            let _ = remove_file(&path);
+            continue;
+        }
+        files.push((path, metadata.len(), modified));
+    }
+
+    let mut total: u64 = files.iter().map(|(_, size, _)| size).sum();
+    if total <= BATCH_OUTPUT_MAX_BYTES {
+        return Ok(());
+    }
+
+    // Never evict a log young enough to belong to a batch that is still
+    // running, possibly in another Nx process. Going over budget recovers on
+    // the next sweep; deleting a live batch's only log does not.
+    files.retain(|(_, _, modified)| {
+        now.duration_since(*modified).unwrap_or(Duration::ZERO) > BATCH_OUTPUT_MIN_EVICTION_AGE
+    });
+    files.sort_by_key(|(_, _, modified)| *modified);
+    for (path, size, _) in files {
+        if total <= BATCH_OUTPUT_MAX_BYTES {
+            break;
+        }
+        if remove_file(&path).is_ok() {
+            total = total.saturating_sub(size);
+        }
+    }
+    Ok(())
+}
+
 #[napi(object)]
 #[derive(Clone, Debug)]
 pub struct TerminalOutputRecord {
@@ -385,88 +470,6 @@ impl NxCache {
     pub fn get_task_outputs_path(&self, hash: String) -> String {
         self.get_task_outputs_path_internal(&hash)
             .to_normalized_string()
-    }
-
-    /// One directory, one file per batch — keyed by the batch rather than a
-    /// task hash, since one worker produces one log and the hash of any task in
-    /// it is still preliminary while it runs. Mirrored by
-    /// `batchOutputPathForKey` in tasks-runner/cache.ts, which writes them.
-    fn get_batch_outputs_path_internal(&self) -> PathBuf {
-        self.cache_path.join("batchOutputs")
-    }
-
-    /// Deletes batch logs by age, then oldest-first while the directory is over
-    /// budget.
-    ///
-    /// No database rows: nothing looks a batch log up by key, so a row would be
-    /// write-only bookkeeping that a hard-killed process could skip, orphaning
-    /// the file forever. The filesystem cannot drift from itself, and the file
-    /// is appended to for the life of its batch, so a size recorded anywhere
-    /// else is wrong until that batch ends.
-    ///
-    /// The budget is separate from `maxCacheSize` on purpose: these are debug
-    /// artifacts, and sharing a budget would let one evict a replayable cache
-    /// entry — trading a rebuild for a text file.
-    ///
-    /// The age sweep deletes at `BATCH_OUTPUT_MAX_AGE`; the eviction skips
-    /// anything written within `BATCH_OUTPUT_MIN_EVICTION_AGE`. That is
-    /// last-write, not creation, so a batch silent through a long quiet phase is
-    /// not protected.
-    #[napi]
-    pub fn sweep_batch_outputs(&self) -> anyhow::Result<()> {
-        let dir = self.get_batch_outputs_path_internal();
-        let entries = match read_dir(&dir) {
-            Ok(entries) => entries,
-            // Nothing has captured a batch log yet.
-            Err(_) => return Ok(()),
-        };
-
-        let now = SystemTime::now();
-        let mut files: Vec<(PathBuf, u64, SystemTime)> = Vec::new();
-        for entry in entries.flatten() {
-            // From the dirent, so a symlink is neither followed for its age nor
-            // counted as a file, and a stray directory is not silently ignored
-            // by the size accounting.
-            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
-                continue;
-            }
-            let path = entry.path();
-            let Ok(metadata) = entry.metadata() else {
-                continue;
-            };
-            let Ok(modified) = metadata.modified() else {
-                continue;
-            };
-            let age = now.duration_since(modified).unwrap_or(Duration::ZERO);
-            if age > BATCH_OUTPUT_MAX_AGE {
-                // Racing another Nx process sweeping the same directory is fine.
-                let _ = remove_file(&path);
-                continue;
-            }
-            files.push((path, metadata.len(), modified));
-        }
-
-        let mut total: u64 = files.iter().map(|(_, size, _)| size).sum();
-        if total <= BATCH_OUTPUT_MAX_BYTES {
-            return Ok(());
-        }
-
-        // Never evict a log young enough to belong to a batch that is still
-        // running, possibly in another Nx process. Going over budget recovers on
-        // the next sweep; deleting a live batch's only log does not.
-        files.retain(|(_, _, modified)| {
-            now.duration_since(*modified).unwrap_or(Duration::ZERO) > BATCH_OUTPUT_MIN_EVICTION_AGE
-        });
-        files.sort_by_key(|(_, _, modified)| *modified);
-        for (path, size, _) in files {
-            if total <= BATCH_OUTPUT_MAX_BYTES {
-                break;
-            }
-            if remove_file(&path).is_ok() {
-                total = total.saturating_sub(size);
-            }
-        }
-        Ok(())
     }
 
     fn record_to_cache(&self, hash: String, code: i16, size: i64) -> anyhow::Result<()> {

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -80,7 +80,7 @@ impl NxCache {
     }
 
     fn setup(&self) -> anyhow::Result<()> {
-        // `has_artifacts` distinguishes a real cache entry, which owns a
+        // `is_cache_entry` distinguishes a real cache entry, which owns a
         // `<cacheDir>/<hash>` directory, from a row that exists only so the
         // terminal output of an uncacheable run is reachable by the GC. Only
         // the former may be served as a cache hit — see `get`/`fetch_cache_rows`.
@@ -89,7 +89,7 @@ impl NxCache {
                 hash    TEXT PRIMARY KEY NOT NULL,
                 code   INTEGER NOT NULL,
                 size   INTEGER NOT NULL,
-                has_artifacts INTEGER NOT NULL DEFAULT 1,
+                is_cache_entry BOOLEAN NOT NULL DEFAULT TRUE CHECK (is_cache_entry IN (0, 1)),
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (hash) REFERENCES task_details (hash)
@@ -100,7 +100,7 @@ impl NxCache {
                 hash    TEXT PRIMARY KEY NOT NULL,
                 code   INTEGER NOT NULL,
                 size   INTEGER NOT NULL,
-                has_artifacts INTEGER NOT NULL DEFAULT 1,
+                is_cache_entry BOOLEAN NOT NULL DEFAULT TRUE CHECK (is_cache_entry IN (0, 1)),
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
@@ -129,7 +129,7 @@ impl NxCache {
             .query_row(
                 "UPDATE cache_outputs
                     SET accessed_at = CURRENT_TIMESTAMP
-                    WHERE hash = ?1 AND has_artifacts = 1
+                    WHERE hash = ?1 AND is_cache_entry
                     RETURNING code, size",
                 params![hash],
                 |row| Ok((row.get::<_, i16>(0)?, row.get::<_, i64>(1)?)),
@@ -198,7 +198,7 @@ impl NxCache {
             .unwrap()
             .query_map(
                 "UPDATE cache_outputs SET accessed_at = CURRENT_TIMESTAMP
-                 WHERE hash IN rarray(?1) AND has_artifacts = 1
+                 WHERE hash IN rarray(?1) AND is_cache_entry
                  RETURNING hash, code, size",
                 [values],
                 |row| {
@@ -319,14 +319,14 @@ impl NxCache {
     ///
     /// Without a row the file is invisible to `remove_old_cache_records`,
     /// which only ever walks hashes it finds in the database, so these files
-    /// would accumulate forever. The row carries `has_artifacts = 0` so it can
-    /// never be served as a cache hit.
+    /// would accumulate forever. The row carries `is_cache_entry = FALSE` so it
+    /// can never be served as a cache hit.
     ///
     /// On conflict `accessed_at` always moves: the reads filter these rows out,
     /// so they would otherwise age from the first write and be collected out
     /// from under a task that is still being run daily. `size` moves only while
-    /// the row is still output-only (`has_artifacts = 0`), so a task rerun with
-    /// a longer log stops undercounting against `maxCacheSize`. `has_artifacts`
+    /// the row is still output-only (`NOT is_cache_entry`), so a task rerun with
+    /// a longer log stops undercounting against `maxCacheSize`. `is_cache_entry`
     /// is never touched, and a row that already has artifacts keeps the size
     /// `put` recorded, so a rewrite can neither demote a real entry nor replace
     /// its whole-entry size with the terminal output's.
@@ -352,11 +352,11 @@ impl NxCache {
                         // otherwise keep its first size forever and undercount
                         // against maxCacheSize. A row with artifacts is owned by
                         // `record_to_cache`, whose size covers the whole entry.
-                        "INSERT INTO cache_outputs (hash, code, size, has_artifacts)
-                         VALUES (?1, 0, ?2, 0)
+                        "INSERT INTO cache_outputs (hash, code, size, is_cache_entry)
+                         VALUES (?1, 0, ?2, FALSE)
                          ON CONFLICT(hash) DO UPDATE SET
                              accessed_at = CURRENT_TIMESTAMP,
-                             size = CASE WHEN has_artifacts = 0 THEN excluded.size ELSE size END",
+                             size = CASE WHEN NOT is_cache_entry THEN excluded.size ELSE size END",
                         params![record.hash, record.size],
                     )?;
                 }
@@ -382,12 +382,12 @@ impl NxCache {
 
     fn record_to_cache(&self, hash: String, code: i16, size: i64) -> anyhow::Result<()> {
         trace!("Recording to cache: {}, {}, {}", &hash, code, size);
-        // `has_artifacts` is forced back to 1 on conflict: an earlier
+        // `is_cache_entry` is forced back to TRUE on conflict: an earlier
         // uncacheable run of the same hash (`--skip-nx-cache`) may have left a
         // terminal-output-only row, and this run did write the artifacts.
         self.db.lock().unwrap().execute(
-            "INSERT INTO cache_outputs (hash, code, size, has_artifacts) VALUES (?1, ?2, ?3, 1)
-             ON CONFLICT(hash) DO UPDATE SET code = excluded.code, size = excluded.size, has_artifacts = 1, created_at = CURRENT_TIMESTAMP, accessed_at = CURRENT_TIMESTAMP",
+            "INSERT INTO cache_outputs (hash, code, size, is_cache_entry) VALUES (?1, ?2, ?3, TRUE)
+             ON CONFLICT(hash) DO UPDATE SET code = excluded.code, size = excluded.size, is_cache_entry = TRUE, created_at = CURRENT_TIMESTAMP, accessed_at = CURRENT_TIMESTAMP",
             params![hash, code, size],
         )?;
         if self.max_cache_size != 0 {
@@ -520,7 +520,7 @@ impl NxCache {
             .query_row(
                 // Only real cache entries own a `<hash>` directory, so only
                 // those can be out of sync with the filesystem.
-                "SELECT EXISTS (SELECT 1 FROM cache_outputs WHERE has_artifacts = 1)",
+                "SELECT EXISTS (SELECT 1 FROM cache_outputs WHERE is_cache_entry)",
                 [],
                 |row| {
                     let exists: bool = row.get(0)?;

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -1,7 +1,7 @@
-use std::fs::{create_dir_all, read_to_string, write};
+use std::fs::{create_dir_all, read_dir, read_to_string, remove_file, write};
 use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
-use std::time::Instant;
+use std::time::{Duration, Instant, SystemTime};
 use tracing::{debug, trace};
 
 use fs_extra::remove_items;
@@ -16,6 +16,13 @@ use crate::native::db::connection::NxDbConnection;
 use crate::native::utils::Normalize;
 use napi::bindgen_prelude::External;
 use std::sync::{Arc, Mutex};
+
+/// Batch logs older than this are swept. Matches `remove_old_cache_records`.
+const BATCH_OUTPUT_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+/// Budget for `batchOutputs/`, separate from `maxCacheSize`.
+const BATCH_OUTPUT_MAX_BYTES: u64 = 1024 * 1024 * 1024;
+/// How recently a log must have been written to count as live.
+const BATCH_OUTPUT_MIN_EVICTION_AGE: Duration = Duration::from_secs(60 * 60);
 
 #[napi(object)]
 #[derive(Clone, Debug)]
@@ -378,6 +385,88 @@ impl NxCache {
     pub fn get_task_outputs_path(&self, hash: String) -> String {
         self.get_task_outputs_path_internal(&hash)
             .to_normalized_string()
+    }
+
+    /// One directory, one file per batch — keyed by the batch rather than a
+    /// task hash, since one worker produces one log and the hash of any task in
+    /// it is still preliminary while it runs. Mirrored by
+    /// `batchOutputPathForKey` in tasks-runner/cache.ts, which writes them.
+    fn get_batch_outputs_path_internal(&self) -> PathBuf {
+        self.cache_path.join("batchOutputs")
+    }
+
+    /// Deletes batch logs by age, then oldest-first while the directory is over
+    /// budget.
+    ///
+    /// No database rows: nothing looks a batch log up by key, so a row would be
+    /// write-only bookkeeping that a hard-killed process could skip, orphaning
+    /// the file forever. The filesystem cannot drift from itself, and the file
+    /// is appended to for the life of its batch, so a size recorded anywhere
+    /// else is wrong until that batch ends.
+    ///
+    /// The budget is separate from `maxCacheSize` on purpose: these are debug
+    /// artifacts, and sharing a budget would let one evict a replayable cache
+    /// entry — trading a rebuild for a text file.
+    ///
+    /// The age sweep deletes at `BATCH_OUTPUT_MAX_AGE`; the eviction skips
+    /// anything written within `BATCH_OUTPUT_MIN_EVICTION_AGE`. That is
+    /// last-write, not creation, so a batch silent through a long quiet phase is
+    /// not protected.
+    #[napi]
+    pub fn sweep_batch_outputs(&self) -> anyhow::Result<()> {
+        let dir = self.get_batch_outputs_path_internal();
+        let entries = match read_dir(&dir) {
+            Ok(entries) => entries,
+            // Nothing has captured a batch log yet.
+            Err(_) => return Ok(()),
+        };
+
+        let now = SystemTime::now();
+        let mut files: Vec<(PathBuf, u64, SystemTime)> = Vec::new();
+        for entry in entries.flatten() {
+            // From the dirent, so a symlink is neither followed for its age nor
+            // counted as a file, and a stray directory is not silently ignored
+            // by the size accounting.
+            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            let path = entry.path();
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            let Ok(modified) = metadata.modified() else {
+                continue;
+            };
+            let age = now.duration_since(modified).unwrap_or(Duration::ZERO);
+            if age > BATCH_OUTPUT_MAX_AGE {
+                // Racing another Nx process sweeping the same directory is fine.
+                let _ = remove_file(&path);
+                continue;
+            }
+            files.push((path, metadata.len(), modified));
+        }
+
+        let mut total: u64 = files.iter().map(|(_, size, _)| size).sum();
+        if total <= BATCH_OUTPUT_MAX_BYTES {
+            return Ok(());
+        }
+
+        // Never evict a log young enough to belong to a batch that is still
+        // running, possibly in another Nx process. Going over budget recovers on
+        // the next sweep; deleting a live batch's only log does not.
+        files.retain(|(_, _, modified)| {
+            now.duration_since(*modified).unwrap_or(Duration::ZERO) > BATCH_OUTPUT_MIN_EVICTION_AGE
+        });
+        files.sort_by_key(|(_, _, modified)| *modified);
+        for (path, size, _) in files {
+            if total <= BATCH_OUTPUT_MAX_BYTES {
+                break;
+            }
+            if remove_file(&path).is_ok() {
+                total = total.saturating_sub(size);
+            }
+        }
+        Ok(())
     }
 
     fn record_to_cache(&self, hash: String, code: i16, size: i64) -> anyhow::Result<()> {

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -55,14 +55,31 @@ fn batch_outputs_path(cache_path: &str) -> PathBuf {
 /// not protected.
 #[napi]
 pub fn sweep_batch_outputs(cache_path: String) -> anyhow::Result<()> {
-    let dir = batch_outputs_path(&cache_path);
-    let entries = match read_dir(&dir) {
+    sweep_batch_outputs_with(
+        &batch_outputs_path(&cache_path),
+        SystemTime::now(),
+        BATCH_OUTPUT_MAX_AGE,
+        BATCH_OUTPUT_MAX_BYTES,
+        BATCH_OUTPUT_MIN_EVICTION_AGE,
+    )
+}
+
+/// The sweep proper, with its thresholds as parameters. Split out so tests can
+/// drive the eviction path without writing a gigabyte, and pin the age window
+/// without waiting a week.
+fn sweep_batch_outputs_with(
+    dir: &Path,
+    now: SystemTime,
+    max_age: Duration,
+    max_bytes: u64,
+    min_eviction_age: Duration,
+) -> anyhow::Result<()> {
+    let entries = match read_dir(dir) {
         Ok(entries) => entries,
         // Nothing has captured a batch log yet.
         Err(_) => return Ok(()),
     };
 
-    let now = SystemTime::now();
     let mut files: Vec<(PathBuf, u64, SystemTime)> = Vec::new();
     for entry in entries.flatten() {
         // From the dirent, so a symlink is neither followed for its age nor
@@ -78,7 +95,7 @@ pub fn sweep_batch_outputs(cache_path: String) -> anyhow::Result<()> {
             continue;
         };
         let age = now.duration_since(modified).unwrap_or(Duration::ZERO);
-        if age > BATCH_OUTPUT_MAX_AGE {
+        if age > max_age {
             // Racing another Nx process sweeping the same directory is fine.
             let _ = remove_file(&path);
             continue;
@@ -87,7 +104,7 @@ pub fn sweep_batch_outputs(cache_path: String) -> anyhow::Result<()> {
     }
 
     let mut total: u64 = files.iter().map(|(_, size, _)| size).sum();
-    if total <= BATCH_OUTPUT_MAX_BYTES {
+    if total <= max_bytes {
         return Ok(());
     }
 
@@ -95,11 +112,11 @@ pub fn sweep_batch_outputs(cache_path: String) -> anyhow::Result<()> {
     // running, possibly in another Nx process. Going over budget recovers on
     // the next sweep; deleting a live batch's only log does not.
     files.retain(|(_, _, modified)| {
-        now.duration_since(*modified).unwrap_or(Duration::ZERO) > BATCH_OUTPUT_MIN_EVICTION_AGE
+        now.duration_since(*modified).unwrap_or(Duration::ZERO) > min_eviction_age
     });
     files.sort_by_key(|(_, _, modified)| *modified);
     for (path, size, _) in files {
-        if total <= BATCH_OUTPUT_MAX_BYTES {
+        if total <= max_bytes {
             break;
         }
         if remove_file(&path).is_ok() {
@@ -735,6 +752,85 @@ fn escapes_workspace(path: &Path) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use assert_fs::TempDir;
+    use std::fs::{File, create_dir_all};
+    use std::time::Duration;
+
+    fn write_log(dir: &Path, name: &str, bytes: usize, age: Duration) -> PathBuf {
+        create_dir_all(dir).unwrap();
+        let path = dir.join(name);
+        std::fs::write(&path, vec![b'x'; bytes]).unwrap();
+        let mtime = SystemTime::now() - age;
+        File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
+        path
+    }
+
+    const HOUR: Duration = Duration::from_secs(3600);
+
+    fn sweep(dir: &Path, max_bytes: u64) {
+        sweep_batch_outputs_with(dir, SystemTime::now(), 7 * 24 * HOUR, max_bytes, HOUR).unwrap();
+    }
+
+    #[test]
+    fn sweep_batch_outputs_is_a_noop_without_the_directory() {
+        let temp = TempDir::new().unwrap();
+        // Nothing has captured a batch log yet; this runs on every command.
+        sweep_batch_outputs(temp.path().to_str().unwrap().to_string()).unwrap();
+    }
+
+    #[test]
+    fn sweep_batch_outputs_deletes_by_age() {
+        let temp = TempDir::new().unwrap();
+        let old = write_log(temp.path(), "old.log", 16, 8 * 24 * HOUR);
+        let fresh = write_log(temp.path(), "fresh.log", 16, Duration::from_secs(30));
+
+        sweep(temp.path(), u64::MAX);
+
+        assert!(
+            !old.exists(),
+            "a log past the age limit should be collected"
+        );
+        assert!(fresh.exists(), "a log inside the window should survive");
+    }
+
+    #[test]
+    fn sweep_batch_outputs_evicts_oldest_first_to_the_budget() {
+        let temp = TempDir::new().unwrap();
+        let oldest = write_log(temp.path(), "a.log", 100, 5 * HOUR);
+        let middle = write_log(temp.path(), "b.log", 100, 4 * HOUR);
+        let newest = write_log(temp.path(), "c.log", 100, 3 * HOUR);
+
+        // 300 bytes present, budget 150: the two oldest go.
+        sweep(temp.path(), 150);
+
+        assert!(!oldest.exists());
+        assert!(!middle.exists());
+        assert!(
+            newest.exists(),
+            "eviction stops as soon as it is under budget"
+        );
+    }
+
+    #[test]
+    fn sweep_batch_outputs_will_not_evict_a_log_a_live_batch_may_still_hold() {
+        let temp = TempDir::new().unwrap();
+        // Far over budget, but written seconds ago - a running batch appends to
+        // its log for the life of the batch, possibly from another Nx process,
+        // so evicting this loses the only copy of a run still going.
+        let live = write_log(temp.path(), "live.log", 500, Duration::from_secs(5));
+        let stale = write_log(temp.path(), "stale.log", 500, 3 * HOUR);
+
+        sweep(temp.path(), 100);
+
+        assert!(live.exists(), "a log written within the hour is off limits");
+        assert!(!stale.exists(), "an older one over budget still goes");
+    }
 
     #[cfg(unix)]
     #[test]

--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, trace};
 
 /// Bump this ONLY when the database schema changes.
-pub const DB_VERSION: &str = "3";
+pub const DB_VERSION: &str = "4";
 
 // Error reporting constants - static strings to avoid allocations in error paths
 const REPORTING_INSTRUCTIONS_PERSISTENT: &str = "If the issue persists, please help us improve Nx by capturing logs and reporting this issue:\n\

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -131,12 +131,14 @@ export declare class NxCache {
    * would accumulate forever. The row carries `has_artifacts = 0` so it can
    * never be served as a cache hit.
    *
-   * On conflict only `accessed_at` moves. Nothing else ever touches these
-   * rows — the reads filter them out, so they would otherwise age from the
-   * first write and be collected out from under a task that is still being
-   * run daily. Leaving `has_artifacts` and `size` alone keeps a rewrite
-   * from demoting a real entry written by `put`, or from replacing its size
-   * (which covers artifacts) with the size of the terminal output alone.
+   * On conflict `accessed_at` always moves: the reads filter these rows out,
+   * so they would otherwise age from the first write and be collected out
+   * from under a task that is still being run daily. `size` moves only while
+   * the row is still output-only (`has_artifacts = 0`), so a task rerun with
+   * a longer log stops undercounting against `maxCacheSize`. `has_artifacts`
+   * is never touched, and a row that already has artifacts keeps the size
+   * `put` recorded, so a rewrite can neither demote a real entry nor replace
+   * its whole-entry size with the terminal output's.
    */
   recordTerminalOutputs(records: Array<TerminalOutputRecord>): void
   getTaskOutputsPath(hash: string): string

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -122,6 +122,23 @@ export declare class NxCache {
   getBatch(hashes: Array<string>): Array<CachedResult | undefined | null>
   put(hash: string, terminalOutput: string, outputs: Array<string>, code: number): Array<string>
   applyRemoteCacheResults(hash: string, result: CachedResult, outputs?: Array<string> | undefined | null): void
+  /**
+   * Register terminal outputs that were written without a cache entry —
+   * uncacheable tasks, and cacheable ones run with `--skip-nx-cache`.
+   *
+   * Without a row the file is invisible to `remove_old_cache_records`,
+   * which only ever walks hashes it finds in the database, so these files
+   * would accumulate forever. The row carries `has_artifacts = 0` so it can
+   * never be served as a cache hit.
+   *
+   * On conflict only `accessed_at` moves. Nothing else ever touches these
+   * rows — the reads filter them out, so they would otherwise age from the
+   * first write and be collected out from under a task that is still being
+   * run daily. Leaving `has_artifacts` and `size` alone keeps a rewrite
+   * from demoting a real entry written by `put`, or from replacing its size
+   * (which covers artifacts) with the size of the terminal output alone.
+   */
+  recordTerminalOutputs(records: Array<TerminalOutputRecord>): void
   getTaskOutputsPath(hash: string): string
   getCacheSize(): number
   copyFilesFromCache(cachedResult: CachedResult, outputs: Array<string>): number
@@ -828,6 +845,15 @@ export interface TaskTarget {
   target: string
   /** The configuration of the target which the task invokes */
   configuration?: string
+}
+
+export interface TerminalOutputRecord {
+  hash: string
+  /**
+   * Byte length of the terminal output written for this hash, so these
+   * files are counted against `maxCacheSize` like any other cache content.
+   */
+  size: number
 }
 
 export declare function testOnlyTransferFileMap(projectFiles: Record<string, Array<FileData>>, nonProjectFiles: Array<FileData>): NxWorkspaceFilesExternals

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -142,6 +142,26 @@ export declare class NxCache {
    */
   recordTerminalOutputs(records: Array<TerminalOutputRecord>): void
   getTaskOutputsPath(hash: string): string
+  /**
+   * Deletes batch logs by age, then oldest-first while the directory is over
+   * budget.
+   *
+   * No database rows: nothing looks a batch log up by key, so a row would be
+   * write-only bookkeeping that a hard-killed process could skip, orphaning
+   * the file forever. The filesystem cannot drift from itself, and the file
+   * is appended to for the life of its batch, so a size recorded anywhere
+   * else is wrong until that batch ends.
+   *
+   * The budget is separate from `maxCacheSize` on purpose: these are debug
+   * artifacts, and sharing a budget would let one evict a replayable cache
+   * entry — trading a rebuild for a text file.
+   *
+   * The age sweep deletes at `BATCH_OUTPUT_MAX_AGE`; the eviction skips
+   * anything written within `BATCH_OUTPUT_MIN_EVICTION_AGE`. That is
+   * last-write, not creation, so a batch silent through a long quiet phase is
+   * not protected.
+   */
+  sweepBatchOutputs(): void
   getCacheSize(): number
   copyFilesFromCache(cachedResult: CachedResult, outputs: Array<string>): number
   removeOldCacheRecords(): void

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -142,26 +142,6 @@ export declare class NxCache {
    */
   recordTerminalOutputs(records: Array<TerminalOutputRecord>): void
   getTaskOutputsPath(hash: string): string
-  /**
-   * Deletes batch logs by age, then oldest-first while the directory is over
-   * budget.
-   *
-   * No database rows: nothing looks a batch log up by key, so a row would be
-   * write-only bookkeeping that a hard-killed process could skip, orphaning
-   * the file forever. The filesystem cannot drift from itself, and the file
-   * is appended to for the life of its batch, so a size recorded anywhere
-   * else is wrong until that batch ends.
-   *
-   * The budget is separate from `maxCacheSize` on purpose: these are debug
-   * artifacts, and sharing a budget would let one evict a replayable cache
-   * entry — trading a rebuild for a text file.
-   *
-   * The age sweep deletes at `BATCH_OUTPUT_MAX_AGE`; the eviction skips
-   * anything written within `BATCH_OUTPUT_MIN_EVICTION_AGE`. That is
-   * last-write, not creation, so a batch silent through a long quiet phase is
-   * not protected.
-   */
-  sweepBatchOutputs(): void
   getCacheSize(): number
   copyFilesFromCache(cachedResult: CachedResult, outputs: Array<string>): number
   removeOldCacheRecords(): void
@@ -759,6 +739,31 @@ export declare const enum SupportedEditor {
   JetBrains = 4,
   Unknown = 5
 }
+
+/**
+ * A free function, not a method: `BatchProcess` writes these logs whichever
+ * cache implementation is active, so the sweep must not be reachable only
+ * through the DB-backed one.
+ *
+ * Deletes batch logs by age, then oldest-first while the directory is over
+ * budget.
+ *
+ * No database rows: nothing looks a batch log up by key, so a row would be
+ * write-only bookkeeping that a hard-killed process could skip, orphaning
+ * the file forever. The filesystem cannot drift from itself, and the file
+ * is appended to for the life of its batch, so a size recorded anywhere
+ * else is wrong until that batch ends.
+ *
+ * The budget is separate from `maxCacheSize` on purpose: these are debug
+ * artifacts, and sharing a budget would let one evict a replayable cache
+ * entry — trading a rebuild for a text file.
+ *
+ * The age sweep deletes at `BATCH_OUTPUT_MAX_AGE`; the eviction skips
+ * anything written within `BATCH_OUTPUT_MIN_EVICTION_AGE`. That is
+ * last-write, not creation, so a batch silent through a long quiet phase is
+ * not protected.
+ */
+export declare function sweepBatchOutputs(cachePath: string): void
 
 /** System information (static system-level data) */
 export interface SystemInfo {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -128,14 +128,14 @@ export declare class NxCache {
    *
    * Without a row the file is invisible to `remove_old_cache_records`,
    * which only ever walks hashes it finds in the database, so these files
-   * would accumulate forever. The row carries `has_artifacts = 0` so it can
-   * never be served as a cache hit.
+   * would accumulate forever. The row carries `is_cache_entry = FALSE` so it
+   * can never be served as a cache hit.
    *
    * On conflict `accessed_at` always moves: the reads filter these rows out,
    * so they would otherwise age from the first write and be collected out
    * from under a task that is still being run daily. `size` moves only while
-   * the row is still output-only (`has_artifacts = 0`), so a task rerun with
-   * a longer log stops undercounting against `maxCacheSize`. `has_artifacts`
+   * the row is still output-only (`NOT is_cache_entry`), so a task rerun with
+   * a longer log stops undercounting against `maxCacheSize`. `is_cache_entry`
    * is never touched, and a row that already has artifacts keeps the size
    * `put` recorded, so a rewrite can neither demote a real entry nor replace
    * its whole-entry size with the terminal output's.

--- a/packages/nx/src/native/native-bindings.js
+++ b/packages/nx/src/native/native-bindings.js
@@ -633,6 +633,7 @@ module.exports.remove = nativeBinding.remove
 module.exports.restoreTerminal = nativeBinding.restoreTerminal
 module.exports.RunMode = nativeBinding.RunMode
 module.exports.SupportedEditor = nativeBinding.SupportedEditor
+module.exports.sweepBatchOutputs = nativeBinding.sweepBatchOutputs
 module.exports.TaskStatus = nativeBinding.TaskStatus
 module.exports.testOnlyTransferFileMap = nativeBinding.testOnlyTransferFileMap
 module.exports.trackEvent = nativeBinding.trackEvent

--- a/packages/nx/src/native/tests/cache.spec.ts
+++ b/packages/nx/src/native/tests/cache.spec.ts
@@ -69,4 +69,61 @@ describe('Cache', () => {
     cache.put('123', 'output 123', ['dist'], 0);
     expect(() => cache.put('123', 'output 123', ['dist'], 0)).not.toThrow();
   });
+
+  describe('terminal output records', () => {
+    it('should not serve a recorded terminal output as a cache hit', () => {
+      // There are no artifacts behind this hash — only a terminal output file
+      // that the GC needs to know about. Replaying it would restore nothing
+      // while reporting a hit.
+      cache.recordTerminalOutputs([{ hash: '123', size: 10 }]);
+
+      expect(cache.get('123')).toBeNull();
+    });
+
+    it('should count a recorded terminal output against the cache size', () => {
+      cache.recordTerminalOutputs([{ hash: '123', size: 10 }]);
+
+      expect(cache.getCacheSize()).toEqual(10);
+    });
+
+    it('should let a real cache entry supersede a recorded terminal output', () => {
+      cache.recordTerminalOutputs([{ hash: '123', size: 10 }]);
+      tempFs.createFileSync('dist/output.txt', 'output contents 123');
+
+      cache.put('123', 'output 123', ['dist'], 0);
+
+      const result = cache.get('123');
+      expect(result).not.toBeNull();
+      expect(result.terminalOutput).toEqual('output 123');
+    });
+
+    it('should not let a recorded terminal output demote a real cache entry', () => {
+      tempFs.createFileSync('dist/output.txt', 'output contents 123');
+      cache.put('123', 'output 123', ['dist'], 0);
+
+      // A later --skip-nx-cache run writes the terminal output again; the
+      // cache entry it would otherwise clobber is still a valid hit.
+      cache.recordTerminalOutputs([{ hash: '123', size: 10 }]);
+
+      const result = cache.get('123');
+      expect(result).not.toBeNull();
+      expect(result.terminalOutput).toEqual('output 123');
+    });
+
+    it('should not resize a real cache entry when its output is rewritten', () => {
+      tempFs.createFileSync('dist/output.txt', 'output contents 123');
+      cache.put('123', 'output 123', ['dist'], 0);
+      const sizeWithArtifacts = cache.getCacheSize();
+
+      // The entry's size covers its artifacts; a bare terminal output rewrite
+      // must not replace it with the size of the output alone.
+      cache.recordTerminalOutputs([{ hash: '123', size: 1 }]);
+
+      expect(cache.getCacheSize()).toEqual(sizeWithArtifacts);
+    });
+
+    it('should ignore an empty batch', () => {
+      expect(() => cache.recordTerminalOutputs([])).not.toThrow();
+    });
+  });
 });

--- a/packages/nx/src/tasks-runner/batch/run-batch.ts
+++ b/packages/nx/src/tasks-runner/batch/run-batch.ts
@@ -112,8 +112,26 @@ async function runTasks(
   } catch (e) {
     const isVerbose = tasks[0].overrides.verbose;
     console.error(isVerbose ? e : e.message);
+    // `process.exit` does not wait for pipe writes, so the reason this worker
+    // died could otherwise be the one line that never arrives.
+    await flushStdio();
     process.exit(1);
   }
+}
+
+/**
+ * Waits until everything written to stdout and stderr so far has reached the
+ * pipe. Writes to a pipe are asynchronous, and the parent learns the batch is
+ * over through a separate IPC channel - so without this it can be told the batch
+ * finished, or see the process exit, while the end of its output is still in
+ * memory here. That tail is where a tool reports what went wrong.
+ */
+function flushStdio(): Promise<void> {
+  const flush = (stream: NodeJS.WriteStream) =>
+    new Promise<void>((resolve) => stream.write('', () => resolve()));
+  return Promise.all([flush(process.stdout), flush(process.stderr)]).then(
+    () => undefined
+  );
 }
 
 process.on('message', async (message: BatchMessage) => {
@@ -125,6 +143,7 @@ process.on('message', async (message: BatchMessage) => {
         message.batchTaskGraph,
         message.fullTaskGraph
       );
+      await flushStdio();
       process.send({
         type: BatchMessageType.CompleteBatchExecution,
         results,

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -74,6 +74,16 @@ export function getCache(options: DefaultTasksRunnerOptions): DbCache | Cache {
     : new Cache(options);
 }
 
+/**
+ * Where a task's terminal output lives on disk, for callers that have a hash but
+ * no cache instance. Mirrors the native layout (`get_task_outputs_path_internal`
+ * in cache.rs) and the legacy cache's `terminalOutputsDir`; both resolve
+ * `<cacheDir>/terminalOutputs/<hash>`.
+ */
+export function terminalOutputPathForHash(hash: string): string {
+  return join(cacheDir, 'terminalOutputs', hash);
+}
+
 export class DbCache {
   private nxJson = readNxJson();
   private cache = new NxCache(

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -236,6 +236,16 @@ export class DbCache {
     });
   }
 
+  /**
+   * Register terminal outputs that were written outside of `put` — uncacheable
+   * tasks, and cacheable ones run with `--skip-nx-cache`. `removeOldCacheRecords`
+   * only collects hashes it finds in the database, so without this the files
+   * would never be cleaned up.
+   */
+  recordTerminalOutputs(records: { hash: string; size: number }[]) {
+    this.cache.recordTerminalOutputs(records);
+  }
+
   copyFilesFromCache(_: string, cachedResult: CachedResult, outputs: string[]) {
     return tryAndRetry(async () =>
       this.cache.copyFilesFromCache(cachedResult, outputs)
@@ -546,6 +556,12 @@ export class Cache {
   temporaryOutputPath(task: Task) {
     return join(this.terminalOutputsDir, task.hash);
   }
+
+  /**
+   * No-op: the legacy cache has no database to record against, and its
+   * collection is directory-based rather than driven by cache records.
+   */
+  recordTerminalOutputs(_records: { hash: string; size: number }[]) {}
 
   private async expandOutputsInWorkspace(outputs: string[]) {
     return this._expandOutputs(outputs, workspaceRoot);

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -86,14 +86,27 @@ export function terminalOutputPathForHash(hash: string): string {
 }
 
 /**
- * Where a batch worker's own log lives. Mirrors `get_batch_outputs_path_internal`
- * in cache.rs, which is what actually sweeps the directory — the same mirroring
- * `terminalOutputPathForHash` does for `get_task_outputs_path_internal`.
+ * Collects the batch worker logs written by `batchOutputPathForKey`.
+ *
+ * Guarded rather than called straight through: `cache.rs` is
+ * `#[cfg(not(target_arch = "wasm32"))]`, so this export does not exist in the
+ * WASM binding and calling it there is a `TypeError`. Every other native cache
+ * entry point is kept off that path by `dbCacheEnabled()`; this one is a free
+ * function, so it needs its own guard. The logs are collected on the next
+ * non-WASM run.
  */
 export function sweepBatchOutputs(): void {
+  if (IS_WASM) {
+    return;
+  }
   nativeSweepBatchOutputs(cacheDir);
 }
 
+/**
+ * Where a batch worker's own log lives. Mirrors `batch_outputs_path` in
+ * cache.rs, which is what sweeps the directory — the same mirroring
+ * `terminalOutputPathForHash` does for `get_task_outputs_path_internal`.
+ */
 export function batchOutputPathForKey(key: string): string {
   return join(cacheDir, 'batchOutputs', `${key}.log`);
 }

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
@@ -82,6 +82,81 @@ export function getCache(options: DefaultTasksRunnerOptions): DbCache | Cache {
  */
 export function terminalOutputPathForHash(hash: string): string {
   return join(cacheDir, 'terminalOutputs', hash);
+}
+
+/**
+ * Where a batch worker's own log lives. Keyed by the batch rather than a task
+ * hash: one worker produces one log, and the hash of any task in the batch is
+ * still preliminary while it runs.
+ */
+export function batchOutputPathForKey(key: string): string {
+  return join(cacheDir, 'batchOutputs', `${key}.log`);
+}
+
+/** Batch logs older than this are swept. Matches `remove_old_cache_records`. */
+const BATCH_OUTPUT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+/**
+ * Budget for `batchOutputs/`, separate from `maxCacheSize` on purpose: these
+ * are debug artifacts, and sharing a budget would let one evict a replayable
+ * cache entry — trading a rebuild for a text file.
+ */
+const BATCH_OUTPUT_MAX_BYTES = 1024 * 1024 * 1024;
+
+/**
+ * Deletes batch logs by age, then oldest-first until the directory is under
+ * budget. No database: nothing looks a batch log up by key, so a row would be
+ * write-only bookkeeping that a hard-killed process could skip, orphaning the
+ * file forever. `stat` cannot drift from what is actually on disk, and the file
+ * is appended to while its batch runs, so a size recorded anywhere else is
+ * wrong until the batch ends.
+ *
+ * The age threshold is what makes this safe to run while other Nx processes
+ * are live: a running batch's log is minutes old, not days.
+ */
+export function sweepBatchOutputs(
+  now = Date.now(),
+  maxAgeMs = BATCH_OUTPUT_MAX_AGE_MS,
+  maxBytes = BATCH_OUTPUT_MAX_BYTES
+): void {
+  const dir = join(cacheDir, 'batchOutputs');
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    // Nothing has captured a batch log yet.
+    return;
+  }
+
+  const files: { path: string; size: number; mtimeMs: number }[] = [];
+  for (const entry of entries) {
+    const path = join(dir, entry);
+    try {
+      const stats = statSync(path);
+      if (!stats.isFile()) continue;
+      if (now - stats.mtimeMs > maxAgeMs) {
+        rmSync(path, { force: true });
+        continue;
+      }
+      files.push({ path, size: stats.size, mtimeMs: stats.mtimeMs });
+    } catch {
+      // Raced with another Nx process sweeping the same directory.
+    }
+  }
+
+  let total = files.reduce((sum, f) => sum + f.size, 0);
+  if (total <= maxBytes) {
+    return;
+  }
+  files.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  for (const file of files) {
+    if (total <= maxBytes) break;
+    try {
+      rmSync(file.path, { force: true });
+      total -= file.size;
+    } catch {
+      // As above.
+    }
+  }
 }
 
 export class DbCache {

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -1,12 +1,5 @@
 import { spawn } from 'child_process';
-import {
-  type Dirent,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  rmSync,
-  statSync,
-} from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
@@ -92,94 +85,12 @@ export function terminalOutputPathForHash(hash: string): string {
 }
 
 /**
- * Where a batch worker's own log lives. Keyed by the batch rather than a task
- * hash: one worker produces one log, and the hash of any task in the batch is
- * still preliminary while it runs.
+ * Where a batch worker's own log lives. Mirrors `get_batch_outputs_path_internal`
+ * in cache.rs, which is what actually sweeps the directory — the same mirroring
+ * `terminalOutputPathForHash` does for `get_task_outputs_path_internal`.
  */
 export function batchOutputPathForKey(key: string): string {
   return join(cacheDir, 'batchOutputs', `${key}.log`);
-}
-
-/** Batch logs older than this are swept. Matches `remove_old_cache_records`. */
-const BATCH_OUTPUT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
-/**
- * Budget for `batchOutputs/`, separate from `maxCacheSize` on purpose: these
- * are debug artifacts, and sharing a budget would let one evict a replayable
- * cache entry — trading a rebuild for a text file.
- */
-const BATCH_OUTPUT_MAX_BYTES = 1024 * 1024 * 1024;
-/**
- * How recently a log must have been written to be treated as live. Measured
- * from mtime, so a batch mid-way through a long silent phase is not protected.
- */
-const MIN_EVICTION_AGE_MS = 60 * 60 * 1000;
-
-/**
- * Deletes batch logs by age, then oldest-first until the directory is under
- * budget. No database: nothing looks a batch log up by key, so a row would be
- * write-only bookkeeping that a hard-killed process could skip, orphaning the
- * file forever. `stat` cannot drift from what is actually on disk, and the file
- * is appended to while its batch runs, so a size recorded anywhere else is
- * wrong until the batch ends.
- *
- * The age sweep deletes at 7 days; the size eviction skips anything written to
- * within `MIN_EVICTION_AGE_MS`. That is last-write, not creation, so a batch
- * that has been silent longer than the window - a long quiet Gradle phase - is
- * evictable once the directory is over budget.
- */
-export function sweepBatchOutputs(
-  now = Date.now(),
-  maxAgeMs = BATCH_OUTPUT_MAX_AGE_MS,
-  maxBytes = BATCH_OUTPUT_MAX_BYTES
-): void {
-  const dir = join(cacheDir, 'batchOutputs');
-  let entries: Dirent[];
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    // Nothing has captured a batch log yet.
-    return;
-  }
-
-  const files: { path: string; size: number; mtimeMs: number }[] = [];
-  for (const entry of entries) {
-    // Regular files only, from the dirent rather than a stat: a symlink here
-    // would otherwise be aged by its target's mtime, and a directory would be
-    // invisible to both the age pass and the size accounting.
-    if (!entry.isFile()) continue;
-    const path = join(dir, entry.name);
-    try {
-      const stats = statSync(path);
-      if (now - stats.mtimeMs > maxAgeMs) {
-        rmSync(path, { force: true });
-        continue;
-      }
-      files.push({ path, size: stats.size, mtimeMs: stats.mtimeMs });
-    } catch {
-      // Raced with another Nx process sweeping the same directory.
-    }
-  }
-
-  let total = files.reduce((sum, f) => sum + f.size, 0);
-  if (total <= maxBytes) {
-    return;
-  }
-  // Never evict a log young enough to belong to a batch that is still running:
-  // the file is appended to for the life of its batch, and another Nx process
-  // may be doing exactly that right now. Going over budget is recoverable on
-  // the next sweep; deleting a live batch's only log is not.
-  const evictable = files
-    .filter((f) => now - f.mtimeMs > MIN_EVICTION_AGE_MS)
-    .sort((a, b) => a.mtimeMs - b.mtimeMs);
-  for (const file of evictable) {
-    if (total <= maxBytes) break;
-    try {
-      rmSync(file.path, { force: true });
-      total -= file.size;
-    } catch {
-      // As above.
-    }
-  }
 }
 
 export class DbCache {
@@ -362,6 +273,10 @@ export class DbCache {
 
   removeOldCacheRecords() {
     return this.cache.removeOldCacheRecords();
+  }
+
+  sweepBatchOutputs() {
+    return this.cache.sweepBatchOutputs();
   }
 
   temporaryOutputPath(task: Task) {
@@ -670,6 +585,8 @@ export class Cache {
    * collection is directory-based rather than driven by cache records.
    */
   recordTerminalOutputs(_records: { hash: string; size: number }[]) {}
+
+  sweepBatchOutputs() {}
 
   private async expandOutputsInWorkspace(outputs: string[]) {
     return this._expandOutputs(outputs, workspaceRoot);

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -12,6 +12,7 @@ import {
   CachedResult as NativeCacheResult,
   NxCache,
   getDefaultMaxCacheSize,
+  sweepBatchOutputs as nativeSweepBatchOutputs,
 } from '../native';
 import {
   NxCloudClientUnavailableError,
@@ -89,6 +90,10 @@ export function terminalOutputPathForHash(hash: string): string {
  * in cache.rs, which is what actually sweeps the directory — the same mirroring
  * `terminalOutputPathForHash` does for `get_task_outputs_path_internal`.
  */
+export function sweepBatchOutputs(): void {
+  nativeSweepBatchOutputs(cacheDir);
+}
+
 export function batchOutputPathForKey(key: string): string {
   return join(cacheDir, 'batchOutputs', `${key}.log`);
 }
@@ -273,10 +278,6 @@ export class DbCache {
 
   removeOldCacheRecords() {
     return this.cache.removeOldCacheRecords();
-  }
-
-  sweepBatchOutputs() {
-    return this.cache.sweepBatchOutputs();
   }
 
   temporaryOutputPath(task: Task) {
@@ -585,8 +586,6 @@ export class Cache {
    * collection is directory-based rather than driven by cache records.
    */
   recordTerminalOutputs(_records: { hash: string; size: number }[]) {}
-
-  sweepBatchOutputs() {}
 
   private async expandOutputsInWorkspace(outputs: string[]) {
     return this._expandOutputs(outputs, workspaceRoot);

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -109,9 +109,8 @@ const BATCH_OUTPUT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
  */
 const BATCH_OUTPUT_MAX_BYTES = 1024 * 1024 * 1024;
 /**
- * A log younger than this may belong to a batch that is still writing to it,
- * possibly in another Nx process. Only the age sweep is safe without this - it
- * deletes at 7 days, where nothing is live.
+ * How recently a log must have been written to be treated as live. Measured
+ * from mtime, so a batch mid-way through a long silent phase is not protected.
  */
 const MIN_EVICTION_AGE_MS = 60 * 60 * 1000;
 
@@ -123,9 +122,10 @@ const MIN_EVICTION_AGE_MS = 60 * 60 * 1000;
  * is appended to while its batch runs, so a size recorded anywhere else is
  * wrong until the batch ends.
  *
- * Neither pass can delete a log a live batch is still writing: the age sweep
- * deletes at 7 days, and the size eviction skips anything younger than
- * `MIN_EVICTION_AGE_MS`.
+ * The age sweep deletes at 7 days; the size eviction skips anything written to
+ * within `MIN_EVICTION_AGE_MS`. That is last-write, not creation, so a batch
+ * that has been silent longer than the window - a long quiet Gradle phase - is
+ * evictable once the directory is over budget.
  */
 export function sweepBatchOutputs(
   now = Date.now(),

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -1,5 +1,12 @@
 import { spawn } from 'child_process';
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import {
+  type Dirent,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
@@ -126,9 +133,9 @@ export function sweepBatchOutputs(
   maxBytes = BATCH_OUTPUT_MAX_BYTES
 ): void {
   const dir = join(cacheDir, 'batchOutputs');
-  let entries: string[];
+  let entries: Dirent[];
   try {
-    entries = readdirSync(dir);
+    entries = readdirSync(dir, { withFileTypes: true });
   } catch {
     // Nothing has captured a batch log yet.
     return;
@@ -136,10 +143,13 @@ export function sweepBatchOutputs(
 
   const files: { path: string; size: number; mtimeMs: number }[] = [];
   for (const entry of entries) {
-    const path = join(dir, entry);
+    // Regular files only, from the dirent rather than a stat: a symlink here
+    // would otherwise be aged by its target's mtime, and a directory would be
+    // invisible to both the age pass and the size accounting.
+    if (!entry.isFile()) continue;
+    const path = join(dir, entry.name);
     try {
       const stats = statSync(path);
-      if (!stats.isFile()) continue;
       if (now - stats.mtimeMs > maxAgeMs) {
         rmSync(path, { force: true });
         continue;

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -101,6 +101,12 @@ const BATCH_OUTPUT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
  * cache entry — trading a rebuild for a text file.
  */
 const BATCH_OUTPUT_MAX_BYTES = 1024 * 1024 * 1024;
+/**
+ * A log younger than this may belong to a batch that is still writing to it,
+ * possibly in another Nx process. Only the age sweep is safe without this - it
+ * deletes at 7 days, where nothing is live.
+ */
+const MIN_EVICTION_AGE_MS = 60 * 60 * 1000;
 
 /**
  * Deletes batch logs by age, then oldest-first until the directory is under
@@ -110,8 +116,9 @@ const BATCH_OUTPUT_MAX_BYTES = 1024 * 1024 * 1024;
  * is appended to while its batch runs, so a size recorded anywhere else is
  * wrong until the batch ends.
  *
- * The age threshold is what makes this safe to run while other Nx processes
- * are live: a running batch's log is minutes old, not days.
+ * Neither pass can delete a log a live batch is still writing: the age sweep
+ * deletes at 7 days, and the size eviction skips anything younger than
+ * `MIN_EVICTION_AGE_MS`.
  */
 export function sweepBatchOutputs(
   now = Date.now(),
@@ -147,8 +154,14 @@ export function sweepBatchOutputs(
   if (total <= maxBytes) {
     return;
   }
-  files.sort((a, b) => a.mtimeMs - b.mtimeMs);
-  for (const file of files) {
+  // Never evict a log young enough to belong to a batch that is still running:
+  // the file is appended to for the life of its batch, and another Nx process
+  // may be doing exactly that right now. Going over budget is recoverable on
+  // the next sweep; deleting a live batch's only log is not.
+  const evictable = files
+    .filter((f) => now - f.mtimeMs > MIN_EVICTION_AGE_MS)
+    .sort((a, b) => a.mtimeMs - b.mtimeMs);
+  for (const file of evictable) {
     if (total <= maxBytes) break;
     try {
       rmSync(file.path, { force: true });

--- a/packages/nx/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/default-tasks-runner.ts
@@ -158,7 +158,8 @@ async function runAllTasks(
     options,
     context.nxArgs?.nxBail,
     context.daemon,
-    context.nxArgs?.outputStyle
+    context.nxArgs?.specifiedOutputStyle,
+    context.nxArgs?.resolvedOutputStyle ?? 'static-failures-only'
   );
 
   return orchestrator.run();

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -52,7 +52,8 @@ export class ForkedProcessTaskRunner {
     { id: batchId, executorName, taskGraph: batchTaskGraph }: Batch,
     projectGraph: ProjectGraph,
     fullTaskGraph: TaskGraph,
-    env: NodeJS.ProcessEnv
+    env: NodeJS.ProcessEnv,
+    printsOutput = true
   ): Promise<BatchProcess> {
     const count = Object.keys(batchTaskGraph.tasks).length;
     if (count > 1) {
@@ -82,7 +83,7 @@ export class ForkedProcessTaskRunner {
       getProcessMetricsService().registerBatch(batchId, taskIds, p.pid);
     }
 
-    const cp = new BatchProcess(p, executorName);
+    const cp = new BatchProcess(p, executorName, printsOutput);
     this.processes.add(cp);
 
     cp.onExit(() => {

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -83,7 +83,7 @@ export class ForkedProcessTaskRunner {
       getProcessMetricsService().registerBatch(batchId, taskIds, p.pid);
     }
 
-    const cp = new BatchProcess(p, executorName, printsOutput);
+    const cp = new BatchProcess(p, executorName, printsOutput, batchId);
     this.processes.add(cp);
 
     cp.onExit(() => {

--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -76,10 +76,9 @@ async function createOrchestrator(
     nxArgs,
     false,
     daemonClient,
-    // These come from `nx.json`'s runner options rather than argv - the caller
-    // passes `{}` and `getRunnerOptions` merges only what `nx.json` names - so
-    // this path renders `static-failures-only` unless a style is configured
-    // there. `--output-style` does not reach `runDiscreteTasks`/`runContinuousTasks`.
+    // No argv on this path, so the output-style middleware never ran and both
+    // fields are unset - this always renders `static-failures-only`. `nx.json`'s
+    // `outputStyle` does not reach them; it merges under its own name.
     nxArgs.specifiedOutputStyle,
     nxArgs.resolvedOutputStyle ?? 'static-failures-only',
     fullTaskGraph

--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -76,7 +76,10 @@ async function createOrchestrator(
     nxArgs,
     false,
     daemonClient,
-    // Previously `undefined`, which discarded the style entirely on this path.
+    // These come from `nx.json`'s runner options rather than argv - the caller
+    // passes `{}` and `getRunnerOptions` merges only what `nx.json` names - so
+    // this path renders `static-failures-only` unless a style is configured
+    // there. `--output-style` does not reach `runDiscreteTasks`/`runContinuousTasks`.
     nxArgs.specifiedOutputStyle,
     nxArgs.resolvedOutputStyle ?? 'static-failures-only',
     fullTaskGraph

--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -76,7 +76,9 @@ async function createOrchestrator(
     nxArgs,
     false,
     daemonClient,
-    undefined,
+    // Previously `undefined`, which discarded the style entirely on this path.
+    nxArgs.specifiedOutputStyle,
+    nxArgs.resolvedOutputStyle ?? 'static-failures-only',
     fullTaskGraph
   );
 

--- a/packages/nx/src/tasks-runner/is-tui-enabled.spec.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.spec.ts
@@ -100,7 +100,11 @@ describe('shouldUseTui', () => {
       },
       () => {
         expect(
-          shouldUseTui({ tui: { enabled: true } }, { outputStyle }, true)
+          shouldUseTui(
+            { tui: { enabled: true } },
+            { specifiedOutputStyle: outputStyle },
+            true
+          )
         ).toBe(false);
       }
     )
@@ -116,7 +120,7 @@ describe('shouldUseTui', () => {
         expect(
           shouldUseTui(
             { tui: { enabled: true } },
-            { outputStyle: 'dynamic' },
+            { specifiedOutputStyle: 'dynamic' },
             true
           )
         ).toBe(true);
@@ -132,7 +136,9 @@ describe('shouldUseTui', () => {
           CI: 'false',
         },
         () => {
-          expect(shouldUseTui({}, { outputStyle: 'dynamic' }, true)).toBe(true);
+          expect(
+            shouldUseTui({}, { specifiedOutputStyle: 'dynamic' }, true)
+          ).toBe(true);
         }
       ));
 

--- a/packages/nx/src/tasks-runner/is-tui-enabled.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.ts
@@ -50,16 +50,19 @@ export function shouldUseTui(
   }
 
   if (
-    isStaticOutputStyle(nxArgs.outputStyle) ||
+    isStaticOutputStyle(nxArgs.specifiedOutputStyle) ||
     ['summary', 'stream', 'stream-without-prefixes', 'dynamic-legacy'].includes(
-      nxArgs.outputStyle
+      nxArgs.specifiedOutputStyle
     )
   ) {
     // If the user has specified a non-TUI output style, we disable the TUI
     return false;
   }
 
-  if (nxArgs.outputStyle === 'dynamic' || nxArgs.outputStyle === 'tui') {
+  if (
+    nxArgs.specifiedOutputStyle === 'dynamic' ||
+    nxArgs.specifiedOutputStyle === 'tui'
+  ) {
     return true;
   }
 

--- a/packages/nx/src/tasks-runner/is-tui-enabled.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.ts
@@ -51,7 +51,7 @@ export function shouldUseTui(
 
   if (
     isStaticOutputStyle(nxArgs.outputStyle) ||
-    ['stream', 'stream-without-prefixes', 'dynamic-legacy'].includes(
+    ['summary', 'stream', 'stream-without-prefixes', 'dynamic-legacy'].includes(
       nxArgs.outputStyle
     )
   ) {

--- a/packages/nx/src/tasks-runner/life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycle.ts
@@ -92,6 +92,13 @@ export interface LifeCycle {
 
   appendBatchOutput?(batchId: string, output: string): void;
 
+  /**
+   * The batch worker's own log is on disk and worth reading — its tasks did not
+   * all succeed. One log per worker, so this is addressed once for the batch
+   * rather than copied into any task's output.
+   */
+  batchOutputAvailable?(batchId: string, path: string): void;
+
   setBatchStatus?(batchId: string, status: BatchStatus): void;
 
   /**
@@ -251,6 +258,14 @@ export class CompositeLifeCycle implements LifeCycle {
     for (let l of this.lifeCycles) {
       if (l.appendBatchOutput) {
         l.appendBatchOutput(batchId, output);
+      }
+    }
+  }
+
+  batchOutputAvailable(batchId: string, path: string): void {
+    for (let l of this.lifeCycles) {
+      if (l.batchOutputAvailable) {
+        l.batchOutputAvailable(batchId, path);
       }
     }
   }

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
@@ -1,0 +1,180 @@
+import { stripVTControlCharacters } from 'util';
+import { Task } from '../../config/task-graph';
+import type { TaskResult } from '../life-cycle';
+import { TaskStatus } from '../tasks-runner';
+import { SummaryTerminalOutputLifeCycle } from './summary-terminal-output-life-cycle';
+
+jest.mock('../cache', () => ({
+  terminalOutputPathForHash: (hash: string) => `/cache/terminalOutputs/${hash}`,
+}));
+
+function makeTask(project: string, target = 'test'): Task {
+  return {
+    id: `${project}:${target}`,
+    target: { project, target },
+    overrides: { __overrides_unparsed__: [] },
+    outputs: [],
+    parallelism: true,
+    hash: `hash-${project}`,
+  } as Partial<Task> as Task;
+}
+
+function result(
+  task: Task,
+  status: TaskStatus,
+  terminalOutput = ''
+): TaskResult {
+  return {
+    task,
+    status,
+    code: status === 'failure' ? 1 : 0,
+    terminalOutput,
+  } as TaskResult;
+}
+
+function captureOutput(cb: () => void): string {
+  const originalStdout = process.stdout.write;
+  const originalStderr = process.stderr.write;
+  let captured = '';
+  const write = (chunk: any, ...rest: any[]) => {
+    captured += chunk;
+    rest.find((a) => typeof a === 'function')?.();
+    return true;
+  };
+  process.stdout.write = write as any;
+  process.stderr.write = write as any;
+  try {
+    cb();
+  } finally {
+    process.stdout.write = originalStdout;
+    process.stderr.write = originalStderr;
+  }
+  return stripVTControlCharacters(captured);
+}
+
+describe('SummaryTerminalOutputLifeCycle', () => {
+  it('prints nothing for a task as it completes', () => {
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([makeTask('a')]);
+
+    const out = captureOutput(() => lifeCycle.printTaskTerminalOutput());
+
+    expect(out).toEqual('');
+  });
+
+  it('reports counts and no task output when everything passes', () => {
+    const a = makeTask('a');
+    const b = makeTask('b');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a, b]);
+
+    const out = captureOutput(() => {
+      lifeCycle.endTasks([
+        result(a, 'success', 'a body'),
+        result(b, 'local-cache', 'b body'),
+      ]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).toContain('2 tasks: 2 succeeded, 1 cached');
+    // A passing run is the case that has to stay small.
+    expect(out).not.toContain('a body');
+    expect(out).not.toContain('b body');
+    expect(out).not.toContain('full log');
+    expect(out.split('\n').filter((l) => l.trim()).length).toBeLessThan(6);
+  });
+
+  it('prints the failure, its exit code, and the path to its full log', () => {
+    const a = makeTask('a');
+    const b = makeTask('b');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a, b]);
+
+    const out = captureOutput(() => {
+      lifeCycle.endTasks([
+        result(a, 'success', 'a body'),
+        result(b, 'failure', 'boom line 1\nboom line 2'),
+      ]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).toContain('1 succeeded');
+    expect(out).toContain('1 failed');
+    expect(out).toContain('nx run b:test');
+    expect(out).toContain('(exit 1)');
+    expect(out).toContain('full log: /cache/terminalOutputs/hash-b');
+    // The log is addressed, not reproduced.
+    expect(out).not.toContain('boom line 1');
+    expect(out).not.toContain('boom line 2');
+    // Still nothing about the task that passed.
+    expect(out).not.toContain('a body');
+  });
+
+  it('stays a fixed size however loud the failure was', () => {
+    const a = makeTask('a');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);
+    const body = Array.from({ length: 5000 }, (_, i) => `line ${i + 1}`).join(
+      '\n'
+    );
+
+    const out = captureOutput(() => {
+      lifeCycle.endTasks([result(a, 'failure', body)]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).not.toContain('line 5000');
+    expect(out).toContain('full log: /cache/terminalOutputs/hash-a');
+    expect(out.split('\n').filter((l) => l.trim()).length).toBeLessThan(8);
+  });
+
+  it('counts tasks that never reported as skipped', () => {
+    const a = makeTask('a');
+    const b = makeTask('b');
+    const c = makeTask('c');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a, b, c]);
+
+    const out = captureOutput(() => {
+      lifeCycle.endTasks([result(a, 'failure', 'boom')]);
+      lifeCycle.endCommand();
+    });
+
+    // b and c never reached endTasks because a failed first.
+    expect(out).toContain('2 skipped');
+  });
+
+  it('reports a stopped run as such rather than as a success', () => {
+    const a = makeTask('a');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);
+
+    const out = captureOutput(() => {
+      lifeCycle.endTasks([result(a, 'stopped', 'partial')]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).toContain('1 stopped');
+    expect(out).toContain('Stopped before finishing:');
+    expect(out).toContain('a:test');
+  });
+
+  it('renders the cloud link when one is set', () => {
+    const a = makeTask('a');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);
+
+    const out = captureOutput(() => {
+      lifeCycle.setCloudLink('View run:', 'https://nx.app/runs/abc');
+      lifeCycle.endTasks([result(a, 'success')]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).toContain('View run: https://nx.app/runs/abc');
+  });
+
+  it('points at the style that inlines logs', () => {
+    const a = makeTask('a');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);
+
+    const out = captureOutput(() => {
+      lifeCycle.endTasks([result(a, 'failure', 'boom')]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).toContain('--output-style=static');
+  });
+});

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
@@ -4,7 +4,7 @@ import type { TaskResult } from '../life-cycle';
 import { TaskStatus } from '../tasks-runner';
 import { SummaryTerminalOutputLifeCycle } from './summary-terminal-output-life-cycle';
 
-jest.mock('../cache', () => ({
+vi.mock('../cache', async () => ({
   terminalOutputPathForHash: (hash: string) => `/cache/terminalOutputs/${hash}`,
 }));
 

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
@@ -177,4 +177,36 @@ describe('SummaryTerminalOutputLifeCycle', () => {
 
     expect(out).toContain('--output-style=static');
   });
+  it('does not address a log for a failure that produced no output', () => {
+    const task = makeTask('a:build');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([task]);
+
+    const result = captureOutput(() => {
+      // A batch executor can report a failure without attributing any output to
+      // the task. `persistTerminalOutputs` skips those, so no file is written -
+      // and a summary whose whole contract is "the log is over there" must not
+      // point at one that does not exist.
+      lifeCycle.endTasks([
+        { task, status: 'failure', code: 1, terminalOutput: undefined } as any,
+      ]);
+      lifeCycle.endCommand();
+    });
+
+    expect(result).toContain('a:build');
+    expect(result).not.toContain('full log:');
+  });
+
+  it('still addresses the log when the failure did produce output', () => {
+    const task = makeTask('a:build');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([task]);
+
+    const result = captureOutput(() => {
+      lifeCycle.endTasks([
+        { task, status: 'failure', code: 1, terminalOutput: 'boom' } as any,
+      ]);
+      lifeCycle.endCommand();
+    });
+
+    expect(result).toContain('full log:');
+  });
 });

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
@@ -82,7 +82,7 @@ describe('SummaryTerminalOutputLifeCycle', () => {
     expect(out.split('\n').filter((l) => l.trim()).length).toBeLessThan(6);
   });
 
-  it('prints the failure, its exit code, and the path to its full log', () => {
+  it('prints the failure and the path to its full log', () => {
     const a = makeTask('a');
     const b = makeTask('b');
     const lifeCycle = new SummaryTerminalOutputLifeCycle([a, b]);
@@ -98,7 +98,9 @@ describe('SummaryTerminalOutputLifeCycle', () => {
     expect(out).toContain('1 succeeded');
     expect(out).toContain('1 failed');
     expect(out).toContain('nx run b:test');
-    expect(out).toContain('(exit 1)');
+    // No exit code: `TaskResult.code` is rebuilt from the status, so it is
+    // always 0 or 1 and would misreport a 137 or a 127 as 1.
+    expect(out).not.toContain('(exit');
     expect(out).toContain('full log: /cache/terminalOutputs/hash-b');
     // The log is addressed, not reproduced.
     expect(out).not.toContain('boom line 1');

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
@@ -155,6 +155,39 @@ describe('SummaryTerminalOutputLifeCycle', () => {
     expect(out).toContain('a:test');
   });
 
+  // A batch stopped by a CI step timeout carries the worker's partial log, the
+  // only record of what got through. Listing the task without addressing it
+  // leaves that log on disk with nothing pointing at it.
+  it('addresses the log of a stopped task that produced output', () => {
+    const a = makeTask('a');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);
+
+    const out = captureOutput(() => {
+      lifeCycle.endTasks([result(a, 'stopped', 'how far gradle got')]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).toContain('Stopped before finishing:');
+    expect(out).toContain('full log: /cache/terminalOutputs/hash-a');
+    // Addressed, not reproduced, exactly as a failure is.
+    expect(out).not.toContain('how far gradle got');
+  });
+
+  it('does not address a log for a stopped task that produced none', () => {
+    const a = makeTask('a');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);
+
+    const out = captureOutput(() => {
+      lifeCycle.endTasks([
+        { ...result(a, 'stopped'), terminalOutput: undefined } as TaskResult,
+      ]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).toContain('a:test');
+    expect(out).not.toContain('full log');
+  });
+
   it('renders the cloud link when one is set', () => {
     const a = makeTask('a');
     const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
@@ -188,6 +188,39 @@ describe('SummaryTerminalOutputLifeCycle', () => {
     expect(out).not.toContain('full log');
   });
 
+  // The production shape: `runBatch` gives every task of a stopped batch `''`,
+  // not `undefined`, and `persistTerminalOutputs` writes that as a 0-byte file.
+  // An address is only worth printing when something is behind it.
+  it('does not address a log for a stopped task whose output is empty', () => {
+    const a = makeTask('a');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);
+
+    const out = captureOutput(() => {
+      lifeCycle.endTasks([result(a, 'stopped')]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).toContain('a:test');
+    expect(out).not.toContain('full log');
+  });
+
+  it('addresses the batch worker log it was told about', () => {
+    const a = makeTask('a');
+    const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);
+
+    const out = captureOutput(() => {
+      lifeCycle.batchOutputAvailable(
+        '@nx/gradle:batch 1',
+        '/cache/batchOutputs/g.log'
+      );
+      lifeCycle.endTasks([result(a, 'stopped')]);
+      lifeCycle.endCommand();
+    });
+
+    expect(out).toContain('Batch worker logs:');
+    expect(out).toContain('@nx/gradle:batch 1: /cache/batchOutputs/g.log');
+  });
+
   it('renders the cloud link when one is set', () => {
     const a = makeTask('a');
     const lifeCycle = new SummaryTerminalOutputLifeCycle([a]);

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
@@ -1,0 +1,127 @@
+import { Task } from '../../config/task-graph';
+import { output } from '../../utils/output';
+import { terminalOutputPathForHash } from '../cache';
+import type { LifeCycle, TaskResult } from '../life-cycle';
+
+/**
+ * Prints a run as a handful of lines rather than a transcript: counts, then one
+ * line per failure naming the file that holds its output. Task output stops
+ * being a stream to read and becomes an artifact to address, so the size of this
+ * renderer's output depends on how many tasks failed, never on how loud they
+ * were.
+ *
+ * Selected by `--output-style=summary`, and by default when Nx is driven by an
+ * AI agent, which otherwise reads thousands of lines of passing output to find
+ * the one failure.
+ */
+export class SummaryTerminalOutputLifeCycle implements LifeCycle {
+  private readonly failed: { task: Task; code: number }[] = [];
+  private readonly stopped: Task[] = [];
+  private readonly completed = new Set<string>();
+  private succeeded = 0;
+  private cached = 0;
+  private cloudLink: { label: string; url: string } | undefined;
+
+  constructor(private readonly tasks: Task[]) {}
+
+  setCloudLink(label: string, url: string): void {
+    this.cloudLink = { label, url };
+  }
+
+  /**
+   * Nothing is printed as tasks complete. A summary that interleaved with
+   * progress would be a transcript again.
+   */
+  printTaskTerminalOutput(): void {}
+
+  endTasks(taskResults: TaskResult[]): void {
+    for (const { task, status, code } of taskResults) {
+      this.completed.add(task.id);
+      switch (status) {
+        case 'failure':
+          this.failed.push({ task, code });
+          break;
+        case 'stopped':
+          this.stopped.push(task);
+          break;
+        case 'local-cache':
+        case 'local-cache-kept-existing':
+        case 'remote-cache':
+          this.cached++;
+          this.succeeded++;
+          break;
+        default:
+          this.succeeded++;
+      }
+    }
+  }
+
+  endCommand(): void {
+    const skipped = this.tasks.filter((t) => !this.completed.has(t.id)).length;
+    const bodyLines: string[] = [];
+
+    for (const { task, code } of this.failed) {
+      bodyLines.push('', ...this.failureBlock(task, code));
+    }
+    if (this.stopped.length > 0) {
+      bodyLines.push(
+        '',
+        output.dim('Stopped before finishing:'),
+        ...this.stopped.map((t) => `${output.dim('-')} ${t.id}`)
+      );
+    }
+    if (this.cloudLink) {
+      bodyLines.push('', `${this.cloudLink.label} ${this.cloudLink.url}`);
+    }
+    bodyLines.push(
+      '',
+      output.dim('Re-run with --output-style=static to inline logs.')
+    );
+
+    const title = this.countsLine(skipped);
+    if (this.failed.length > 0 || this.stopped.length > 0) {
+      output.error({ title, bodyLines });
+    } else {
+      output.success({ title, bodyLines });
+    }
+  }
+
+  private countsLine(skipped: number): string {
+    const parts = [`${this.succeeded} succeeded`];
+    if (this.cached > 0) {
+      parts.push(`${this.cached} cached`);
+    }
+    if (this.failed.length > 0) {
+      parts.push(`${this.failed.length} failed`);
+    }
+    if (this.stopped.length > 0) {
+      parts.push(`${this.stopped.length} stopped`);
+    }
+    if (skipped > 0) {
+      parts.push(`${skipped} skipped`);
+    }
+    return `${this.tasks.length} ${
+      this.tasks.length === 1 ? 'task' : 'tasks'
+    }: ${parts.join(', ')}`;
+  }
+
+  private failureBlock(task: Task, code: number): string[] {
+    // formatCommand is what every other renderer uses, so a task reads the same
+    // here as it does under --output-style=static.
+    const lines = [
+      `${output.colors.red('✖')} ${output.formatCommand(task.id)}  ${output.dim(
+        `(exit ${code})`
+      )}`,
+    ];
+
+    // The log is addressed, not reproduced. `hash` is optional on the type but
+    // always set by the time a task has run — processTask hashes before it
+    // schedules — so this only guards against printing a bogus path.
+    if (task.hash) {
+      lines.push(
+        output.dim(`  full log: ${terminalOutputPathForHash(task.hash)}`)
+      );
+    }
+    return lines;
+  }
+}

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
@@ -17,7 +17,6 @@ import type { LifeCycle, TaskResult } from '../life-cycle';
 export class SummaryTerminalOutputLifeCycle implements LifeCycle {
   private readonly failed: {
     task: Task;
-    code: number;
     hasOutput: boolean;
   }[] = [];
   private readonly stopped: Task[] = [];
@@ -39,7 +38,7 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
   printTaskTerminalOutput(): void {}
 
   endTasks(taskResults: TaskResult[]): void {
-    for (const { task, status, code, terminalOutput } of taskResults) {
+    for (const { task, status, terminalOutput } of taskResults) {
       this.completed.add(task.id);
       switch (status) {
         case 'failure':
@@ -50,7 +49,6 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
           // output to the task produces exactly that.
           this.failed.push({
             task,
-            code,
             hasOutput: terminalOutput !== undefined,
           });
           break;
@@ -73,8 +71,8 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
     const skipped = this.tasks.filter((t) => !this.completed.has(t.id)).length;
     const bodyLines: string[] = [];
 
-    for (const { task, code, hasOutput } of this.failed) {
-      bodyLines.push('', ...this.failureBlock(task, code, hasOutput));
+    for (const { task, hasOutput } of this.failed) {
+      bodyLines.push('', ...this.failureBlock(task, hasOutput));
     }
     if (this.stopped.length > 0) {
       bodyLines.push(
@@ -118,13 +116,15 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
     }: ${parts.join(', ')}`;
   }
 
-  private failureBlock(task: Task, code: number, hasOutput: boolean): string[] {
-    // formatCommand is what every other renderer uses, so a task reads the same
-    // here as it does under --output-style=static.
+  private failureBlock(task: Task, hasOutput: boolean): string[] {
+    // No exit code: `completeTasks` rebuilds `TaskResult.code` from the status,
+    // so every failure arrives as 1 and a task killed with 137 or a missing
+    // binary's 127 would all render `(exit 1)`. Printing a number that is
+    // always 1 to a reader whose job is to machine-read this line is worse than
+    // printing none. formatCommand is what every other renderer uses, so a task
+    // reads the same here as it does under --output-style=static.
     const lines = [
-      `${output.colors.red('✖')} ${output.formatCommand(task.id)}  ${output.dim(
-        `(exit ${code})`
-      )}`,
+      `${output.colors.red('✖')} ${output.formatCommand(task.id)}`,
     ];
 
     // The log is addressed, not reproduced. `hash` is optional on the type but

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
@@ -15,7 +15,11 @@ import type { LifeCycle, TaskResult } from '../life-cycle';
  * the one failure.
  */
 export class SummaryTerminalOutputLifeCycle implements LifeCycle {
-  private readonly failed: { task: Task; code: number }[] = [];
+  private readonly failed: {
+    task: Task;
+    code: number;
+    hasOutput: boolean;
+  }[] = [];
   private readonly stopped: Task[] = [];
   private readonly completed = new Set<string>();
   private succeeded = 0;
@@ -35,11 +39,20 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
   printTaskTerminalOutput(): void {}
 
   endTasks(taskResults: TaskResult[]): void {
-    for (const { task, status, code } of taskResults) {
+    for (const { task, status, code, terminalOutput } of taskResults) {
       this.completed.add(task.id);
       switch (status) {
         case 'failure':
-          this.failed.push({ task, code });
+          // Whether a log file exists is decided here, not at render time:
+          // `persistTerminalOutputs` skips a result whose `terminalOutput` is
+          // undefined, so pointing at its path would address a file nobody
+          // wrote. A batch executor that reports a failure without attributing
+          // output to the task produces exactly that.
+          this.failed.push({
+            task,
+            code,
+            hasOutput: terminalOutput !== undefined,
+          });
           break;
         case 'stopped':
           this.stopped.push(task);
@@ -60,8 +73,8 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
     const skipped = this.tasks.filter((t) => !this.completed.has(t.id)).length;
     const bodyLines: string[] = [];
 
-    for (const { task, code } of this.failed) {
-      bodyLines.push('', ...this.failureBlock(task, code));
+    for (const { task, code, hasOutput } of this.failed) {
+      bodyLines.push('', ...this.failureBlock(task, code, hasOutput));
     }
     if (this.stopped.length > 0) {
       bodyLines.push(
@@ -105,7 +118,7 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
     }: ${parts.join(', ')}`;
   }
 
-  private failureBlock(task: Task, code: number): string[] {
+  private failureBlock(task: Task, code: number, hasOutput: boolean): string[] {
     // formatCommand is what every other renderer uses, so a task reads the same
     // here as it does under --output-style=static.
     const lines = [
@@ -116,8 +129,9 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
 
     // The log is addressed, not reproduced. `hash` is optional on the type but
     // always set by the time a task has run — processTask hashes before it
-    // schedules — so this only guards against printing a bogus path.
-    if (task.hash) {
+    // schedules — so that half only guards against printing a bogus path.
+    // `hasOutput` is the load-bearing half: no output, no file, no address.
+    if (task.hash && hasOutput) {
       lines.push(
         output.dim(`  full log: ${terminalOutputPathForHash(task.hash)}`)
       );

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
@@ -19,7 +19,10 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
     task: Task;
     hasOutput: boolean;
   }[] = [];
-  private readonly stopped: Task[] = [];
+  private readonly stopped: {
+    task: Task;
+    hasOutput: boolean;
+  }[] = [];
   private readonly completed = new Set<string>();
   private succeeded = 0;
   private cached = 0;
@@ -53,7 +56,13 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
           });
           break;
         case 'stopped':
-          this.stopped.push(task);
+          // A stopped batch's tasks carry the worker's partial log, which is
+          // the only record of what got through before the cancellation, so
+          // they are addressed the same way a failure is.
+          this.stopped.push({
+            task,
+            hasOutput: terminalOutput !== undefined,
+          });
           break;
         case 'local-cache':
         case 'local-cache-kept-existing':
@@ -78,7 +87,17 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
       bodyLines.push(
         '',
         output.dim('Stopped before finishing:'),
-        ...this.stopped.map((t) => `${output.dim('-')} ${t.id}`)
+        ...this.stopped.flatMap(({ task, hasOutput }) => {
+          const line = `${output.dim('-')} ${task.id}`;
+          return task.hash && hasOutput
+            ? [
+                line,
+                output.dim(
+                  `  full log: ${terminalOutputPathForHash(task.hash)}`
+                ),
+              ]
+            : [line];
+        })
       );
     }
     if (this.cloudLink) {

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
@@ -27,11 +27,16 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
   private succeeded = 0;
   private cached = 0;
   private cloudLink: { label: string; url: string } | undefined;
+  private readonly batchLogs = new Map<string, string>();
 
   constructor(private readonly tasks: Task[]) {}
 
   setCloudLink(label: string, url: string): void {
     this.cloudLink = { label, url };
+  }
+
+  batchOutputAvailable(batchId: string, path: string): void {
+    this.batchLogs.set(batchId, path);
   }
 
   /**
@@ -99,6 +104,14 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
             : [line];
         })
       );
+    }
+    if (this.batchLogs.size > 0) {
+      // One line per worker, not per task: a batch's log explains the whole
+      // batch, and no task's own output file contains it.
+      bodyLines.push('', output.dim('Batch worker logs:'));
+      for (const [batchId, path] of this.batchLogs) {
+        bodyLines.push(output.dim(`${output.dim('-')} ${batchId}: ${path}`));
+      }
     }
     if (this.cloudLink) {
       bodyLines.push('', `${this.cloudLink.label} ${this.cloudLink.url}`);

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
@@ -50,23 +50,23 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
       this.completed.add(task.id);
       switch (status) {
         case 'failure':
-          // Whether a log file exists is decided here, not at render time:
-          // `persistTerminalOutputs` skips a result whose `terminalOutput` is
-          // undefined, so pointing at its path would address a file nobody
-          // wrote. A batch executor that reports a failure without attributing
-          // output to the task produces exactly that.
+          // Whether a log file exists is decided here, not at render time.
+          // `persistTerminalOutputs` skips only an undefined `terminalOutput`,
+          // so an empty one still writes a 0-byte file - truthiness, not
+          // definedness, is what says a reader will find something there.
           this.failed.push({
             task,
-            hasOutput: terminalOutput !== undefined,
+            hasOutput: !!terminalOutput,
           });
           break;
         case 'stopped':
-          // A stopped batch's tasks carry the worker's partial log, which is
-          // the only record of what got through before the cancellation, so
-          // they are addressed the same way a failure is.
+          // Every task of a stopped batch carries `''`: the worker's partial
+          // log is announced as the batch's own artifact now, not folded into
+          // any task. So these address a file only when something else wrote
+          // one, and the batch log is addressed once below.
           this.stopped.push({
             task,
-            hasOutput: terminalOutput !== undefined,
+            hasOutput: !!terminalOutput,
           });
           break;
         case 'local-cache':
@@ -110,7 +110,9 @@ export class SummaryTerminalOutputLifeCycle implements LifeCycle {
       // batch, and no task's own output file contains it.
       bodyLines.push('', output.dim('Batch worker logs:'));
       for (const [batchId, path] of this.batchLogs) {
-        bodyLines.push(output.dim(`${output.dim('-')} ${batchId}: ${path}`));
+        bodyLines.push(
+          `${output.dim('-')} ${output.dim(`${batchId}: ${path}`)}`
+        );
       }
     }
     if (this.cloudLink) {

--- a/packages/nx/src/tasks-runner/run-command.spec.ts
+++ b/packages/nx/src/tasks-runner/run-command.spec.ts
@@ -183,7 +183,7 @@ describe('setEnvVarsBasedOnArgs', () => {
     expect(
       resolveStreaming(
         { NX_BATCH_MODE: 'true', GITHUB_ACTIONS: 'true' },
-        { outputStyle: 'stream' }
+        { specifiedOutputStyle: 'stream' }
       )
     ).toBe(true);
   });
@@ -192,7 +192,7 @@ describe('setEnvVarsBasedOnArgs', () => {
     expect(
       resolveStreaming(
         { GITHUB_ACTIONS: 'true' },
-        { outputStyle: 'stream-without-prefixes' }
+        { specifiedOutputStyle: 'stream-without-prefixes' }
       )
     ).toBe(true);
   });

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -377,7 +377,7 @@ async function getTerminalOutputLifeCycle(
     };
   }
 
-  if (nxArgs.outputStyle === 'summary') {
+  if (nxArgs.resolvedOutputStyle === 'summary') {
     return {
       lifeCycle: new SummaryTerminalOutputLifeCycle(tasks),
       renderIsDone: Promise.resolve(),
@@ -388,7 +388,7 @@ async function getTerminalOutputLifeCycle(
   const useDynamicOutput = shouldUseDynamicLifeCycle(
     tasks,
     runnerOptions,
-    nxArgs.outputStyle
+    nxArgs.specifiedOutputStyle
   );
 
   if (isRunOne) {
@@ -954,13 +954,13 @@ export function setEnvVarsBasedOnArgs(
   // user asked for explicitly still wins over grouping.
   const batchMode = process.env.NX_BATCH_MODE === 'true' || nxArgs.batch;
   if (
-    nxArgs.outputStyle == 'stream' ||
+    nxArgs.specifiedOutputStyle == 'stream' ||
     (batchMode && !isLogGroupingEnabled())
   ) {
     process.env.NX_STREAM_OUTPUT = 'true';
     process.env.NX_PREFIX_OUTPUT = 'true';
   }
-  if (nxArgs.outputStyle == 'stream-without-prefixes') {
+  if (nxArgs.specifiedOutputStyle == 'stream-without-prefixes') {
     process.env.NX_STREAM_OUTPUT = 'true';
     process.env.NX_PREFIX_OUTPUT = 'false';
   }

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -61,6 +61,7 @@ import { createRunManyDynamicOutputRenderer } from './life-cycles/dynamic-run-ma
 import { createRunOneDynamicOutputRenderer } from './life-cycles/dynamic-run-one-terminal-output-life-cycle';
 import { StaticRunManyTerminalOutputLifeCycle } from './life-cycles/static-run-many-terminal-output-life-cycle';
 import { StaticRunOneTerminalOutputLifeCycle } from './life-cycles/static-run-one-terminal-output-life-cycle';
+import { SummaryTerminalOutputLifeCycle } from './life-cycles/summary-terminal-output-life-cycle';
 import { StoreRunInformationLifeCycle } from './life-cycles/store-run-information-life-cycle';
 import { getTasksHistoryLifeCycle } from './life-cycles/task-history-life-cycle';
 import { TaskProfilingLifeCycle } from './life-cycles/task-profiling-life-cycle';
@@ -373,6 +374,13 @@ async function getTerminalOutputLifeCycle(
       },
       printSummary: () => printSummary(),
       renderIsDone,
+    };
+  }
+
+  if (nxArgs.outputStyle === 'summary') {
+    return {
+      lifeCycle: new SummaryTerminalOutputLifeCycle(tasks),
+      renderIsDone: Promise.resolve(),
     };
   }
 
@@ -1164,6 +1172,7 @@ function shouldUseDynamicLifeCycle(
   if (isCI()) return false;
   if (
     isStaticOutputStyle(outputStyle) ||
+    outputStyle === 'summary' ||
     outputStyle === 'stream' ||
     outputStyle === 'stream-without-prefixes'
   )

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
@@ -479,7 +479,7 @@ describe('BatchProcess', () => {
     const forwarded = withEnvironmentVariables(
       { GITHUB_ACTIONS: undefined, NX_SKIP_LOG_GROUPING: undefined },
       () => {
-        const b = new BatchProcess(child, '@nx/js:tsc', false);
+        new BatchProcess(child, '@nx/js:tsc', false);
         return captureForwarded(() => {
           (child as any).stdout.emit('data', Buffer.from('worker chatter\n'));
           (child as any).stderr.emit('data', Buffer.from('worker warning\n'));
@@ -505,5 +505,30 @@ describe('BatchProcess', () => {
     );
 
     expect(forwarded.stdout).toContain('worker chatter');
+  });
+  it('captures rather than drops when the style will not print it', () => {
+    const child = fakeChildProcess();
+
+    // No grouping AND a style that prints nothing. Suppressing the live write
+    // without capturing loses the bytes outright - and a batch worker's crash
+    // output is exactly what no task ever claims, so nothing else holds a copy.
+    const batch = withEnvironmentVariables(
+      { GITHUB_ACTIONS: undefined, NX_SKIP_LOG_GROUPING: undefined },
+      () => {
+        const b = new BatchProcess(child, '@nx/gradle:batch', false);
+        captureForwarded(() => {
+          (child as any).stdout.emit(
+            'data',
+            Buffer.from('why the worker died\n')
+          );
+        });
+        return b;
+      }
+    );
+
+    const path = batch.getCapturedOutputPath();
+    expect(path).toBeDefined();
+    expect(readFileSync(path, 'utf-8')).toContain('why the worker died');
+    batch.discardCapturedOutput();
   });
 });

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
@@ -469,4 +469,41 @@ describe('BatchProcess', () => {
       warn.mockRestore();
     }
   });
+
+  it('prints nothing live when the style does not print task output', () => {
+    const child = fakeChildProcess();
+
+    // No grouping, so this is the branch that forwards live. `summary` reports
+    // each task's log by path, and this class writes to `output` directly from
+    // a stream handler - the life cycle cannot stop it, so it has to be told.
+    const forwarded = withEnvironmentVariables(
+      { GITHUB_ACTIONS: undefined, NX_SKIP_LOG_GROUPING: undefined },
+      () => {
+        const b = new BatchProcess(child, '@nx/js:tsc', false);
+        return captureForwarded(() => {
+          (child as any).stdout.emit('data', Buffer.from('worker chatter\n'));
+          (child as any).stderr.emit('data', Buffer.from('worker warning\n'));
+        });
+      }
+    );
+
+    expect(forwarded.stdout).not.toContain('worker chatter');
+    expect(forwarded.stderr).not.toContain('worker warning');
+  });
+
+  it('still prints live when the style does print task output', () => {
+    const child = fakeChildProcess();
+
+    const forwarded = withEnvironmentVariables(
+      { GITHUB_ACTIONS: undefined, NX_SKIP_LOG_GROUPING: undefined },
+      () => {
+        new BatchProcess(child, '@nx/js:tsc');
+        return captureForwarded(() => {
+          (child as any).stdout.emit('data', Buffer.from('worker chatter\n'));
+        });
+      }
+    );
+
+    expect(forwarded.stdout).toContain('worker chatter');
+  });
 });

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
@@ -15,6 +15,9 @@ let mockFailOpenSync = false;
 let mockFailWriteSync = false;
 // Writes a prefix, then fails on the next call - a disk filling mid-chunk.
 let mockPartialWriteBytes: number | null = null;
+// Fails the next N writes and then recovers - a momentarily full disk, which is
+// the case the capture retries rather than gives up on.
+let mockFailWriteSyncTimes = 0;
 vi.mock('fs', async () => {
   const actual = require('fs');
   const enospc = () =>
@@ -32,6 +35,10 @@ vi.mock('fs', async () => {
     // The likelier real failure: the file opens fine and the disk fills later.
     writeSync: (...args: unknown[]) => {
       if (mockFailWriteSync) {
+        throw enospc();
+      }
+      if (mockFailWriteSyncTimes > 0) {
+        mockFailWriteSyncTimes--;
         throw enospc();
       }
       if (mockPartialWriteBytes !== null) {
@@ -530,5 +537,105 @@ describe('BatchProcess', () => {
     expect(path).toBeDefined();
     expect(readFileSync(path, 'utf-8')).toContain('why the worker died');
     batch.discardCapturedOutput();
+  });
+
+  it('recovers the capture after a transient write failure, naming the gap', () => {
+    const child = fakeChildProcess();
+    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
+
+    try {
+      const { batch, forwarded } = withEnvironmentVariables(FOLDING_ENV, () => {
+        const b = new BatchProcess(
+          child,
+          '@nx/gradle:batch',
+          true,
+          '@nx/gradle:batch 1'
+        );
+        const f = captureForwarded(() => {
+          (child as any).stdout.emit('data', Buffer.from('before\n'));
+          mockFailWriteSyncTimes = 1;
+          (child as any).stdout.emit('data', Buffer.from('during\n'));
+          (child as any).stdout.emit('data', Buffer.from('after\n'));
+        });
+        return { batch: b, forwarded: f };
+      });
+
+      const captured = readFileSync(batch.getCapturedOutputPath(), 'utf-8');
+      // The head survives the failure and the file keeps filling afterwards,
+      // rather than the capture ending on the first bad write.
+      expect(captured).toContain('before');
+      expect(captured).toContain('after');
+      // The bytes that missed the file went to the terminal instead, so the
+      // file says so rather than reading as continuous prose with a hole.
+      expect(captured).not.toContain('during');
+      expect(captured).toContain('capture interrupted');
+      expect(forwarded.stdout).toContain('during');
+      batch.discardCapturedOutput();
+    } finally {
+      mockFailWriteSyncTimes = 0;
+      warn.mockRestore();
+    }
+  });
+
+  it('reopens the same file rather than orphaning what it captured', () => {
+    const child = fakeChildProcess();
+    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
+
+    try {
+      const { batch, first } = withEnvironmentVariables(FOLDING_ENV, () => {
+        const b = new BatchProcess(
+          child,
+          '@nx/gradle:batch',
+          true,
+          '@nx/gradle:batch 1'
+        );
+        captureForwarded(() => {
+          (child as any).stdout.emit('data', Buffer.from('head\n'));
+        });
+        const p1 = b.getCapturedOutputPath();
+        captureForwarded(() => {
+          mockFailWriteSyncTimes = 1;
+          (child as any).stdout.emit('data', Buffer.from('lost\n'));
+          (child as any).stdout.emit('data', Buffer.from('tail\n'));
+        });
+        return { batch: b, first: p1 };
+      });
+
+      // A counter-derived name minted a second file here, leaving the head
+      // unreferenced on disk and the reader seeing only post-failure bytes.
+      expect(batch.getCapturedOutputPath()).toEqual(first);
+      expect(readFileSync(first, 'utf-8')).toContain('head');
+      batch.discardCapturedOutput();
+    } finally {
+      mockFailWriteSyncTimes = 0;
+      warn.mockRestore();
+    }
+  });
+
+  it('gives up on the capture once the failures stop looking transient', () => {
+    const child = fakeChildProcess();
+    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
+
+    try {
+      const forwarded = withEnvironmentVariables(FOLDING_ENV, () => {
+        new BatchProcess(child, '@nx/gradle:batch', true, '@nx/gradle:batch 1');
+        return captureForwarded(() => {
+          mockFailWriteSyncTimes = 10;
+          for (let i = 0; i < 5; i++) {
+            (child as any).stdout.emit('data', Buffer.from(`chunk${i}\n`));
+          }
+        });
+      });
+
+      // Every chunk still reaches a reader, and a permanently unwritable data
+      // directory does not warn once per chunk on the way.
+      for (let i = 0; i < 5; i++) {
+        expect(forwarded.stdout).toContain(`chunk${i}`);
+      }
+      expect(warn.mock.calls.length).toBeLessThanOrEqual(2);
+    } finally {
+      mockFailWriteSyncTimes = 0;
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
@@ -15,6 +15,9 @@ let mockFailWriteStream = false;
 // Applies backpressure and never drains, without failing: the shape a slow
 // disk produces, where only an explicit resume can unpause the source.
 let mockBackpressureOnly = false;
+// Backpressure that still writes. `mockBackpressureOnly` drops the bytes, so it
+// cannot show whether a paused source's tail survives the flush.
+let mockBackpressureButWrites = false;
 vi.mock('fs', async () => {
   const actual = require('fs');
   return {
@@ -23,6 +26,14 @@ vi.mock('fs', async () => {
       const stream = (actual.createWriteStream as any)(...args);
       if (mockBackpressureOnly) {
         stream.write = () => false;
+      }
+      if (mockBackpressureButWrites) {
+        const realWrite = stream.write.bind(stream);
+        stream.write = (...writeArgs: unknown[]) => {
+          realWrite(...writeArgs);
+          // Always "full", so every chunk pauses the source.
+          return false;
+        };
       }
       if (mockFailWriteStream) {
         // Never performs the real write: a genuine 'drain' would resume the
@@ -88,6 +99,33 @@ function captureForwarded(cb: () => void): { stdout: string; stderr: string } {
     process.stderr.write = originalStderr;
   }
   return { stdout, stderr };
+}
+
+/**
+ * `withEnvironmentVariables` is synchronous, but a real `stream.write` delivers
+ * its 'data' on a later tick - after the env has been restored, so the capture
+ * would see no grouping. Holds FOLDING_ENV across awaits instead. Deletes
+ * rather than assigning `undefined`, which would restore as the string.
+ */
+function withFoldingEnvAsync<T>(cb: () => Promise<T>): Promise<T> {
+  const prior = {
+    GITHUB_ACTIONS: process.env.GITHUB_ACTIONS,
+    NX_SKIP_LOG_GROUPING: process.env.NX_SKIP_LOG_GROUPING,
+    NX_STREAM_OUTPUT: process.env.NX_STREAM_OUTPUT,
+  };
+  process.env.GITHUB_ACTIONS = 'true';
+  delete process.env.NX_SKIP_LOG_GROUPING;
+  delete process.env.NX_STREAM_OUTPUT;
+  const restore = () => {
+    for (const [key, value] of Object.entries(prior)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+  return cb().finally(restore);
 }
 
 const FOLDING_ENV = {
@@ -421,8 +459,9 @@ describe('BatchProcess', () => {
     batch.discardCapturedOutput();
   });
 
-  it('survives a capture write error rather than taking the run down', async () => {
+  it('forwards to the terminal and warns when the capture cannot be written', async () => {
     const child = fakeChildProcess();
+    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
 
     try {
       mockFailWriteStream = true;
@@ -435,27 +474,66 @@ describe('BatchProcess', () => {
       });
       const path = batch.getCapturedOutputPath();
 
-      // The failure reaches a stream as an 'error' event, asynchronously.
-      // Without a listener on the stream that is an uncaught exception, which
-      // would kill a run that had nothing else wrong with it.
-      await new Promise((resolve) => setImmediate(resolve));
+      // The failure reaches a stream as an 'error' event, asynchronously, so
+      // wait for the effect rather than a fixed number of turns.
+      await vi.waitFor(() => expect(warn).toHaveBeenCalled());
 
-      // Capture is over, but the batch keeps running and later chunks are not
-      // an error either.
+      // Capture is over, but the batch keeps running - and the bytes are not
+      // optional. A style withholds output on the promise that it is readable
+      // elsewhere; once the file cannot keep that promise, the terminal does.
+      let forwarded = { stdout: '', stderr: '' };
       expect(() =>
         withEnvironmentVariables(FOLDING_ENV, () => {
-          captureForwarded(() => {
+          forwarded = captureForwarded(() => {
             (child as any).stdout.emit('data', Buffer.from('after\n'));
+            (child as any).stderr.emit('data', Buffer.from('err after\n'));
           });
         })
       ).not.toThrow();
+      expect(forwarded.stdout).toContain('after');
+      expect(forwarded.stderr).toContain('err after');
+
+      // Once, not per chunk: an unwritable directory fails every write, and
+      // warning on each would bury the output this path exists to save.
+      expect(warn).toHaveBeenCalledTimes(1);
 
       // What reached the file before the failure is kept, not unlinked: it is
-      // the head of the batch's log.
-      expect(existsSync(path)).toBe(true);
+      // the head of the batch's log. The open is asynchronous, so wait for it.
+      await vi.waitFor(() => expect(existsSync(path)).toBe(true));
       batch.discardCapturedOutput();
     } finally {
       mockFailWriteStream = false;
+      warn.mockRestore();
+    }
+  });
+
+  it('keeps the tail a paused source still holds when the capture is flushed', async () => {
+    const child = fakeChildProcess();
+
+    try {
+      mockBackpressureButWrites = true;
+      await withFoldingEnvAsync(async () => {
+        const batch = new BatchProcess(child, '@nx/gradle:batch');
+
+        // Written through the stream rather than emitted as 'data': the tail
+        // has to sit in the source's own buffer while it is paused, which a
+        // synthetic emit bypasses entirely.
+        (child as any).stdout.write('head\n');
+        await new Promise((resolve) => setImmediate(resolve));
+        (child as any).stdout.write('TAIL-AFTER-PAUSE\n');
+
+        await batch.flushCapturedOutput();
+
+        // `resume()` delivers on the next tick and `end()` takes effect in this
+        // one, so without a drain the tail is written to an ended stream and
+        // lost.
+        const captured = readFileSync(batch.getCapturedOutputPath(), 'utf-8');
+        expect(captured).toContain('head');
+        expect(captured).toContain('TAIL-AFTER-PAUSE');
+        batch.discardCapturedOutput();
+      });
+    } finally {
+      mockBackpressureButWrites = false;
     }
   });
   it('lets the worker keep writing when the capture dies mid-backpressure', async () => {

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
@@ -1,16 +1,8 @@
 import * as figures from 'figures';
 import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
 import { existsSync, readFileSync } from 'fs';
 
-// Replaces the module rather than spying, and gates the failure on a flag so
-// every other test here keeps the real fs.
-//
-// A spy would also work, but only through `require('fs')` - NOT through an
-// `import * as fs`, which under this repo's transform is an interop wrapper
-// around the module rather than the module object itself, so mutating it
-// changes nothing `capture()` can see. Measured: namespace spy 0 calls,
-// `require` spy 1, for the same code path. The module mock sidesteps the
-// distinction entirely.
 // Fails the capture stream on its first write - a full disk. Gated on a flag so
 // every other test here keeps the real fs.
 //
@@ -54,11 +46,14 @@ import { BatchProcess } from './batch-process';
 
 function fakeChildProcess() {
   const child = new EventEmitter() as unknown as ChildProcess & {
-    stdout: EventEmitter;
-    stderr: EventEmitter;
+    stdout: PassThrough;
+    stderr: PassThrough;
   };
-  (child as any).stdout = new EventEmitter();
-  (child as any).stderr = new EventEmitter();
+  // Real streams, not bare emitters: the capture pauses the source when the
+  // file's write buffer fills, so a double without `pause`/`resume` would pass
+  // tests that production cannot reach.
+  (child as any).stdout = new PassThrough();
+  (child as any).stderr = new PassThrough();
   return child;
 }
 
@@ -145,7 +140,6 @@ describe('BatchProcess', () => {
       return b;
     });
 
-    // The stream buffers, so the file is only complete once flushed.
     await batch.flushCapturedOutput();
     const captured = readFileSync(batch.getCapturedOutputPath(), 'utf-8');
     expect(captured).toContain('build log line');
@@ -190,7 +184,6 @@ describe('BatchProcess', () => {
       return b;
     });
 
-    // The stream buffers, so the file is only complete once flushed.
     await batch.flushCapturedOutput();
     const captured = readFileSync(batch.getCapturedOutputPath(), 'utf-8');
     expect(captured.length).toEqual(3_000_000 + 'FINAL_FATAL'.length);
@@ -212,7 +205,6 @@ describe('BatchProcess', () => {
       return b;
     });
 
-    // The stream buffers, so the file is only complete once flushed.
     await batch.flushCapturedOutput();
     const path = batch.getCapturedOutputPath();
     expect(path).toBeDefined();
@@ -299,7 +291,6 @@ describe('BatchProcess', () => {
       });
     });
 
-    // The stream buffers, so the file is only complete once flushed.
     await batch.flushCapturedOutput();
     expect(batch.getCapturedOutputPath()).toEqual(path);
     expect(readFileSync(path, 'utf-8')).toEqual('during\nafter handover\n');
@@ -413,7 +404,6 @@ describe('BatchProcess', () => {
       }
     );
 
-    // The stream buffers, so the file is only complete once flushed.
     await batch.flushCapturedOutput();
     const path = batch.getCapturedOutputPath();
     expect(path).toBeDefined();

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
@@ -12,15 +12,22 @@ import { existsSync, readFileSync } from 'fs';
 // changes nothing the capture can see. The module mock sidesteps the
 // distinction entirely.
 let mockFailWriteStream = false;
+// Applies backpressure and never drains, without failing: the shape a slow
+// disk produces, where only an explicit resume can unpause the source.
+let mockBackpressureOnly = false;
 vi.mock('fs', async () => {
   const actual = require('fs');
   return {
     ...actual,
     createWriteStream: (...args: unknown[]) => {
       const stream = (actual.createWriteStream as any)(...args);
+      if (mockBackpressureOnly) {
+        stream.write = () => false;
+      }
       if (mockFailWriteStream) {
-        const write = stream.write.bind(stream);
-        stream.write = (chunk: any) => {
+        // Never performs the real write: a genuine 'drain' would resume the
+        // source on its own and the test would pass on unfixed code.
+        stream.write = () => {
           // Asynchronous, like the real thing: the write is accepted and the
           // failure arrives as an 'error' event afterwards.
           setImmediate(() =>
@@ -31,7 +38,7 @@ vi.mock('fs', async () => {
               })
             )
           );
-          return write(chunk);
+          return false;
         };
       }
       return stream;
@@ -472,6 +479,32 @@ describe('BatchProcess', () => {
       expect((child as any).stdout.isPaused()).toBe(false);
     } finally {
       mockFailWriteStream = false;
+    }
+  });
+  it('resumes the worker when a paused capture is flushed', async () => {
+    const child = fakeChildProcess();
+
+    try {
+      mockBackpressureOnly = true;
+      const batch = withEnvironmentVariables(FOLDING_ENV, () => {
+        const b = new BatchProcess(child, '@nx/gradle:batch');
+        captureForwarded(() => {
+          (child as any).stdout.emit('data', Buffer.alloc(128 * 1024, 'x'));
+        });
+        return b;
+      });
+      expect((child as any).stdout.isPaused()).toBe(true);
+
+      await batch.flushCapturedOutput();
+
+      // `end()` means the pending 'drain' will never arrive, so without an
+      // explicit resume the worker stays blocked on a full pipe for the rest
+      // of the run - which is the announced-log path, where the file is
+      // deliberately kept and `discardCapturedOutput` never runs.
+      expect((child as any).stdout.isPaused()).toBe(false);
+      batch.discardCapturedOutput();
+    } finally {
+      mockBackpressureOnly = false;
     }
   });
 });

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
@@ -11,44 +11,38 @@ import { existsSync, readFileSync } from 'fs';
 // changes nothing `capture()` can see. Measured: namespace spy 0 calls,
 // `require` spy 1, for the same code path. The module mock sidesteps the
 // distinction entirely.
-let mockFailOpenSync = false;
-let mockFailWriteSync = false;
-// Writes a prefix, then fails on the next call - a disk filling mid-chunk.
-let mockPartialWriteBytes: number | null = null;
-// Fails the next N writes and then recovers - a momentarily full disk, which is
-// the case the capture retries rather than gives up on.
-let mockFailWriteSyncTimes = 0;
+// Fails the capture stream on its first write - a full disk. Gated on a flag so
+// every other test here keeps the real fs.
+//
+// A spy would also work, but only through `require('fs')` - NOT through an
+// `import * as fs`, which under this repo's transform is an interop wrapper
+// around the module rather than the module object itself, so mutating it
+// changes nothing the capture can see. The module mock sidesteps the
+// distinction entirely.
+let mockFailWriteStream = false;
 vi.mock('fs', async () => {
   const actual = require('fs');
-  const enospc = () =>
-    Object.assign(new Error('ENOSPC: no space left on device'), {
-      code: 'ENOSPC',
-    });
   return {
     ...actual,
-    openSync: (...args: unknown[]) => {
-      if (mockFailOpenSync) {
-        throw enospc();
+    createWriteStream: (...args: unknown[]) => {
+      const stream = (actual.createWriteStream as any)(...args);
+      if (mockFailWriteStream) {
+        const write = stream.write.bind(stream);
+        stream.write = (chunk: any) => {
+          // Asynchronous, like the real thing: the write is accepted and the
+          // failure arrives as an 'error' event afterwards.
+          setImmediate(() =>
+            stream.emit(
+              'error',
+              Object.assign(new Error('ENOSPC: no space left on device'), {
+                code: 'ENOSPC',
+              })
+            )
+          );
+          return write(chunk);
+        };
       }
-      return (actual.openSync as any)(...args);
-    },
-    // The likelier real failure: the file opens fine and the disk fills later.
-    writeSync: (...args: unknown[]) => {
-      if (mockFailWriteSync) {
-        throw enospc();
-      }
-      if (mockFailWriteSyncTimes > 0) {
-        mockFailWriteSyncTimes--;
-        throw enospc();
-      }
-      if (mockPartialWriteBytes !== null) {
-        const n = mockPartialWriteBytes;
-        mockPartialWriteBytes = null;
-        mockFailWriteSync = true;
-        const [fd, buffer, offset] = args as [number, Buffer, number];
-        return (actual.writeSync as any)(fd, buffer, offset, n);
-      }
-      return (actual.writeSync as any)(...args);
+      return stream;
     },
   };
 });
@@ -137,7 +131,7 @@ describe('BatchProcess', () => {
     expect(result.stderr).toEqual('');
   });
 
-  it('captures both streams while folding, so the fold can surface them', () => {
+  it('captures both streams while folding, so the fold can surface them', async () => {
     const child = fakeChildProcess();
 
     const batch = withEnvironmentVariables(FOLDING_ENV, () => {
@@ -151,6 +145,8 @@ describe('BatchProcess', () => {
       return b;
     });
 
+    // The stream buffers, so the file is only complete once flushed.
+    await batch.flushCapturedOutput();
     const captured = readFileSync(batch.getCapturedOutputPath(), 'utf-8');
     expect(captured).toContain('build log line');
     expect(captured).toContain('OutOfMemoryError');
@@ -174,7 +170,7 @@ describe('BatchProcess', () => {
     expect(batch.getCapturedOutputPath()).toBeUndefined();
   });
 
-  it('captures a batch log without capping it, keeping the head', () => {
+  it('captures a batch log without capping it, keeping the head', async () => {
     const child = fakeChildProcess();
 
     const batch = withEnvironmentVariables(FOLDING_ENV, () => {
@@ -194,6 +190,8 @@ describe('BatchProcess', () => {
       return b;
     });
 
+    // The stream buffers, so the file is only complete once flushed.
+    await batch.flushCapturedOutput();
     const captured = readFileSync(batch.getCapturedOutputPath(), 'utf-8');
     expect(captured.length).toEqual(3_000_000 + 'FINAL_FATAL'.length);
     // Both the head, where a compiler's first errors land, and the tail, where
@@ -203,7 +201,7 @@ describe('BatchProcess', () => {
     batch.discardCapturedOutput();
   });
 
-  it('holds the captured log on disk rather than in memory', () => {
+  it('holds the captured log on disk rather than in memory', async () => {
     const child = fakeChildProcess();
 
     const batch = withEnvironmentVariables(FOLDING_ENV, () => {
@@ -214,6 +212,8 @@ describe('BatchProcess', () => {
       return b;
     });
 
+    // The stream buffers, so the file is only complete once flushed.
+    await batch.flushCapturedOutput();
     const path = batch.getCapturedOutputPath();
     expect(path).toBeDefined();
     expect(existsSync(path)).toBe(true);
@@ -278,7 +278,7 @@ describe('BatchProcess', () => {
     expect(seen).toEqual(['out chunk']);
   });
 
-  it('replays a chunk that arrives after the path is handed over', () => {
+  it('replays a chunk that arrives after the path is handed over', async () => {
     const child = fakeChildProcess();
 
     const batch = withEnvironmentVariables(FOLDING_ENV, () => {
@@ -299,6 +299,8 @@ describe('BatchProcess', () => {
       });
     });
 
+    // The stream buffers, so the file is only complete once flushed.
+    await batch.flushCapturedOutput();
     expect(batch.getCapturedOutputPath()).toEqual(path);
     expect(readFileSync(path, 'utf-8')).toEqual('during\nafter handover\n');
     batch.discardCapturedOutput();
@@ -355,128 +357,6 @@ describe('BatchProcess', () => {
     expect(index).toBeGreaterThan(-1);
     expect(stdout[index - 1]).toEqual('\n');
   });
-  it('keeps the run alive and streams live when the capture cannot be written', () => {
-    const child = fakeChildProcess();
-    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
-    // A stream 'data' handler is not inside any try the orchestrator owns, so a
-    // throw here is an uncaught exception that takes down the whole run,
-    // including every task that already passed. ENOSPC and a read-only data
-    // directory both reach this line.
-    mockFailOpenSync = true;
-
-    try {
-      const result = withEnvironmentVariables(FOLDING_ENV, () => {
-        const b = new BatchProcess(child, '@nx/gradle:batch');
-        const forwarded = captureForwarded(() => {
-          expect(() =>
-            (child as any).stdout.emit('data', Buffer.from('gradle output\n'))
-          ).not.toThrow();
-        });
-        return { b, forwarded };
-      });
-
-      // Degraded, not dead: the bytes go to the terminal instead of the file,
-      // so the capture is what is lost rather than the output or the run.
-      expect(result.forwarded.stdout).toContain('gradle output');
-      expect(result.b.getCapturedOutputPath()).toBeUndefined();
-      expect(warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: expect.stringContaining('@nx/gradle:batch'),
-        })
-      );
-    } finally {
-      mockFailOpenSync = false;
-      warn.mockRestore();
-    }
-  });
-  it('keeps streaming every later chunk after a capture failure, not just the first', () => {
-    const child = fakeChildProcess();
-    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
-    mockFailOpenSync = true;
-
-    try {
-      const forwarded = withEnvironmentVariables(FOLDING_ENV, () => {
-        new BatchProcess(child, '@nx/gradle:batch');
-        return captureForwarded(() => {
-          (child as any).stdout.emit('data', Buffer.from('first\n'));
-          (child as any).stdout.emit('data', Buffer.from('second\n'));
-          (child as any).stderr.emit('data', Buffer.from('on stderr\n'));
-        });
-      });
-
-      // Latching the discard flag would make every chunk after the first return
-      // early - captured nowhere and printed nowhere.
-      expect(forwarded.stdout).toContain('first');
-      expect(forwarded.stdout).toContain('second');
-      // And a stderr chunk has to stay on stderr rather than being folded into
-      // stdout by a fallback that forgot which stream it came from.
-      expect(forwarded.stderr).toContain('on stderr');
-      expect(forwarded.stdout).not.toContain('on stderr');
-    } finally {
-      mockFailOpenSync = false;
-      warn.mockRestore();
-    }
-  });
-
-  it('keeps what it already captured when the disk fills mid-batch', () => {
-    const child = fakeChildProcess();
-    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
-
-    try {
-      const { batch, forwarded } = withEnvironmentVariables(FOLDING_ENV, () => {
-        const b = new BatchProcess(child, '@nx/gradle:batch');
-        const f = captureForwarded(() => {
-          (child as any).stdout.emit('data', Buffer.from('head of the log\n'));
-          // Opens fine, fills later - so there are already good bytes on disk.
-          mockFailWriteSync = true;
-          (child as any).stdout.emit('data', Buffer.from('tail of the log\n'));
-        });
-        return { batch: b, forwarded: f };
-      });
-
-      // The head is where a compiler's first non-cascading errors are, so
-      // unlinking the file on failure would discard the most useful part.
-      const path = batch.getCapturedOutputPath();
-      expect(path).toBeDefined();
-      expect(readFileSync(path, 'utf-8')).toContain('head of the log');
-      expect(forwarded.stdout).toContain('tail of the log');
-      batch.discardCapturedOutput();
-    } finally {
-      mockFailWriteSync = false;
-      warn.mockRestore();
-    }
-  });
-  it('does not replay bytes that already reached the file when a write fails partway', () => {
-    const child = fakeChildProcess();
-    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
-    // The first write lands 5 of the chunk's bytes and the next one fails, so
-    // the file holds a prefix that the fold will replay later.
-    mockPartialWriteBytes = 5;
-
-    try {
-      const { batch, forwarded } = withEnvironmentVariables(FOLDING_ENV, () => {
-        const b = new BatchProcess(child, '@nx/gradle:batch');
-        const f = captureForwarded(() => {
-          (child as any).stdout.emit('data', Buffer.from('HEAD:TAIL\n'));
-        });
-        return { batch: b, forwarded: f };
-      });
-
-      // Forwarding the whole chunk would print HEAD: twice - once live now,
-      // once from the fold - so only the unwritten remainder goes out.
-      expect(readFileSync(batch.getCapturedOutputPath(), 'utf-8')).toEqual(
-        'HEAD:'
-      );
-      expect(forwarded.stdout).toContain('TAIL');
-      expect(forwarded.stdout).not.toContain('HEAD:');
-      batch.discardCapturedOutput();
-    } finally {
-      mockPartialWriteBytes = null;
-      mockFailWriteSync = false;
-      warn.mockRestore();
-    }
-  });
-
   it('prints nothing live when the style does not print task output', () => {
     const child = fakeChildProcess();
 
@@ -513,7 +393,7 @@ describe('BatchProcess', () => {
 
     expect(forwarded.stdout).toContain('worker chatter');
   });
-  it('captures rather than drops when the style will not print it', () => {
+  it('captures rather than drops when the style will not print it', async () => {
     const child = fakeChildProcess();
 
     // No grouping AND a style that prints nothing. Suppressing the live write
@@ -533,109 +413,49 @@ describe('BatchProcess', () => {
       }
     );
 
+    // The stream buffers, so the file is only complete once flushed.
+    await batch.flushCapturedOutput();
     const path = batch.getCapturedOutputPath();
     expect(path).toBeDefined();
     expect(readFileSync(path, 'utf-8')).toContain('why the worker died');
     batch.discardCapturedOutput();
   });
 
-  it('recovers the capture after a transient write failure, naming the gap', () => {
+  it('survives a capture write error rather than taking the run down', async () => {
     const child = fakeChildProcess();
-    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
 
     try {
-      const { batch, forwarded } = withEnvironmentVariables(FOLDING_ENV, () => {
-        const b = new BatchProcess(
-          child,
-          '@nx/gradle:batch',
-          true,
-          '@nx/gradle:batch 1'
-        );
-        const f = captureForwarded(() => {
-          (child as any).stdout.emit('data', Buffer.from('before\n'));
-          mockFailWriteSyncTimes = 1;
-          (child as any).stdout.emit('data', Buffer.from('during\n'));
-          (child as any).stdout.emit('data', Buffer.from('after\n'));
-        });
-        return { batch: b, forwarded: f };
-      });
-
-      const captured = readFileSync(batch.getCapturedOutputPath(), 'utf-8');
-      // The head survives the failure and the file keeps filling afterwards,
-      // rather than the capture ending on the first bad write.
-      expect(captured).toContain('before');
-      expect(captured).toContain('after');
-      // The bytes that missed the file went to the terminal instead, so the
-      // file says so rather than reading as continuous prose with a hole.
-      expect(captured).not.toContain('during');
-      expect(captured).toContain('capture interrupted');
-      expect(forwarded.stdout).toContain('during');
-      batch.discardCapturedOutput();
-    } finally {
-      mockFailWriteSyncTimes = 0;
-      warn.mockRestore();
-    }
-  });
-
-  it('reopens the same file rather than orphaning what it captured', () => {
-    const child = fakeChildProcess();
-    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
-
-    try {
-      const { batch, first } = withEnvironmentVariables(FOLDING_ENV, () => {
-        const b = new BatchProcess(
-          child,
-          '@nx/gradle:batch',
-          true,
-          '@nx/gradle:batch 1'
-        );
+      mockFailWriteStream = true;
+      const batch = withEnvironmentVariables(FOLDING_ENV, () => {
+        const b = new BatchProcess(child, '@nx/gradle:batch');
         captureForwarded(() => {
           (child as any).stdout.emit('data', Buffer.from('head\n'));
         });
-        const p1 = b.getCapturedOutputPath();
-        captureForwarded(() => {
-          mockFailWriteSyncTimes = 1;
-          (child as any).stdout.emit('data', Buffer.from('lost\n'));
-          (child as any).stdout.emit('data', Buffer.from('tail\n'));
-        });
-        return { batch: b, first: p1 };
+        return b;
       });
+      const path = batch.getCapturedOutputPath();
 
-      // A counter-derived name minted a second file here, leaving the head
-      // unreferenced on disk and the reader seeing only post-failure bytes.
-      expect(batch.getCapturedOutputPath()).toEqual(first);
-      expect(readFileSync(first, 'utf-8')).toContain('head');
+      // The failure reaches a stream as an 'error' event, asynchronously.
+      // Without a listener on the stream that is an uncaught exception, which
+      // would kill a run that had nothing else wrong with it.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Capture is over, but the batch keeps running and later chunks are not
+      // an error either.
+      expect(() =>
+        withEnvironmentVariables(FOLDING_ENV, () => {
+          captureForwarded(() => {
+            (child as any).stdout.emit('data', Buffer.from('after\n'));
+          });
+        })
+      ).not.toThrow();
+
+      // What reached the file before the failure is kept, not unlinked: it is
+      // the head of the batch's log.
+      expect(existsSync(path)).toBe(true);
       batch.discardCapturedOutput();
     } finally {
-      mockFailWriteSyncTimes = 0;
-      warn.mockRestore();
-    }
-  });
-
-  it('gives up on the capture once the failures stop looking transient', () => {
-    const child = fakeChildProcess();
-    const warn = vi.spyOn(output, 'warn').mockImplementation(() => {});
-
-    try {
-      const forwarded = withEnvironmentVariables(FOLDING_ENV, () => {
-        new BatchProcess(child, '@nx/gradle:batch', true, '@nx/gradle:batch 1');
-        return captureForwarded(() => {
-          mockFailWriteSyncTimes = 10;
-          for (let i = 0; i < 5; i++) {
-            (child as any).stdout.emit('data', Buffer.from(`chunk${i}\n`));
-          }
-        });
-      });
-
-      // Every chunk still reaches a reader, and a permanently unwritable data
-      // directory does not warn once per chunk on the way.
-      for (let i = 0; i < 5; i++) {
-        expect(forwarded.stdout).toContain(`chunk${i}`);
-      }
-      expect(warn.mock.calls.length).toBeLessThanOrEqual(2);
-    } finally {
-      mockFailWriteSyncTimes = 0;
-      warn.mockRestore();
+      mockFailWriteStream = false;
     }
   });
 });

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
@@ -270,7 +270,7 @@ describe('BatchProcess', () => {
     expect(seen).toEqual(['out chunk']);
   });
 
-  it('replays a chunk that arrives after the path is handed over', async () => {
+  it('drops a chunk that arrives after the flush, without a second file', async () => {
     const child = fakeChildProcess();
 
     const batch = withEnvironmentVariables(FOLDING_ENV, () => {
@@ -282,18 +282,21 @@ describe('BatchProcess', () => {
     });
 
     const path = batch.getCapturedOutputPath();
-    // stdout can deliver past the exit event that getResults() settles on, and
-    // that trailing output is what the fold exists to carry - so it belongs in
-    // the same file, not dropped and not in a second one.
-    withEnvironmentVariables(FOLDING_ENV, () => {
-      captureForwarded(() => {
-        (child as any).stdout.emit('data', Buffer.from('after handover\n'));
-      });
-    });
-
+    // Production order: both readers flush before touching the path. stdout can
+    // still deliver past the exit event that getResults() settles on, and the
+    // flush has ended the stream by then - so the late chunk is lost. What must
+    // NOT happen is a second file, or the write killing the run.
     await batch.flushCapturedOutput();
+    expect(() =>
+      withEnvironmentVariables(FOLDING_ENV, () => {
+        captureForwarded(() => {
+          (child as any).stdout.emit('data', Buffer.from('after handover\n'));
+        });
+      })
+    ).not.toThrow();
+
     expect(batch.getCapturedOutputPath()).toEqual(path);
-    expect(readFileSync(path, 'utf-8')).toEqual('during\nafter handover\n');
+    expect(readFileSync(path, 'utf-8')).toEqual('during\n');
     batch.discardCapturedOutput();
     expect(existsSync(path)).toBe(false);
   });

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.spec.ts
@@ -451,4 +451,27 @@ describe('BatchProcess', () => {
       mockFailWriteStream = false;
     }
   });
+  it('lets the worker keep writing when the capture dies mid-backpressure', async () => {
+    const child = fakeChildProcess();
+
+    try {
+      mockFailWriteStream = true;
+      withEnvironmentVariables(FOLDING_ENV, () => {
+        new BatchProcess(child, '@nx/gradle:batch');
+        captureForwarded(() => {
+          // Big enough to exceed the write buffer, so the source is paused
+          // awaiting a 'drain' that a failed stream never emits.
+          (child as any).stdout.emit('data', Buffer.alloc(128 * 1024, 'x'));
+        });
+      });
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Left paused, the worker blocks once its stdout pipe fills, never sends
+      // its results, and the run hangs with nothing on screen.
+      expect((child as any).stdout.isPaused()).toBe(false);
+    } finally {
+      mockFailWriteStream = false;
+    }
+  });
 });

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -38,17 +38,33 @@ export class BatchProcess {
   private capturedOutputFd: number | undefined;
   /**
    * Set once the capture is released. A chunk can still arrive after that —
-   * stdout delivers past the exit event — and reopening then would mint a
-   * second numbered file that nothing ever cleans up.
+   * stdout delivers past the exit event — and reopening then would write to a
+   * file the renderer has already read.
    */
   private capturedOutputDiscarded = false;
   /**
-   * Set when writing the capture failed. Distinct from discarded: the bytes
-   * already on disk are still the best record of the batch, so the file is kept
-   * and rendered, while everything after the failure goes live to the terminal.
+   * Set when writing the capture has failed often enough to give up on it. The
+   * bytes already on disk are still the best record of the batch, so the file is
+   * kept and rendered, while everything after goes live to the terminal.
    */
   private capturedOutputFailed = false;
-  private static capturedOutputCount = 0;
+  /** Consecutive write failures. A transient one is retried; see MAX below. */
+  private capturedOutputFailures = 0;
+  /**
+   * A failed write is usually transient (a momentarily full disk), and under
+   * `summary` this file is the only copy the reader ever sees, so one failure
+   * should not end the capture. A permanently read-only data directory throws on
+   * every chunk though, and this runs in a stream handler, so the retries are
+   * bounded rather than unlimited.
+   */
+  private static readonly MAX_CAPTURE_FAILURES = 3;
+  /** True once the file has been opened, so a reopen appends rather than truncates. */
+  private capturedOutputOpened = false;
+  /**
+   * Bytes that went to the terminal instead of the file. Recorded so the gap can
+   * be named in the file rather than leaving a hole a reader cannot see.
+   */
+  private capturedOutputGapBytes = 0;
 
   constructor(
     private childProcess: ChildProcess,
@@ -64,7 +80,13 @@ export class BatchProcess {
      * captures them - and the worker's own crash output is exactly what no task
      * ever claims, so it would exist nowhere.
      */
-    private readonly printsOutput: boolean = true
+    private readonly printsOutput: boolean = true,
+    /**
+     * Names the capture file, so a reopen after a failed write lands on the
+     * same one. Already unique per run (`<executor> <n>`, from `TasksSchedule`)
+     * and already carries the executor, so it is the whole name.
+     */
+    private readonly batchId: string = executorName
   ) {
     this.childProcess.on('message', (message: BatchMessage) => {
       switch (message.type) {
@@ -188,15 +210,41 @@ export class BatchProcess {
       if (this.capturedOutputFd === undefined) {
         const dir = join(workspaceDataDirectory, 'batch-outputs');
         mkdirSync(dir, { recursive: true });
-        const name = `${this.executorName.replace(/[^a-zA-Z0-9]+/g, '-')}-${
+        // Derived from the batch id rather than a counter, so reopening after a
+        // failed write returns to the same file. A counter minted a new name on
+        // every reopen, orphaning the bytes captured so far - which is where a
+        // compiler's first non-cascading errors are.
+        const name = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
           process.pid
-        }-${++BatchProcess.capturedOutputCount}.log`;
+        }.log`;
         const path = join(dir, name);
+        // Truncate on the first open and append after, so a reopen extends this
+        // run's file while a stale one left by a dead run whose pid was recycled
+        // is overwritten rather than appended to.
+        const fd = openSync(path, this.capturedOutputOpened ? 'a' : 'w');
         // Assigned only once the file is actually open, so a path always names
         // an fd rather than a file that failed to open.
-        const fd = openSync(path, 'w');
         this.capturedOutputPath = path;
         this.capturedOutputFd = fd;
+        this.capturedOutputOpened = true;
+      }
+      if (this.capturedOutputGapBytes > 0) {
+        // Name the hole rather than leaving one a reader cannot see. A file that
+        // reads as continuous prose with a chunk missing from the middle is
+        // worse than one that says what it lost, especially for an agent that
+        // never saw the bytes go past on the terminal.
+        const marker = Buffer.from(
+          `\n[nx] capture interrupted: ${this.capturedOutputGapBytes} bytes went to the terminal instead\n`
+        );
+        let markerWritten = 0;
+        while (markerWritten < marker.length) {
+          markerWritten += writeSync(
+            this.capturedOutputFd,
+            marker,
+            markerWritten
+          );
+        }
+        this.capturedOutputGapBytes = 0;
       }
       // Written synchronously so the file is complete the moment the batch ends,
       // with no flush to sequence against the read that renders the fold.
@@ -213,11 +261,16 @@ export class BatchProcess {
       // Latch on a flag of its own rather than reusing the discard flag: that
       // one makes `capture` return early, which would drop every later chunk
       // on the floor - captured nowhere and printed nowhere.
-      this.capturedOutputFailed = true;
+      this.capturedOutputFailures++;
+      const givingUp =
+        this.capturedOutputFailures >= BatchProcess.MAX_CAPTURE_FAILURES;
+      this.capturedOutputFailed = givingUp;
       // Close the fd but keep the file. Whatever was written before the failure
       // is still the head of the batch's log, which is where a compiler's first
       // non-cascading errors live; unlinking it here would throw away the most
-      // useful bytes precisely when the disk is in trouble.
+      // useful bytes precisely when the disk is in trouble. The next chunk
+      // reopens the same path and appends, so a transient failure costs the gap
+      // rather than the rest of the batch.
       this.closeCapturedOutput();
       // Forward only what did not reach the file, and do it before warning.
       // `output.warn` writes to the terminal as well, so if that is the thing
@@ -226,15 +279,23 @@ export class BatchProcess {
       // to prevent.
       const unwritten = bytes.subarray(written);
       if (unwritten.length > 0) {
+        this.capturedOutputGapBytes += unwritten.length;
         output.writeTaskOutputChunk(unwritten, stream);
       }
-      output.warn({
-        title: `Could not capture batch output for ${this.executorName}`,
-        bodyLines: [
-          e.message,
-          'Streaming the rest of it live instead; the fold holds what was captured first.',
-        ],
-      });
+      // Only the two transitions that change what the reader gets: the first
+      // failure, and giving up. Warning on every chunk would bury the run's own
+      // output on the read-only-directory path this bound exists for.
+      if (this.capturedOutputFailures === 1 || givingUp) {
+        output.warn({
+          title: `Could not capture batch output for ${this.executorName}`,
+          bodyLines: [
+            e.message,
+            givingUp
+              ? 'Streaming the rest of it live instead; the fold holds what was captured first.'
+              : 'Streamed that much live instead; still capturing the rest.',
+          ],
+        });
+      }
     }
   }
 

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -58,6 +58,11 @@ export class BatchProcess {
      * `summary` does not, and its life cycle cannot enforce that here: this
      * class writes to `output` directly from a stream handler, so without being
      * told it would print a whole batch into a run that asked for log paths.
+     *
+     * False makes this capture rather than print. Suppressing the write alone
+     * would drop the bytes entirely off GitHub Actions, where nothing else
+     * captures them - and the worker's own crash output is exactly what no task
+     * ever claims, so it would exist nowhere.
      */
     private readonly printsOutput: boolean = true
   ) {
@@ -106,9 +111,9 @@ export class BatchProcess {
         // current terminal output behavior. These chunks are forwarded raw and
         // routinely end mid-line, so they go through `output` to keep its line
         // tracking accurate for whatever prints next.
-        if (shouldGroupBatchOutput()) {
+        if (shouldGroupBatchOutput() || !this.printsOutput) {
           this.capture(chunk);
-        } else if (this.printsOutput) {
+        } else {
           output.writeTaskOutputChunk(chunk);
         }
 
@@ -124,9 +129,9 @@ export class BatchProcess {
       this.childProcess.stderr.on('data', (chunk) => {
         const text = chunk.toString();
 
-        if (shouldGroupBatchOutput()) {
+        if (shouldGroupBatchOutput() || !this.printsOutput) {
           this.capture(chunk, process.stderr);
-        } else if (this.printsOutput) {
+        } else {
           // Maintain current terminal output behavior
           output.writeTaskOutputChunk(chunk, process.stderr);
         }
@@ -165,8 +170,11 @@ export class BatchProcess {
       return;
     }
     if (this.capturedOutputFailed) {
-      // Capture is over, but the output is not optional. Everything from here
-      // goes straight to the terminal, on the stream it arrived on.
+      // Capture is over, but the output is not optional - so this prints even
+      // when the style says not to. A style that withholds output does so on
+      // the promise that it is readable elsewhere; once the file is gone that
+      // promise cannot be kept, and printing breaks the format while losing
+      // the bytes breaks the contract.
       output.writeTaskOutputChunk(chunk, stream);
       return;
     }
@@ -217,7 +225,7 @@ export class BatchProcess {
       // the warning is survivable, losing task output is what this path exists
       // to prevent.
       const unwritten = bytes.subarray(written);
-      if (unwritten.length > 0 && this.printsOutput) {
+      if (unwritten.length > 0) {
         output.writeTaskOutputChunk(unwritten, stream);
       }
       output.warn({

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -52,7 +52,14 @@ export class BatchProcess {
 
   constructor(
     private childProcess: ChildProcess,
-    private executorName: string
+    private executorName: string,
+    /**
+     * Whether the active output style puts task bytes on the terminal at all.
+     * `summary` does not, and its life cycle cannot enforce that here: this
+     * class writes to `output` directly from a stream handler, so without being
+     * told it would print a whole batch into a run that asked for log paths.
+     */
+    private readonly printsOutput: boolean = true
   ) {
     this.childProcess.on('message', (message: BatchMessage) => {
       switch (message.type) {
@@ -101,7 +108,7 @@ export class BatchProcess {
         // tracking accurate for whatever prints next.
         if (shouldGroupBatchOutput()) {
           this.capture(chunk);
-        } else {
+        } else if (this.printsOutput) {
           output.writeTaskOutputChunk(chunk);
         }
 
@@ -119,7 +126,7 @@ export class BatchProcess {
 
         if (shouldGroupBatchOutput()) {
           this.capture(chunk, process.stderr);
-        } else {
+        } else if (this.printsOutput) {
           // Maintain current terminal output behavior
           output.writeTaskOutputChunk(chunk, process.stderr);
         }
@@ -210,7 +217,7 @@ export class BatchProcess {
       // the warning is survivable, losing task output is what this path exists
       // to prevent.
       const unwritten = bytes.subarray(written);
-      if (unwritten.length > 0) {
+      if (unwritten.length > 0 && this.printsOutput) {
         output.writeTaskOutputChunk(unwritten, stream);
       }
       output.warn({

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -50,6 +50,15 @@ export class BatchProcess {
   private capturedOutputFailed = false;
   /** Consecutive write failures. A transient one is retried; see MAX below. */
   private capturedOutputFailures = 0;
+  private static captureSeq = 0;
+  /**
+   * Discriminates this capture file from every other in the process. Assigned
+   * once here rather than at open time: a value minted inside the lazy open
+   * changed the name on every reopen, orphaning what had already been captured.
+   * `batchId` alone is not enough, since it defaults to the executor name for
+   * callers that do not pass one.
+   */
+  private readonly captureSeq = ++BatchProcess.captureSeq;
   /**
    * A failed write is usually transient (a momentarily full disk), and under
    * `summary` this file is the only copy the reader ever sees, so one failure
@@ -216,7 +225,7 @@ export class BatchProcess {
         // compiler's first non-cascading errors are.
         const name = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
           process.pid
-        }.log`;
+        }-${this.captureSeq}.log`;
         const path = join(dir, name);
         // Truncate on the first open and append after, so a reopen extends this
         // run's file while a stale one left by a dead run whose pid was recycled
@@ -251,6 +260,10 @@ export class BatchProcess {
       while (written < bytes.length) {
         written += writeSync(this.capturedOutputFd, bytes, written);
       }
+      // Consecutive, so a batch that writes for an hour and hiccups three times
+      // far apart keeps capturing. Only an unbroken run of failures, which is
+      // what an unwritable directory looks like, gives up.
+      this.capturedOutputFailures = 0;
     } catch (e) {
       // This runs inside a stream 'data' handler, where a throw is an uncaught
       // exception rather than something the orchestrator's try can see - so a

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -55,8 +55,9 @@ export class BatchProcess {
    * Discriminates this capture file from every other in the process. Assigned
    * once here rather than at open time: a value minted inside the lazy open
    * changed the name on every reopen, orphaning what had already been captured.
-   * `batchId` alone is not enough, since it defaults to the executor name for
-   * callers that do not pass one.
+   * `batchId` alone is not enough: `TasksSchedule.batchCounters` is per
+   * instance, so a second schedule in the same process mints `<executor> 1`
+   * again and the pid does not separate them either.
    */
   private readonly captureSeq = ++BatchProcess.captureSeq;
   /**
@@ -91,9 +92,10 @@ export class BatchProcess {
      */
     private readonly printsOutput: boolean = true,
     /**
-     * Names the capture file, so a reopen after a failed write lands on the
-     * same one. Already unique per run (`<executor> <n>`, from `TasksSchedule`)
-     * and already carries the executor, so it is the whole name.
+     * Labels the capture file so it is identifiable in `batch-outputs/`. Carries
+     * the executor already (`<executor> <n>`, from `TasksSchedule`), and is one
+     * of the three components of the name; `captureSeq` is what makes it
+     * unique.
      */
     private readonly batchId: string = executorName
   ) {
@@ -224,8 +226,8 @@ export class BatchProcess {
         // it at open time minted a new name on every reopen, orphaning the
         // bytes captured so far - which is where a compiler's first
         // non-cascading errors are. The batch id names it for a human reading
-        // the directory; `captureSeq` is what actually makes it unique, since
-        // the id falls back to the executor name.
+        // the directory; `captureSeq` is what actually makes it unique, since a
+        // second `TasksSchedule` in the same process re-mints the same id.
         const name = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
           process.pid
         }-${this.captureSeq}.log`;

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -219,10 +219,13 @@ export class BatchProcess {
       if (this.capturedOutputFd === undefined) {
         const dir = join(workspaceDataDirectory, 'batch-outputs');
         mkdirSync(dir, { recursive: true });
-        // Derived from the batch id rather than a counter, so reopening after a
-        // failed write returns to the same file. A counter minted a new name on
-        // every reopen, orphaning the bytes captured so far - which is where a
-        // compiler's first non-cascading errors are.
+        // Every component is fixed for the life of this instance, so reopening
+        // after a failed write returns to the same file. Deriving any part of
+        // it at open time minted a new name on every reopen, orphaning the
+        // bytes captured so far - which is where a compiler's first
+        // non-cascading errors are. The batch id names it for a human reading
+        // the directory; `captureSeq` is what actually makes it unique, since
+        // the id falls back to the executor name.
         const name = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
           process.pid
         }-${this.captureSeq}.log`;
@@ -320,7 +323,7 @@ export class BatchProcess {
    * The file is deliberately left open rather than closed here. A worker's
    * stdout can deliver after its exit event — which is what `getResults()`
    * settles on — and leaving the fd open keeps such a chunk appending to this
-   * same file instead of minting a second numbered one that nothing cleans up.
+   * same file rather than opening a second one that nothing cleans up.
    * The caller reads the file once, synchronously, while rendering the fold, so
    * anything arriving after that read is not shown; writes are unbuffered, so
    * the read always sees a complete prefix of what has arrived by then.

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess, Serializable } from 'child_process';
-import { closeSync, mkdirSync, openSync, rmSync, writeSync } from 'fs';
+import { createWriteStream, mkdirSync, rmSync, type WriteStream } from 'fs';
 import { join } from 'path';
 import { killProcessTreeGraceful } from '../../native';
 import type { TaskResult } from '../../config/misc-interfaces';
@@ -35,21 +35,19 @@ export class BatchProcess {
    * length of a JS string.
    */
   private capturedOutputPath: string | undefined;
-  private capturedOutputFd: number | undefined;
+  private capturedOutputStream: WriteStream | undefined;
   /**
    * Set once the capture is released. A chunk can still arrive after that —
-   * stdout delivers past the exit event — and reopening then would write to a
-   * file the renderer has already read.
+   * stdout delivers past the exit event — and writing then would reach a file
+   * the renderer has already read.
    */
   private capturedOutputDiscarded = false;
   /**
-   * Set when writing the capture has failed often enough to give up on it. The
-   * bytes already on disk are still the best record of the batch, so the file is
-   * kept and rendered, while everything after goes live to the terminal.
+   * Set when the capture file could not be written. Whatever reached it is kept
+   * and still rendered: that is the head of the batch's log, where a compiler's
+   * first non-cascading errors are.
    */
   private capturedOutputFailed = false;
-  /** Consecutive write failures. A transient one is retried; see MAX below. */
-  private capturedOutputFailures = 0;
   private static captureSeq = 0;
   /**
    * Discriminates this capture file from every other in the process. Assigned
@@ -60,21 +58,6 @@ export class BatchProcess {
    * again and the pid does not separate them either.
    */
   private readonly captureSeq = ++BatchProcess.captureSeq;
-  /**
-   * A failed write is usually transient (a momentarily full disk), and under
-   * `summary` this file is the only copy the reader ever sees, so one failure
-   * should not end the capture. A permanently read-only data directory throws on
-   * every chunk though, and this runs in a stream handler, so the retries are
-   * bounded rather than unlimited.
-   */
-  private static readonly MAX_CAPTURE_FAILURES = 3;
-  /** True once the file has been opened, so a reopen appends rather than truncates. */
-  private capturedOutputOpened = false;
-  /**
-   * Bytes that went to the terminal instead of the file. Recorded so the gap can
-   * be named in the file rather than leaving a hole a reader cannot see.
-   */
-  private capturedOutputGapBytes = 0;
 
   constructor(
     private childProcess: ChildProcess,
@@ -163,7 +146,7 @@ export class BatchProcess {
         const text = chunk.toString();
 
         if (shouldGroupBatchOutput() || !this.printsOutput) {
-          this.capture(chunk, process.stderr);
+          this.capture(chunk);
         } else {
           // Maintain current terminal output behavior
           output.writeTaskOutputChunk(chunk, process.stderr);
@@ -193,128 +176,68 @@ export class BatchProcess {
     this.outputCallbacks.push(cb);
   }
 
-  private capture(
-    chunk: string | Buffer,
-    stream: NodeJS.WriteStream = process.stdout
-  ) {
+  private capture(chunk: string | Buffer) {
     // Only a released capture stops recording; a handed-over one keeps
     // appending until the fold is rendered.
-    if (this.capturedOutputDiscarded) {
+    if (this.capturedOutputDiscarded || this.capturedOutputFailed) {
       return;
     }
-    if (this.capturedOutputFailed) {
-      // Capture is over, but the output is not optional - so this prints even
-      // when the style says not to. A style that withholds output does so on
-      // the promise that it is readable elsewhere; once the file is gone that
-      // promise cannot be kept, and printing breaks the format while losing
-      // the bytes breaks the contract.
-      output.writeTaskOutputChunk(chunk, stream);
-      return;
+    this.openCapturedOutput()?.write(chunk);
+  }
+
+  /**
+   * The capture file, opened on the first chunk. A `WriteStream` rather than a
+   * hand-rolled `writeSync` loop: it already handles partial writes and
+   * backpressure, and backpressure is what should happen here — a slow disk
+   * should slow the worker rather than grow an unbounded buffer in this
+   * process.
+   */
+  private openCapturedOutput(): WriteStream | undefined {
+    if (this.capturedOutputStream) {
+      return this.capturedOutputStream;
     }
-    // Hoisted so the catch can tell how much of this chunk reached the file: a
-    // `writeSync` that fails partway leaves a prefix on disk, and replaying the
-    // whole chunk live would print that prefix twice - once now, once when the
-    // fold reads the file.
-    const bytes = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
-    let written = 0;
     try {
-      if (this.capturedOutputFd === undefined) {
-        const dir = join(workspaceDataDirectory, 'batch-outputs');
-        mkdirSync(dir, { recursive: true });
-        // Every component is fixed for the life of this instance, so reopening
-        // after a failed write returns to the same file. Deriving any part of
-        // it at open time minted a new name on every reopen, orphaning the
-        // bytes captured so far - which is where a compiler's first
-        // non-cascading errors are. The batch id names it for a human reading
-        // the directory; `captureSeq` is what actually makes it unique, since a
-        // second `TasksSchedule` in the same process re-mints the same id.
-        const name = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
-          process.pid
-        }-${this.captureSeq}.log`;
-        const path = join(dir, name);
-        // Truncate on the first open and append after, so a reopen extends this
-        // run's file while a stale one left by a dead run whose pid was recycled
-        // is overwritten rather than appended to.
-        const fd = openSync(path, this.capturedOutputOpened ? 'a' : 'w');
-        // Assigned only once the file is actually open, so a path always names
-        // an fd rather than a file that failed to open.
-        this.capturedOutputPath = path;
-        this.capturedOutputFd = fd;
-        this.capturedOutputOpened = true;
-      }
-      if (this.capturedOutputGapBytes > 0) {
-        // Name the hole rather than leaving one a reader cannot see. A file that
-        // reads as continuous prose with a chunk missing from the middle is
-        // worse than one that says what it lost, especially for an agent that
-        // never saw the bytes go past on the terminal.
-        const marker = Buffer.from(
-          `\n[nx] capture interrupted: ${this.capturedOutputGapBytes} bytes went to the terminal instead\n`
-        );
-        let markerWritten = 0;
-        while (markerWritten < marker.length) {
-          markerWritten += writeSync(
-            this.capturedOutputFd,
-            marker,
-            markerWritten
-          );
-        }
-        this.capturedOutputGapBytes = 0;
-      }
-      // Written synchronously so the file is complete the moment the batch ends,
-      // with no flush to sequence against the read that renders the fold.
-      while (written < bytes.length) {
-        written += writeSync(this.capturedOutputFd, bytes, written);
-      }
-      // Consecutive, so a batch that writes for an hour and hiccups three times
-      // far apart keeps capturing. Only an unbroken run of failures, which is
-      // what an unwritable directory looks like, gives up.
-      this.capturedOutputFailures = 0;
-    } catch (e) {
-      // This runs inside a stream 'data' handler, where a throw is an uncaught
-      // exception rather than something the orchestrator's try can see - so a
-      // full disk or a read-only data directory would take down a run that
-      // otherwise had nothing wrong with it. The capture is an optimization
-      // that the common path discards anyway, so give it up and put the bytes
-      // back on the terminal instead of losing both them and the run.
-      // Latch on a flag of its own rather than reusing the discard flag: that
-      // one makes `capture` return early, which would drop every later chunk
-      // on the floor - captured nowhere and printed nowhere.
-      this.capturedOutputFailures++;
-      const givingUp =
-        this.capturedOutputFailures >= BatchProcess.MAX_CAPTURE_FAILURES;
-      this.capturedOutputFailed = givingUp;
-      // Close the fd but keep the file. Whatever was written before the failure
-      // is still the head of the batch's log, which is where a compiler's first
-      // non-cascading errors live; unlinking it here would throw away the most
-      // useful bytes precisely when the disk is in trouble. The next chunk
-      // reopens the same path and appends, so a transient failure costs the gap
-      // rather than the rest of the batch.
-      this.closeCapturedOutput();
-      // Forward only what did not reach the file, and do it before warning.
-      // `output.warn` writes to the terminal as well, so if that is the thing
-      // failing, the bytes this handler was handed must already be out - losing
-      // the warning is survivable, losing task output is what this path exists
-      // to prevent.
-      const unwritten = bytes.subarray(written);
-      if (unwritten.length > 0) {
-        this.capturedOutputGapBytes += unwritten.length;
-        output.writeTaskOutputChunk(unwritten, stream);
-      }
-      // Only the two transitions that change what the reader gets: the first
-      // failure, and giving up. Warning on every chunk would bury the run's own
-      // output on the read-only-directory path this bound exists for.
-      if (this.capturedOutputFailures === 1 || givingUp) {
-        output.warn({
-          title: `Could not capture batch output for ${this.executorName}`,
-          bodyLines: [
-            e.message,
-            givingUp
-              ? 'Streaming the rest of it live instead; the fold holds what was captured first.'
-              : 'Streamed that much live instead; still capturing the rest.',
-          ],
-        });
-      }
+      const dir = join(workspaceDataDirectory, 'batch-outputs');
+      mkdirSync(dir, { recursive: true });
+      // `batchId` names the file for a human reading the directory;
+      // `captureSeq` is what makes it unique, since a second `TasksSchedule`
+      // in the same process re-mints the same id and the pid cannot separate
+      // them.
+      const name = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
+        process.pid
+      }-${this.captureSeq}.log`;
+      const path = join(dir, name);
+      const stream = createWriteStream(path);
+      // Mandatory, not defensive: a write error reaches a stream as an 'error'
+      // event, and an unhandled one is an uncaught exception that would take
+      // down a run with nothing else wrong with it. Stop capturing and keep
+      // what already reached the file — that is the head of the batch's log,
+      // where a compiler's first non-cascading errors are.
+      stream.on('error', () => {
+        this.capturedOutputFailed = true;
+      });
+      this.capturedOutputPath = path;
+      this.capturedOutputStream = stream;
+    } catch {
+      // mkdir is the only synchronous throw here; the stream reports its own
+      // failures through the handler above.
+      this.capturedOutputFailed = true;
     }
+    return this.capturedOutputStream;
+  }
+
+  /**
+   * Flushes and closes the capture so the file is complete before a caller
+   * reads it. A `WriteStream` buffers, unlike the synchronous writes this
+   * replaced, so the read has to be sequenced against the flush rather than
+   * relying on every byte already being on disk.
+   */
+  async flushCapturedOutput(): Promise<void> {
+    const stream = this.capturedOutputStream;
+    if (!stream || stream.destroyed || stream.writableEnded) {
+      return;
+    }
+    await new Promise<void>((resolve) => stream.end(resolve));
   }
 
   /**
@@ -322,13 +245,12 @@ export class BatchProcess {
    * log grouping, or undefined if nothing was captured. Used to render the whole
    * batch as one fold, so output no task claimed is not lost.
    *
-   * The file is deliberately left open rather than closed here. A worker's
+   * The stream is deliberately left open rather than closed here. A worker's
    * stdout can deliver after its exit event — which is what `getResults()`
-   * settles on — and leaving the fd open keeps such a chunk appending to this
-   * same file rather than opening a second one that nothing cleans up.
-   * The caller reads the file once, synchronously, while rendering the fold, so
-   * anything arriving after that read is not shown; writes are unbuffered, so
-   * the read always sees a complete prefix of what has arrived by then.
+   * settles on — and leaving it open keeps such a chunk appending to this same
+   * file rather than opening a second one that nothing cleans up. Call
+   * `flushCapturedOutput` before reading: the stream buffers, so a read that
+   * has not been sequenced against the flush can see a short file.
    */
   getCapturedOutputPath(): string | undefined {
     return this.capturedOutputPath;
@@ -360,13 +282,11 @@ export class BatchProcess {
     }
   }
 
-  /** Closes the fd, keeping the file and its path readable. */
+  /** Closes the stream, keeping the file and its path readable. */
   private closeCapturedOutput() {
-    if (this.capturedOutputFd !== undefined) {
-      try {
-        closeSync(this.capturedOutputFd);
-      } catch {}
-      this.capturedOutputFd = undefined;
+    if (this.capturedOutputStream) {
+      this.capturedOutputStream.destroy();
+      this.capturedOutputStream = undefined;
     }
   }
 

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -75,7 +75,7 @@ export class BatchProcess {
      * ever claims, so it would exist nowhere.
      */
     private readonly printsOutput: boolean = true,
-    /** Labels the capture file so it is identifiable in `batch-outputs/`. */
+    /** Labels the capture file so it is identifiable in `batchOutputs/`. */
     private readonly batchId: string = executorName
   ) {
     this.childProcess.on('message', (message: BatchMessage) => {
@@ -183,17 +183,13 @@ export class BatchProcess {
       return;
     }
     // A full write buffer pauses the worker rather than growing in this
-    // process - which is the whole reason the capture is a file and not a
-    // string.
+    // process.
     if (!stream.write(chunk) && source) {
       source.pause();
       stream.once('drain', () => source.resume());
     }
   }
 
-  /**
-   * The capture file, opened on the first chunk.
-   */
   private openCapturedOutput(): WriteStream | undefined {
     if (this.capturedOutputStream) {
       return this.capturedOutputStream;
@@ -242,12 +238,9 @@ export class BatchProcess {
    * log grouping, or undefined if nothing was captured. Used to render the whole
    * batch as one fold, so output no task claimed is not lost.
    *
-   * The stream is deliberately left open rather than closed here. A worker's
-   * stdout can deliver after its exit event — which is what `getResults()`
-   * settles on — and leaving it open keeps such a chunk appending to this same
-   * file rather than opening a second one that nothing cleans up. Call
-   * `flushCapturedOutput` before reading: the stream buffers, so a read that
-   * has not been sequenced against the flush can see a short file.
+   * Not valid to read before `flushCapturedOutput`; that flush ends the stream,
+   * so a chunk arriving afterwards - a worker's stdout can deliver past the
+   * exit event `getResults()` settles on - is dropped rather than appended.
    */
   getCapturedOutputPath(): string | undefined {
     return this.capturedOutputPath;

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess, Serializable } from 'child_process';
 import type { Readable } from 'stream';
 import { createWriteStream, mkdirSync, rmSync, type WriteStream } from 'fs';
+import { randomBytes } from 'crypto';
 import { dirname } from 'path';
 import { killProcessTreeGraceful } from '../../native';
 import type { TaskResult } from '../../config/misc-interfaces';
@@ -48,19 +49,31 @@ export class BatchProcess {
   /**
    * Set when the capture file could not be written. Whatever reached it is kept
    * and still rendered: that is the head of the batch's log, where a compiler's
-   * first non-cascading errors are.
+   * first non-cascading errors are. Everything after it goes to the terminal -
+   * see `capture`.
    */
   private capturedOutputFailed = false;
+  /** Set once the failure has been reported, so it is said once per batch. */
+  private capturedOutputWarned = false;
   private static captureSeq = 0;
+  /** Turns `flushCapturedOutput` waits for a resumed source to empty. */
+  private static readonly MAX_DRAIN_TURNS = 100;
   /**
    * Makes the capture file unique across every batch in the process, which
    * `batchId` alone does not: `TasksSchedule.batchCounters` is per instance, so
    * a second orchestrator in the same process - `runDiscreteTasks` and
    * `runContinuousTasks`, not the CLI - re-mints `<executor> 1`, and the pid
-   * cannot separate them. These files now outlive their batch, so a collision
-   * would truncate a log an earlier run is still pointing at.
+   * cannot separate them.
    */
   private readonly captureSeq = ++BatchProcess.captureSeq;
+  /**
+   * Separates this capture from one minted by a DIFFERENT process, which
+   * `captureSeq` cannot: it is a per-process static that restarts at 1. These
+   * files now outlive their batch and `cacheDir` can be shared across checkouts
+   * of a repo, so without this a recycled pid truncates a log an earlier run's
+   * summary is still pointing at.
+   */
+  private readonly captureNonce = randomBytes(4).toString('hex');
 
   constructor(
     private childProcess: ChildProcess,
@@ -175,14 +188,24 @@ export class BatchProcess {
   }
 
   private capture(chunk: string | Buffer, source?: Readable | null) {
-    // Stops on release or on a capture failure; otherwise it keeps appending
-    // until `flushCapturedOutput` ends the stream, which `runBatch` does before
-    // anything reads the file.
-    if (this.capturedOutputDiscarded || this.capturedOutputFailed) {
+    // A released capture drops the chunk. The renderer has already read the
+    // file, so there is nothing left for these bytes to reach.
+    if (this.capturedOutputDiscarded) {
+      return;
+    }
+    // A failed one does not. The style withheld these bytes on the promise that
+    // they are readable elsewhere; once the file is unwritable that promise
+    // cannot be kept, so they go to the terminal even under a style that prints
+    // nothing. Losing the format is survivable, losing task output is what this
+    // path exists to prevent.
+    if (this.capturedOutputFailed) {
+      this.forwardUncaptured(chunk, source);
       return;
     }
     const stream = this.openCapturedOutput();
     if (!stream) {
+      // Opening is what failed, so nothing of this chunk reached disk.
+      this.forwardUncaptured(chunk, source);
       return;
     }
     // A full write buffer pauses the worker rather than growing in this
@@ -199,17 +222,46 @@ export class BatchProcess {
   }
 
   /**
+   * Puts bytes the capture could not take back on the terminal, on the stream
+   * they arrived on.
+   */
+  private forwardUncaptured(chunk: string | Buffer, source?: Readable | null) {
+    output.writeTaskOutputChunk(
+      chunk,
+      source === this.childProcess.stderr ? process.stderr : process.stdout
+    );
+  }
+
+  /**
+   * Names the failure once. A stream reports it asynchronously, so the chunk
+   * that tripped it may or may not have reached disk - unlike a `writeSync`,
+   * there is no byte count to tell. Every chunk after it is forwarded.
+   */
+  private warnCaptureFailed(reason: string) {
+    if (this.capturedOutputWarned) {
+      return;
+    }
+    this.capturedOutputWarned = true;
+    output.warn({
+      title: `Could not capture batch output for ${this.executorName}`,
+      bodyLines: [reason, 'Streaming the rest of it live instead.'],
+    });
+  }
+
+  /**
    * Lets the worker write again after the capture has stopped.
    *
    * Without this a failed capture wedges the whole run: the source stays
    * paused, so the worker blocks once its stdout pipe fills, never sends its
    * results, and `getResults` waits on a batch that can no longer finish.
    */
-  private resumeCapturedSources() {
-    for (const source of this.pausedSources) {
+  private resumeCapturedSources(): Readable[] {
+    const resumed = [...this.pausedSources];
+    for (const source of resumed) {
       source.resume();
     }
     this.pausedSources.clear();
+    return resumed;
   }
 
   private openCapturedOutput(): WriteStream | undefined {
@@ -218,28 +270,32 @@ export class BatchProcess {
     }
     try {
       // `batchId` names the file for a human reading the directory;
-      // `captureSeq` is what makes it unique - see the field.
+      // `captureSeq` separates batches within this process and `captureNonce`
+      // separates it from every other process - see both fields.
       const key = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
         process.pid
-      }-${this.captureSeq}`;
+      }-${this.captureSeq}-${this.captureNonce}`;
       const path = batchOutputPathForKey(key);
       mkdirSync(dirname(path), { recursive: true });
       const stream = createWriteStream(path);
       // Mandatory, not defensive: a write error reaches a stream as an 'error'
       // event, and an unhandled one is an uncaught exception that would take
-      // down a run with nothing else wrong with it. Stop capturing and keep
-      // what already reached the file — that is the head of the batch's log,
-      // where a compiler's first non-cascading errors are.
-      stream.on('error', () => {
+      // down a run with nothing else wrong with it. Stop capturing, keep what
+      // already reached the file — the head of the batch's log, where a
+      // compiler's first non-cascading errors are — and put everything after
+      // it on the terminal.
+      stream.on('error', (e) => {
         this.capturedOutputFailed = true;
         this.resumeCapturedSources();
+        this.warnCaptureFailed(e.message);
       });
       this.capturedOutputPath = path;
       this.capturedOutputStream = stream;
-    } catch {
+    } catch (e) {
       // mkdir is the only synchronous throw here; the stream reports its own
       // failures through the handler above.
       this.capturedOutputFailed = true;
+      this.warnCaptureFailed(e.message);
     }
     return this.capturedOutputStream;
   }
@@ -253,7 +309,19 @@ export class BatchProcess {
     // 'drain' will never arrive, so a source paused for backpressure has
     // nothing left to resume it. Measured: 20/20 runs reach 'finish' with the
     // source still paused.
-    this.resumeCapturedSources();
+    const resumed = this.resumeCapturedSources();
+    // `resume()` delivers on the next tick while `end()` takes effect in this
+    // one, so ending here would strand everything the source still holds - the
+    // tail of the log, which is where a build tool puts what went wrong.
+    // Bounded, because a source that never empties must not hold the run open.
+    for (
+      let turn = 0;
+      turn < BatchProcess.MAX_DRAIN_TURNS &&
+      resumed.some((source) => source.readableLength > 0);
+      turn++
+    ) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
     const stream = this.capturedOutputStream;
     if (!stream || stream.destroyed || stream.writableEnded) {
       return;

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -1,10 +1,10 @@
 import type { ChildProcess, Serializable } from 'child_process';
 import type { Readable } from 'stream';
 import { createWriteStream, mkdirSync, rmSync, type WriteStream } from 'fs';
-import { join } from 'path';
+import { dirname } from 'path';
 import { killProcessTreeGraceful } from '../../native';
 import type { TaskResult } from '../../config/misc-interfaces';
-import { workspaceDataDirectory } from '../../utils/cache-directory';
+import { batchOutputPathForKey } from '../cache';
 import { signalToCode } from '../../utils/exit-codes';
 import { output, shouldGroupBatchOutput } from '../../utils/output';
 import {
@@ -192,16 +192,15 @@ export class BatchProcess {
       return this.capturedOutputStream;
     }
     try {
-      const dir = join(workspaceDataDirectory, 'batch-outputs');
-      mkdirSync(dir, { recursive: true });
       // `batchId` names the file for a human reading the directory;
       // `captureSeq` is what makes it unique, since a second `TasksSchedule`
       // in the same process re-mints the same id and the pid cannot separate
       // them.
-      const name = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
+      const key = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
         process.pid
-      }-${this.captureSeq}.log`;
-      const path = join(dir, name);
+      }-${this.captureSeq}`;
+      const path = batchOutputPathForKey(key);
+      mkdirSync(dirname(path), { recursive: true });
       const stream = createWriteStream(path);
       // Mandatory, not defensive: a write error reaches a stream as an 'error'
       // event, and an unhandled one is an uncaught exception that would take

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess, Serializable } from 'child_process';
+import type { Readable } from 'stream';
 import { createWriteStream, mkdirSync, rmSync, type WriteStream } from 'fs';
 import { join } from 'path';
 import { killProcessTreeGraceful } from '../../native';
@@ -49,14 +50,7 @@ export class BatchProcess {
    */
   private capturedOutputFailed = false;
   private static captureSeq = 0;
-  /**
-   * Discriminates this capture file from every other in the process. Assigned
-   * once here rather than at open time: a value minted inside the lazy open
-   * changed the name on every reopen, orphaning what had already been captured.
-   * `batchId` alone is not enough: `TasksSchedule.batchCounters` is per
-   * instance, so a second schedule in the same process mints `<executor> 1`
-   * again and the pid does not separate them either.
-   */
+  /** Discriminates this capture file from every other in the process. */
   private readonly captureSeq = ++BatchProcess.captureSeq;
 
   constructor(
@@ -74,12 +68,7 @@ export class BatchProcess {
      * ever claims, so it would exist nowhere.
      */
     private readonly printsOutput: boolean = true,
-    /**
-     * Labels the capture file so it is identifiable in `batch-outputs/`. Carries
-     * the executor already (`<executor> <n>`, from `TasksSchedule`), and is one
-     * of the three components of the name; `captureSeq` is what makes it
-     * unique.
-     */
+    /** Labels the capture file so it is identifiable in `batch-outputs/`. */
     private readonly batchId: string = executorName
   ) {
     this.childProcess.on('message', (message: BatchMessage) => {
@@ -128,7 +117,7 @@ export class BatchProcess {
         // routinely end mid-line, so they go through `output` to keep its line
         // tracking accurate for whatever prints next.
         if (shouldGroupBatchOutput() || !this.printsOutput) {
-          this.capture(chunk);
+          this.capture(chunk, this.childProcess.stdout);
         } else {
           output.writeTaskOutputChunk(chunk);
         }
@@ -146,7 +135,7 @@ export class BatchProcess {
         const text = chunk.toString();
 
         if (shouldGroupBatchOutput() || !this.printsOutput) {
-          this.capture(chunk);
+          this.capture(chunk, this.childProcess.stderr);
         } else {
           // Maintain current terminal output behavior
           output.writeTaskOutputChunk(chunk, process.stderr);
@@ -176,21 +165,27 @@ export class BatchProcess {
     this.outputCallbacks.push(cb);
   }
 
-  private capture(chunk: string | Buffer) {
-    // Only a released capture stops recording; a handed-over one keeps
-    // appending until the fold is rendered.
+  private capture(chunk: string | Buffer, source?: Readable | null) {
+    // Stops on release or on a capture failure; otherwise a handed-over
+    // capture keeps appending until the fold is rendered.
     if (this.capturedOutputDiscarded || this.capturedOutputFailed) {
       return;
     }
-    this.openCapturedOutput()?.write(chunk);
+    const stream = this.openCapturedOutput();
+    if (!stream) {
+      return;
+    }
+    // A full write buffer pauses the worker rather than growing in this
+    // process - which is the whole reason the capture is a file and not a
+    // string.
+    if (!stream.write(chunk) && source) {
+      source.pause();
+      stream.once('drain', () => source.resume());
+    }
   }
 
   /**
-   * The capture file, opened on the first chunk. A `WriteStream` rather than a
-   * hand-rolled `writeSync` loop: it already handles partial writes and
-   * backpressure, and backpressure is what should happen here — a slow disk
-   * should slow the worker rather than grow an unbounded buffer in this
-   * process.
+   * The capture file, opened on the first chunk.
    */
   private openCapturedOutput(): WriteStream | undefined {
     if (this.capturedOutputStream) {
@@ -228,9 +223,7 @@ export class BatchProcess {
 
   /**
    * Flushes and closes the capture so the file is complete before a caller
-   * reads it. A `WriteStream` buffers, unlike the synchronous writes this
-   * replaced, so the read has to be sequenced against the flush rather than
-   * relying on every byte already being on disk.
+   * reads it.
    */
   async flushCapturedOutput(): Promise<void> {
     const stream = this.capturedOutputStream;
@@ -263,9 +256,9 @@ export class BatchProcess {
   }
 
   /**
-   * Closes the fd and unlinks the file, leaving no path behind for a caller to
-   * read. Tolerates a partially-initialized capture, since it also runs when
-   * opening or writing the file is what failed.
+   * Destroys the stream and unlinks the file, leaving no path behind for a
+   * caller to read. Tolerates a partially-initialized capture, since it also
+   * runs when opening or writing the file is what failed.
    */
   private releaseCapturedOutput() {
     this.closeCapturedOutput();
@@ -282,7 +275,7 @@ export class BatchProcess {
     }
   }
 
-  /** Closes the stream, keeping the file and its path readable. */
+  /** Destroys the stream, dropping anything still buffered. The file stays. */
   private closeCapturedOutput() {
     if (this.capturedOutputStream) {
       this.capturedOutputStream.destroy();

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -50,7 +50,14 @@ export class BatchProcess {
    */
   private capturedOutputFailed = false;
   private static captureSeq = 0;
-  /** Discriminates this capture file from every other in the process. */
+  /**
+   * Makes the capture file unique across every batch in the process, which
+   * `batchId` alone does not: `TasksSchedule.batchCounters` is per instance, so
+   * a second orchestrator in the same process - `runDiscreteTasks` and
+   * `runContinuousTasks`, not the CLI - re-mints `<executor> 1`, and the pid
+   * cannot separate them. These files now outlive their batch, so a collision
+   * would truncate a log an earlier run is still pointing at.
+   */
   private readonly captureSeq = ++BatchProcess.captureSeq;
 
   constructor(
@@ -193,9 +200,7 @@ export class BatchProcess {
     }
     try {
       // `batchId` names the file for a human reading the directory;
-      // `captureSeq` is what makes it unique, since a second `TasksSchedule`
-      // in the same process re-mints the same id and the pid cannot separate
-      // them.
+      // `captureSeq` is what makes it unique - see the field.
       const key = `${this.batchId.replace(/[^a-zA-Z0-9]+/g, '-')}-${
         process.pid
       }-${this.captureSeq}`;

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -249,6 +249,11 @@ export class BatchProcess {
    * reads it.
    */
   async flushCapturedOutput(): Promise<void> {
+    // Before the early return, and unconditionally: `end()` means a pending
+    // 'drain' will never arrive, so a source paused for backpressure has
+    // nothing left to resume it. Measured: 20/20 runs reach 'finish' with the
+    // source still paused.
+    this.resumeCapturedSources();
     const stream = this.capturedOutputStream;
     if (!stream || stream.destroyed || stream.writableEnded) {
       return;

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -37,6 +37,8 @@ export class BatchProcess {
    */
   private capturedOutputPath: string | undefined;
   private capturedOutputStream: WriteStream | undefined;
+  /** Sources paused for backpressure, awaiting a 'drain' that may never come. */
+  private readonly pausedSources = new Set<Readable>();
   /**
    * Set once the capture is released. A chunk can still arrive after that —
    * stdout delivers past the exit event — and writing then would reach a file
@@ -183,11 +185,30 @@ export class BatchProcess {
       return;
     }
     // A full write buffer pauses the worker rather than growing in this
-    // process.
+    // process. Tracked, because only 'drain' resumes it and a stream that
+    // errors never emits one - see `resumeCapturedSources`.
     if (!stream.write(chunk) && source) {
+      this.pausedSources.add(source);
       source.pause();
-      stream.once('drain', () => source.resume());
+      stream.once('drain', () => {
+        this.pausedSources.delete(source);
+        source.resume();
+      });
     }
+  }
+
+  /**
+   * Lets the worker write again after the capture has stopped.
+   *
+   * Without this a failed capture wedges the whole run: the source stays
+   * paused, so the worker blocks once its stdout pipe fills, never sends its
+   * results, and `getResults` waits on a batch that can no longer finish.
+   */
+  private resumeCapturedSources() {
+    for (const source of this.pausedSources) {
+      source.resume();
+    }
+    this.pausedSources.clear();
   }
 
   private openCapturedOutput(): WriteStream | undefined {
@@ -210,6 +231,7 @@ export class BatchProcess {
       // where a compiler's first non-cascading errors are.
       stream.on('error', () => {
         this.capturedOutputFailed = true;
+        this.resumeCapturedSources();
       });
       this.capturedOutputPath = path;
       this.capturedOutputStream = stream;
@@ -274,6 +296,7 @@ export class BatchProcess {
 
   /** Destroys the stream, dropping anything still buffered. The file stays. */
   private closeCapturedOutput() {
+    this.resumeCapturedSources();
     if (this.capturedOutputStream) {
       this.capturedOutputStream.destroy();
       this.capturedOutputStream = undefined;

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -175,8 +175,9 @@ export class BatchProcess {
   }
 
   private capture(chunk: string | Buffer, source?: Readable | null) {
-    // Stops on release or on a capture failure; otherwise a handed-over
-    // capture keeps appending until the fold is rendered.
+    // Stops on release or on a capture failure; otherwise it keeps appending
+    // until `flushCapturedOutput` ends the stream, which `runBatch` does before
+    // anything reads the file.
     if (this.capturedOutputDiscarded || this.capturedOutputFailed) {
       return;
     }

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -403,13 +403,27 @@ describe('TaskOrchestrator', () => {
 
   describe('terminal output persistence', () => {
     let terminalOutputsDir: string;
+    let originalCacheFailures: string | undefined;
 
     beforeEach(() => {
       terminalOutputsDir = mkdtempSync(join(tmpdir(), 'nx-terminal-outputs-'));
+      // These tests assert that a FAILED task is not cached, which is only true
+      // while `NX_CACHE_FAILURES` is off - `shouldCacheTaskResult` returns true
+      // for any code when it is set. Reading it from the ambient environment
+      // makes the outcome depend on whatever else ran first: this suite passes
+      // locally and fails in CI, where something sets it. State it here rather
+      // than inherit it.
+      originalCacheFailures = process.env.NX_CACHE_FAILURES;
+      delete process.env.NX_CACHE_FAILURES;
     });
 
     afterEach(() => {
       rmSync(terminalOutputsDir, { recursive: true, force: true });
+      if (originalCacheFailures === undefined) {
+        delete process.env.NX_CACHE_FAILURES;
+      } else {
+        process.env.NX_CACHE_FAILURES = originalCacheFailures;
+      }
     });
 
     function makeTask(id: string, overrides: Partial<Task> = {}): Task {

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -439,6 +439,7 @@ describe('TaskOrchestrator', () => {
           // The real cache writes the same file this backstop targets.
           writeFileSync(join(terminalOutputsDir, task.hash), terminalOutput);
         }),
+        recordTerminalOutputs: jest.fn(),
       };
       orchestrator.recordOutputsHashBatch = jest.fn();
       orchestrator.complete = jest.fn();
@@ -572,6 +573,86 @@ describe('TaskOrchestrator', () => {
       await orchestrator.postRunSteps([{ task, status: 'success' }], true, 0);
 
       expect(readOutput(task)).toBeNull();
+    });
+
+    it('registers an uncacheable output with the cache so the GC can collect it', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build', { cache: false });
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'success', terminalOutput: 'batch body' }],
+        true,
+        0
+      );
+
+      expect(orchestrator.cache.recordTerminalOutputs).toHaveBeenCalledWith([
+        { hash: task.hash, size: 'batch body'.length },
+      ]);
+    });
+
+    it('registers output a runner wrote, which the GC cannot see either', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build', { cache: false });
+      writeFileSync(join(terminalOutputsDir, task.hash), 'from the runner');
+      orchestrator.tasksWithPersistedOutput.add(task.id);
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'success', terminalOutput: 'from the runner' }],
+        true,
+        0
+      );
+
+      // Skipping the write must not skip the bookkeeping.
+      expect(orchestrator.cache.recordTerminalOutputs).toHaveBeenCalledWith([
+        { hash: task.hash, size: 'from the runner'.length },
+      ]);
+    });
+
+    it('does not register output the cache recorded itself', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build');
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'success', terminalOutput: 'cached body' }],
+        true,
+        0
+      );
+
+      expect(orchestrator.cache.put).toHaveBeenCalled();
+      expect(orchestrator.cache.recordTerminalOutputs).not.toHaveBeenCalled();
+    });
+
+    it('does not register output replayed from the cache', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build');
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'local-cache', terminalOutput: 'replayed' }],
+        false,
+        0
+      );
+
+      // That hash is already recorded — it is what the replay read.
+      expect(orchestrator.cache.recordTerminalOutputs).not.toHaveBeenCalled();
+    });
+
+    it('registers a cacheable task run with --skip-nx-cache', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build');
+
+      // shouldCache false is how --skip-nx-cache reaches postRunSteps: the
+      // output lands on disk but no artifacts do.
+      await orchestrator.postRunSteps(
+        [{ task, status: 'success', terminalOutput: 'uncached body' }],
+        false,
+        0
+      );
+
+      expect(readOutput(task)).toBe('uncached body');
+      expect(orchestrator.cache.put).not.toHaveBeenCalled();
+      expect(orchestrator.cache.recordTerminalOutputs).toHaveBeenCalledWith([
+        { hash: task.hash, size: 'uncached body'.length },
+      ]);
     });
 
     it('writes every task of a batch that could not be cached', async () => {

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -449,15 +449,15 @@ describe('TaskOrchestrator', () => {
       orchestrator.cache = {
         temporaryOutputPath: (task: Task) =>
           join(terminalOutputsDir, task.hash),
-        put: jest.fn(async (task: Task, terminalOutput: string) => {
+        put: vi.fn(async (task: Task, terminalOutput: string) => {
           // The real cache writes the same file this backstop targets.
           writeFileSync(join(terminalOutputsDir, task.hash), terminalOutput);
         }),
-        recordTerminalOutputs: jest.fn(),
+        recordTerminalOutputs: vi.fn(),
       };
-      orchestrator.recordOutputsHashBatch = jest.fn();
-      orchestrator.complete = jest.fn();
-      orchestrator.scheduleNextTasksAndReleaseThreads = jest.fn();
+      orchestrator.recordOutputsHashBatch = vi.fn();
+      orchestrator.complete = vi.fn();
+      orchestrator.scheduleNextTasksAndReleaseThreads = vi.fn();
       return orchestrator;
     }
 
@@ -513,7 +513,7 @@ describe('TaskOrchestrator', () => {
       const orchestrator = createOrchestrator();
       const task = makeTask('app:build');
       const writes: string[] = [];
-      orchestrator.cache.put = jest.fn(
+      orchestrator.cache.put = vi.fn(
         async (t: Task, terminalOutput: string) => {
           writes.push(terminalOutput);
           writeFileSync(join(terminalOutputsDir, t.hash), terminalOutput);

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -739,7 +739,12 @@ describe('TaskOrchestrator', () => {
       // argument, sourced from `nxArgs`, while `options` is the merged runner
       // options object. Putting the style in `options` here would let a read of
       // the wrong one pass.
-      orchestrator.outputStyle = args.outputStyle;
+      // Mirrors the two constructor fields: what the user named, and what the
+      // run renders with. A fixture that set only one would let a read of the
+      // wrong field pass.
+      orchestrator.specifiedOutputStyle = args.outputStyle;
+      orchestrator.resolvedOutputStyle =
+        args.outputStyle ?? 'static-failures-only';
       // Object.create bypasses field initializers.
       orchestrator.batchFoldRenders = new Map();
       return orchestrator;

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { stripVTControlCharacters } from 'util';
@@ -392,6 +398,198 @@ describe('TaskOrchestrator', () => {
 
       expect(await orchestrator.resolveCachedTasksBulk()).toBe(false);
       expect(orchestrator.cache.getBatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('terminal output persistence', () => {
+    let terminalOutputsDir: string;
+
+    beforeEach(() => {
+      terminalOutputsDir = mkdtempSync(join(tmpdir(), 'nx-terminal-outputs-'));
+    });
+
+    afterEach(() => {
+      rmSync(terminalOutputsDir, { recursive: true, force: true });
+    });
+
+    function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+      const [project, target] = id.split(':');
+      return {
+        id,
+        target: { project, target },
+        overrides: {},
+        outputs: [],
+        projectRoot: project,
+        cache: true,
+        parallelism: true,
+        hash: `${id}-hash`,
+        ...overrides,
+      } as Task;
+    }
+
+    function createOrchestrator() {
+      const orchestrator: any = Object.create(TaskOrchestrator.prototype);
+      // Object.create bypasses field initializers.
+      orchestrator.tasksWithPersistedOutput = new Set<string>();
+      orchestrator.stopRequested = false;
+      orchestrator.cache = {
+        temporaryOutputPath: (task: Task) =>
+          join(terminalOutputsDir, task.hash),
+        put: jest.fn(async (task: Task, terminalOutput: string) => {
+          // The real cache writes the same file this backstop targets.
+          writeFileSync(join(terminalOutputsDir, task.hash), terminalOutput);
+        }),
+      };
+      orchestrator.recordOutputsHashBatch = jest.fn();
+      orchestrator.complete = jest.fn();
+      orchestrator.scheduleNextTasksAndReleaseThreads = jest.fn();
+      return orchestrator;
+    }
+
+    function readOutput(task: Task): string | null {
+      const path = join(terminalOutputsDir, task.hash);
+      return existsSync(path) ? readFileSync(path, 'utf-8') : null;
+    }
+
+    it('writes the terminal output of an uncacheable task', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build', { cache: false });
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'success', terminalOutput: 'batch body' }],
+        true,
+        0
+      );
+
+      expect(readOutput(task)).toBe('batch body');
+      expect(orchestrator.cache.put).not.toHaveBeenCalled();
+    });
+
+    it('writes the terminal output of a failed cacheable task', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:test');
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'failure', terminalOutput: 'assertion failed' }],
+        true,
+        0
+      );
+
+      // Failures aren't cached (without NX_CACHE_FAILURES), so the cache would
+      // never have written this one.
+      expect(orchestrator.cache.put).not.toHaveBeenCalled();
+      expect(readOutput(task)).toBe('assertion failed');
+    });
+
+    it('writes the terminal output of a stopped task', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build');
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'stopped', terminalOutput: 'partial output' }],
+        true,
+        0
+      );
+
+      expect(readOutput(task)).toBe('partial output');
+    });
+
+    it('leaves the write to the cache when the task is cached', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build');
+      const writes: string[] = [];
+      orchestrator.cache.put = jest.fn(
+        async (t: Task, terminalOutput: string) => {
+          writes.push(terminalOutput);
+          writeFileSync(join(terminalOutputsDir, t.hash), terminalOutput);
+        }
+      );
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'success', terminalOutput: 'cached body' }],
+        true,
+        0
+      );
+
+      // Written once, by the cache — not twice.
+      expect(writes).toEqual(['cached body']);
+      expect(readOutput(task)).toBe('cached body');
+      expect(orchestrator.tasksWithPersistedOutput.has(task.id)).toBe(false);
+    });
+
+    it('does not rewrite output a runner already persisted', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build', { cache: false });
+      // The runner wrote the real PTY bytes when the process exited.
+      writeFileSync(join(terminalOutputsDir, task.hash), 'from the runner');
+      orchestrator.tasksWithPersistedOutput.add(task.id);
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'success', terminalOutput: 'from the result' }],
+        true,
+        0
+      );
+
+      expect(readOutput(task)).toBe('from the runner');
+    });
+
+    it('does not rewrite output replayed from the cache', async () => {
+      const orchestrator = createOrchestrator();
+      const local = makeTask('app:build');
+      const remote = makeTask('app:test');
+
+      await orchestrator.postRunSteps(
+        [
+          { task: local, status: 'local-cache', terminalOutput: 'replayed' },
+          { task: remote, status: 'remote-cache', terminalOutput: 'replayed' },
+        ],
+        false,
+        0
+      );
+
+      // The replayed output was read from these very files.
+      expect(readOutput(local)).toBeNull();
+      expect(readOutput(remote)).toBeNull();
+    });
+
+    it('writes nothing for a skipped task', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build', { cache: false });
+
+      await orchestrator.postRunSteps(
+        [{ task, status: 'skipped', terminalOutput: '' }],
+        true,
+        0
+      );
+
+      expect(readOutput(task)).toBeNull();
+    });
+
+    it('writes nothing when the result carries no terminal output', async () => {
+      const orchestrator = createOrchestrator();
+      const task = makeTask('app:build', { cache: false });
+
+      await orchestrator.postRunSteps([{ task, status: 'success' }], true, 0);
+
+      expect(readOutput(task)).toBeNull();
+    });
+
+    it('writes every task of a batch that could not be cached', async () => {
+      const orchestrator = createOrchestrator();
+      const a = makeTask('a:build', { cache: false });
+      const b = makeTask('b:build', { cache: false });
+
+      await orchestrator.postRunSteps(
+        [
+          { task: a, status: 'success', terminalOutput: 'a body' },
+          { task: b, status: 'failure', terminalOutput: 'b body' },
+        ],
+        true,
+        0
+      );
+
+      expect(readOutput(a)).toBe('a body');
+      expect(readOutput(b)).toBe('b body');
     });
   });
 

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -887,6 +887,36 @@ describe('TaskOrchestrator', () => {
       }
     );
 
+    it('never folds under --output-style=summary, even when a task failed', async () => {
+      const orchestrator = createOrchestrator({ outputStyle: 'summary' });
+      const a = makeTask('a:build');
+      const b = makeTask('b:build');
+      const taskResults = [
+        { task: a, status: 'success', code: 0, terminalOutput: 'a body' },
+        { task: b, status: 'failure', code: 1, terminalOutput: 'b failed' },
+      ];
+
+      const out = await captureStdout(() =>
+        orchestrator.printGroupedBatchOutput(
+          BATCH,
+          taskResults,
+          capturedOutputFile('the entire gradle build log')
+        )
+      );
+
+      // summary addresses logs by path rather than printing them. The fold
+      // bypasses the life cycle and writes to `output` directly, so without an
+      // explicit check it would dump the whole worker log into exactly the run
+      // that asked not to see it.
+      expect(out).not.toContain('the entire gradle build log');
+      expect(out).not.toContain('batch @nx/js:tsc');
+      // The tasks still report themselves - the summary life cycle is what
+      // turns that into a path.
+      expect(
+        orchestrator.options.lifeCycle.printTaskTerminalOutput
+      ).toHaveBeenCalledWith(b, 'failure', 'b failed');
+    });
+
     it('still collapses an all-green batch on the default, captured log or not', async () => {
       const orchestrator = createOrchestrator();
       const a = makeTask('a:build');

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -936,6 +936,87 @@ describe('TaskOrchestrator', () => {
       ).toHaveBeenCalledWith(b, 'failure', 'b failed');
     });
 
+    // The fold above is the only consumer of the captured file on the results
+    // path, and the test above is why it does not run under summary. Without
+    // the handoff below, the worker's own stderr is captured, read by nobody,
+    // and unlinked by `discardCapturedOutput` when the batch ends.
+    it('gives a failed batch its worker log under summary', () => {
+      const orchestrator = createOrchestrator({ outputStyle: 'summary' });
+      const a = makeTask('a:build');
+      const b = { ...makeTask('b:build'), hash: 'hash-b' } as Task;
+      const taskResults = [
+        { task: a, status: 'success', code: 0, terminalOutput: 'a body' },
+        { task: b, status: 'failure', code: 1, terminalOutput: 'b failed' },
+      ];
+
+      const withLog = orchestrator.attachBatchWorkerLog(
+        taskResults,
+        capturedOutputFile('gradlew: OutOfMemoryError')
+      );
+
+      // The failing task carries it, so the path summary prints for b holds the
+      // reason the batch runner died rather than only b's own line.
+      expect(withLog[1].terminalOutput).toContain('gradlew: OutOfMemoryError');
+      expect(withLog[1].terminalOutput).toContain('b failed');
+      // A task that succeeded is left alone; there is nothing to explain.
+      expect(withLog[0].terminalOutput).toEqual('a body');
+    });
+
+    it('points the other failures at that copy rather than duplicating it', () => {
+      const orchestrator = createOrchestrator({ outputStyle: 'summary' });
+      const a = { ...makeTask('a:build'), hash: 'hash-a' } as Task;
+      const b = { ...makeTask('b:build'), hash: 'hash-b' } as Task;
+      const taskResults = [
+        { task: a, status: 'failure', code: 1, terminalOutput: 'a failed' },
+        { task: b, status: 'failure', code: 1, terminalOutput: 'b failed' },
+      ];
+
+      const withLog = orchestrator.attachBatchWorkerLog(
+        taskResults,
+        capturedOutputFile('gradlew: OutOfMemoryError')
+      );
+
+      // The log is unbounded, so a copy per task would write a byte-identical
+      // file for each and charge every one against maxCacheSize.
+      expect(withLog[0].terminalOutput).toContain('gradlew: OutOfMemoryError');
+      expect(withLog[1].terminalOutput).not.toContain(
+        'gradlew: OutOfMemoryError'
+      );
+      expect(withLog[1].terminalOutput).toContain('batch worker log:');
+    });
+
+    it('leaves an all-green batch alone, so its chatter is not persisted', () => {
+      const orchestrator = createOrchestrator({ outputStyle: 'summary' });
+      const a = makeTask('a:build');
+      const taskResults = [
+        { task: a, status: 'success', code: 0, terminalOutput: 'a body' },
+      ];
+
+      expect(
+        orchestrator.attachBatchWorkerLog(
+          taskResults,
+          capturedOutputFile('noisy but harmless')
+        )
+      ).toBe(taskResults);
+    });
+
+    it('leaves the results alone when the style prints task output', () => {
+      const orchestrator = createOrchestrator({ outputStyle: 'static' });
+      const a = { ...makeTask('a:build'), hash: 'hash-a' } as Task;
+      const taskResults = [
+        { task: a, status: 'failure', code: 1, terminalOutput: 'a failed' },
+      ];
+
+      // static already streamed it or folded it; adding it here would duplicate
+      // the whole worker log into the task's persisted output.
+      expect(
+        orchestrator.attachBatchWorkerLog(
+          taskResults,
+          capturedOutputFile('already on the terminal')
+        )
+      ).toBe(taskResults);
+    });
+
     it('still collapses an all-green batch on the default, captured log or not', async () => {
       const orchestrator = createOrchestrator();
       const a = makeTask('a:build');
@@ -1119,6 +1200,39 @@ describe('TaskOrchestrator', () => {
       executorName: '@nx/gradle:batch',
       taskGraph: { tasks: { 'a:build': {} } },
     };
+
+    // Drives the RESULTS path rather than the crash path: the worker reported
+    // results, so `getResults` resolves. Without the handoff in `runBatch` the
+    // captured file is read by nobody here and unlinked on the way out, and a
+    // unit test of the handoff alone still passes.
+    it("surfaces a reporting batch's worker log under summary", async () => {
+      const orchestrator = createOrchestrator(
+        'gradlew: OutOfMemoryError in the daemon',
+        false
+      );
+      orchestrator.resolvedOutputStyle = 'summary';
+      orchestrator.taskGraph.tasks['a:build'].hash = 'hash-a';
+      orchestrator.forkedProcessTaskRunner.forkProcessForBatch = vi
+        .fn()
+        .mockResolvedValue({
+          onOutput: vi.fn(),
+          onTaskResults: vi.fn(),
+          getResults: vi.fn().mockResolvedValue({
+            'a:build': { success: false, terminalOutput: 'a failed' },
+          }),
+          getCapturedOutputPath: () =>
+            capturedPath('gradlew: OutOfMemoryError in the daemon'),
+          discardCapturedOutput: () => {},
+        });
+
+      const results: any = await orchestrator.runBatch(batch, {}, 0);
+
+      expect(results[0].status).toEqual('failure');
+      expect(results[0].terminalOutput).toContain(
+        'gradlew: OutOfMemoryError in the daemon'
+      );
+      expect(results[0].terminalOutput).toContain('a failed');
+    });
 
     it("surfaces a crashed batch's captured log alongside the exit error", async () => {
       const orchestrator = createOrchestrator(

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -982,7 +982,15 @@ describe('TaskOrchestrator', () => {
       expect(withLog[1].terminalOutput).not.toContain(
         'gradlew: OutOfMemoryError'
       );
-      expect(withLog[1].terminalOutput).toContain('batch worker log:');
+      // Names the task, not a path built from its hash. The hash is still
+      // preliminary here - applyFromCacheOrRunBatch re-hashes depsOutputs tasks
+      // that ran, failures included, before persistTerminalOutputs writes under
+      // the new one - so a path minted now addresses a file nothing writes.
+      expect(withLog[1].terminalOutput).toContain(
+        'batch worker log: reported with a:build'
+      );
+      expect(withLog[1].terminalOutput).not.toContain('terminalOutputs');
+      expect(withLog[1].terminalOutput).not.toContain('hash-a');
     });
 
     it('leaves an all-green batch alone, so its chatter is not persisted', () => {
@@ -1232,6 +1240,25 @@ describe('TaskOrchestrator', () => {
         'gradlew: OutOfMemoryError in the daemon'
       );
       expect(results[0].terminalOutput).toContain('a failed');
+    });
+
+    // The fold tests above all run under grouping, where the handoff is a no-op,
+    // so none of them notice if the crash path stops calling it. Under summary
+    // the results are the only route the captured log has.
+    it("carries a crashed batch's log in its results under summary", async () => {
+      const orchestrator = createOrchestrator(
+        'FAILURE: Could not resolve all dependencies',
+        false
+      );
+      orchestrator.resolvedOutputStyle = 'summary';
+
+      const results: any = await orchestrator.runBatch(batch, {}, 0);
+
+      expect(results[0].status).toEqual('failure');
+      expect(results[0].terminalOutput).toContain(
+        'FAILURE: Could not resolve all dependencies'
+      );
+      expect(results[0].terminalOutput).toContain(EXIT_ERROR);
     });
 
     it("surfaces a crashed batch's captured log alongside the exit error", async () => {

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -1276,6 +1276,25 @@ describe('TaskOrchestrator', () => {
       expect(out).toContain(EXIT_ERROR);
     });
 
+    // The fold cannot carry it under summary, so the results are the only route
+    // and the finally would otherwise unlink the only copy.
+    it("carries a stopped batch's partial log in its results under summary", async () => {
+      const orchestrator = createOrchestrator(
+        'gradle: still resolving dependencies',
+        true
+      );
+      orchestrator.resolvedOutputStyle = 'summary';
+
+      const results: any = await orchestrator.runBatch(batch, {}, 0);
+
+      expect(results[0].status).toEqual('stopped');
+      expect(results[0].terminalOutput).toContain(
+        'gradle: still resolving dependencies'
+      );
+      // The exit error still stays out: it restates the cancellation.
+      expect(results[0].terminalOutput).not.toContain(EXIT_ERROR);
+    });
+
     it("surfaces a stopped batch's captured log, without the exit error", async () => {
       const orchestrator = createOrchestrator(
         'gradle: still resolving dependencies',

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -937,10 +937,6 @@ describe('TaskOrchestrator', () => {
       ).toHaveBeenCalledWith(b, 'failure', 'b failed');
     });
 
-    // The fold above is the only consumer of the captured file on the results
-    // path, and the test above is why it does not run under summary. Without
-    // the handoff below, the worker's own stderr is captured, read by nobody,
-    // and unlinked by `discardCapturedOutput` when the batch ends.
     it('still collapses an all-green batch on the default, captured log or not', async () => {
       const orchestrator = createOrchestrator();
       const a = makeTask('a:build');

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -747,6 +747,7 @@ describe('TaskOrchestrator', () => {
         args.outputStyle ?? 'static-failures-only';
       // Object.create bypasses field initializers.
       orchestrator.batchFoldRenders = new Map();
+      orchestrator.announcedBatchLogs = new Set();
       return orchestrator;
     }
 
@@ -940,91 +941,6 @@ describe('TaskOrchestrator', () => {
     // path, and the test above is why it does not run under summary. Without
     // the handoff below, the worker's own stderr is captured, read by nobody,
     // and unlinked by `discardCapturedOutput` when the batch ends.
-    it('gives a failed batch its worker log under summary', () => {
-      const orchestrator = createOrchestrator({ outputStyle: 'summary' });
-      const a = makeTask('a:build');
-      const b = { ...makeTask('b:build'), hash: 'hash-b' } as Task;
-      const taskResults = [
-        { task: a, status: 'success', code: 0, terminalOutput: 'a body' },
-        { task: b, status: 'failure', code: 1, terminalOutput: 'b failed' },
-      ];
-
-      const withLog = orchestrator.attachBatchWorkerLog(
-        taskResults,
-        capturedOutputFile('gradlew: OutOfMemoryError')
-      );
-
-      // The failing task carries it, so the path summary prints for b holds the
-      // reason the batch runner died rather than only b's own line.
-      expect(withLog[1].terminalOutput).toContain('gradlew: OutOfMemoryError');
-      expect(withLog[1].terminalOutput).toContain('b failed');
-      // A task that succeeded is left alone; there is nothing to explain.
-      expect(withLog[0].terminalOutput).toEqual('a body');
-    });
-
-    it('points the other failures at that copy rather than duplicating it', () => {
-      const orchestrator = createOrchestrator({ outputStyle: 'summary' });
-      const a = { ...makeTask('a:build'), hash: 'hash-a' } as Task;
-      const b = { ...makeTask('b:build'), hash: 'hash-b' } as Task;
-      const taskResults = [
-        { task: a, status: 'failure', code: 1, terminalOutput: 'a failed' },
-        { task: b, status: 'failure', code: 1, terminalOutput: 'b failed' },
-      ];
-
-      const withLog = orchestrator.attachBatchWorkerLog(
-        taskResults,
-        capturedOutputFile('gradlew: OutOfMemoryError')
-      );
-
-      // The log is unbounded, so a copy per task would write a byte-identical
-      // file for each and charge every one against maxCacheSize.
-      expect(withLog[0].terminalOutput).toContain('gradlew: OutOfMemoryError');
-      expect(withLog[1].terminalOutput).not.toContain(
-        'gradlew: OutOfMemoryError'
-      );
-      // Names the task, not a path built from its hash. The hash is still
-      // preliminary here - applyFromCacheOrRunBatch re-hashes depsOutputs tasks
-      // that ran, failures included, before persistTerminalOutputs writes under
-      // the new one - so a path minted now addresses a file nothing writes.
-      expect(withLog[1].terminalOutput).toContain(
-        'batch worker log: reported with a:build'
-      );
-      expect(withLog[1].terminalOutput).not.toContain('terminalOutputs');
-      expect(withLog[1].terminalOutput).not.toContain('hash-a');
-    });
-
-    it('leaves an all-green batch alone, so its chatter is not persisted', () => {
-      const orchestrator = createOrchestrator({ outputStyle: 'summary' });
-      const a = makeTask('a:build');
-      const taskResults = [
-        { task: a, status: 'success', code: 0, terminalOutput: 'a body' },
-      ];
-
-      expect(
-        orchestrator.attachBatchWorkerLog(
-          taskResults,
-          capturedOutputFile('noisy but harmless')
-        )
-      ).toBe(taskResults);
-    });
-
-    it('leaves the results alone when the style prints task output', () => {
-      const orchestrator = createOrchestrator({ outputStyle: 'static' });
-      const a = { ...makeTask('a:build'), hash: 'hash-a' } as Task;
-      const taskResults = [
-        { task: a, status: 'failure', code: 1, terminalOutput: 'a failed' },
-      ];
-
-      // static already streamed it or folded it; adding it here would duplicate
-      // the whole worker log into the task's persisted output.
-      expect(
-        orchestrator.attachBatchWorkerLog(
-          taskResults,
-          capturedOutputFile('already on the terminal')
-        )
-      ).toBe(taskResults);
-    });
-
     it('still collapses an all-green batch on the default, captured log or not', async () => {
       const orchestrator = createOrchestrator();
       const a = makeTask('a:build');
@@ -1151,10 +1067,12 @@ describe('TaskOrchestrator', () => {
           printTaskTerminalOutput: vi.fn(),
           appendTaskOutput: vi.fn(),
           setTaskStatus: vi.fn(),
+          batchOutputAvailable: vi.fn(),
         },
       };
       // Object.create bypasses field initializers.
       orchestrator.batchFoldRenders = new Map();
+      orchestrator.announcedBatchLogs = new Set();
       orchestrator.stopRequested = stopRequested;
       orchestrator.projectGraph = {} as ProjectGraph;
       orchestrator.taskGraph = {
@@ -1237,11 +1155,17 @@ describe('TaskOrchestrator', () => {
 
       const results: any = await orchestrator.runBatch(batch, {}, 0);
 
-      expect(results[0].status).toEqual('failure');
-      expect(results[0].terminalOutput).toContain(
-        'gradlew: OutOfMemoryError in the daemon'
+      // The log is addressed, not copied: one worker means one log, and it
+      // explains the batch rather than any single task.
+      expect(
+        orchestrator.options.lifeCycle.batchOutputAvailable
+      ).toHaveBeenCalledWith(
+        batch.id,
+        capturedPath('gradlew: OutOfMemoryError in the daemon')
       );
-      expect(results[0].terminalOutput).toContain('a failed');
+      expect(results[0].status).toEqual('failure');
+      expect(results[0].terminalOutput).toEqual('a failed');
+      expect(results[0].terminalOutput).not.toContain('OutOfMemoryError');
     });
 
     // The fold tests above all run under grouping, where the handoff is a no-op,
@@ -1256,11 +1180,16 @@ describe('TaskOrchestrator', () => {
 
       const results: any = await orchestrator.runBatch(batch, {}, 0);
 
-      expect(results[0].status).toEqual('failure');
-      expect(results[0].terminalOutput).toContain(
-        'FAILURE: Could not resolve all dependencies'
+      expect(
+        orchestrator.options.lifeCycle.batchOutputAvailable
+      ).toHaveBeenCalledWith(
+        batch.id,
+        capturedPath('FAILURE: Could not resolve all dependencies')
       );
+      expect(results[0].status).toEqual('failure');
+      // The task's own file holds the exit error; the worker log is addressed.
       expect(results[0].terminalOutput).toContain(EXIT_ERROR);
+      expect(results[0].terminalOutput).not.toContain('Could not resolve');
     });
 
     it("surfaces a crashed batch's captured log alongside the exit error", async () => {
@@ -1289,12 +1218,17 @@ describe('TaskOrchestrator', () => {
 
       const results: any = await orchestrator.runBatch(batch, {}, 0);
 
-      expect(results[0].status).toEqual('stopped');
-      expect(results[0].terminalOutput).toContain(
-        'gradle: still resolving dependencies'
+      // A stopped batch's partial log is the only record of what got through,
+      // so it is still addressed - but no task's file is given a copy, which
+      // previously left every non-holder holding only a pointer sentence.
+      expect(
+        orchestrator.options.lifeCycle.batchOutputAvailable
+      ).toHaveBeenCalledWith(
+        batch.id,
+        capturedPath('gradle: still resolving dependencies')
       );
-      // The exit error still stays out: it restates the cancellation.
-      expect(results[0].terminalOutput).not.toContain(EXIT_ERROR);
+      expect(results[0].status).toEqual('stopped');
+      expect(results[0].terminalOutput).toEqual('');
     });
 
     it("surfaces a stopped batch's captured log, without the exit error", async () => {

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -1087,6 +1087,10 @@ describe('TaskOrchestrator', () => {
       // batches with different bodies - which is what makes the fold-count map
       // key load-bearing in `labels each fold with the batch it came from`.
       orchestrator.capturedForTest = captured;
+      // Observable so a test can pin whether the log survived the run: the
+      // `finally` skips the discard for any batch whose log was announced, and
+      // that guard is the only thing keeping the file on disk for the sweep.
+      orchestrator.discardedForTest = vi.fn();
       orchestrator.forkedProcessTaskRunner = {
         forkProcessForBatch: vi.fn().mockResolvedValue({
           onOutput: vi.fn(),
@@ -1097,7 +1101,7 @@ describe('TaskOrchestrator', () => {
               ? capturedPath(orchestrator.capturedForTest)
               : undefined,
           flushCapturedOutput: async () => {},
-          discardCapturedOutput: () => {},
+          discardCapturedOutput: orchestrator.discardedForTest,
         }),
       };
       return orchestrator;
@@ -1186,6 +1190,34 @@ describe('TaskOrchestrator', () => {
       // The task's own file holds the exit error; the worker log is addressed.
       expect(results[0].terminalOutput).toContain(EXIT_ERROR);
       expect(results[0].terminalOutput).not.toContain('Could not resolve');
+    });
+
+    it('keeps an announced batch log rather than unlinking it', async () => {
+      const orchestrator = createOrchestrator(
+        'FAILURE: Could not resolve all dependencies',
+        false
+      );
+      orchestrator.resolvedOutputStyle = 'summary';
+
+      await orchestrator.runBatch(batch, {}, 0);
+
+      // Announced, so the file has to outlive the run - the sweep collects it
+      // later. Discarding here would unlink the only copy the moment the
+      // summary printed its path.
+      expect(
+        orchestrator.options.lifeCycle.batchOutputAvailable
+      ).toHaveBeenCalled();
+      expect(orchestrator.discardedForTest).not.toHaveBeenCalled();
+    });
+
+    it('discards a batch log nobody was told about', async () => {
+      const orchestrator = createOrchestrator('noisy but harmless', false);
+      // A printing style never announces, so nothing will ever read this file.
+      orchestrator.resolvedOutputStyle = 'static';
+
+      await orchestrator.runBatch(batch, {}, 0);
+
+      expect(orchestrator.discardedForTest).toHaveBeenCalled();
     });
 
     it("surfaces a crashed batch's captured log alongside the exit error", async () => {

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -1182,6 +1182,7 @@ describe('TaskOrchestrator', () => {
             orchestrator.capturedForTest
               ? capturedPath(orchestrator.capturedForTest)
               : undefined,
+          flushCapturedOutput: async () => {},
           discardCapturedOutput: () => {},
         }),
       };
@@ -1230,6 +1231,7 @@ describe('TaskOrchestrator', () => {
           }),
           getCapturedOutputPath: () =>
             capturedPath('gradlew: OutOfMemoryError in the daemon'),
+          flushCapturedOutput: async () => {},
           discardCapturedOutput: () => {},
         });
 

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -996,12 +996,14 @@ export class TaskOrchestrator {
       // The same handoff the results path uses, rather than a second copy of
       // it: a style that prints nothing renders no fold, so the captured log
       // reaches a reader only by riding in the results, and a crashed worker's
-      // output is exactly what no task claims. A stopped batch passes no path
-      // because its tasks carry no output at all and the fold below is where
-      // its partial log belongs.
+      // output is exactly what no task claims. A stopped batch is included: its
+      // partial log is the only record of what got through before the
+      // cancellation, and the fold below cannot carry it under `summary`
+      // because that gate gets `printsTaskOutput` too, so without this the
+      // `finally` unlinks the only copy.
       const withWorkerLog = this.attachBatchWorkerLog(
         taskResults,
-        isBatchStopping ? undefined : batchProcess?.getCapturedOutputPath()
+        batchProcess?.getCapturedOutputPath()
       );
 
       // The worker died without reporting results, so nothing was attributed to

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1,5 +1,5 @@
 import { defaultMaxListeners } from 'events';
-import { existsSync, statSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { relative } from 'path';
 import { performance } from 'perf_hooks';
 import * as pc from 'picocolors';
@@ -86,6 +86,22 @@ function resolveBatchTaskStatus(result: {
   status?: TaskStatus;
 }): TaskStatus {
   return result.status ?? (result.success ? 'success' : 'failure');
+}
+
+/**
+ * The captured batch log, or empty if there is nothing readable. Reading it
+ * fully is acceptable only on the crash path: the batch is over, and the
+ * alternative is losing the only copy of why the worker died.
+ */
+function readCapturedBatchLog(path: string | undefined): string {
+  if (!path) {
+    return '';
+  }
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return '';
+  }
 }
 
 export class TaskOrchestrator {
@@ -952,6 +968,16 @@ export class TaskOrchestrator {
     } catch (e) {
       const isBatchStopping = this.stopRequested;
 
+      // A style that prints nothing renders no fold, so the captured log has no
+      // other route to a reader - and the worker's crash output is precisely
+      // what no task claims. Carry it in the results instead, so the file
+      // `persistTerminalOutputs` writes holds the reason the worker died rather
+      // than only the orchestrator's exit-code stack, which is what `summary`
+      // addresses by path.
+      const workerLog = printsTaskOutput(this.outputStyle)
+        ? ''
+        : readCapturedBatchLog(batchProcess?.getCapturedOutputPath());
+
       const taskResults = Object.keys(batch.taskGraph.tasks).map((taskId) => {
         const task = this.taskGraph.tasks[taskId];
         if (isBatchStopping) {
@@ -961,19 +987,23 @@ export class TaskOrchestrator {
           task,
           code: 1,
           status: (isBatchStopping ? 'stopped' : 'failure') as TaskStatus,
-          terminalOutput: isBatchStopping ? '' : (e.stack ?? e.message ?? ''),
+          terminalOutput: isBatchStopping
+            ? ''
+            : [workerLog, e.stack ?? e.message ?? '']
+                .filter(Boolean)
+                .join('\n'),
         };
       });
 
       // The worker died without reporting results, so nothing was attributed to
       // a task and no per-task output ran. Everything it wrote went to
-      // stdout/stderr, held back under log grouping — surface it as one fold.
-      // Outside grouping it already streamed live. This matters just as much
-      // when the batch was stopped: every task is marked stopped whether or not
-      // it finished, so the log is the only record of what got through. Only
-      // the exit-code error is dropped there, since it restates the
-      // cancellation.
-      if (shouldGroupBatchOutput()) {
+      // stdout/stderr, held back under grouping or under a style that prints
+      // nothing — surface it as one fold. Outside both, it already streamed
+      // live. This matters just as much when the batch was stopped: every task
+      // is marked stopped whether or not it finished, so the log is the only
+      // record of what got through. Only the exit-code error is dropped there,
+      // since it restates the cancellation.
+      if (shouldGroupBatchOutput() && printsTaskOutput(this.outputStyle)) {
         const capturedOutputPath = batchProcess?.getCapturedOutputPath();
         const trailer = isBatchStopping ? undefined : e.message;
         if (capturedOutputPath || trailer) {
@@ -1772,8 +1802,9 @@ export class TaskOrchestrator {
   /**
    * Guarantee that every task that actually ran leaves its terminal output at
    * `<cacheDir>/terminalOutputs/<hash>`, whatever its cache setting, output
-   * style, or batch membership. That path is what the static output styles
-   * point users and agents at, and what Nx Cloud falls back to reading when a
+   * style, or batch membership. That path is what `--output-style=summary`
+   * addresses each failure by, what the DB cache reads back on a hit
+   * (`build_cached_result`), and what Nx Cloud falls back to reading when a
    * task's in-memory output is undefined, so a task that reaches a terminal
    * state without a file there is a dangling reference.
    *
@@ -1784,9 +1815,10 @@ export class TaskOrchestrator {
    *
    * Written exactly once per task: tasks whose runner owns the file are
    * recorded in `tasksWithPersistedOutput`, and tasks `cache.put` is about to
-   * write are skipped here. Cache replays are skipped too — their output was
-   * read from this very file. Skipped tasks never ran, so there is nothing to
-   * write.
+   * write are skipped here. Cache hits are skipped by status — their output was
+   * read from this very file — except a replayed cached *failure*, which comes
+   * back as `failure` and is rewritten with the bytes it was just read with.
+   * Skipped tasks never ran, so there is nothing to write.
    *
    * Every file written without a cache entry behind it is then registered with
    * the cache, because `removeOldCacheRecords` only collects hashes it finds in

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1,4 +1,5 @@
 import { defaultMaxListeners } from 'events';
+import type { OutputStyle } from '../command-line/yargs-utils/shared-options';
 import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { relative } from 'path';
 import { performance } from 'perf_hooks';
@@ -217,7 +218,10 @@ export class TaskOrchestrator {
     private readonly options: NxArgs & DefaultTasksRunnerOptions,
     private readonly bail: boolean,
     private readonly daemon: DaemonClient,
-    private readonly outputStyle: string,
+    /** What the user named; undefined means they named nothing. */
+    private readonly specifiedOutputStyle: OutputStyle | undefined,
+    /** What this run renders with, after defaults. */
+    private readonly resolvedOutputStyle: OutputStyle,
     private readonly fullTaskGraph: TaskGraph = taskGraph
   ) {}
 
@@ -885,7 +889,7 @@ export class TaskOrchestrator {
         this.projectGraph,
         this.fullTaskGraph,
         env,
-        printsTaskOutput(this.outputStyle)
+        printsTaskOutput(this.resolvedOutputStyle)
       );
 
       // Stream output from batch process to the batch
@@ -974,7 +978,7 @@ export class TaskOrchestrator {
       // `persistTerminalOutputs` writes holds the reason the worker died rather
       // than only the orchestrator's exit-code stack, which is what `summary`
       // addresses by path.
-      const workerLog = printsTaskOutput(this.outputStyle)
+      const workerLog = printsTaskOutput(this.resolvedOutputStyle)
         ? ''
         : readCapturedBatchLog(batchProcess?.getCapturedOutputPath());
 
@@ -1003,7 +1007,10 @@ export class TaskOrchestrator {
       // is marked stopped whether or not it finished, so the log is the only
       // record of what got through. Only the exit-code error is dropped there,
       // since it restates the cancellation.
-      if (shouldGroupBatchOutput() && printsTaskOutput(this.outputStyle)) {
+      if (
+        shouldGroupBatchOutput() &&
+        printsTaskOutput(this.resolvedOutputStyle)
+      ) {
         const capturedOutputPath = batchProcess?.getCapturedOutputPath();
         const trailer = isBatchStopping ? undefined : e.message;
         if (capturedOutputPath || trailer) {
@@ -1102,13 +1109,13 @@ export class TaskOrchestrator {
     // no style argument at all, so on that path only `options` can carry one.
     const printsFullOutput = printsFullTaskOutput({
       verbose: this.options.verbose,
-      outputStyle: this.outputStyle,
+      outputStyle: this.resolvedOutputStyle,
     });
     const batchOwnsTheDiagnostic = taskResults.some(
       (r) => r.status === 'failure' || r.status === 'stopped'
     );
     if (
-      printsTaskOutput(this.outputStyle) &&
+      printsTaskOutput(this.resolvedOutputStyle) &&
       (printsFullOutput || batchOwnsTheDiagnostic) &&
       capturedOutputPath
     ) {
@@ -1308,8 +1315,8 @@ export class TaskOrchestrator {
     // task a run-one is most likely to have. Continuous tasks are deliberately
     // NOT suppressed the same way; see `startContinuousTask`.
     const streamOutput =
-      isStaticOutputStyle(this.outputStyle) ||
-      !printsTaskOutput(this.outputStyle)
+      isStaticOutputStyle(this.specifiedOutputStyle) ||
+      !printsTaskOutput(this.resolvedOutputStyle)
         ? false
         : shouldStreamOutput(task, this.initiatingProject);
 
@@ -1641,7 +1648,7 @@ export class TaskOrchestrator {
     // end - so suppressing here would leave a `nx serve` under `summary` with a
     // permanently silent terminal and no file to read yet. Streaming is the only
     // channel a continuous task has.
-    const streamOutput = isStaticOutputStyle(this.outputStyle)
+    const streamOutput = isStaticOutputStyle(this.specifiedOutputStyle)
       ? false
       : shouldStreamOutput(task, this.initiatingProject);
 

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -969,7 +969,15 @@ export class TaskOrchestrator {
         );
       }
 
-      return taskResults;
+      // The worker reported results, but its own stderr is not any task's
+      // output and has no route to a reader under a style that prints nothing:
+      // the fold above needs `shouldGroupBatchOutput`, `printGroupedBatchOutput`
+      // needs `printsTaskOutput` on top of that, and `discardCapturedOutput`
+      // unlinks the file when this method returns.
+      return this.attachBatchWorkerLog(
+        taskResults,
+        batchProcess.getCapturedOutputPath()
+      );
     } catch (e) {
       const isBatchStopping = this.stopRequested;
 
@@ -1050,6 +1058,62 @@ export class TaskOrchestrator {
         runBatchEnd.name
       );
     }
+  }
+
+  /**
+   * Gives the batch worker's captured log to the results that need it, for a
+   * style that prints nothing and so renders no fold.
+   *
+   * Only when something failed. A batch whose tasks all succeeded has nothing
+   * the worker's chatter would explain, and `summary`'s contract is that a
+   * failure's log is readable, not that every byte the run produced is.
+   *
+   * One worker means one log, so a single task carries it and the rest address
+   * that copy. Inlining it into each would write a byte-identical unbounded
+   * file per task, every one charged in full against `maxCacheSize`.
+   */
+  private attachBatchWorkerLog<
+    T extends { task: Task; status: TaskStatus; terminalOutput?: string },
+  >(results: T[], capturedOutputPath: string | undefined): T[] {
+    if (printsTaskOutput(this.resolvedOutputStyle)) {
+      return results;
+    }
+    const failures = results.filter(
+      (r) => r.status === 'failure' || r.status === 'stopped'
+    );
+    if (!failures.length) {
+      return results;
+    }
+    const workerLog = readCapturedBatchLog(capturedOutputPath);
+    if (!workerLog) {
+      return results;
+    }
+
+    const holder = failures[0];
+    const holderHash = holder.task?.hash;
+    const pointer =
+      holderHash &&
+      `batch worker log: ${terminalOutputPathForHash(holderHash)}`;
+
+    return results.map((result) => {
+      if (result === holder) {
+        return {
+          ...result,
+          terminalOutput: [workerLog, result.terminalOutput]
+            .filter(Boolean)
+            .join('\n'),
+        };
+      }
+      if (pointer && failures.includes(result)) {
+        return {
+          ...result,
+          terminalOutput: [result.terminalOutput, pointer]
+            .filter(Boolean)
+            .join('\n'),
+        };
+      }
+      return result;
+    });
   }
 
   /**

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1,5 +1,5 @@
 import { defaultMaxListeners } from 'events';
-import { writeFileSync } from 'fs';
+import { existsSync, statSync, writeFileSync } from 'fs';
 import { relative } from 'path';
 import { performance } from 'perf_hooks';
 import * as pc from 'picocolors';
@@ -1635,6 +1635,9 @@ export class TaskOrchestrator {
       new Promise<void>((resolve) => {
         childProcess.onExit(async (code) => {
           await this.handleContinuousTaskExit(code, task, groupId, true);
+          // Registered after the runner's own exit handler, which is what
+          // wrote the file.
+          this.recordContinuousTerminalOutput(task);
           resolve();
         });
       })
@@ -1765,8 +1768,13 @@ export class TaskOrchestrator {
    * recorded in `tasksWithPersistedOutput`, and tasks `cache.put` is about to
    * write are skipped here. Cache replays are skipped too — their output was
    * read from this very file. Skipped tasks never ran, so there is nothing to
-   * write and no reason to leave an empty file behind for the cache's
-   * age-based GC to never collect.
+   * write.
+   *
+   * Every file written without a cache entry behind it is then registered with
+   * the cache, because `removeOldCacheRecords` only collects hashes it finds in
+   * the database — an unregistered file would never be cleaned up. That covers
+   * files this method wrote AND ones a runner wrote, which are equally
+   * invisible to the GC.
    */
   private persistTerminalOutputs(
     results: {
@@ -1777,6 +1785,7 @@ export class TaskOrchestrator {
     resultsToCache: { task: Task }[]
   ) {
     const writtenByCache = new Set(resultsToCache.map(({ task }) => task.id));
+    const toRecord: { hash: string; size: number }[] = [];
     for (const { task, status, terminalOutput } of results) {
       if (
         terminalOutput === undefined ||
@@ -1786,14 +1795,39 @@ export class TaskOrchestrator {
         status === 'local-cache' ||
         status === 'local-cache-kept-existing' ||
         status === 'remote-cache' ||
-        writtenByCache.has(task.id) ||
-        this.tasksWithPersistedOutput.has(task.id)
+        // `cache.put` writes the file and records the hash itself.
+        writtenByCache.has(task.id)
       ) {
         continue;
       }
-      this.tasksWithPersistedOutput.add(task.id);
-      writeFileSync(this.cache.temporaryOutputPath(task), terminalOutput);
+      if (!this.tasksWithPersistedOutput.has(task.id)) {
+        this.tasksWithPersistedOutput.add(task.id);
+        writeFileSync(this.cache.temporaryOutputPath(task), terminalOutput);
+      }
+      toRecord.push({
+        hash: task.hash,
+        size: Buffer.byteLength(terminalOutput),
+      });
     }
+    if (toRecord.length > 0) {
+      this.cache.recordTerminalOutputs(toRecord);
+    }
+  }
+
+  /**
+   * Register a continuous task's terminal output with the cache so the GC can
+   * collect it. Continuous tasks never reach postRunSteps — their file is
+   * written by whichever runner ran them, as the process exits — so this is
+   * the only place their hash gets recorded. Read off disk rather than from a
+   * result, because a continuous task completes without one.
+   */
+  private recordContinuousTerminalOutput(task: Task) {
+    if (!task.hash) return;
+    const path = this.cache.temporaryOutputPath(task);
+    if (!existsSync(path)) return;
+    this.cache.recordTerminalOutputs([
+      { hash: task.hash, size: statSync(path).size },
+    ]);
   }
 
   private async scheduleNextTasksAndReleaseThreads() {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -43,7 +43,6 @@ import {
   DbCache,
   dbCacheEnabled,
   getCache,
-  sweepBatchOutputs,
 } from './cache';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { ForkedProcessTaskRunner } from './forked-process-task-runner';
@@ -286,7 +285,7 @@ export class TaskOrchestrator {
     );
     if (!this.stopRequested) {
       this.cache.removeOldCacheRecords();
-      sweepBatchOutputs();
+      this.cache.sweepBatchOutputs();
     }
     await this.cleanup();
     await this.dispose();

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1,6 +1,6 @@
 import { defaultMaxListeners } from 'events';
 import type { OutputStyle } from '../command-line/yargs-utils/shared-options';
-import { existsSync, statSync, writeFileSync } from 'fs';
+import { statSync, writeFileSync } from 'fs';
 import { relative } from 'path';
 import { performance } from 'perf_hooks';
 import * as pc from 'picocolors';
@@ -1902,11 +1902,12 @@ export class TaskOrchestrator {
    */
   private recordContinuousTerminalOutput(task: Task) {
     if (!task.hash) return;
-    const path = this.cache.temporaryOutputPath(task);
-    if (!existsSync(path)) return;
-    this.cache.recordTerminalOutputs([
-      { hash: task.hash, size: statSync(path).size },
-    ]);
+    try {
+      const { size } = statSync(this.cache.temporaryOutputPath(task));
+      this.cache.recordTerminalOutputs([{ hash: task.hash, size }]);
+    } catch {
+      // Exit handler: a throw here would be an unhandled rejection.
+    }
   }
 
   private async scheduleNextTasksAndReleaseThreads() {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -992,9 +992,9 @@ export class TaskOrchestrator {
 
       // The worker died without reporting results, so nothing was attributed to
       // a task and no per-task output ran. Everything it wrote went to
-      // stdout/stderr, held back under grouping or under a style that prints
-      // nothing — surface it as one fold. Outside both, it already streamed
-      // live. This matters just as much when the batch was stopped: every task
+      // stdout/stderr, held back under grouping - surface it as one fold. Under
+      // a style that prints nothing there is no fold; the log is announced by
+      // path above instead. Outside both, it already streamed live. This matters just as much when the batch was stopped: every task
       // is marked stopped whether or not it finished, so the log is the only
       // record of what got through. Only the exit-code error is dropped there,
       // since it restates the cancellation.

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -43,7 +43,6 @@ import {
   DbCache,
   dbCacheEnabled,
   getCache,
-  terminalOutputPathForHash,
 } from './cache';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { ForkedProcessTaskRunner } from './forked-process-task-runner';
@@ -981,48 +980,29 @@ export class TaskOrchestrator {
     } catch (e) {
       const isBatchStopping = this.stopRequested;
 
-      // A style that prints nothing renders no fold, so the captured log has no
-      // other route to a reader - and the worker's crash output is precisely
-      // what no task claims. Carry it in the results instead, so the file
-      // `persistTerminalOutputs` writes holds the reason the worker died rather
-      // than only the orchestrator's exit-code stack, which is what `summary`
-      // addresses by path.
-      const workerLog = printsTaskOutput(this.resolvedOutputStyle)
-        ? ''
-        : readCapturedBatchLog(batchProcess?.getCapturedOutputPath());
-
-      // One worker died, so one log explains every task in the batch. It is
-      // unbounded by design (batch-process.ts: a Gradle batch spans the whole
-      // command), so it is carried by the first task alone and the rest address
-      // that copy. Inlining it into all of them wrote a byte-identical
-      // unbounded file per task, each charged in full against `maxCacheSize`,
-      // and recorded one task's bytes as another's in task history and Nx Cloud.
-      const batchTaskIds = Object.keys(batch.taskGraph.tasks);
-      const logHolder = workerLog ? batchTaskIds[0] : undefined;
-      const logHolderHash = logHolder
-        ? this.taskGraph.tasks[logHolder]?.hash
-        : undefined;
-      const logPointer =
-        logHolderHash &&
-        `batch worker log: ${terminalOutputPathForHash(logHolderHash)}`;
-
-      const taskResults = batchTaskIds.map((taskId) => {
+      const taskResults = Object.keys(batch.taskGraph.tasks).map((taskId) => {
         const task = this.taskGraph.tasks[taskId];
         if (isBatchStopping) {
           task.endTime = Date.now();
         }
-        const stack = e.stack ?? e.message ?? '';
         return {
           task,
           code: 1,
           status: (isBatchStopping ? 'stopped' : 'failure') as TaskStatus,
-          terminalOutput: isBatchStopping
-            ? ''
-            : (taskId === logHolder ? [workerLog, stack] : [stack, logPointer])
-                .filter(Boolean)
-                .join('\n'),
+          terminalOutput: isBatchStopping ? '' : (e.stack ?? e.message ?? ''),
         };
       });
+
+      // The same handoff the results path uses, rather than a second copy of
+      // it: a style that prints nothing renders no fold, so the captured log
+      // reaches a reader only by riding in the results, and a crashed worker's
+      // output is exactly what no task claims. A stopped batch passes no path
+      // because its tasks carry no output at all and the fold below is where
+      // its partial log belongs.
+      const withWorkerLog = this.attachBatchWorkerLog(
+        taskResults,
+        isBatchStopping ? undefined : batchProcess?.getCapturedOutputPath()
+      );
 
       // The worker died without reporting results, so nothing was attributed to
       // a task and no per-task output ran. Everything it wrote went to
@@ -1048,7 +1028,7 @@ export class TaskOrchestrator {
         }
       }
 
-      return taskResults;
+      return withWorkerLog;
     } finally {
       batchProcess?.discardCapturedOutput();
       const runBatchEnd = performance.mark('TaskOrchestrator-run-batch:end');
@@ -1089,11 +1069,14 @@ export class TaskOrchestrator {
       return results;
     }
 
+    // Names the task rather than a path. `task.hash` is still preliminary here:
+    // `applyFromCacheOrRunBatch` clears and recomputes it for any depsOutputs
+    // task that ran, failures included, before `persistTerminalOutputs` writes
+    // under the NEW hash. A path minted from the hash as it stands would address
+    // a file nothing ever writes. The reader loses nothing, since the holder
+    // failed too and `summary` prints its own `full log:` line.
     const holder = failures[0];
-    const holderHash = holder.task?.hash;
-    const pointer =
-      holderHash &&
-      `batch worker log: ${terminalOutputPathForHash(holderHash)}`;
+    const pointer = `batch worker log: reported with ${holder.task.id}`;
 
     return results.map((result) => {
       if (result === holder) {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -90,6 +90,15 @@ function resolveBatchTaskStatus(result: {
   return result.status ?? (result.success ? 'success' : 'failure');
 }
 
+/** Whether a path names a file with bytes in it. */
+function hasContent(path: string): boolean {
+  try {
+    return statSync(path).size > 0;
+  } catch {
+    return false;
+  }
+}
+
 export class TaskOrchestrator {
   private taskDetails: TaskDetails | null = getTaskDetails();
   private cache: DbCache | Cache = getCache(this.options);
@@ -287,7 +296,8 @@ export class TaskOrchestrator {
     if (!this.stopRequested) {
       this.cache.removeOldCacheRecords();
       // Free function, not a cache method: `BatchProcess` writes these logs
-      // whichever cache implementation is active.
+      // whichever cache implementation is active. It no-ops under WASM, where
+      // the native half does not exist.
       sweepBatchOutputs();
     }
     await this.cleanup();
@@ -1054,6 +1064,13 @@ export class TaskOrchestrator {
       (r) => r.status === 'failure' || r.status === 'stopped'
     );
     if (!failed) {
+      return;
+    }
+    // The path is minted when the file is opened, before any byte reaches it,
+    // so a capture that failed on its first write leaves one that exists and is
+    // empty. Announcing that offers the reader an address holding nothing.
+    // Checked after the flush, so the size is what a reader will actually see.
+    if (!hasContent(capturedOutputPath)) {
       return;
     }
     this.announcedBatchLogs.add(batchId);

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1,6 +1,6 @@
 import { defaultMaxListeners } from 'events';
 import type { OutputStyle } from '../command-line/yargs-utils/shared-options';
-import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { existsSync, statSync, writeFileSync } from 'fs';
 import { relative } from 'path';
 import { performance } from 'perf_hooks';
 import * as pc from 'picocolors';
@@ -43,6 +43,7 @@ import {
   DbCache,
   dbCacheEnabled,
   getCache,
+  sweepBatchOutputs,
 } from './cache';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { ForkedProcessTaskRunner } from './forked-process-task-runner';
@@ -87,22 +88,6 @@ function resolveBatchTaskStatus(result: {
   status?: TaskStatus;
 }): TaskStatus {
   return result.status ?? (result.success ? 'success' : 'failure');
-}
-
-/**
- * The captured batch log, or empty if there is nothing readable. Reading it
- * fully is acceptable only on the crash path: the batch is over, and the
- * alternative is losing the only copy of why the worker died.
- */
-function readCapturedBatchLog(path: string | undefined): string {
-  if (!path) {
-    return '';
-  }
-  try {
-    return readFileSync(path, 'utf-8');
-  } catch {
-    return '';
-  }
 }
 
 export class TaskOrchestrator {
@@ -206,6 +191,8 @@ export class TaskOrchestrator {
   // exit, and the paths that never spawn one write it inline. The backstop in
   // postRunSteps consults this so a task's output is written exactly once.
   private tasksWithPersistedOutput = new Set<string>();
+  /** Batches whose worker log was handed to the life cycle, so it must survive. */
+  private announcedBatchLogs = new Set<string>();
   // endregion internal state
 
   constructor(
@@ -299,6 +286,9 @@ export class TaskOrchestrator {
     );
     if (!this.stopRequested) {
       this.cache.removeOldCacheRecords();
+      // Batch logs are swept from disk rather than the database: nothing looks
+      // one up by key, so a row would only ever be bookkeeping.
+      sweepBatchOutputs();
     }
     await this.cleanup();
     await this.dispose();
@@ -972,15 +962,12 @@ export class TaskOrchestrator {
         );
       }
 
-      // The worker reported results, but its own stderr is not any task's
-      // output and has no route to a reader under a style that prints nothing:
-      // the fold above needs `shouldGroupBatchOutput`, `printGroupedBatchOutput`
-      // needs `printsTaskOutput` on top of that, and `discardCapturedOutput`
-      // unlinks the file when this method returns.
-      return this.attachBatchWorkerLog(
+      this.announceBatchWorkerLog(
+        batch.id,
         taskResults,
         batchProcess.getCapturedOutputPath()
       );
+      return taskResults;
     } catch (e) {
       const isBatchStopping = this.stopRequested;
 
@@ -999,15 +986,8 @@ export class TaskOrchestrator {
 
       await batchProcess?.flushCapturedOutput();
 
-      // The same handoff the results path uses, rather than a second copy of
-      // it: a style that prints nothing renders no fold, so the captured log
-      // reaches a reader only by riding in the results, and a crashed worker's
-      // output is exactly what no task claims. A stopped batch is included: its
-      // partial log is the only record of what got through before the
-      // cancellation, and the fold below cannot carry it under `summary`
-      // because that gate gets `printsTaskOutput` too, so without this the
-      // `finally` unlinks the only copy.
-      const withWorkerLog = this.attachBatchWorkerLog(
+      this.announceBatchWorkerLog(
+        batch.id,
         taskResults,
         batchProcess?.getCapturedOutputPath()
       );
@@ -1036,9 +1016,14 @@ export class TaskOrchestrator {
         }
       }
 
-      return withWorkerLog;
+      return taskResults;
     } finally {
-      batchProcess?.discardCapturedOutput();
+      // Kept only when something failed and the log was announced; an all-green
+      // batch's chatter explains nothing and would sit in `batchOutputs/` until
+      // the sweep.
+      if (!this.announcedBatchLogs.has(batch.id)) {
+        batchProcess?.discardCapturedOutput();
+      }
       const runBatchEnd = performance.mark('TaskOrchestrator-run-batch:end');
       performance.measure(
         'TaskOrchestrator-run-batch',
@@ -1060,51 +1045,30 @@ export class TaskOrchestrator {
    * that copy. Inlining it into each would write a byte-identical unbounded
    * file per task, every one charged in full against `maxCacheSize`.
    */
-  private attachBatchWorkerLog<
-    T extends { task: Task; status: TaskStatus; terminalOutput?: string },
-  >(results: T[], capturedOutputPath: string | undefined): T[] {
-    if (printsTaskOutput(this.resolvedOutputStyle)) {
-      return results;
+  /**
+   * Tells the life cycle where the batch worker's own log is, when something
+   * failed and a style that prints nothing would otherwise leave it unread.
+   *
+   * The path is announced rather than the bytes copied into a task: one worker
+   * produces one log, it explains the batch rather than any single task, and a
+   * task's own output file is read back verbatim on a cache hit.
+   */
+  private announceBatchWorkerLog(
+    batchId: string,
+    results: { status: TaskStatus }[],
+    capturedOutputPath: string | undefined
+  ): void {
+    if (!capturedOutputPath || printsTaskOutput(this.resolvedOutputStyle)) {
+      return;
     }
-    const failures = results.filter(
+    const failed = results.some(
       (r) => r.status === 'failure' || r.status === 'stopped'
     );
-    if (!failures.length) {
-      return results;
+    if (!failed) {
+      return;
     }
-    const workerLog = readCapturedBatchLog(capturedOutputPath);
-    if (!workerLog) {
-      return results;
-    }
-
-    // Names the task rather than a path. `task.hash` is still preliminary here:
-    // `applyFromCacheOrRunBatch` clears and recomputes it for any depsOutputs
-    // task that ran, failures included, before `persistTerminalOutputs` writes
-    // under the NEW hash. A path minted from the hash as it stands would address
-    // a file nothing ever writes. The reader loses nothing, since the holder
-    // failed too and `summary` prints its own `full log:` line.
-    const holder = failures[0];
-    const pointer = `batch worker log: reported with ${holder.task.id}`;
-
-    return results.map((result) => {
-      if (result === holder) {
-        return {
-          ...result,
-          terminalOutput: [workerLog, result.terminalOutput]
-            .filter(Boolean)
-            .join('\n'),
-        };
-      }
-      if (pointer && failures.includes(result)) {
-        return {
-          ...result,
-          terminalOutput: [result.terminalOutput, pointer]
-            .filter(Boolean)
-            .join('\n'),
-        };
-      }
-      return result;
-    });
+    this.announcedBatchLogs.add(batchId);
+    this.options.lifeCycle.batchOutputAvailable?.(batchId, capturedOutputPath);
   }
 
   /**

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -31,6 +31,7 @@ import {
   isStaticOutputStyle,
   output,
   printsFullTaskOutput,
+  printsTaskOutput,
   shouldGroupBatchOutput,
 } from '../utils/output';
 import { combineOptionsForExecutor, Options } from '../utils/params';
@@ -1075,7 +1076,11 @@ export class TaskOrchestrator {
     const batchOwnsTheDiagnostic = taskResults.some(
       (r) => r.status === 'failure' || r.status === 'stopped'
     );
-    if ((printsFullOutput || batchOwnsTheDiagnostic) && capturedOutputPath) {
+    if (
+      printsTaskOutput(this.outputStyle) &&
+      (printsFullOutput || batchOwnsTheDiagnostic) &&
+      capturedOutputPath
+    ) {
       // No redirect lines: every task renders itself below, so there is nothing
       // to redirect anyone to.
       this.printBatchFold(

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -286,8 +286,6 @@ export class TaskOrchestrator {
     );
     if (!this.stopRequested) {
       this.cache.removeOldCacheRecords();
-      // Batch logs are swept from disk rather than the database: nothing looks
-      // one up by key, so a row would only ever be bookkeeping.
       sweepBatchOutputs();
     }
     await this.cleanup();
@@ -1033,18 +1031,6 @@ export class TaskOrchestrator {
     }
   }
 
-  /**
-   * Gives the batch worker's captured log to the results that need it, for a
-   * style that prints nothing and so renders no fold.
-   *
-   * Only when something failed. A batch whose tasks all succeeded has nothing
-   * the worker's chatter would explain, and `summary`'s contract is that a
-   * failure's log is readable, not that every byte the run produced is.
-   *
-   * One worker means one log, so a single task carries it and the rest address
-   * that copy. Inlining it into each would write a byte-identical unbounded
-   * file per task, every one charged in full against `maxCacheSize`.
-   */
   /**
    * Tells the life cycle where the batch worker's own log is, when something
    * failed and a style that prints nothing would otherwise leave it unread.

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -868,7 +868,8 @@ export class TaskOrchestrator {
         batch,
         this.projectGraph,
         this.fullTaskGraph,
-        env
+        env,
+        printsTaskOutput(this.outputStyle)
       );
 
       // Stream output from batch process to the batch
@@ -1272,9 +1273,15 @@ export class TaskOrchestrator {
 
     const pipeOutput = await this.pipeOutputCapture(task);
     const temporaryOutputPath = this.cache.temporaryOutputPath(task);
-    const streamOutput = isStaticOutputStyle(this.outputStyle)
-      ? false
-      : shouldStreamOutput(task, this.initiatingProject);
+    // `summary` prints log paths rather than logs, and `shouldStreamOutput`
+    // would otherwise stream the initiating project's output in full - the one
+    // task a run-one is most likely to have. Continuous tasks are deliberately
+    // NOT suppressed the same way; see `startContinuousTask`.
+    const streamOutput =
+      isStaticOutputStyle(this.outputStyle) ||
+      !printsTaskOutput(this.outputStyle)
+        ? false
+        : shouldStreamOutput(task, this.initiatingProject);
 
     const env = pipeOutput
       ? getEnvVariablesForTask(
@@ -1598,6 +1605,12 @@ export class TaskOrchestrator {
     const pipeOutput = await this.pipeOutputCapture(task);
     // obtain metadata
     const temporaryOutputPath = this.cache.temporaryOutputPath(task);
+    // Deliberately not gated on `printsTaskOutput`, unlike `runTaskDirectly`.
+    // `SummaryTerminalOutputLifeCycle.printTaskTerminalOutput` is a no-op and it
+    // only reports at `endCommand`, which never runs for a task that does not
+    // end - so suppressing here would leave a `nx serve` under `summary` with a
+    // permanently silent terminal and no file to read yet. Streaming is the only
+    // channel a continuous task has.
     const streamOutput = isStaticOutputStyle(this.outputStyle)
       ? false
       : shouldStreamOutput(task, this.initiatingProject);

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -43,6 +43,7 @@ import {
   DbCache,
   dbCacheEnabled,
   getCache,
+  sweepBatchOutputs,
 } from './cache';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { ForkedProcessTaskRunner } from './forked-process-task-runner';
@@ -285,7 +286,9 @@ export class TaskOrchestrator {
     );
     if (!this.stopRequested) {
       this.cache.removeOldCacheRecords();
-      this.cache.sweepBatchOutputs();
+      // Free function, not a cache method: `BatchProcess` writes these logs
+      // whichever cache implementation is active.
+      sweepBatchOutputs();
     }
     await this.cleanup();
     await this.dispose();

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -958,6 +958,10 @@ export class TaskOrchestrator {
         };
       });
 
+      // The capture stream buffers, so both readers below would otherwise be
+      // racing bytes that have not reached the file yet.
+      await batchProcess.flushCapturedOutput();
+
       if (shouldGroupBatchOutput()) {
         this.renderBatchOutputSafely(batch.id, () =>
           this.printGroupedBatchOutput(
@@ -992,6 +996,8 @@ export class TaskOrchestrator {
           terminalOutput: isBatchStopping ? '' : (e.stack ?? e.message ?? ''),
         };
       });
+
+      await batchProcess?.flushCapturedOutput();
 
       // The same handoff the results path uses, rather than a second copy of
       // it: a style that prints nothing renders no fold, so the captured log

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -996,7 +996,8 @@ export class TaskOrchestrator {
       // a task and no per-task output ran. Everything it wrote went to
       // stdout/stderr, held back under grouping - surface it as one fold. Under
       // a style that prints nothing there is no fold; the log is announced by
-      // path above instead. Outside both, it already streamed live. This matters just as much when the batch was stopped: every task
+      // path above instead. Outside both, it already streamed live. This
+      // matters just as much when the batch was stopped: every task
       // is marked stopped whether or not it finished, so the log is the only
       // record of what got through. Only the exit-code error is dropped there,
       // since it restates the cancellation.

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -183,6 +183,11 @@ export class TaskOrchestrator {
   private continuousTaskExitHandled = new Map<string, Promise<void>>();
   private cleanupPromise: Promise<void> | null = null;
   private signalHandlers: Array<[NodeJS.Signals, () => void]> = [];
+  // Tasks whose runner already owns the write to
+  // `<cacheDir>/terminalOutputs/<hash>` — forked processes write it as they
+  // exit, and the paths that never spawn one write it inline. The backstop in
+  // postRunSteps consults this so a task's output is written exactly once.
+  private tasksWithPersistedOutput = new Set<string>();
   // endregion internal state
 
   constructor(
@@ -1229,6 +1234,10 @@ export class TaskOrchestrator {
   ): Promise<void> {
     if (this.completedTasks.has(task.id)) return;
     const terminalOutput = e?.message ?? '';
+    // The worker rejected, so whatever the runner was going to leave on disk
+    // either never landed or can't be trusted. Hand the file back to
+    // postRunSteps so the failure itself is what the task's output path holds.
+    this.tasksWithPersistedOutput.delete(task.id);
     this.options.lifeCycle.printTaskTerminalOutput(
       task,
       'failure',
@@ -1410,17 +1419,22 @@ export class TaskOrchestrator {
           }
         }
 
-        if (!streamOutput && !shouldPrefix) {
-          // TODO: shouldn't this be checking if the task is continuous before writing anything to disk or calling printTaskTerminalOutput?
-          runningTask.onExit((code, terminalOutput) => {
+        runningTask.onExit((code, terminalOutput) => {
+          if (!streamOutput && !shouldPrefix) {
             this.options.lifeCycle.printTaskTerminalOutput(
               task,
               code === 0 ? 'success' : 'failure',
               terminalOutput
             );
+          }
+          // A continuous task never reaches postRunSteps, so exiting is its
+          // only chance to leave its output on disk. A discrete one is written
+          // there instead, whatever its output style — writing here too would
+          // just duplicate it.
+          if (task.continuous) {
             writeFileSync(temporaryOutputPath, terminalOutput);
-          });
-        }
+          }
+        });
 
         return runningTask;
       } catch (e) {
@@ -1431,6 +1445,7 @@ export class TaskOrchestrator {
         }
         const terminalOutput = e.stack ?? e.message ?? '';
         writeFileSync(temporaryOutputPath, terminalOutput);
+        this.tasksWithPersistedOutput.add(task.id);
         return new NoopChildProcess({
           code: 1,
           terminalOutput,
@@ -1438,6 +1453,7 @@ export class TaskOrchestrator {
       }
     } else if (targetConfiguration.executor === 'nx:noop') {
       writeFileSync(temporaryOutputPath, '');
+      this.tasksWithPersistedOutput.add(task.id);
       return new NoopChildProcess({
         code: 0,
         terminalOutput: '',
@@ -1451,6 +1467,12 @@ export class TaskOrchestrator {
         temporaryOutputPath,
         streamOutput
       );
+      // Every forked path leaves the file behind whatever the output style:
+      // the pseudo-terminal and prefixed processes write it when they exit,
+      // the direct-output capture has the child write it itself, and the
+      // fork-failure fallback writes the error. Continuous tasks depend on
+      // that — they never reach postRunSteps.
+      this.tasksWithPersistedOutput.add(task.id);
       if (this.tuiEnabled) {
         if (runningTask instanceof PseudoTtyProcess) {
           // This is an external of a the pseudo terminal where a task is running and can be passed to the TUI
@@ -1516,9 +1538,14 @@ export class TaskOrchestrator {
       if (process.env.NX_VERBOSE_LOGGING === 'true') {
         console.error(e);
       }
+      const terminalOutput = e.stack ?? e.message ?? '';
+      // No process ever started, so nothing else will write the file. Record
+      // why, so the task's terminal output path resolves to the fork error
+      // rather than to nothing.
+      writeFileSync(temporaryOutputPath, terminalOutput);
       return new NoopChildProcess({
         code: 1,
-        terminalOutput: e.stack ?? e.message ?? '',
+        terminalOutput,
       });
     }
   }
@@ -1659,35 +1686,19 @@ export class TaskOrchestrator {
     // Caller decides whether these results should be written to the cache.
     // Cache replays pass false so a replayed failure (reported as 'failure' so
     // it counts as a failed run) isn't re-written to the cache on every replay.
-    if (shouldCache && !this.stopRequested) {
+    const resultsToCache =
+      shouldCache && !this.stopRequested ? this.resultsToCache(results) : [];
+
+    // Resolved before the cache writes so the two never write the same file.
+    this.persistTerminalOutputs(results, resultsToCache);
+
+    if (resultsToCache.length > 0) {
       // cache the results
       performance.mark('cache-results-start');
       await Promise.all(
-        results
-          .filter(
-            ({ status }) =>
-              status !== 'local-cache' &&
-              status !== 'local-cache-kept-existing' &&
-              status !== 'remote-cache' &&
-              status !== 'skipped' &&
-              status !== 'stopped'
-          )
-          .map((result) => ({
-            ...result,
-            code:
-              result.status === 'local-cache' ||
-              result.status === 'local-cache-kept-existing' ||
-              result.status === 'remote-cache' ||
-              result.status === 'success'
-                ? 0
-                : 1,
-            outputs: result.task.outputs,
-          }))
-          .filter(({ task, code }) => this.shouldCacheTaskResult(task, code))
-          .filter(({ terminalOutput, outputs }) => terminalOutput || outputs)
-          .map(async ({ task, code, terminalOutput, outputs }) =>
-            this.cache.put(task, terminalOutput, outputs, code)
-          )
+        resultsToCache.map(async ({ task, code, terminalOutput, outputs }) =>
+          this.cache.put(task, terminalOutput, outputs, code)
+        )
       );
       performance.mark('cache-results-end');
       performance.measure(
@@ -1699,6 +1710,90 @@ export class TaskOrchestrator {
 
     await this.complete(results, groupId);
     await this.scheduleNextTasksAndReleaseThreads();
+  }
+
+  /**
+   * The results `cache.put` will write, in the shape it wants them. Pulled out
+   * of postRunSteps so the terminal-output backstop can be told exactly which
+   * tasks the cache is already writing a file for.
+   */
+  private resultsToCache(
+    results: {
+      task: Task;
+      status: TaskStatus;
+      terminalOutput?: string;
+    }[]
+  ) {
+    return results
+      .filter(
+        ({ status }) =>
+          status !== 'local-cache' &&
+          status !== 'local-cache-kept-existing' &&
+          status !== 'remote-cache' &&
+          status !== 'skipped' &&
+          status !== 'stopped'
+      )
+      .map((result) => ({
+        ...result,
+        code:
+          result.status === 'local-cache' ||
+          result.status === 'local-cache-kept-existing' ||
+          result.status === 'remote-cache' ||
+          result.status === 'success'
+            ? 0
+            : 1,
+        outputs: result.task.outputs,
+      }))
+      .filter(({ task, code }) => this.shouldCacheTaskResult(task, code))
+      .filter(({ terminalOutput, outputs }) => terminalOutput || outputs);
+  }
+
+  /**
+   * Guarantee that every task that actually ran leaves its terminal output at
+   * `<cacheDir>/terminalOutputs/<hash>`, whatever its cache setting, output
+   * style, or batch membership. That path is what the static output styles
+   * point users and agents at, and what Nx Cloud falls back to reading when a
+   * task's in-memory output is undefined, so a task that reaches a terminal
+   * state without a file there is a dangling reference.
+   *
+   * Batch tasks are why this exists. Their output only ever arrives over IPC,
+   * so the sole thing that ever put it on disk was `cache.put` — leaving a
+   * `cache:false` batch task (the shape CI runs under `NX_BATCH_MODE`) with no
+   * file at all.
+   *
+   * Written exactly once per task: tasks whose runner owns the file are
+   * recorded in `tasksWithPersistedOutput`, and tasks `cache.put` is about to
+   * write are skipped here. Cache replays are skipped too — their output was
+   * read from this very file. Skipped tasks never ran, so there is nothing to
+   * write and no reason to leave an empty file behind for the cache's
+   * age-based GC to never collect.
+   */
+  private persistTerminalOutputs(
+    results: {
+      task: Task;
+      status: TaskStatus;
+      terminalOutput?: string;
+    }[],
+    resultsToCache: { task: Task }[]
+  ) {
+    const writtenByCache = new Set(resultsToCache.map(({ task }) => task.id));
+    for (const { task, status, terminalOutput } of results) {
+      if (
+        terminalOutput === undefined ||
+        // A task that failed before it was hashed has no path to write to.
+        !task.hash ||
+        status === 'skipped' ||
+        status === 'local-cache' ||
+        status === 'local-cache-kept-existing' ||
+        status === 'remote-cache' ||
+        writtenByCache.has(task.id) ||
+        this.tasksWithPersistedOutput.has(task.id)
+      ) {
+        continue;
+      }
+      this.tasksWithPersistedOutput.add(task.id);
+      writeFileSync(this.cache.temporaryOutputPath(task), terminalOutput);
+    }
   }
 
   private async scheduleNextTasksAndReleaseThreads() {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -43,6 +43,7 @@ import {
   DbCache,
   dbCacheEnabled,
   getCache,
+  terminalOutputPathForHash,
 } from './cache';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { ForkedProcessTaskRunner } from './forked-process-task-runner';
@@ -982,18 +983,34 @@ export class TaskOrchestrator {
         ? ''
         : readCapturedBatchLog(batchProcess?.getCapturedOutputPath());
 
-      const taskResults = Object.keys(batch.taskGraph.tasks).map((taskId) => {
+      // One worker died, so one log explains every task in the batch. It is
+      // unbounded by design (batch-process.ts: a Gradle batch spans the whole
+      // command), so it is carried by the first task alone and the rest address
+      // that copy. Inlining it into all of them wrote a byte-identical
+      // unbounded file per task, each charged in full against `maxCacheSize`,
+      // and recorded one task's bytes as another's in task history and Nx Cloud.
+      const batchTaskIds = Object.keys(batch.taskGraph.tasks);
+      const logHolder = workerLog ? batchTaskIds[0] : undefined;
+      const logHolderHash = logHolder
+        ? this.taskGraph.tasks[logHolder]?.hash
+        : undefined;
+      const logPointer =
+        logHolderHash &&
+        `batch worker log: ${terminalOutputPathForHash(logHolderHash)}`;
+
+      const taskResults = batchTaskIds.map((taskId) => {
         const task = this.taskGraph.tasks[taskId];
         if (isBatchStopping) {
           task.endTime = Date.now();
         }
+        const stack = e.stack ?? e.message ?? '';
         return {
           task,
           code: 1,
           status: (isBatchStopping ? 'stopped' : 'failure') as TaskStatus,
           terminalOutput: isBatchStopping
             ? ''
-            : [workerLog, e.stack ?? e.message ?? '']
+            : (taskId === logHolder ? [workerLog, stack] : [stack, logPointer])
                 .filter(Boolean)
                 .join('\n'),
         };
@@ -1102,11 +1119,12 @@ export class TaskOrchestrator {
     taskResults: TaskResult[],
     capturedOutputPath: string | undefined
   ) {
-    // Read from the same field the streaming decision uses. `this.options` has
-    // its own `outputStyle`, merged from `nx.json`'s tasksRunnerOptions, so the
-    // two disagree whenever a style is configured there but not named on the
-    // command line - and `init-tasks-runner` passes a populated `options` with
-    // no style argument at all, so on that path only `options` can carry one.
+    // Reads `resolvedOutputStyle` - what the run actually renders with. The
+    // streaming decision deliberately reads `specifiedOutputStyle` instead,
+    // since it has to tell a named style from an inferred default. `this.options`
+    // has its own `outputStyle`, merged from `nx.json`'s tasksRunnerOptions, so
+    // the two disagree whenever a style is configured there but not named on the
+    // command line.
     const printsFullOutput = printsFullTaskOutput({
       verbose: this.options.verbose,
       outputStyle: this.resolvedOutputStyle,

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -8,6 +8,8 @@ import { ProjectGraph } from '../config/project-graph';
 import { assertValidGitRevision } from './git-revision';
 import { workspaceRoot } from './workspace-root';
 import { readParallelFromArgsAndEnv } from '../command-line/yargs-utils/shared-options';
+// Type-only, so it erases and cannot deepen the existing cycle with that module.
+import type { OutputStyle } from '../command-line/yargs-utils/shared-options';
 
 export interface RawNxArgs extends NxArgs {
   prod?: boolean;
@@ -37,6 +39,20 @@ export interface NxArgs {
   graph?: string | boolean;
   skipNxCache?: boolean;
   skipRemoteCache?: boolean;
+  /**
+   * The style the user named - CLI flag or `NX_DEFAULT_OUTPUT_STYLE`. Left
+   * undefined when they named none, and that absence is load-bearing: it is how
+   * the streaming and renderer-selection decisions tell "the user wants static"
+   * from "we defaulted to static", which stream continuous tasks differently.
+   */
+  specifiedOutputStyle?: OutputStyle;
+  /**
+   * What the run actually renders with, after the TUI, agent and failures-only
+   * defaults are applied. Always set. Every decision about what to PRINT reads
+   * this; every decision about what the user ASKED FOR reads the field above.
+   */
+  resolvedOutputStyle?: OutputStyle;
+  /** @deprecated Read `specifiedOutputStyle` or `resolvedOutputStyle` instead. */
   outputStyle?: string;
   tui?: boolean;
   nxBail?: boolean;

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -52,7 +52,11 @@ export interface NxArgs {
    * this; every decision about what the user ASKED FOR reads the field above.
    */
   resolvedOutputStyle?: OutputStyle;
-  /** @deprecated Read `specifiedOutputStyle` or `resolvedOutputStyle` instead. */
+  /**
+   * @deprecated Read `specifiedOutputStyle` for what the user named, or
+   * `resolvedOutputStyle` for what the run renders with. This will be removed
+   * in Nx 24.
+   */
   outputStyle?: string;
   tui?: boolean;
   nxBail?: boolean;

--- a/packages/nx/src/utils/output.spec.ts
+++ b/packages/nx/src/utils/output.spec.ts
@@ -1,4 +1,8 @@
-import { printsFullTaskOutput, isStaticOutputStyle } from './output';
+import {
+  printsFullTaskOutput,
+  isStaticOutputStyle,
+  printsTaskOutput,
+} from './output';
 
 describe('printsFullTaskOutput', () => {
   // This predicate decides whether a successful task's body is printed or
@@ -16,6 +20,7 @@ describe('printsFullTaskOutput', () => {
     ['tui', true],
     ['static', true],
     ['static-failures-only', false],
+    ['summary', false],
   ])('%s prints full output: %s', (outputStyle, expected) => {
     expect(printsFullTaskOutput({ outputStyle })).toBe(expected);
   });
@@ -74,5 +79,27 @@ describe('isStaticOutputStyle', () => {
 
   it('treats an absent style as not-static, so streaming stays negotiable', () => {
     expect(isStaticOutputStyle(undefined)).toBe(false);
+  });
+});
+
+describe('printsTaskOutput', () => {
+  // `summary` addresses each task's log by path instead of printing it, so
+  // anything that would put task bytes on the terminal has to check here first.
+  // The batch fold is the one that bypasses the life cycle and would otherwise
+  // dump a whole worker log into a run that asked for paths.
+  it('is false only for summary', () => {
+    expect(printsTaskOutput('summary')).toBe(false);
+    for (const style of [
+      'static',
+      'static-failures-only',
+      'stream',
+      'stream-without-prefixes',
+      'dynamic',
+      'dynamic-legacy',
+      'tui',
+      undefined,
+    ]) {
+      expect(printsTaskOutput(style)).toBe(true);
+    }
   });
 });

--- a/packages/nx/src/utils/output.spec.ts
+++ b/packages/nx/src/utils/output.spec.ts
@@ -103,3 +103,25 @@ describe('printsTaskOutput', () => {
     }
   });
 });
+describe('the specified/resolved split', () => {
+  // Rows 1 and 2 render identically and stream differently. That difference is
+  // the whole reason the style is carried as two values: one enum cannot say
+  // both "render as failures-only" and "the user did not ask for static, so a
+  // continuous task may still stream". Collapsing them broke 36 e2e tasks.
+  it.each([
+    [undefined, 'static-failures-only', false, false],
+    ['static-failures-only', 'static-failures-only', true, false],
+    ['static', 'static', true, true],
+    ['summary', 'summary', false, false],
+    ['stream', 'stream', false, true],
+    ['tui', 'tui', false, true],
+  ])(
+    'specified=%s resolved=%s suppressesStreaming=%s printsFull=%s',
+    (specified, resolved, suppresses, printsFull) => {
+      expect(isStaticOutputStyle(specified as any)).toBe(suppresses);
+      expect(printsFullTaskOutput({ outputStyle: resolved as any })).toBe(
+        printsFull
+      );
+    }
+  );
+});

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -29,6 +29,20 @@ export function isStaticOutputStyle(outputStyle: string | undefined): boolean {
 }
 
 /**
+ * Whether a style puts task output on the terminal at all.
+ *
+ * `summary` does not - it prints a status line and the path to each task's log,
+ * deliberately addressing the output instead of reproducing it. So every
+ * decision that would put a task's bytes on the terminal has to consult this
+ * first, including ones that bypass the life cycle: the batch renderer folds a
+ * captured worker log directly, and under `summary` that would dump exactly
+ * what the style exists to keep off the screen.
+ */
+export function printsTaskOutput(outputStyle: string | undefined): boolean {
+  return outputStyle !== 'summary';
+}
+
+/**
  * Whether a run prints every task's output in full rather than collapsing the
  * ones that succeeded. Both static life cycles and the batch renderer have to
  * agree on this, so they read it from here rather than each deriving it.
@@ -52,8 +66,9 @@ export function printsFullTaskOutput(args: {
   outputStyle?: string;
 }): boolean {
   return (
-    !!args.verbose ||
-    (args.outputStyle ?? 'static-failures-only') !== 'static-failures-only'
+    printsTaskOutput(args.outputStyle) &&
+    (!!args.verbose ||
+      (args.outputStyle ?? 'static-failures-only') !== 'static-failures-only')
   );
 }
 

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -34,9 +34,14 @@ export function isStaticOutputStyle(outputStyle: string | undefined): boolean {
  * `summary` does not - it prints a status line and the path to each task's log,
  * deliberately addressing the output instead of reproducing it. So every
  * decision that would put a task's bytes on the terminal has to consult this
- * first, including ones that bypass the life cycle: the batch renderer folds a
- * captured worker log directly, and under `summary` that would dump exactly
- * what the style exists to keep off the screen.
+ * first, including ones that bypass the life cycle: both batch folds and
+ * `BatchProcess`'s live forward write to `output` directly, and under `summary`
+ * each would dump exactly what the style exists to keep off the screen.
+ *
+ * Withholding is only half of it. Whatever a caller suppresses here has to be
+ * readable somewhere else, because the style's contract is that the output
+ * moved, not that it is gone - `BatchProcess` captures to a file rather than
+ * dropping, and `runBatch`'s crash path folds that file into the task results.
  */
 export function printsTaskOutput(outputStyle: string | undefined): boolean {
   return outputStyle !== 'summary';

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -52,9 +52,12 @@ export function printsTaskOutput(outputStyle: string | undefined): boolean {
  * ones that succeeded. Both static life cycles and the batch renderer have to
  * agree on this, so they read it from here rather than each deriving it.
  *
- * Exactly one style collapses, and it is also what a run that named no style
- * gets. Every other style prints in full because it was asked for explicitly,
- * so none may quietly withhold output. Note the static life cycles serve more
+ * Two styles collapse. `static-failures-only` shows only what failed, and is
+ * what a run that named no style gets; `summary` withholds task output
+ * altogether, addressing each log by path instead, and outranks `verbose` -
+ * asking for more detail cannot turn a style whose whole contract is "the
+ * output is on disk" back into one that prints. Every other style prints in
+ * full because it was asked for explicitly. Note the static life cycles serve more
  * styles than the static-sounding ones: `shouldUseDynamicLifeCycle` bails on
  * `isCI()` before it looks at the style at all, so in CI `dynamic` and `tui`
  * land here too. This is written as a deny-list for that reason — a new style

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -41,7 +41,7 @@ export function isStaticOutputStyle(outputStyle: string | undefined): boolean {
  * Withholding is only half of it. Whatever a caller suppresses here has to be
  * readable somewhere else, because the style's contract is that the output
  * moved, not that it is gone - `BatchProcess` captures to a file rather than
- * dropping, and `runBatch`'s crash path folds that file into the task results.
+ * dropping, and `runBatch` hands its path to the life cycle.
  */
 export function printsTaskOutput(outputStyle: string | undefined): boolean {
   return outputStyle !== 'summary';


### PR DESCRIPTION
Two tickets, in one PR at Jason's request — the second is meaningless without the first.

## Current Behavior

**Terminal output files are not guaranteed.** The `writeFileSync` that persists task output lives only in the non-streaming single-task branch. Batch output arrives over IPC in memory and only lands on disk via `cache.put`, which is gated on `task.cache`. So a `cache:false` batch task — the main CI path under `NX_BATCH_MODE` — leaves **no** terminal output file, and anything pointing at `<cacheDir>/terminalOutputs/<hash>` dangles exactly there.

**Agents read transcripts to find one failure.** With the TUI off they get the static renderer and thousands of lines of passing output.

## Expected Behavior

### NXC-4694 — every task leaves its output on disk

Every task that reaches a terminal state writes to `<cacheDir>/terminalOutputs/<hash>`, regardless of `cache` setting, streaming mode, or batch membership. No double-write when `cache.put` also stores it.

Outputs written *without* a cache entry (uncacheable tasks, and cacheable ones under `--skip-nx-cache`) get a row via a new napi `record_terminal_outputs`, carrying `has_artifacts = 0`. Without a row the file is invisible to `remove_old_cache_records`, which only walks hashes it finds in the database, so these files would accumulate forever. The flag means such a row can never be served as a cache hit — there are no artifacts behind it.

Bonus interop: Nx Cloud's upload fallback already reads this exact path when in-memory output is undefined, so guaranteed files make that path real for streamed and continuous tasks.

### NXC-4698 — `--output-style=summary`

Because the files are now guaranteed, a run no longer has to carry that text:

```
 NX   34 tasks: 31 succeeded, 29 cached, 1 failed, 2 skipped

✖  nx run js:test  (exit 3)
   full log: /repo/.nx/cache/terminalOutputs/9f2c…

Re-run with --output-style=static to inline logs.
```

Nothing is printed for a successful task, and **no task output is inlined at all** — so the size of a run's output depends on how many tasks failed, never on how much they logged.

It is the default when `isAiAgent()` and no style was given. That resolution sits in the existing yargs middleware chain, **after** `NX_DEFAULT_OUTPUT_STYLE` and **before** the TUI check, so an explicitly requested style always wins and the TUI correctly declines. Deciding it at life-cycle selection instead would have skipped `NX_DEFAULT_OUTPUT_STYLE` and landed after `--output-style` was already normalized.

## Decisions worth reviewing

**The summary points at the raw log, not a stripped-ANSI sibling.** That keeps NXC-4696 out of scope. It only works because nothing is inlined — an inlined excerpt would carry escape codes.

**An earlier cut inlined the last ~20 lines of each failure. It was dropped.** The argument for it is one fewer round trip; the arguments against won: every consumer of this style can read the file (it is chosen for agents or asked for explicitly), a fixed tail is as likely to catch a runner's footer as its error, and with 8 failures a 21-line-each bound is a transcript again.

**`DB_VERSION` goes 3 → 4 rather than adding the column in place.** Conventional here, and task hashes include the nx version so the cache is cold on upgrade anyway — but it does start an empty DB, orphaning existing cache dirs from both GCs and firing one "Unrecognized Cache Artifacts" warning.

**Continuous tasks still stream under `summary`.** The style prints nothing until `endCommand`, which never runs for a task that does not end — so suppressing them would leave `nx serve` silent with no completed log to read instead. A deliberate exception to the style's contract.

**The inline fallback for an unhashed task was removed as unreachable.** `processTask` hashes before it schedules, and the only `task.hash = undefined` in the codebase is a transient clear immediately followed by a re-hash — so a task with terminal output always has a hash. The remaining `if (task.hash)` is a type guard against printing a bogus path, and says so.

## Verification

- `tsc` clean on `packages/nx` and `e2e/nx`; **195 unit tests** green; `cargo check` passes on the Rust change.
- New e2e (`e2e/nx/src/terminal-outputs.test.ts`): `cache:false` under `NX_BATCH_MODE` and under `--output-style=stream` each leave a readable file; the cached replay path is unchanged; a `--skip-nx-cache` record is never served as a hit. Plus the summary cases — a passing run stays under 10 lines, a failing run under 30, an explicit style beats the agent default, and **the printed path is opened and asserted to contain the task's output**, which is the seam between the two tickets.
- Not run locally: the e2e (needs a published local-registry build) and the native `cache.spec.ts` (the committed `.node` predates `record_terminal_outputs`). CI covers both.

## Related Issue(s)

Tracked in Linear rather than as GitHub issues:

* [NXC-4694](https://linear.app/nxdev/issue/NXC-4694/always-write-terminaloutputs-files-streamed-batch-cachefalse) — Always write terminalOutputs files (streamed, batch, cache:false)
* [NXC-4698](https://linear.app/nxdev/issue/NXC-4698/output-stylesummary-auto-selected-under-isaiagent) — `--output-style=summary`, auto-selected under `isAiAgent()`

Both belong to the *Terminal Logs available from disk* milestone of Agent Friendly Task Output. NXC-4694 unblocks NXC-4696 and NXC-4695; NXC-4698 unblocks NXC-4699.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fixup-36543-91040986">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->
