### PR TITLE
fix(core): register nodenext esm resolvers at daemon startup

### DIFF
--- a/e2e/nx/src/sync.test.ts
+++ b/e2e/nx/src/sync.test.ts
@@ -1,0 +1,162 @@
+import {
+  cleanupProject,
+  newProject,
+  readFile,
+  runCLI,
+  runCommand,
+  updateFile,
+  updateJson,
+} from '@nx/e2e-utils';
+import { typescriptVersion } from '@nx/js/src/utils/versions';
+
+describe('nx sync', () => {
+  beforeAll(() => {
+    newProject({ packages: [], packageManager: 'npm' });
+  });
+
+  afterAll(() => cleanupProject());
+
+  // Regression test: the daemon runs sync generators in-process and is spawned
+  // with the workspace's custom resolve conditions, so a generator's workspace
+  // imports resolve to TypeScript source whose NodeNext `.js` specifiers need
+  // the `.js` -> `.ts` resolver hooks registered at daemon startup.
+  it('should run a global sync generator whose workspace imports resolve to TypeScript source via custom conditions', () => {
+    updateJson('package.json', (json) => {
+      json.workspaces = ['packages/*'];
+      json.devDependencies ??= {};
+      json.devDependencies['typescript'] = typescriptVersion;
+      return json;
+    });
+    updateFile(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          module: 'nodenext',
+          moduleResolution: 'nodenext',
+          target: 'es2022',
+          strict: true,
+          declaration: true,
+          customConditions: ['source'],
+        },
+      })
+    );
+
+    // ESM workspace lib exposing its TypeScript source via the custom condition
+    updateFile(
+      'packages/utils/package.json',
+      JSON.stringify({
+        name: '@proj/utils',
+        version: '0.0.0',
+        type: 'module',
+        exports: {
+          '.': {
+            source: './src/index.ts',
+            types: './dist/index.d.ts',
+            default: './dist/index.js',
+          },
+        },
+      })
+    );
+    updateFile(
+      'packages/utils/tsconfig.json',
+      JSON.stringify({
+        extends: '../../tsconfig.base.json',
+        compilerOptions: { rootDir: 'src', outDir: 'dist' },
+        include: ['src'],
+      })
+    );
+    // NodeNext convention: `.js` specifier for a `.ts` source file
+    updateFile(
+      'packages/utils/src/index.ts',
+      `export { greet } from './lib/greet.js';`
+    );
+    updateFile(
+      'packages/utils/src/lib/greet.ts',
+      `export function greet(name: string): string {
+        return \`Hello, \${name}!\`;
+      }`
+    );
+
+    // ESM plugin whose sync generator imports the workspace lib
+    updateFile(
+      'packages/plugin/package.json',
+      JSON.stringify({
+        name: '@proj/plugin',
+        version: '0.0.0',
+        type: 'module',
+        exports: {
+          './package.json': './package.json',
+          '.': {
+            source: './src/index.ts',
+            types: './dist/index.d.ts',
+            default: './dist/index.js',
+          },
+        },
+        generators: './generators.json',
+        dependencies: { '@proj/utils': '*' },
+      })
+    );
+    updateFile(
+      'packages/plugin/tsconfig.json',
+      JSON.stringify({
+        extends: '../../tsconfig.base.json',
+        compilerOptions: { rootDir: 'src', outDir: 'dist' },
+        include: ['src'],
+      })
+    );
+    updateFile(
+      'packages/plugin/generators.json',
+      JSON.stringify({
+        generators: {
+          sync: {
+            factory: './dist/generators/sync.js',
+            schema: './generators-schema.json',
+            description: 'Sync generator that imports @proj/utils',
+          },
+        },
+      })
+    );
+    updateFile(
+      'packages/plugin/generators-schema.json',
+      JSON.stringify({ type: 'object', properties: {} })
+    );
+    updateFile(
+      'packages/plugin/src/index.ts',
+      `export const createNodesV2 = ['**/package.json', async () => []];`
+    );
+    updateFile(
+      'packages/plugin/src/generators/sync.ts',
+      `import { greet } from '@proj/utils';
+
+      export default function syncGenerator(tree: {
+        write(path: string, content: string): void;
+      }) {
+        tree.write('sync-output.txt', greet('sync'));
+      }`
+    );
+
+    updateJson('nx.json', (json) => {
+      json.plugins = [...(json.plugins ?? []), '@proj/plugin'];
+      json.sync = { globalGenerators: ['@proj/plugin:sync'] };
+      return json;
+    });
+
+    // Build with tsc directly: running builds through nx would itself trigger
+    // the sync check before the packages exist in dist.
+    runCommand('npm install');
+    runCommand('npx tsc -p packages/utils/tsconfig.json');
+    runCommand('npx tsc -p packages/plugin/tsconfig.json');
+
+    // Kill any daemon started before the custom conditions existed, so the
+    // sync below spawns one with the workspace's resolve conditions.
+    runCLI('reset');
+    runCLI('sync', { env: { NX_DAEMON: 'true' } });
+
+    expect(readFile('sync-output.txt')).toBe('Hello, sync!');
+    // Guard against a silently disabled daemon: the generator must have run in
+    // the daemon process, which is the process this regression is about.
+    expect(readFile('.nx/workspace-data/d/daemon.log')).toContain(
+      'running scheduled generator @proj/plugin:sync'
+    );
+  });
+});

--- a/packages/nx/src/daemon/server/start.ts
+++ b/packages/nx/src/daemon/server/start.ts
@@ -1,8 +1,23 @@
 // Must be the first import — see enable-compile-cache.ts.
 import '../../utils/enable-compile-cache';
+import {
+  ensureCjsResolverPatched,
+  ensureNodeNextEsmResolverRegistered,
+  isNativeStripPreferred,
+} from '../../plugins/js/utils/register';
 import { output } from '../../utils/output';
 import { startServer } from './server';
 import * as process from 'process';
+
+// The daemon is spawned with the workspace's resolve conditions (see
+// startInBackground in client.ts), so in-process sync generator imports can
+// reach workspace TypeScript source. Register the NodeNext `.js` -> `.ts`
+// resolvers up front — plugin workers get them via registerPluginTSTranspiler,
+// but nothing else registers them in this process before a generator loads.
+if (isNativeStripPreferred()) {
+  ensureCjsResolverPatched();
+  ensureNodeNextEsmResolverRegistered();
+}
 
 (async () => {
   try {


### PR DESCRIPTION
## Current Behavior

In a workspace with `customConditions` in `tsconfig.base.json` (e.g. a `source` condition mapping workspace packages to their TypeScript source), `nx sync` fails when the daemon runs a sync generator that imports a workspace library:

```
NX   The workspace is probably out of sync because a sync generator failed to run

[@example/nx-plugin:sync]: Cannot find module '.../packages/utils/src/lib/greet.js'
imported from .../packages/utils/src/index.ts
```

Since #36296 (shipped in 23.1.1) the daemon is spawned with the workspace's resolve conditions (`getPluginResolveConditionNodeArgs()`), so the generator's transitive workspace imports resolve to TypeScript source. That source uses NodeNext-style `.js` specifiers for `.ts` files, which need Nx's NodeNext resolver hooks, but those hooks were only ever registered in plugin worker processes (via `registerPluginTSTranspiler()`), never in the daemon server process, which loads and runs sync generators in-process. Note the generator entry itself resolves to built `dist/*.js`; the TypeScript source enters through the transitive workspace import, so registration has to be process-level rather than tied to loading a `.ts` entrypoint.

`NX_DAEMON=false` masks the bug because the CLI process runs without the injected conditions and resolves the workspace library to its built `dist` output instead.

## Expected Behavior

The daemon registers the NodeNext `.js` -> `.ts` resolvers (`ensureCjsResolverPatched()` + `ensureNodeNextEsmResolverRegistered()`) at startup, gated on `isNativeStripPreferred()`, mirroring `registerPluginTSTranspiler()`. Sync generators whose workspace imports resolve to TypeScript source now load and run in the daemon.

Verified red/green against the minimal reproduction https://github.com/mugli/nx-esm-resolve-bug (fails on 23.1.1 and current master without this change, passes with it; the repro's `NODE_OPTIONS --import` resolve-hook control also passes). The new e2e (`e2e/nx/src/sync.test.ts`) mirrors that reproduction, was observed failing with the exact reported error before the fix, and asserts via the daemon log that the generator ran in the daemon process rather than a silently daemon-less fallback.

## Related Issue(s)

No open GitHub issue. Reported in the Nx Slack (thread https://nrwl.slack.com/archives/C095YGAEJ1L/p1787141198800679?thread_ts=1769434770.555049&cid=C095YGAEJ1L) with the minimal reproduction https://github.com/mugli/nx-esm-resolve-bug.

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/humble-owl-e99fc61a">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->