### PR TITLE
fix(core): keep npm overrides that only constrain a package's own deps

### DIFF
--- a/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
@@ -1111,6 +1111,104 @@ describe('createPackageJson', () => {
       expect(result).not.toHaveProperty('overrides');
     });
 
+    it('should keep an npm override that only constrains the dependencies of a direct dependency', () => {
+      spies.push(
+        jest
+          .spyOn(fs, 'existsSync')
+          .mockImplementation(
+            (path) =>
+              path === 'libs/lib1/package.json' || path === 'package.json'
+          )
+      );
+      spies.push(
+        jest
+          .spyOn(fileutilsModule, 'readJsonFile')
+          .mockImplementation((path) => {
+            if (path === 'package.json') {
+              return {
+                ...rootPackageJson(),
+                overrides: {
+                  // `typescript` is a direct dependency of the generated
+                  // package.json, but this sets no version for `typescript`
+                  // itself, so npm accepts it and it is what makes a
+                  // conflicting peer requirement resolvable in the dist.
+                  typescript: { foo: '1.0.0' },
+                },
+              };
+            }
+            if (path === 'libs/lib1/package.json') {
+              return projectPackageJson();
+            }
+          })
+      );
+
+      expect(
+        createPackageJson('lib1', graph, {
+          root: '',
+        })
+      ).toEqual({
+        dependencies: {
+          random: '1.0.0',
+          typescript: '^4.8.4',
+        },
+        name: 'other-name',
+        version: '1.2.3',
+        overrides: {
+          typescript: { foo: '1.0.0' },
+        },
+      });
+    });
+
+    it('should drop an npm override that pins a direct dependency through a "." key', () => {
+      spies.push(
+        jest
+          .spyOn(fs, 'existsSync')
+          .mockImplementation(
+            (path) =>
+              path === 'libs/lib1/package.json' || path === 'package.json'
+          )
+      );
+      spies.push(
+        jest
+          .spyOn(fileutilsModule, 'readJsonFile')
+          .mockImplementation((path) => {
+            if (path === 'package.json') {
+              return {
+                ...rootPackageJson(),
+                overrides: {
+                  // `.` sets the version of `typescript` itself, which npm
+                  // rejects with EOVERRIDE against the direct dependency.
+                  typescript: { '.': '5.0.0', foo: '1.0.0' },
+                  // transitive-only, in either form - must be carried through.
+                  foo: '1.0.0',
+                  bar: { '.': '2.0.0' },
+                },
+              };
+            }
+            if (path === 'libs/lib1/package.json') {
+              return projectPackageJson();
+            }
+          })
+      );
+
+      expect(
+        createPackageJson('lib1', graph, {
+          root: '',
+        })
+      ).toEqual({
+        dependencies: {
+          random: '1.0.0',
+          typescript: '^4.8.4',
+        },
+        name: 'other-name',
+        version: '1.2.3',
+        overrides: {
+          foo: '1.0.0',
+          bar: { '.': '2.0.0' },
+        },
+      });
+    });
+
     it('should add resolutions (yarn)', () => {
       spies.push(
         jest

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -225,9 +225,12 @@ export function createPackageJson(
 
   // npm
   if (rootPackageJson.overrides && !options.skipOverrides) {
-    // npm throws EOVERRIDE when an override key is also a direct dependency
-    // (unless specs match). The pruned dist pins exact versions and already
-    // resolved everything via the lockfile, so drop those redundant overrides.
+    // npm throws EOVERRIDE when an override sets the version of a package that
+    // is also a direct dependency (unless specs match). The pruned dist pins
+    // exact versions and already resolved everything via the lockfile, so drop
+    // those redundant overrides. An object form without a `.` key sets no
+    // version for the package itself, only for its dependencies, so npm
+    // accepts it next to a direct dependency and it has to be kept.
     const mergedOverrides = {
       ...rootPackageJson.overrides,
       ...packageJson.overrides,
@@ -235,15 +238,19 @@ export function createPackageJson(
     const overrides: typeof mergedOverrides = {};
     let hasOverrides = false;
     for (const name in mergedOverrides) {
+      const override = mergedOverrides[name];
+      const constrainsDependenciesOnly =
+        typeof override === 'object' && override !== null && !('.' in override);
       if (
-        packageJson.dependencies?.[name] ||
-        packageJson.devDependencies?.[name] ||
-        packageJson.peerDependencies?.[name] ||
-        packageJson.optionalDependencies?.[name]
+        !constrainsDependenciesOnly &&
+        (packageJson.dependencies?.[name] ||
+          packageJson.devDependencies?.[name] ||
+          packageJson.peerDependencies?.[name] ||
+          packageJson.optionalDependencies?.[name])
       ) {
         continue;
       }
-      overrides[name] = mergedOverrides[name];
+      overrides[name] = override;
       hasOverrides = true;
     }
     if (hasOverrides) {


### PR DESCRIPTION
## Current Behavior

`createPackageJson` drops every root `overrides` entry whose key is also a direct dependency of the generated `package.json`. That filter arrived with #36040 to fix the `EOVERRIDE` reported in #35675, and it treats both npm override forms alike.

Only one of the two forms can raise `EOVERRIDE`. The string form, `"debug": "4.3.5"`, sets the version of `debug` itself, so it collides with a direct dependency on `debug`. The object form, `"debug": { "ms": "2.1.3" }`, sets no version for `debug` at all, it only constrains that package's own dependencies.

I ran `npm install --package-lock-only` against a workspace whose direct dependencies are `debug@4.3.4` and `ms@2.1.2`, one override shape per run:

| overrides | npm 10.9.8 | npm 11.19.0 |
| --- | --- | --- |
| `{}` | ok | ok |
| `{ "debug": "4.3.5" }` | EOVERRIDE | EOVERRIDE |
| `{ "debug": { "ms": "2.1.3" } }` | ok | ok |
| `{ "debug": { ".": "4.3.5", "ms": "2.1.3" } }` | EOVERRIDE | EOVERRIDE |
| `{ "supports-color": "9.0.0" }` | ok | ok |

The object form is rejected only when it carries a `.` key, and that key is the entry inside it that sets the package's own version.

Dropping the object form has a cost: it can be the thing that makes a pruned dist installable when a direct dependency has a conflicting peer requirement. With the packages from #36721, where `libphonenumber-geo-carrier@2.0.0` has an exact peer pin on `libphonenumber-js@1.12.31` and both are direct dependencies at `libphonenumber-js@1.13.11`, `npm install` in the generated `package.json` fails with `ERESOLVE` today. Putting the object override back into that same file makes it install.

## Expected Behavior

The filter skips only the overrides that set the package's own version, which is the string form plus the object form carrying a `.` key. Everything else is written to the generated `package.json`, and from there into the pruned lockfile, since `pruneNpmLockFile` copies `packageJson.overrides` as it stands.

pnpm `overrides` and yarn `resolutions` stay untouched, as before.

Two tests come with the change. The first covers an object-form override surviving next to a direct dependency, and it is the one that fails without the fix. The second covers a `.` key still being dropped; it passes on `master` as well, and it is there to keep the filter from being loosened past what npm actually rejects. The `createPackageJson` suite is green at 22 tests.

One case I deliberately left alone: an object override that mixes `.` with sibling keys is still dropped whole rather than having only the `.` entry stripped. That matches today's behaviour, and narrowing it further felt like a separate call for you to make.

## Related Issue(s)

Fixes #36721
