### PR TITLE
fix(devkit): correct version floor validation for ranges and prereleases

### DIFF
--- a/packages/devkit/src/utils/installed-version.ts
+++ b/packages/devkit/src/utils/installed-version.ts
@@ -11,12 +11,21 @@ import { getDependencyVersionFromPackageJson } from './package-json';
  * Use this from executor / runtime contexts where node_modules is present.
  * Generator-time code should use `getDeclaredPackageVersion` instead.
  *
+ * Pass `requirePaths` to resolve from specific directories only (e.g. the
+ * workspace root, excluding the `.nx/installation` fallback); otherwise the
+ * default nx require paths are used.
+ *
  * Returns `null` when the package is not resolvable.
  */
-export function getInstalledPackageVersion(packageName: string): string | null {
+export function getInstalledPackageVersion(
+  packageName: string,
+  requirePaths?: string[]
+): string | null {
   try {
-    const { packageJson } = readModulePackageJson(packageName);
-    return packageJson.version ?? null;
+    const { packageJson } = requirePaths
+      ? readModulePackageJson(packageName, requirePaths)
+      : readModulePackageJson(packageName);
+    return typeof packageJson.version === 'string' ? packageJson.version : null;
   } catch {
     return null;
   }
@@ -45,6 +54,31 @@ export function getDeclaredPackageVersion(
     if (normalized) return normalized;
   }
   return latestKnownVersion ? normalizeSemver(latestKnownVersion) : null;
+}
+
+/**
+ * Reads the installed version of a package from the tree's `node_modules`,
+ * so it reflects in-flight tree changes and stays controllable in tests.
+ * Returns `null` when the package is not present in the tree's
+ * `node_modules`.
+ */
+export function getInstalledPackageVersionFromTree(
+  tree: Tree,
+  packageName: string
+): string | null {
+  try {
+    const pkgJson = tree.read(
+      `node_modules/${packageName}/package.json`,
+      'utf-8'
+    );
+    if (!pkgJson) {
+      return null;
+    }
+    const version = JSON.parse(pkgJson).version;
+    return typeof version === 'string' ? version : null;
+  } catch {
+    return null;
+  }
 }
 
 export const NON_SEMVER_DIST_TAGS = ['latest', 'next'] as const;

--- a/packages/devkit/src/utils/installed-version.ts
+++ b/packages/devkit/src/utils/installed-version.ts
@@ -9,7 +9,9 @@ import { getDependencyVersionFromPackageJson } from './package-json';
  * `package.json` — not the workspace's declared range.
  *
  * Use this from executor / runtime contexts where node_modules is present.
- * Generator-time code should use `getDeclaredPackageVersion` instead.
+ * Generator-time code should read from the tree first (the declared range or
+ * `getInstalledPackageVersionFromTree`) and may fall back to this with
+ * `requirePaths` restricted to the workspace root.
  *
  * Pass `requirePaths` to resolve from specific directories only (e.g. the
  * workspace root, excluding the `.nx/installation` fallback); otherwise the

--- a/packages/devkit/src/utils/installed-version.ts
+++ b/packages/devkit/src/utils/installed-version.ts
@@ -1,5 +1,5 @@
 import { readModulePackageJson } from 'nx/src/devkit-internals';
-import type { Tree } from 'nx/src/devkit-exports';
+import { readJson, type Tree } from 'nx/src/devkit-exports';
 import { clean, coerce } from 'semver';
 import { getDependencyVersionFromPackageJson } from './package-json';
 
@@ -69,14 +69,10 @@ export function getInstalledPackageVersionFromTree(
   packageName: string
 ): string | null {
   try {
-    const pkgJson = tree.read(
-      `node_modules/${packageName}/package.json`,
-      'utf-8'
+    const { version } = readJson(
+      tree,
+      `node_modules/${packageName}/package.json`
     );
-    if (!pkgJson) {
-      return null;
-    }
-    const version = JSON.parse(pkgJson).version;
     return typeof version === 'string' ? version : null;
   } catch {
     return null;

--- a/packages/devkit/src/utils/version-floor.spec.ts
+++ b/packages/devkit/src/utils/version-floor.spec.ts
@@ -1,4 +1,5 @@
-import { updateJson } from 'nx/src/devkit-exports';
+import { updateJson, workspaceRoot } from 'nx/src/devkit-exports';
+import { FsTree } from 'nx/src/generators/tree';
 import { createTreeWithEmptyWorkspace } from '../../testing';
 import {
   assertSupportedInstalledPackageVersion,
@@ -88,6 +89,273 @@ describe('assertSupportedPackageVersion', () => {
     expect(() =>
       assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
     ).not.toThrow();
+  });
+
+  it('asks to install dependencies when the declared range straddles the floor and no installed version resolves', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=1.5.0 <3.0.0' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Unable to determine the installed version of `some-pkg`/);
+  });
+
+  it('does not throw when the exact declared version is a prerelease of the floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '2.0.0-rc.1' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('throws when the exact declared version is a prerelease below the floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '1.9.0-rc.1' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Unsupported version of `some-pkg` detected/);
+  });
+
+  it('does not throw when the declared range only reaches the floor through its prereleases', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=2.0.0-rc.1 <2.0.0' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('does not throw when the installed version is a prerelease of the floor within a prerelease-only range', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=2.0.0-rc.1 <2.0.0' },
+    }));
+    tree.write(
+      'node_modules/some-pkg/package.json',
+      JSON.stringify({ name: 'some-pkg', version: '2.0.0-rc.2' })
+    );
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('conservatively asks to install dependencies for a prerelease range below the floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=1.9.0-rc.1 <2.0.0' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Unable to determine the installed version of `some-pkg`/);
+  });
+
+  it('does not throw when the declared range minimum is a prerelease of the floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=2.0.0-rc.1 <3.0.0' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('throws when a compound declared range is entirely below the floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=1.0.0 <1.6.0' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Unsupported version of `some-pkg` detected/);
+  });
+
+  it('throws when the installed version satisfies the declared range and is below the floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=1.0.0 <3.0.0' },
+    }));
+    tree.write(
+      'node_modules/some-pkg/package.json',
+      JSON.stringify({ name: 'some-pkg', version: '1.5.0' })
+    );
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Installed: 1\.5\.0/);
+  });
+
+  it('does not throw when the installed version satisfies the declared range and meets the floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=1.0.0 <3.0.0' },
+    }));
+    tree.write(
+      'node_modules/some-pkg/package.json',
+      JSON.stringify({ name: 'some-pkg', version: '2.5.0' })
+    );
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('ignores an installed version that does not satisfy the declared range (declared intent wins)', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '~1.5.0' },
+    }));
+    tree.write(
+      'node_modules/some-pkg/package.json',
+      JSON.stringify({ name: 'some-pkg', version: '2.5.0' })
+    );
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Installed: ~1\.5\.0/);
+  });
+
+  it('treats an installed prerelease as its release version', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=1.0.0 <3.0.0' },
+    }));
+    tree.write(
+      'node_modules/some-pkg/package.json',
+      JSON.stringify({ name: 'some-pkg', version: '1.5.0-beta.1' })
+    );
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Installed: 1\.5\.0-beta\.1/);
+  });
+
+  it('does not throw when an installed prerelease meets the floor within a plain range', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=1.0.0 <3.0.0' },
+    }));
+    tree.write(
+      'node_modules/some-pkg/package.json',
+      JSON.stringify({ name: 'some-pkg', version: '2.5.0-rc.1' })
+    );
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('ignores an installed package.json with a non-string version', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=1.0.0 <3.0.0' },
+    }));
+    tree.write(
+      'node_modules/some-pkg/package.json',
+      JSON.stringify({ name: 'some-pkg', version: 42 })
+    );
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Unable to determine the installed version of `some-pkg`/);
+  });
+
+  it('ignores an installed package.json with an object version', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '>=1.0.0 <3.0.0' },
+    }));
+    tree.write(
+      'node_modules/some-pkg/package.json',
+      JSON.stringify({ name: 'some-pkg', version: { value: '2.5.0' } })
+    );
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Unable to determine the installed version of `some-pkg`/);
+  });
+
+  it('does not throw when an installed floor prerelease matches an upper prerelease bound', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '<=2.0.0-rc.1' },
+    }));
+    tree.write(
+      'node_modules/some-pkg/package.json',
+      JSON.stringify({ name: 'some-pkg', version: '2.0.0-rc.1' })
+    );
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('falls back to module resolution when the tree has no node_modules (e.g. Yarn PnP)', () => {
+    const spy = jest
+      .spyOn(installedVersion, 'getInstalledPackageVersion')
+      .mockReturnValue('1.5.0');
+    try {
+      const tree = new FsTree(workspaceRoot, false);
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: { 'some-pkg': '>=1.0.0 <3.0.0' },
+      }));
+
+      expect(() =>
+        assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+      ).toThrow(/Installed: 1\.5\.0/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('does not resolve from the process for a tree not rooted at the workspace', () => {
+    const spy = jest
+      .spyOn(installedVersion, 'getInstalledPackageVersion')
+      .mockReturnValue('1.5.0');
+    try {
+      const tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: { 'some-pkg': '>=1.0.0 <3.0.0' },
+      }));
+
+      expect(() =>
+        assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+      ).toThrow(/Unable to determine the installed version of `some-pkg`/);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/packages/devkit/src/utils/version-floor.ts
+++ b/packages/devkit/src/utils/version-floor.ts
@@ -1,9 +1,17 @@
-import type { Tree } from 'nx/src/devkit-exports';
-import { coerce, lt } from 'semver';
+import { workspaceRoot, type Tree } from 'nx/src/devkit-exports';
+import {
+  clean,
+  coerce,
+  intersects,
+  lt,
+  minVersion,
+  satisfies,
+  validRange,
+} from 'semver';
 import {
   getInstalledPackageVersion,
+  getInstalledPackageVersionFromTree,
   isNonSemverDistTag,
-  normalizeSemver,
 } from './installed-version';
 import { getDependencyVersionFromPackageJson } from './package-json';
 
@@ -35,9 +43,21 @@ export function throwForUnsupportedVersion(
 /**
  * Asserts that a package detected in the workspace is at or above the
  * plugin's supported floor. No-op when the package is not detected
- * (fresh-install path) or when declared as `latest`/`next`. Throws via
- * `throwForUnsupportedVersion` (with the original declared range for
- * clarity) when below floor.
+ * (fresh-install path) or when declared as `latest`/`next`.
+ *
+ * Resolution order:
+ * - When the installed version satisfies the declared range, the installed
+ *   version decides. This resolves open ranges (e.g. `>=4.8.4 <6.1.0`) to
+ *   what is actually installed.
+ * - An exact declared version is compared to the floor directly.
+ * - A declared range that cannot reach the floor throws as unsupported. A
+ *   range that straddles the floor cannot be judged without an installed
+ *   version (the lockfile may pin either side), so when none resolves it
+ *   throws asking to install dependencies first.
+ *
+ * Prereleases count as their release version throughout (e.g. `6.0.0-rc.1`
+ * as `6.0.0`), for installed versions, exact declared versions, and range
+ * endpoints alike.
  *
  * Use from generator entry points to fail fast on unsupported workspaces
  * before writing any incompatible config.
@@ -51,10 +71,74 @@ export function assertSupportedPackageVersion(
   if (!declared || isNonSemverDistTag(declared)) {
     return;
   }
-  const cleaned = normalizeSemver(declared);
-  if (cleaned && lt(cleaned, minSupportedVersion)) {
+
+  const installed =
+    getInstalledPackageVersionFromTree(tree, packageName) ??
+    getInstalledPackageVersionFromProcess(tree, packageName);
+  if (installed) {
+    // An installed prerelease can match the declared range in either form:
+    // raw (a same-tuple prerelease comparator) or as its release version.
+    const release = coerce(installed)?.version ?? installed;
+    if (satisfies(installed, declared) || satisfies(release, declared)) {
+      if (lt(release, minSupportedVersion)) {
+        throwForUnsupportedVersion(packageName, installed, minSupportedVersion);
+      }
+      return;
+    }
+  }
+
+  const cleaned = clean(declared);
+  if (cleaned) {
+    // Strip any prerelease so it counts as its release version.
+    const release = coerce(cleaned)?.version ?? cleaned;
+    if (lt(release, minSupportedVersion)) {
+      throwForUnsupportedVersion(packageName, declared, minSupportedVersion);
+    }
+    return;
+  }
+
+  if (validRange(declared)) {
+    // The `-0` floor comparator admits prereleases of the floor version, so
+    // a range reaching the floor only through its prereleases still counts.
+    if (!intersects(declared, `>=${minSupportedVersion}-0`)) {
+      throwForUnsupportedVersion(packageName, declared, minSupportedVersion);
+    }
+    const min = minVersion(declared);
+    const rangeMinimum = min ? `${min.major}.${min.minor}.${min.patch}` : null;
+    if (rangeMinimum && lt(rangeMinimum, minSupportedVersion)) {
+      throw new Error(
+        `Unable to determine the installed version of \`${packageName}\`.\n\n` +
+          `  Declared: ${declared}\n` +
+          `  Supported: >= ${minSupportedVersion}\n\n` +
+          `The declared range allows versions below the supported minimum. ` +
+          `Install the workspace dependencies so the installed version can be verified, then try again.`
+      );
+    }
+    return;
+  }
+
+  const coerced = coerce(declared)?.version;
+  if (coerced && lt(coerced, minSupportedVersion)) {
     throwForUnsupportedVersion(packageName, declared, minSupportedVersion);
   }
+}
+
+/**
+ * Module-resolution fallback for installs without a `node_modules` layout
+ * (e.g. Yarn PnP). Only valid when the tree is the running process's
+ * workspace; unit trees (e.g. rooted at `/virtual`) must not resolve
+ * packages from the process environment. Resolves from the workspace root
+ * only, so a copy hoisted into `.nx/installation` cannot shadow the
+ * workspace's own install.
+ */
+function getInstalledPackageVersionFromProcess(
+  tree: Tree,
+  packageName: string
+): string | null {
+  if (tree.root !== workspaceRoot) {
+    return null;
+  }
+  return getInstalledPackageVersion(packageName, [tree.root]);
 }
 
 /**

--- a/packages/js/src/utils/assert-supported-typescript-version.spec.ts
+++ b/packages/js/src/utils/assert-supported-typescript-version.spec.ts
@@ -52,6 +52,32 @@ describe('assertSupportedTypescriptVersion', () => {
     expect(() => assertSupportedTypescriptVersion(tree)).not.toThrow();
   });
 
+  it('does not throw when the declared range straddles the floor and the installed version meets it (e.g. typescript-eslint style ranges)', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      devDependencies: { typescript: '>=4.8.4 <6.1.0' },
+    }));
+    tree.write(
+      'node_modules/typescript/package.json',
+      JSON.stringify({ name: 'typescript', version: '6.0.2' })
+    );
+
+    expect(() => assertSupportedTypescriptVersion(tree)).not.toThrow();
+  });
+
+  it('asks to install dependencies when the declared range straddles the floor and no installed version resolves', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      devDependencies: { typescript: '>=4.8.4 <6.1.0' },
+    }));
+
+    expect(() => assertSupportedTypescriptVersion(tree)).toThrow(
+      /Unable to determine the installed version of `typescript`/
+    );
+  });
+
   it('does not throw when typescript is within the supported window', () => {
     const tree = createTreeWithEmptyWorkspace();
     updateJson(tree, 'package.json', (json) => ({


### PR DESCRIPTION
## Current Behavior

Generators calling devkit's `assertSupportedPackageVersion` reject a workspace whose package is declared as a version range, even when the installed version is supported. The declared range is coerced to its first version token and compared to the floor:

```
[@nx/js:typescript-sync]: Unsupported version of `typescript` detected.

  Installed: >=4.8.4 <6.1.0
  Supported: >= 5.8.0
```

This workspace has TypeScript 6.0.2 installed (a pnpm override), which satisfies the floor.

## Expected Behavior

The installed version decides when it satisfies the declared range, so the workspace above passes validation. A declared range that cannot reach the floor still fails as unsupported. A range that straddles the floor with no resolvable installed version fails asking to install dependencies first. Prereleases count as their release version.

## Related Issue(s)

NXC-4820

## Implementation Notes

- The installed version is read from the tree's node_modules first, then through workspace-root module resolution for layouts without node_modules (Yarn PnP). Resolution is restricted to the workspace root so a copy under `.nx/installation` cannot shadow the workspace's install.
- A straddling range without a resolvable install cannot be judged: the lockfile may pin either side, and `.nx/installation` setups run generators before workspace packages are installed. It fails with an install-dependencies error rather than guessing in either direction.
- An installed prerelease matches the declared range in raw form (same-tuple prerelease comparator) or as its release version; the floor comparison always uses the release version.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4820-7fbd7f9d">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->