### PR TITLE
fix(core): stop resending accumulated task hash results to the daemon when hashing tasks

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -347,12 +347,28 @@ export class DaemonClient {
     cwd: string,
     collectInputs?: boolean
   ): Promise<Hash[]> {
+    // Task results get written back onto these task objects as the run
+    // progresses — hash/hashDetails/timestamps by hashing and the
+    // orchestrator, terminalOutput by the Nx Cloud life cycle (untyped) —
+    // so a later message would otherwise re-ship every earlier result.
+    const trimmedTasks: Record<string, Task> = {};
+    for (const [id, t] of Object.entries(taskGraph.tasks)) {
+      const {
+        hash,
+        hashDetails,
+        startTime,
+        endTime,
+        terminalOutput,
+        ...strippedTask
+      } = t as Task & { terminalOutput?: string };
+      trimmedTasks[id] = strippedTask as Task;
+    }
     return this.sendToDaemonViaQueue({
       type: 'HASH_TASKS',
       runnerOptions,
       perTaskEnvs,
-      tasks,
-      taskGraph,
+      tasks: tasks.map((t) => trimmedTasks[t.id]),
+      taskGraph: { ...taskGraph, tasks: trimmedTasks },
       cwd,
       collectInputs,
     });


### PR DESCRIPTION
## Current Behavior

Task hashing happens in waves — tasks with `dependentTasksOutputFiles` inputs can only be hashed after their dependencies complete — and every `HASH_TASKS` message sends the full task graph to the daemon. As the run progresses, results get written back onto the graph's shared `Task` objects: hashing writes `hash`/`hashDetails` (an entry per hashed input — ~1,200 for a typical lint task in this repo), the orchestrator stamps `startTime`/`endTime`, and the Nx Cloud life cycle attaches each task's `terminalOutput` (untyped — it is not on the `Task` interface). Every later wave then re-serializes all of it back to the daemon, which needs none of it — it is the daemon that produces the hashes in the first place.

The growth is dramatic. Measured on a fully cached `nx run-many -t lint,oxlint` in this repo (375 tasks, 41 hash waves): the graph message grows from 150 KB on the first wave to **41.7 MB** by the last (a single task's cached build log alone contributed 609 KB), and the run ships **1.37 GB** of serialized task graph in total. That costs **59–93s inside task hashing** — most of the warm run's wall time — of which 11–16s is client-side message serialization alone.

## Expected Behavior

The client strips the accumulated results (`hash`, `hashDetails`, `startTime`, `endTime`, `terminalOutput`) from the task copies it puts on the wire; each task is stripped once per message and the in-process task objects are untouched, so life cycles (including Nx Cloud's) see exactly what they saw before. Every message now carries the same byte-identical 150 KB graph — verified flat across all 41 waves — for **~6 MB** per run instead of 1.37 GB.

Measured on the same workload:

| | before | after |
|---|---|---|
| total task-hashing time | 59–93s | **7–13s** |
| client HASH_TASKS serialization | 11–16s | **~35ms** |
| graph bytes shipped per run | 1.37 GB | ~6 MB |
| largest single message | 41.7 MB | 150 KB |

An alternative fix — registering the task graph with the daemon once per connection and sending only task ids afterwards — was prototyped and measured equivalent (interleaved A/B runs; the strip was at-or-ahead in every round). This change was chosen because it achieves the same win in one file with no protocol change and no daemon-side state; the registration approach remains an option if per-wave shipping of even the clean graph ever matters for far larger workspaces.

## Related Issue(s)

N/A — found while investigating slow warm `lint,oxlint` runs in this repo.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Send-task-graph-to-daemon-once-per-connection-when-hashing-c06f7311">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->