### PR TITLE
fix(core): apply targetDefaults options to an inferred target that is not redeclared

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1830,6 +1830,57 @@ describe('project-configuration-utils', () => {
       expect(errors).toEqual([]);
     });
 
+    it('should apply a targetDefaults command shorthand to an inferred target that is not redeclared', () => {
+      // The top-level `command` shorthand desugars to an `nx:run-commands`
+      // executor the entry never wrote, which must not make the entry look
+      // incompatible with — and so replace — the inferred target.
+      const specifiedResults = [
+        [
+          [
+            '@nx/js/typescript',
+            'packages/a/tsconfig.lib.json',
+            {
+              projects: {
+                'packages/a': {
+                  name: 'a',
+                  root: 'packages/a',
+                  targets: {
+                    build: {
+                      command: 'tsc --build tsconfig.lib.json',
+                      options: { cwd: 'packages/a' },
+                      cache: true,
+                      inputs: ['inferred-input'],
+                      outputs: ['{projectRoot}/dist'],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        [],
+        { targetDefaults: { build: { command: 'echo FROM-TARGET-DEFAULTS' } } },
+        '/tmp/test',
+        errors
+      );
+
+      const buildTarget = result.projectRootMap['packages/a'].targets!['build'];
+      expect(buildTarget.options).toEqual({
+        cwd: 'packages/a',
+        command: 'echo FROM-TARGET-DEFAULTS',
+      });
+      // Fields the entry does not name keep the inferred target's values.
+      expect(buildTarget.cache).toEqual(true);
+      expect(buildTarget.inputs).toEqual(['inferred-input']);
+      expect(buildTarget.outputs).toEqual(['{projectRoot}/dist']);
+      expect(errors).toEqual([]);
+    });
+
     it('should merge multiple specified plugins contributing to the same project', () => {
       const specifiedResults = [
         [

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1585,6 +1585,251 @@ describe('project-configuration-utils', () => {
       expect(errors).toEqual([]);
     });
 
+    it('should apply targetDefaults options to an inferred target that is not redeclared (#36700)', () => {
+      // Repro for #36700: `@nx/js/typescript` infers a run-commands `build`
+      // target, nothing redeclares it, and the target default names a
+      // different command. The default's `options.command` must reach the
+      // target the same way its `outputs`/`cache`/`inputs` already do —
+      // target defaults layer above the specified plugins.
+      const specifiedResults = [
+        [
+          [
+            '@nx/js/typescript',
+            'packages/a/tsconfig.lib.json',
+            {
+              projects: {
+                'packages/a': {
+                  name: 'a',
+                  root: 'packages/a',
+                  targets: {
+                    // The shape `@nx/js/typescript` emits: the `command`
+                    // shorthand plus a `cwd`, desugared into an
+                    // `nx:run-commands` target during the merge.
+                    build: {
+                      command: 'tsc --build tsconfig.lib.json',
+                      options: { cwd: 'packages/a' },
+                      cache: true,
+                      inputs: ['inferred-input'],
+                      outputs: ['{projectRoot}/dist'],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        [],
+        {
+          targetDefaults: {
+            build: {
+              cache: true,
+              inputs: ['production'],
+              outputs: ['{projectRoot}/MARKER-OUTPUT'],
+              options: { command: 'echo FROM-TARGET-DEFAULTS' },
+            },
+          },
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const buildTarget = result.projectRootMap['packages/a'].targets!['build'];
+      expect(buildTarget.options).toEqual({
+        command: 'echo FROM-TARGET-DEFAULTS',
+        // Option keys the default does not name keep the plugin's values.
+        cwd: 'packages/a',
+      });
+      // The fields that were already applied before the regression still are.
+      expect(buildTarget.outputs).toEqual(['{projectRoot}/MARKER-OUTPUT']);
+      expect(buildTarget.inputs).toEqual(['production']);
+      expect(buildTarget.cache).toEqual(true);
+      expect(buildTarget.executor).toEqual('nx:run-commands');
+      expect(errors).toEqual([]);
+    });
+
+    it('should apply a targetDefaults commands array to an inferred target that is not redeclared', () => {
+      // The `options.commands` form carries the same command identity as
+      // `options.command`, so it has to survive synthesis the same way.
+      const specifiedResults = [
+        [
+          [
+            '@nx/js/typescript',
+            'packages/a/tsconfig.lib.json',
+            {
+              projects: {
+                'packages/a': {
+                  name: 'a',
+                  root: 'packages/a',
+                  targets: {
+                    build: {
+                      executor: 'nx:run-commands',
+                      options: { commands: ['tsc --build tsconfig.lib.json'] },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        [],
+        {
+          targetDefaults: {
+            build: {
+              options: { commands: ['tsdown', 'tsc --emitDeclarationOnly'] },
+            },
+          },
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const buildTarget = result.projectRootMap['packages/a'].targets!['build'];
+      expect(buildTarget.options).toEqual({
+        commands: ['tsdown', 'tsc --emitDeclarationOnly'],
+      });
+      expect(errors).toEqual([]);
+    });
+
+    it('should let an inferred target keep its command when the targetDefaults entry names no command', () => {
+      // The complement of #36700: a default that only carries ordinary
+      // options must not disturb what the inferred target runs.
+      const specifiedResults = [
+        [
+          [
+            '@nx/js/typescript',
+            'packages/a/tsconfig.lib.json',
+            {
+              projects: {
+                'packages/a': {
+                  name: 'a',
+                  root: 'packages/a',
+                  targets: {
+                    build: {
+                      executor: 'nx:run-commands',
+                      options: {
+                        command: 'tsc --build tsconfig.lib.json',
+                        color: false,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        [],
+        {
+          targetDefaults: {
+            build: { cache: true, options: { color: true, parallel: false } },
+          },
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const buildTarget = result.projectRootMap['packages/a'].targets!['build'];
+      expect(buildTarget.options).toEqual({
+        command: 'tsc --build tsconfig.lib.json',
+        color: true,
+        parallel: false,
+      });
+      expect(buildTarget.cache).toEqual(true);
+      expect(errors).toEqual([]);
+    });
+
+    it('should let project.json override a targetDefaults command while its other fields still apply (#36067)', () => {
+      // The #36067 guarantee, with the target default also naming a command:
+      // project.json outranks target defaults, so its command wins, and the
+      // default's `cache`/`outputs` must still ride onto the winning target
+      // rather than being dropped with the replaced inferred one.
+      const specifiedResults = [
+        [
+          [
+            '@nx/js/typescript',
+            'packages/a/tsconfig.lib.json',
+            {
+              projects: {
+                'packages/a': {
+                  name: 'a',
+                  root: 'packages/a',
+                  targets: {
+                    build: {
+                      executor: 'nx:run-commands',
+                      options: { command: 'tsc --build tsconfig.lib.json' },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const defaultResults = [
+        [
+          [
+            'nx/core/project-json',
+            'packages/a/project.json',
+            {
+              projects: {
+                'packages/a': {
+                  name: 'a',
+                  root: 'packages/a',
+                  targets: {
+                    build: {
+                      executor: 'nx:run-commands',
+                      options: { commands: ['tsdown'], cwd: 'packages/a' },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        defaultResults as any,
+        {
+          targetDefaults: {
+            build: {
+              cache: true,
+              outputs: ['{projectRoot}/MARKER-OUTPUT'],
+              options: { command: 'echo FROM-TARGET-DEFAULTS' },
+            },
+          },
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const buildTarget = result.projectRootMap['packages/a'].targets!['build'];
+      expect(buildTarget.options).toEqual(
+        expect.objectContaining({ commands: ['tsdown'], cwd: 'packages/a' })
+      );
+      expect(buildTarget.options.command).toBeUndefined();
+      expect(buildTarget.cache).toEqual(true);
+      expect(buildTarget.outputs).toEqual(['{projectRoot}/MARKER-OUTPUT']);
+      expect(errors).toEqual([]);
+    });
+
     it('should merge multiple specified plugins contributing to the same project', () => {
       const specifiedResults = [
         [

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -201,6 +201,9 @@ type EffectiveTarget = {
   // incompatible-replaced and dropped when the winner uses the
   // `options.commands` form (#36067).
   options?: { command?: unknown; commands?: unknown };
+  // True when the layers are incompatible, so the default layer
+  // wholesale-replaces the specified one during the real merge.
+  replacesSpecified: boolean;
 };
 
 function effectiveTargetForLookup(
@@ -217,7 +220,7 @@ function effectiveTargetForLookup(
 
   if (resolvedSpecified && resolvedDefault) {
     if (!isCompatibleTarget(resolvedSpecified, resolvedDefault)) {
-      return effectiveFromWinner(resolvedDefault);
+      return effectiveFromWinner(resolvedDefault, true);
     }
     return {
       executor: resolvedDefault.executor ?? resolvedSpecified.executor,
@@ -225,22 +228,27 @@ function effectiveTargetForLookup(
       options:
         runCommandsCommandIdentity(resolvedDefault) ??
         runCommandsCommandIdentity(resolvedSpecified),
+      replacesSpecified: false,
     };
   }
   if (resolvedSpecified) {
-    return effectiveFromWinner(resolvedSpecified);
+    return effectiveFromWinner(resolvedSpecified, false);
   }
   if (resolvedDefault) {
-    return effectiveFromWinner(resolvedDefault);
+    return effectiveFromWinner(resolvedDefault, false);
   }
   return undefined;
 }
 
-function effectiveFromWinner(target: TargetConfiguration): EffectiveTarget {
+function effectiveFromWinner(
+  target: TargetConfiguration,
+  replacesSpecified: boolean
+): EffectiveTarget {
   return {
     executor: target.executor,
     command: target.command,
     options: runCommandsCommandIdentity(target),
+    replacesSpecified,
   };
 }
 
@@ -260,17 +268,27 @@ function runCommandsCommandIdentity(
   };
 }
 
+// Whether an entry states what the target runs. run-commands identity lives in
+// these two option keys, which are also what the identity stamp overwrites.
+function authorsCommandIdentity(target: TargetConfiguration): boolean {
+  return (
+    target.options?.command !== undefined ||
+    target.options?.commands !== undefined
+  );
+}
+
 /**
  * Returns one synthetic defaults target per matching `targetDefaults` entry for
  * `targetName` at `root` (empty when no defaults apply). Emitting per entry
  * rather than a single pre-merged target lets source maps attribute fields to
  * the specific array element they came from; the entries merge downstream in
- * document order. Each synthetic stamps the effective executor/command (and the
- * winner's run-commands options identity) so neither merge neighbor can
- * incompatible-replace it and drop its contributions.
+ * document order. A synthetic normally stamps the effective executor/command
+ * (and the winner's run-commands options identity) so neither merge neighbor
+ * can incompatible-replace it and drop its contributions; an entry naming its
+ * own command keeps that command instead, per {@link authorsCommandIdentity}.
  *
- * @param effective The shape the real merge will land on. Used both as the
- *   executor filter context and as the locked identity stamped onto the
+ * @param effective The shape the real merge will land on. Used as the executor
+ *   filter context and, in most cases, as the identity stamped onto the
  *   synthetic.
  */
 function buildSyntheticTargetsForRoot(
@@ -312,19 +330,30 @@ function buildSyntheticTargetsForRoot(
       continue;
     }
 
-    // Pre-stamp executor/command from the effective shape so the
-    // synthetic can't be incompatible-replaced during the real merge.
-    if (effective.executor !== undefined) {
-      synthetic.executor = effective.executor;
-    }
-    if (effective.command !== undefined) {
-      synthetic.command = effective.command;
-    }
-    // run-commands compatibility keys off options.command/commands, not the
-    // top-level command. Stamp the winner's so the synthetic stays compatible
-    // when the winning target uses the options.commands form (#36067).
-    if (effective.options !== undefined) {
-      synthetic.options = { ...synthetic.options, ...effective.options };
+    // Stamping over an entry that names its own command would discard it
+    // (#36700). Only a replacing default layer needs the stamp: without a
+    // replace an entry that declares no executor already survives the merge.
+    const wouldOverwriteAuthoredCommand =
+      effective.options !== undefined && authorsCommandIdentity(synthetic);
+
+    if (effective.replacesSpecified || !wouldOverwriteAuthoredCommand) {
+      // Pre-stamp executor/command from the effective shape so the
+      // synthetic can't be incompatible-replaced during the real merge.
+      if (effective.executor !== undefined) {
+        synthetic.executor = effective.executor;
+      }
+      if (effective.command !== undefined) {
+        synthetic.command = effective.command;
+      }
+      // run-commands compatibility keys off options.command/commands, not the
+      // top-level command. Stamp the winner's so the synthetic stays compatible
+      // when the winning target uses the options.commands form (#36067). Both
+      // keys are cleared first, since `isCompatibleTarget` reads `command` in
+      // preference to `commands` and a leftover one would defeat the stamp.
+      if (effective.options !== undefined) {
+        const { command, commands, ...rest } = synthetic.options ?? {};
+        synthetic.options = { ...rest, ...effective.options };
+      }
     }
 
     synthetics.push({ key: resolved.key, index, target: synthetic });

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -315,6 +315,8 @@ function buildSyntheticTargetsForRoot(
     target: TargetConfiguration;
   }[] = [];
   for (const { index, config } of resolved.matches) {
+    // Read before desugaring, which synthesises an executor for `command`.
+    const authoredExecutor = config.executor;
     const synthetic = resolveCommandSyntacticSugar(deepClone(config), root);
 
     // Compatibility guard, per entry: an entry incompatible with the effective
@@ -331,8 +333,8 @@ function buildSyntheticTargetsForRoot(
     }
 
     // Stamping over an entry that names its own command would discard it
-    // (#36700). Only a replacing default layer needs the stamp: without a
-    // replace an entry that declares no executor already survives the merge.
+    // (#36700), so the stamp is limited to the replacing path it was added
+    // for (#36142).
     const wouldOverwriteAuthoredCommand =
       effective.options !== undefined && authorsCommandIdentity(synthetic);
 
@@ -354,6 +356,11 @@ function buildSyntheticTargetsForRoot(
         const { command, commands, ...rest } = synthetic.options ?? {};
         synthetic.options = { ...rest, ...effective.options };
       }
+    } else if (authoredExecutor === undefined) {
+      // Unstamped, an executor desugaring synthesised for the `command`
+      // shorthand reads as a rival run-commands target and replaces the one
+      // this entry should merge into.
+      delete synthetic.executor;
     }
 
     synthetics.push({ key: resolved.key, index, target: synthetic });


### PR DESCRIPTION
## Current Behavior

For a target inferred by a plugin and not redeclared in `project.json`, the `options` from a `targetDefaults` entry stopped applying in 23.1.0. Every other field of the entry still applies, so `outputs` and `cache` land while `options` alone is dropped, and the target silently runs a different command. 23.0.2 is the last good release.

The identity stamp arrives with #36142 (fix for #36067), which copies the winning target's run-commands identity (`options.command` / `options.commands`) onto the synthetic defaults target so it stays command-compatible with a `project.json` target that wholesale-replaces an inferred one. There it ran on one branch only: where the default layer replaces the specified layer. The regression is #36049, the nested-array `targetDefaults` shape in 23.1.0, which rewrote synthesis around a single `effectiveTargetForLookup` result and carried the stamp onto every path, including the specified-only path here, where nothing is being replaced. On that path it spreads the plugin's `options.command` over the entry's own, discarding the authored command before the real merge runs.

## Expected Behavior

A target default naming a command applies it to an inferred target, the way its `outputs` and `cache` already do; one naming no command leaves the inferred command alone; and a `project.json` target still outranks it while the default's other fields ride onto the winner, which is #36142's guarantee.

Synthesis now skips the stamp in one narrow case: the entry sets `options.command` or `options.commands` and the default layer is not replacing the specified layer. It still runs whenever the default layer does replace, so #36142 keeps working. The skip is safe because an entry with no executor of its own is compatible with every neighbor it can meet, so on a non-replacing path the stamp protects nothing. `effectiveTargetForLookup` grows a `replacesSpecified` flag, since the nested-array redesign had collapsed that distinction.

The stamp also had to become authoritative. It spread the winner's identity keys over the entry's `options`, leaving an entry's own `command` beside a stamped `commands`; `isCompatibleTarget` prefers `command`, so the leftover key still decided the comparison and defeated the stamp. Both keys are now cleared before the winner's are written.

## Testing

Four cases in `project-configuration-utils.spec.ts` alongside the existing #36067 test: an entry's `options.command` reaching an inferred run-commands target (written the way `@nx/js/typescript` writes it, so shorthand desugaring is exercised), the same through `options.commands`, an entry with only ordinary options leaving the inferred command alone, and a `project.json` target replacing an inferred one while the default also names a command. The first, second and fourth fail against the pre-change `target-defaults.ts`; the fourth fails on `master` today because of the leftover-key problem.

`npx jest` across `packages/nx`: 280/295 suites, 6263/6427 tests pass. The 15 failing suites need the Rust native bindings, which my machine cannot build; running them against unmodified `target-defaults.ts` gives the identical 162 failures. `pseudo-terminal.spec.ts` was excluded because it aborts the jest process rather than failing, for the same reason. Also ran `tsc --noEmit` for `packages/nx/tsconfig.lib.json`, eslint on both changed files, and prettier. E2E left to CI.

## Related Issue(s)

Fixes #36700
