### PR TITLE
fix(core): skip target group members without a target

### DIFF
--- a/packages/nx/src/tasks-runner/task-env.spec.ts
+++ b/packages/nx/src/tasks-runner/task-env.spec.ts
@@ -271,6 +271,39 @@ describe('getEnvFilesForTask', () => {
     const envFiles = getEnvFilesForTask(task, graph);
     expect(envFiles).toMatchSnapshot();
   });
+  it('should ignore target group members the project does not define', () => {
+    const task = {
+      projectRoot: 'libs/test-project',
+      target: {
+        project: 'test-project',
+        target: 'build',
+      },
+    } as any as Task;
+    const graph = {
+      nodes: {
+        'test-project': {
+          data: {
+            targets: {
+              build: {},
+            },
+            metadata: {
+              targetGroups: {
+                build: ['build', 'phantomTarget'],
+              },
+            },
+          },
+        },
+      },
+    } as any as ProjectGraph;
+    expect(() => getEnvFilesForTask(task, graph)).not.toThrow();
+    expect(getEnvFilesForTask(task, graph)).toEqual(
+      getEnvFilesForTask(task, {
+        nodes: {
+          'test-project': { data: { targets: { build: {} } } },
+        },
+      } as any as ProjectGraph)
+    );
+  });
 });
 
 describe('getForceColorForChild', () => {

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -228,10 +228,13 @@ function getOwnerTargetForTask(
     for (const targets of Object.values(project.data.metadata.targetGroups)) {
       if (targets.includes(task.target.target)) {
         for (const target of targets) {
-          if (project.data.targets[target].metadata?.nonAtomizedTarget) {
+          // a target group can name a target the project does not define —
+          // inference plugins build the group and the targets separately, so
+          // the two can disagree. skip the phantom rather than dereferencing it.
+          if (project.data.targets[target]?.metadata?.nonAtomizedTarget) {
             return [
               target,
-              project.data.targets[target].metadata?.nonAtomizedTarget,
+              project.data.targets[target]?.metadata?.nonAtomizedTarget,
             ];
           }
         }


### PR DESCRIPTION
## Current Behavior

`getOwnerTargetForTask` in `packages/nx/src/tasks-runner/task-env.ts` walks every member of the matching `metadata.targetGroups` group and indexes `targets` with no guard:

```ts
for (const target of targets) {
  if (project.data.targets[target].metadata?.nonAtomizedTarget) {
```

The optional chain protects `metadata`, but not the lookup that produces the object it reads from. If the group names a target the project does not define, `project.data.targets[target]` is `undefined` and reading `.metadata` throws:

```
NX   Cannot read properties of undefined (reading 'metadata')

TypeError: Cannot read properties of undefined (reading 'metadata')
    at getOwnerTargetForTask  tasks-runner/task-env.js:169
    at getEnvFilesForTask     task-env.js:182
    at loadDotEnvFilesForTask task-env.js:186
    at getTaskSpecificEnv     task-env.js:61
    at hashTasksThatDoNotDependOnOutputsOfOtherTasks  hasher/hash-task.js:46
    at async invokeTasksRunner  tasks-runner/run-command.js:678
```

It fires from `hashTasksThatDoNotDependOnOutputsOfOtherTasks`, so the whole run aborts during hashing before a single task executes, and the message names neither the project nor the plugin responsible.

This is reachable from plugins, not only from hand-written config. Groups and targets are built separately, so an inference plugin can emit the two out of step. `@nx/gradle` does on Micronaut/GraalVM projects: it puts `dockerfileNative` in the `build` target group while creating only a `dockerfile` target, so every `nx affected` or `nx run-many` touching one of those projects dies during hashing.

Present since #33013, which introduced `getOwnerTargetForTask`. Reproduced on 23.1.1, and the unguarded lookup is still on `master`.

## Expected Behavior

A group member that is not a real target on the project is skipped, and `getOwnerTargetForTask` falls through to the task's own target, exactly as it does for a project with no `targetGroups`. The run proceeds instead of aborting.

## Related Issue(s)

Fixes #36712 36712
