### PR TITLE
fix(gradle): surface project graph timeout errors when the process ignores the kill signal

### DIFF
--- a/packages/gradle/package.json
+++ b/packages/gradle/package.json
@@ -77,7 +77,6 @@
   "dependencies": {
     "@nx/devkit": "workspace:*",
     "toml-eslint-parser": "^0.10.0",
-    "tree-kill": "catalog:",
     "tslib": "catalog:typescript"
   },
   "devDependencies": {

--- a/packages/gradle/src/utils/exec-gradle.spec.ts
+++ b/packages/gradle/src/utils/exec-gradle.spec.ts
@@ -205,6 +205,34 @@ describe('execGradleAsync', () => {
     ).rejects.toThrow('spawn EACCES');
   });
 
+  // A wedged JVM can survive the kill signal; the promise must still settle
+  // on abort or the timeout error never surfaces.
+  it('should reject on abort even if the process never exits', async () => {
+    const killProcessTreeGraceful = jest.fn(() => Promise.resolve());
+    jest.doMock('@nx/devkit/internal', () => ({
+      ...jest.requireActual('@nx/devkit/internal'),
+      safeSpawn: jest.fn(() => {
+        const EventEmitter = require('events');
+        const cp: any = new EventEmitter();
+        cp.pid = 123;
+        cp.stdout = new EventEmitter();
+        cp.stderr = new EventEmitter();
+        return cp; // never emits `exit`
+      }),
+      killProcessTreeGraceful,
+    }));
+    const { execGradleAsync } = require('./exec-gradle');
+
+    const controller = new AbortController();
+    const promise = execGradleAsync('/ws/gradlew', ['nxProjectGraph'], {
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    await expect(promise).rejects.toBeDefined();
+    expect(killProcessTreeGraceful).toHaveBeenCalledWith(123);
+  });
+
   it('should drop empty args the shell used to swallow', async () => {
     const { execGradleAsync, getCaptured } = loadWithMockedSpawn();
 

--- a/packages/gradle/src/utils/exec-gradle.ts
+++ b/packages/gradle/src/utils/exec-gradle.ts
@@ -7,8 +7,11 @@ import { SpawnOptions } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, join, isAbsolute } from 'node:path';
 import { GradlePluginOptions } from '../plugin/utils/gradle-plugin-options';
-import treeKill from 'tree-kill';
-import { safeSpawn, signalToCode } from '@nx/devkit/internal';
+import {
+  killProcessTreeGraceful,
+  safeSpawn,
+  signalToCode,
+} from '@nx/devkit/internal';
 
 export const fileSeparator = process.platform.startsWith('win')
   ? 'file:///'
@@ -38,7 +41,7 @@ export function execGradleAsync(
   args: ReadonlyArray<string>,
   execOptions: Omit<SpawnOptions, 'shell'> = {}
 ): Promise<Buffer> {
-  // Extract signal so we can handle cancellation with tree-kill
+  // Extract signal so we can handle cancellation with a process-tree kill
   // instead of Node's default which only kills the immediate child.
   const { signal, ...restOptions } = execOptions;
 
@@ -50,16 +53,18 @@ export function execGradleAsync(
       ...restOptions,
     });
 
-    // Use tree-kill on abort to kill the entire process tree
-    // (gradlew spawns java), not just the direct child.
+    let stdout = Buffer.from('');
+
+    // On abort, kill the entire process tree (gradlew spawns java) and settle
+    // immediately — a wedged JVM that outlives the kill signal would otherwise
+    // keep this promise pending and the abort error would never surface.
     const onAbort = () => {
       if (cp.pid) {
-        treeKill(cp.pid);
+        killProcessTreeGraceful(cp.pid).catch(() => {});
       }
+      rej(stdout);
     };
     signal?.addEventListener('abort', onAbort, { once: true });
-
-    let stdout = Buffer.from('');
     cp.stdout?.on('data', (data) => {
       stdout += data;
     });

--- a/packages/maven/package.json
+++ b/packages/maven/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "@nx/devkit": "workspace:*",
     "@xmldom/xmldom": "^0.8.10",
-    "tree-kill": "catalog:",
     "tslib": "catalog:typescript"
   },
   "devDependencies": {

--- a/packages/maven/src/plugins/maven-analyzer.spec.ts
+++ b/packages/maven/src/plugins/maven-analyzer.spec.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 import { readJsonFile } from '@nx/devkit';
 import { EventEmitter } from 'events';
 import {
+  killProcessTreeGraceful,
   safeExecFileSync,
   safeSpawn,
   workspaceDataDirectory,
@@ -15,6 +16,7 @@ jest.mock('@nx/devkit/internal', () => ({
   ...jest.requireActual('@nx/devkit/internal'),
   safeSpawn: jest.fn(),
   safeExecFileSync: jest.fn(),
+  killProcessTreeGraceful: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual('@nx/devkit'),
@@ -228,6 +230,26 @@ describe('Maven Analyzer', () => {
       await expect(promise).rejects.toThrow(
         'Maven analysis failed with code 1'
       );
+    });
+
+    // A process that never exits must still settle the promise, or the
+    // timeout error is never reported.
+    it('should report the timeout even if the process never exits', async () => {
+      const mockChild = new EventEmitter() as any;
+      mockChild.stdout = new EventEmitter();
+      mockChild.stderr = new EventEmitter();
+      mockChild.pid = 1234;
+      (safeSpawn as jest.Mock).mockReturnValue(mockChild);
+
+      process.env.NX_MAVEN_ANALYSIS_TIMEOUT = '0.001';
+      try {
+        await expect(runMavenAnalysis(workspaceRoot, {})).rejects.toThrow(
+          'Maven analysis timed out'
+        );
+        expect(killProcessTreeGraceful).toHaveBeenCalledWith(1234);
+      } finally {
+        delete process.env.NX_MAVEN_ANALYSIS_TIMEOUT;
+      }
     });
 
     it('should handle spawn error', async () => {

--- a/packages/maven/src/plugins/maven-analyzer.ts
+++ b/packages/maven/src/plugins/maven-analyzer.ts
@@ -3,8 +3,12 @@ import { existsSync } from 'fs';
 import { logger, readJsonFile } from '@nx/devkit';
 import { MavenAnalysisData, MavenPluginOptions } from './types';
 import { detectMavenExecutable } from '../utils/detect-maven-executable';
-import treeKill from 'tree-kill';
-import { isCI, safeSpawn, workspaceDataDirectory } from '@nx/devkit/internal';
+import {
+  isCI,
+  killProcessTreeGraceful,
+  safeSpawn,
+  workspaceDataDirectory,
+} from '@nx/devkit/internal';
 
 const DEFAULT_ANALYSIS_TIMEOUT_SECONDS = isCI() ? 600 : 120;
 
@@ -105,11 +109,14 @@ export async function runMavenAnalysis(
         stdio: 'pipe', // Always use pipe so we can control output
       });
 
-      // Use tree-kill on abort to kill the entire process tree
+      // On abort, kill the entire process tree and settle immediately — a
+      // wedged process that outlives the kill signal would otherwise keep
+      // this promise pending and the abort error would never surface.
       const onAbort = () => {
         if (child.pid) {
-          treeKill(child.pid);
+          killProcessTreeGraceful(child.pid).catch(() => {});
         }
+        reject(new Error('Maven analysis aborted'));
       };
       signal.addEventListener('abort', onAbort, { once: true });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2725,9 +2725,6 @@ importers:
       toml-eslint-parser:
         specifier: ^0.10.0
         version: 0.10.0
-      tree-kill:
-        specifier: 'catalog:'
-        version: 1.2.2
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -2926,9 +2923,6 @@ importers:
       '@xmldom/xmldom':
         specifier: ^0.8.10
         version: 0.8.11
-      tree-kill:
-        specifier: 'catalog:'
-        version: 1.2.2
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -27670,7 +27664,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2201.2(chokidar@5.0.0)
-      '@angular-devkit/build-webpack': 0.2201.2(chokidar@5.0.0)(webpack-dev-server@5.2.6(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
+      '@angular-devkit/build-webpack': 0.2201.2(chokidar@5.0.0)(webpack-dev-server@5.2.6(tslib@2.8.1)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
       '@angular-devkit/core': 22.1.2(chokidar@5.0.0)
       '@angular/build': 22.1.2(aaab729c3dba3d026dcb875f0ba2b76d)
       '@angular/compiler-cli': 22.1.0(@angular/compiler@22.1.0)(typescript@6.0.3)
@@ -27720,7 +27714,7 @@ snapshots:
       typescript: 6.0.3
       webpack: 5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)
       webpack-dev-middleware: 8.0.3(tslib@2.8.1)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
+      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.0(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
     optionalDependencies:
@@ -27818,7 +27812,7 @@ snapshots:
       typescript: 6.0.3
       webpack: 5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)
       webpack-dev-middleware: 8.0.3(tslib@2.8.1)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
+      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.0(webpack@5.105.2))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
     optionalDependencies:
@@ -27867,16 +27861,16 @@ snapshots:
       '@angular-devkit/architect': 0.2201.2(chokidar@3.6.0)
       rxjs: 7.8.2
       webpack: 5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
+      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-webpack@0.2201.2(chokidar@5.0.0)(webpack-dev-server@5.2.6(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))':
+  '@angular-devkit/build-webpack@0.2201.2(chokidar@5.0.0)(webpack-dev-server@5.2.6(tslib@2.8.1)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))':
     dependencies:
       '@angular-devkit/architect': 0.2201.2(chokidar@5.0.0)
       rxjs: 7.8.2
       webpack: 5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
+      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3))
     transitivePeerDependencies:
       - chokidar
 
@@ -57827,7 +57821,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)):
+  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4


### PR DESCRIPTION
## Current Behavior

When the Gradle `nxProjectGraph` invocation (or Maven analysis) hits its timeout, the abort handler only fires `tree-kill` (SIGTERM, fire-and-forget) at the process tree. The promise settles only when the process actually exits — but the timeout scenario is precisely a wedged process, which often ignores SIGTERM. The result:

- The "Gradle project graph generation timed out after N seconds" / "Maven analysis timed out" error is never thrown, so the user sees nothing and `createNodes` hangs indefinitely.
- The wedged process tree survives, which is the daemon accumulation #35143 set out to prevent.

This regressed in #35143: before that PR the abort signal went directly to `execFile`, which killed the shell wrapper and guaranteed the `exit` event (and therefore the timeout error) fired.

## Expected Behavior

On abort (timeout or cancellation):

- The promise settles immediately, so the timeout error always surfaces to the user with its remediation steps — even if the process refuses to die.
- The process tree is killed via the existing native `killProcessTreeGraceful` (signal → wait → SIGKILL), so a JVM that ignores SIGTERM is force-killed instead of surviving as an orphan. This also drops the `tree-kill` dependency from `@nx/gradle` and `@nx/maven`.

Covered by new unit tests: `execGradleAsync` rejects on abort even when the child never emits `exit`, and `runMavenAnalysis` reports its timeout even when the process never closes.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Surface-gradle-maven-createNodes-timeout-errors-when-the-process-ignore-160a3958">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->