### PR TITLE
chore(repo): bump default Node.js version to 26.7.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ env:
   DEBUG: napi:*
   NX_RUN_GROUP: ${{ github.run_id }}-${{ github.run_attempt }}
   CYPRESS_INSTALL_BINARY: 0
-  NODE_VERSION: 26.3.0
+  NODE_VERSION: 26.7.0
   PNPM_VERSION: 11.2.2 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
   NX_GRADLE_PROJECT_GRAPH_TIMEOUT: 600
 
@@ -321,7 +321,7 @@ jobs:
               export PATH="$JAVA_HOME\bin:$PATH"
               java -version
               pnpm nx run-many --target=build-native -- --target=aarch64-pc-windows-msvc
-    name: stable - ${{ matrix.settings.target }} - node@26.3.0
+    name: stable - ${{ matrix.settings.target }} - node@26.7.0
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -434,7 +434,7 @@ jobs:
           DEBUG: napi:*
           RUSTUP_IO_THREADS: 1
           PLAYWRIGHT_BROWSERS_PATH: 0
-          NODE_VERSION: 26.3.0
+          NODE_VERSION: 26.7.0
           NX_GRADLE_DISABLE: 'true'
           NX_DOTNET_DISABLE: 'true'
           NODE_OPTIONS: '--max-old-space-size=4096'

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 bun = "1.3"
 java = "24"
-node = "{{ env['NODE_VERSION'] | default(value='26.3.0') }}"
+node = "{{ env['NODE_VERSION'] | default(value='26.7.0') }}"
 maven = "3.9.11"
 rust = "1.95.0"
 vale = "3.13.1"


### PR DESCRIPTION
## Current Behavior

The repo pins Node.js `26.3.0` — as the `mise.toml` default, and explicitly in `publish.yml`.

`26.3.0` can deadlock on `process.exit()`. Calling `process.exit()` invokes C `exit()`, which joins the V8 platform worker threads from outside V8. If a background Maglev compile job is in flight at that moment and needs to allocate, it parks on the collection barrier waiting for the main thread to service a GC — but the main thread is already blocked in `uv_thread_join`. Neither side can proceed.

Sampled stacks from a wedged process:

```
main thread:
  node::Environment::Exit -> DisposePlatform -> NodePlatform::Shutdown
    -> WorkerThreadsTaskRunner::Shutdown -> uv_thread_join -> __ulock_wait

node-V8Worker:
  MaglevConcurrentDispatcher::JobTask::Run -> MaglevCodeGenerator::BuildCodeObject
    -> HeapAllocator::AllocateRawSlowPath -> CollectGarbageAndRetryAllocation
    -> CollectionBarrier::AwaitCollectionBackground -> cond wait
```

This was hit locally during `nx-release`: the run stalled with a `run-executor` child that had already finished its task and called `process.exit()`, but could never terminate. It is a race, so it is intermittent — most tasks in the same run exited fine.

## Expected Behavior

Node.js `26.7.0` (released 2026-08-05, latest on the 26 line) is the default, picking up four patch releases of V8 changes.

Scope / notes:

- `mise.toml` stays overridable via the `NODE_VERSION` env var — only the default value changes.
- `publish.yml` pinned `26.3.0` in three places (workflow `env`, the native-build job name, and the `NODE_VERSION` passed into the cross-build container); all three move together so the release workflow stays consistent with the local toolchain. The `unofficial-builds.nodejs.org` musl tarball for `v26.7.0` was confirmed to exist, since `publish.yml` downloads it directly.
- Utility workflows using `actions/setup-node` (`pr-title-validation`, `generate-embeddings`, `banner-monitor`, `issue-notifier`) remain on Node 24 and are out of scope.
- This is a mitigation, not a fix. The underlying bug is upstream — Node should not join platform worker threads that can still request a GC from the main thread. Same family as https://github.com/nodejs/node/issues/54918; this Maglev variant appears unreported for Node 26. There is no guarantee `26.7.0` closes the race, but staying on a version with a known reproduction of it is worse.

## Related Issue(s)

N/A — internal toolchain bump.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Bump-default-Node.js-to-26.7.0-process.exit-deadlock-bc0d3442">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->