### PR TITLE
fix(core): isolate pnpm version detection from workspace

### DIFF
--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -283,7 +283,7 @@ describe('package-manager', () => {
         switch (p) {
           case 'yarn --version':
             return '1.22.10';
-          case 'pnpm --version':
+          case 'pnpm --ignore-workspace --version':
             return '5.17.5';
           case 'npm --version':
             return '7.20.3';
@@ -993,7 +993,7 @@ describe('package-manager', () => {
     it('should return pnpm publish command with scoped registry when provided for pnpm version >= 9.15.7 < 10.0.0 || >= 10.5.0', () => {
       jest.spyOn(childProcess, 'execSync').mockImplementation((p) => {
         switch (p) {
-          case 'pnpm --version':
+          case 'pnpm --ignore-workspace --version':
             return '9.15.7';
         }
       });
@@ -1006,7 +1006,7 @@ describe('package-manager', () => {
     it('should return pnpm publish command without use scoped registry for pnpm version < 9.15.7', () => {
       jest.spyOn(childProcess, 'execSync').mockImplementation((p) => {
         switch (p) {
-          case 'pnpm --version':
+          case 'pnpm --ignore-workspace --version':
             return '9.10.1';
           default:
             throw new Error('Command failed');
@@ -1028,7 +1028,7 @@ describe('package-manager', () => {
 
     it('should return pnpm add commands with --config.frozen-lockfile=false in a workspace', () => {
       jest.spyOn(childProcess, 'execSync').mockImplementation((p) => {
-        if (p === 'pnpm --version') {
+        if (p === 'pnpm --ignore-workspace --version') {
           return '9.15.7';
         }
         throw new Error(`Unexpected command: ${p}`);
@@ -1047,7 +1047,7 @@ describe('package-manager', () => {
 
     it('should return pnpm add commands with --config.frozen-lockfile=false outside a workspace', () => {
       jest.spyOn(childProcess, 'execSync').mockImplementation((p) => {
-        if (p === 'pnpm --version') {
+        if (p === 'pnpm --ignore-workspace --version') {
           return '9.15.7';
         }
         throw new Error(`Unexpected command: ${p}`);

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -296,6 +296,23 @@ describe('package-manager', () => {
       expect(getPackageManagerVersion('npm')).toEqual('7.20.3');
     });
 
+    it('should ignore workspace configuration when detecting the pnpm version', () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const execSync = jest
+        .spyOn(childProcess, 'execSync')
+        .mockReturnValue('11.2.2');
+
+      expect(getPackageManagerVersion('pnpm', '/workspace')).toEqual('11.2.2');
+      expect(execSync).toHaveBeenCalledWith(
+        'pnpm --ignore-workspace --version',
+        {
+          cwd: '/workspace',
+          encoding: 'utf-8',
+          windowsHide: true,
+        }
+      );
+    });
+
     it('should detect pnpm package manager version from package.json packageManager', () => {
       jest.spyOn(fs, 'existsSync').mockReturnValueOnce(true);
       jest.spyOn(childProcess, 'execSync').mockImplementation(() => {

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -352,7 +352,11 @@ export function getPackageManagerVersion(
   }
   if (!version) {
     try {
-      version = execSync(`${packageManager} --version`, {
+      const versionArgs =
+        packageManager === 'pnpm'
+          ? '--ignore-workspace --version'
+          : '--version';
+      version = execSync(`${packageManager} ${versionArgs}`, {
         cwd,
         encoding: 'utf-8',
         windowsHide: true,


### PR DESCRIPTION
## Current Behavior

When `packageManager` is absent, Nx runs `pnpm --version` inside the workspace. pnpm config dependencies can emit watched temporary-file events, causing the daemon to repeatedly rebuild the project graph.

## Expected Behavior

Detect the pnpm version without loading workspace configuration, so project graph creation and `nx sync` complete normally.

## Related Issue(s)

Fixes #36727

Generated with Codex.