### PR TITLE
docs(nx-cloud): rewrite flaky task docs around flaky test vocabulary

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
@@ -359,7 +359,7 @@ For a more thorough explanation of how Nx Agents optimize your CI pipeline, read
 
 {% linkcard title="Automatically Split E2E Tasks" description="Split large e2e tasks into a separate task for each spec file"  href="/docs/features/ci-features/split-e2e-tasks" /%}
 
-{% linkcard title="Identify and Re-run Flaky Tasks" description="Re-run flaky tasks in CI whenever they fail" href="/docs/features/ci-features/flaky-tasks" /%}
+{% linkcard title="Detect and Retry Flaky Tasks" description="Re-run flaky tests and tasks in CI whenever they fail" href="/docs/features/ci-features/flaky-tasks" /%}
 
 {% /cardgrid %}
 

--- a/astro-docs/src/content/docs/features/CI Features/flaky-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/flaky-tasks.mdoc
@@ -1,14 +1,33 @@
 ---
-title: Identify and Re-run Flaky Tasks
-description: Automatically detect and re-run flaky tasks in CI with Nx Cloud
+title: Detect and Retry Flaky Tasks
+description: Nx Cloud detects flaky tasks - tests, e2e runs, or builds - by tracking results for the same task hash across CI runs, then retries them on a different agent.
 sidebar:
+  label: Flaky tasks
   order: 16
 filter: 'type:Features'
 ---
 
-Tasks that fail only sometimes and only in certain environments are called "flaky tasks". They are enormously time consuming to identify and debug. Nx Cloud can **reliably detect flaky tasks** and **automatically schedule them to be re-run** on a different agent.
+A flaky task passes on one run and fails on the next with no change to its inputs. Flaky e2e tests
+are the most common case, but any [task](/docs/reference/glossary#task) can flake. For example,
+builds that reach for the network. A flaky task blocks a green pull request. The usual response is
+to hit rerun, which is slow and manual.
 
-Ideally as a developer you don't even notice flaky tasks any more as they're automatically re-run and solved for you.
+Nx Cloud detects flaky tasks and reruns them on a different agent automatically, so most of the
+time you never see the failure.
+
+## How Nx detects flaky tasks
+
+Nx uses its cache mechanism for detection.
+
+- Nx creates a **hash of all the inputs** for a task whenever it is run.
+- If Nx ever encounters a task that fails with a particular set of inputs and then succeeds with those same inputs, it marks that task as **flaky**.
+
+The hash pins the inputs, so a failure after a code change is not mistaken for a flake, and results
+from different machines and CI runs count as the same evidence. Detection works at the task level.
+A task can run a single Playwright spec file, a Jest project, or a whole suite, so the flag names
+the nondeterministic task, not an individual test inside it.
+
+Nx can't know with certainty when the task has been fixed to no longer be flaky, so if a particular task has **no flakiness incidents for 2 weeks**, the `flaky` flag is removed for that task.
 
 ## Enable flaky task detection
 
@@ -22,22 +41,18 @@ npx nx@latest connect
 
 See the [connect to Nx Cloud recipe](/docs/kb/setup-ci) for all the details.
 
-## How Nx identifies flaky tasks
+## Automatically re-run flaky tasks
 
-Nx leverages its cache mechanism to identify flaky tasks.
-
-- Nx creates a **hash of all the inputs** for a task whenever it is run.
-- If Nx ever encounters a task that fails with a particular set of inputs and then succeeds with those same inputs, Nx **knows for a fact that the task is flaky**.
-
-Nx can't know with certainty when the task has been fixed to no longer be flaky, so if a particular task has **no flakiness incidents for 2 weeks**, the `flaky` flag is removed for that task.
+When a flaky task fails in CI with [distributed task execution](/docs/features/ci-features/distribute-task-execution) enabled, Nx will **automatically send that task to a different agent** and run it again (up to 2 tries in total). It's important to run the task on a different agent to ensure that the agent itself or the other tasks that were run on that agent are not the reason for the flakiness.
 
 ![Flaky tasks in CI](../../../../assets/features/ci-features/flaky-tasks-ci.png)
 
-In this image, the `e2e-ci--src/e2e/app.cy.ts` task is a flaky task that has been automatically retried once. There is a `1 retry` indicator to show that it has been retried and, once expanded, you can see tabs that contain the logs for `Attempt 1` and `Attempt 2`. With this UI, you can easily compare the output between a successful and unsuccessful run of a flaky task.
+In this image, the `e2e-ci--src/e2e/app.cy.ts` task is a flaky task that has been automatically retried once. There is a `1 retry` indicator to show that it has been retried and, once expanded, you can see tabs that contain the logs for `Attempt 1` and `Attempt 2`. Comparing the output of a successful and an unsuccessful run side by side is usually where the cause shows up.
 
-## Automatically re-run flaky tasks
-
-When a flaky task fails in CI with [distributed task execution](/docs/features/ci-features/distribute-task-execution) enabled, Nx will **automatically send that task to a different agent** and run it again (up to 2 tries in total). Its important to run the task on a different agent to ensure that the agent itself or the other tasks that were run on that agent are not the reason for the flakiness.
+The narrower the task, the cheaper the retry. [Automated task splitting](/docs/features/ci-features/split-e2e-tasks)
+turns an e2e suite into one task per test file for `@nx/playwright`, `@nx/cypress`, `@nx/jest`, and
+`@nx/vitest`, so a single flaky spec file reruns on its own instead of dragging the whole suite
+with it.
 
 ## Flaky task analytics
 
@@ -45,54 +60,39 @@ When a flaky task fails in CI with [distributed task execution](/docs/features/c
 Workspace flaky task analytics is currently available for organizations on the Enterprise plan. Reach out if your organization is [interested in Nx Enterprise](https://nx.dev/enterprise?utm_source=nx.dev&utm_medium=callout&utm_campaign=flaky-task-analytics).
 {% /aside %}
 
-Nx Cloud provides analytics to help you understand and manage flaky tasks across your workspace. The analytics dashboard gives you insights into which tasks are flaky, how often they fail, and how much time is being wasted on reruns.
+Once a workspace has more flaky tasks than anyone will fix this week, the useful question is which
+one to fix first. The Nx Cloud dashboard ranks every flaky task in your workspace so you can work
+down the list instead of guessing.
 
 ![Flaky Tasks dashboard](../../../../assets/features/ci-features/nx-cloud-flaky-tasks-metrics-chart.avif)
 
-The dashboard displays key metrics over the time range selected (7 days vs 30 days) to give you a quick overview of your workspace health.
+The dashboard displays key metrics over the selected time range (7 days vs 30 days):
 
 - **Active flaky tasks** - The total number of tasks in your workspace that have a flake rate greater than 0 within the selected time window.
-- **Average flake rate** - A weighted average flake rate across all tasks in your workspace. This metric uses the sample size to weight each task's flake rate proportionally, so a task that ran 1000 times with 5% flake rate has more impact than one that ran 10 times with 50% flake rate.
-- **High risk tasks** - The number of tasks with a flake rate higher than 20%, indicating severe reliability issues that need immediate attention.
+- **Average flake rate** - A weighted average flake rate across all tasks in your workspace. A task that ran 1000 times with a 5% flake rate has more impact than one that ran 10 times with a 50% flake rate.
+- **High risk tasks** - The number of tasks with a flake rate higher than 20%.
 
-The chart shown provides a visual representation of your flaky tasks, helping you quickly identify which tasks need the most attention.
-
-Tasks are plotted based on their **impact score**, which is calculated as `flake_rate × sample_size`. This means frequently-run flaky tasks are weighted higher than rarely-run flaky tasks.
-
-Priority levels are determined using percentile-based thresholds that scale across organizations of any size:
-
-- **High priority** (red) - Top 10% of tasks by impact score (90th percentile and above). These tasks have severe flakiness and should be addressed immediately.
-- **Medium priority** (yellow) - Next 23% of tasks by impact score (67th-90th percentile). These tasks have moderate flakiness with sufficient data.
-- **Low priority** (gray) - Bottom 67% of tasks by impact score. These tasks have minor flakiness or not enough data to be concerning.
-
-Tasks on the right side of the chart typically represent the highest priority items that need attention. The scatter plot shows up to 50 results, sorted by most recent flaked tasks.
+Tasks are plotted by **impact score**, calculated as `flake_rate × sample_size`, so frequently-run
+flaky tasks are weighted higher than rarely-run ones.
 
 ### Flaky task table
 
-The table provides detailed information about each flaky task in your workspace:
-
 ![Flaky Tasks Analytics Table](../../../../assets/features/ci-features/nx-cloud-flaky-tasks-table.avif)
 
-By default, the table loads your most recent flaky tasks. Each row includes:
+Each row includes:
 
 - **Task** - The project and target combination (e.g., `my-app:test`)
-- **Flake rate** - Measures how often a task succeeds due to flakiness. Specifically, it represents the percentage of total successes that came from unreliable (flaky) task hashes: `flaky_successes / (flaky_successes + non_flaky_successes)`. This tells you: "Of all the times this task succeeded, how many successes came from unreliable code?"
-- **Total reruns** - The number of times a task was executed more than once due to flakiness. This counts the "extra" executions that happened because the task failed and needed to be retried. Calculated as: `total_executions - unique_hash_count`
-- **Time wasted** - An estimate of the total time spent on reruns, calculated by multiplying the total reruns by the average task duration
+- **Flake rate** - The percentage of total successes that came from unreliable (flaky) task hashes: `flaky_successes / (flaky_successes + non_flaky_successes)`
+- **Total reruns** - The number of extra executions caused by flakiness: `total_executions - unique_hash_count`
+- **Time wasted** - An estimate of the total time spent on reruns: total reruns multiplied by the average task duration
 - **Last failure** - The timestamp of the most recent failure across all contributing task hashes
 
-#### Flaky task detail view
-
-Click on any row in the table to view detailed information about a specific flaky task.
-
-The **Overview** tab shows summary statistics and trends for the selected task such as flake rate, time wasted and automatic deflake counts
+Click a row to open the detail view. The **Overview** tab shows flake rate, time wasted, and
+automatic deflake counts for the task, the **Activity** tab shows a timeline of failed and
+successful executions to jump into the runs, and the **Environments** tab shows where the task was
+executed to help identify whether certain environments contribute to the flakiness.
 
 ![Flaky Task Detail Overview](../../../../assets/features/ci-features/nx-cloud-flaky-tasks-details.avif)
 
-The **Activity** tab displays a timeline of all executions, showing when the task failed and succeeded to jump directly into the runs.
-
-![Flaky Task Detail Activity](../../../../assets/features/ci-features/nx-cloud-flaky-tasks-detail-activity.avif)
-
-The **Environments** tab provides insights into the different environments where the task was executed, helping identify if certain environments contribute to flakiness.
-
-![Flaky Task Detail Environments](../../../../assets/features/ci-features/nx-cloud-flaky-tasks-detail-environment.avif)
+Comparing a failed attempt against a successful one is usually where the cause shows up. [Find and
+fix flaky tests](/docs/kb/flaky-tests-in-ci) covers the common causes and how to fix them.

--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -18,7 +18,7 @@ Certain tasks like end-to-end (e2e) tests, integration tests, or large unit test
 Manually splitting these slow tasks can be complex and require ongoing maintenance. Nx Atomizer solves this by **automatically generating runnable targets for each test file**. For example, a task that takes 10 minutes can be split and distributed as five 2-minute tasks per agent. This allows for:
 
 - parallelization across multiple machines with [Nx Agents](/docs/features/ci-features/distribute-task-execution)
-- faster [flakiness detection & retries](/docs/features/ci-features/flaky-tasks) by isolating and re-running only the failed tests
+- faster [flaky test detection & retries](/docs/features/ci-features/flaky-tasks) by isolating and re-running only the failed tests
 
 ## Enable automated task splitting
 

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -30,7 +30,7 @@ Nx:
 2. **Understands your codebase** - Builds [project and task graphs](/docs/features/explore-graph) showing how everything connects.
 3. **Orchestrates intelligently** - Runs tasks in the [right order](/docs/concepts/task-pipeline-configuration), parallelizing when possible.
 4. **Enforces boundaries** - [Module boundary rules](/docs/features/enforce-module-boundaries) prevent unwanted dependencies between projects.
-5. **Handles flakiness** - [Automatically re-runs flaky tasks](/docs/features/ci-features/flaky-tasks) and [self-heals CI failures](/docs/features/ci-features/self-healing-ci).
+5. **Handles flakiness** - [Automatically detects and re-runs flaky tests](/docs/features/ci-features/flaky-tasks) and [self-heals CI failures](/docs/features/ci-features/self-healing-ci).
 
 ## Start small, grow as needed
 

--- a/astro-docs/src/content/docs/guides/Nx Cloud/optimize-your-ttg.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/optimize-your-ttg.mdoc
@@ -93,8 +93,8 @@ Once feedback and context switching are handled, compress the compute side.
 
 **Flaky task rate is high**
 
-- Enable [Flaky task detection and automatic retries](/docs/features/ci-features/flaky-tasks).
-- [Find and fix flaky CI tasks](/docs/kb/flaky-tests-in-ci) before they consume more pipeline time.
+- Enable [flaky test detection and automatic retries](/docs/features/ci-features/flaky-tasks).
+- [Find and fix flaky tests](/docs/kb/flaky-tests-in-ci) before they consume more pipeline time.
 
 **Late failure discovery / PR babysitting**
 

--- a/astro-docs/src/content/docs/kb/flaky-tests-in-ci.mdoc
+++ b/astro-docs/src/content/docs/kb/flaky-tests-in-ci.mdoc
@@ -1,6 +1,6 @@
 ---
-title: 'Flaky Tests in CI: Detection and Remediation'
-description: 'Learn how to detect, isolate, and fix flaky tests in CI without rerunning an entire pipeline.'
+title: 'What Is a Flaky Test? Causes, Detection, and Fixes'
+description: 'A flaky test passes and fails on the same code. Learn what causes flaky tests, how to detect them in CI, and how to fix the common patterns.'
 sidebar:
   label: Flaky Tests in CI
 filter: 'type:Guides'
@@ -8,29 +8,15 @@ topics:
   - 'Continuous integration'
 ---
 
-Most developers have seen this CI problem: a test fails, then passes after a rerun, even though the
-code did not change.
+A **flaky test** is a test that passes on one run and fails on another without any change to the
+code under test or to the test itself. Its result is nondeterministic, so the same commit can
+produce a green pipeline and a red one.
 
-That is a flaky test. The pull request is green again, but the failure still matters. Treat the
-passing retry as evidence to investigate, not proof that the problem disappeared.
+Most developers meet one the same way: CI fails, they hit rerun, the build goes green, and the pull
+request merges. The failure still matters. Treat the passing retry as evidence to investigate, not
+as proof that the problem disappeared.
 
-## A passing retry does not clear a failure
-
-A flaky test passes and fails with the same inputs. Its result can change because of shared state,
-timing, test order, a port collision, or an external service.
-
-A failure after a source or configuration change may be a regression instead. Fix a failure that
-reproduces with the changed inputs. Do not retry it until it passes.
-
-## Stop rerunning the whole pipeline
-
-A full-pipeline retry repeats work that already passed. It wastes compute, delays feedback, and
-makes failing CI easier to ignore.
-
-Re-run the failed test or test task by itself. A narrow retry gives you a cleaner result and keeps
-the rest of the pipeline moving.
-
-## Check the common causes
+## What causes flaky tests
 
 Most flakes match one of these patterns:
 
@@ -42,26 +28,63 @@ Most flakes match one of these patterns:
 | Test-order dependence | A different order changes the result.                      | Make each test create and clean up its own prerequisites.                    |
 | External services     | Network, API, or third-party failures appear in the logs.  | Stub the dependency where practical, or isolate and monitor the integration. |
 
-Manual investigation limits wasted work, but teams also need reliable evidence across CI runs. Nx
-provides that evidence and automates narrow retries.
+A failure after a source or configuration change may be a regression instead. Fix a failure that
+reproduces with the changed inputs. Do not retry it until it passes.
 
-## Detect and retry flaky tasks with Nx Cloud
+## How to fix a flaky test
+
+Work through the failed test in this order:
+
+1. Re-run the failed test or test task by itself. A full-pipeline retry repeats work that already passed, wastes compute, and delays the result.
+2. Compare the failed attempt with the successful attempt.
+3. Check the logs, machine image, environment values, network calls, and test order.
+4. Fix the cause that differs between attempts, using the table above to narrow it down.
+5. Quarantine the test only when the team cannot fix it immediately.
+
+Record an owner and review date for each quarantine. A quarantine protects the pipeline, but it
+also reduces test coverage.
+
+## Flaky tests in Playwright, Cypress, Jest, and Vitest
+
+End-to-end tests flake more than unit tests because they carry real browsers, real servers, and
+real network calls. Both major e2e runners can retry a failed test - `retries` in
+`playwright.config.ts`, and `retries` (with separate `runMode` and `openMode` values) in the Cypress
+config. Playwright even labels a fail-then-pass result as flaky in its report.
+
+A framework retry runs on the same machine, so a port conflict or a process leaked by an earlier
+test is still there when the test runs again. The record is also scoped to one run's report, and
+nothing accumulates into a picture of which tests flake the most across your CI.
+
+Nx Cloud retries on a different machine to rule out the environment, and tracks results per task
+across runs. [Automated task splitting](/docs/features/ci-features/split-e2e-tasks) creates one
+task per test file for `@nx/playwright`, `@nx/cypress`, `@nx/jest`, and `@nx/vitest`, so only the
+failed spec file runs again.
+
+## A passing retry does not clear a failure
+
+A rerun that goes green tells you the test is nondeterministic. It does not tell you which of the
+patterns above caused it, and it does not tell you whether the underlying race can also corrupt
+production behavior. Teams need evidence that survives across CI runs rather than one developer's
+recollection that "that one is always flaky".
+
+## Detect flaky tests automatically with Nx Cloud
 
 Nx runs a test command as a task. A task can run one test file, a group of files, or an entire
 test suite. Nx creates a hash from that task's inputs each time it runs.
 
-When one task hash both fails and succeeds, Nx Cloud knows that task is flaky. This is stronger
-evidence than a retry count. A test that fails once after a new commit may be a regression. A task
-that passes and fails with one hash is nondeterministic.
+When one task hash both fails and succeeds, Nx Cloud knows that task is flaky. A task that fails
+once after a new commit has a new hash and may be a regression.
+A task that passes and fails with one hash - even on different machines, days apart - is
+nondeterministic.
 
 When a known flaky task fails, Nx Cloud sends it to a different [Nx Agent](/docs/features/ci-features/distribute-task-execution).
 It makes at most two attempts in total. The retry targets the failed work instead of the complete
 pipeline.
 
-[Enable flaky task detection](/docs/features/ci-features/flaky-tasks) to use this behavior in your
+[Enable flaky test detection](/docs/features/ci-features/flaky-tasks) to use this behavior in your
 CI pipeline.
 
-## Use flaky task analytics to choose what to fix
+## Choose which flaky test to fix first
 
 ![Flaky task analytics in Nx Cloud](../../../assets/features/ci-features/nx-cloud-flaky-tasks-metrics-chart.avif)
 
@@ -70,29 +93,8 @@ tasks by impact, which combines a task's flake rate with how often it runs.
 
 Start with a frequently run task that fails often. It blocks more pull requests and wastes more CI
 time than a task with one isolated failure. Open the task to inspect its attempts, logs, and
-execution environments before you change the test.
-
-## Fix the flaky task
-
-Use the attempt details from Nx Cloud and work through the failed task in this order:
-
-1. Re-run the failed test or test task by itself.
-2. Compare the failed attempt with the successful attempt.
-3. Check the logs, machine image, environment values, network calls, and test order.
-4. Fix the cause that differs between attempts.
-5. Quarantine the test only when the team cannot fix it immediately.
-
-Record an owner and review date for each quarantine. A quarantine protects the pipeline, but it
-also reduces test coverage.
-
-## Make e2e retries smaller with Nx
-
-A failed spec should not re-run a 40-minute e2e suite. Nx can split a large suite into independently
-runnable file-level tasks. Then Nx Cloud can retry the failed spec and leave successful specs alone.
-
-[Automated task splitting](/docs/features/ci-features/split-e2e-tasks) creates one task per test
-file for supported Nx plugins. Fix hidden shared state before you distribute a suite across workers
-or machines.
+execution environments before you change the test. The dashboard is part of [flaky task
+analytics](/docs/features/ci-features/flaky-tasks#flaky-task-analytics) in Nx Cloud.
 
 ## Keep task inputs complete
 

--- a/astro-docs/src/content/docs/kb/monorepo-ci-best-practices.mdoc
+++ b/astro-docs/src/content/docs/kb/monorepo-ci-best-practices.mdoc
@@ -393,7 +393,7 @@ A general approach needs three things, in order of preference:
 A task cache makes the first one tractable, because "identical inputs" is already the cache key.
 Nx Cloud [detects flaky tasks](/docs/features/ci-features/flaky-tasks) from that history, re-runs
 only those tasks instead of the whole pipeline, and puts them on a different agent so an environment
-problem doesn't reproduce itself. [Find and fix flaky CI tasks](/docs/kb/flaky-tests-in-ci) before
+problem doesn't reproduce itself. [Find and fix flaky tests](/docs/kb/flaky-tests-in-ci) before
 they force another full-pipeline retry.
 
 ## Use trunk-based development

--- a/astro-docs/src/content/docs/reference/glossary.mdoc
+++ b/astro-docs/src/content/docs/reference/glossary.mdoc
@@ -103,13 +103,13 @@ A script that performs some action on your code. This can include building, lint
 
 A metric that measures how often a task succeeds due to flakiness rather than reliable code. It represents the percentage of total successes that came from unreliable (flaky) task hashes: `flaky_successes / (flaky_successes + non_flaky_successes)`. This answers the question: "Of all the times this task succeeded, how many successes came from unreliable code?"
 
-> See: [Flaky Task Analytics](/docs/features/ci-features/flaky-tasks#flaky-task-analytics)
+> See: [Flaky task analytics](/docs/features/ci-features/flaky-tasks#flaky-task-analytics)
 
 ### Flaky tasks
 
 Tasks that will sometimes succeed and sometimes fail without any change to the inputs. These tasks are often e2e tests and are particularly problematic in CI. Nx Cloud automatically detects flaky tasks and re-runs them.
 
-> See: [Identify and Re-run Flaky Tasks](/docs/features/ci-features/flaky-tasks)
+> See: [Detect and Retry Flaky Tasks](/docs/features/ci-features/flaky-tasks)
 
 ### Generator
 
@@ -127,7 +127,7 @@ A computer science concept that consists of nodes connected by edges. In the Nx 
 
 A metric used in [Flaky Task Analytics](#flaky-tasks) to prioritize which flaky tasks need attention. Calculated as `flake_rate × sample_size`, it weights frequently-run flaky tasks higher than rarely-run flaky tasks. For example, a task with 50% flake rate and 100 runs has an impact score of 50, the same as a task with 10% flake rate and 500 runs.
 
-> See: [Flaky Task Analytics](/docs/features/ci-features/flaky-tasks#flaky-task-analytics)
+> See: [Flaky task analytics](/docs/features/ci-features/flaky-tasks#flaky-task-analytics)
 
 ### Launch template
 


### PR DESCRIPTION
## Current Behavior

Flaky docs use "flaky task" exclusively; search volume (~1900/mo) is on "flaky test". The feature page ranks for zero US keywords.

## Expected Behavior

Previews:

- https://deploy-preview-36732--nx-docs.netlify.app/docs/features/ci-features/flaky-tasks
- https://deploy-preview-36732--nx-docs.netlify.app/docs/kb/flaky-tests-in-ci

**features/CI Features/flaky-tasks.mdoc**

- Retitled "Detect and Retry Flaky Tasks". "flaky test detection" (46/mo, KD 9) is the only verb-form query with volume, so "detect" replaces "identify". Task vocabulary stays - builds and e2e can be flaky too - but the description and intro now mention flaky tests (previously zero mentions on the page).
- Detection section renamed "How Nx detects flaky tasks" and promoted to first H2: it is the differentiator (task-level hash correlation across CI runs), so it leads instead of the setup instructions.
- Enterprise analytics section shortened to under half the page but keeps the full outline (metrics, table, detail view) since there is no preview outside the Enterprise plan.

**kb/flaky-tests-in-ci.mdoc**

- Retitled "What Is a Flaky Test? Causes, Detection, and Fixes". Definition-first opening for AI Overview extraction; this page owns the head cluster ("flaky test", "what is a flaky test").
- Added causes table, fix checklist, and a Playwright/Cypress/Jest/Vitest section (playwright 80/mo, cypress 20, jest 0 - sections instead of the standalone pages the issue proposed).
- Framework retry comparison: framework retries rerun on the same machine and their record is scoped to one run's report; Nx Cloud retries on a different machine and tracks results across runs (Playwright does label flaky results in its own report).

Other pages: anchor text on 5 inbound links switched to "flaky test" wording (internal anchor text is a relevance signal for the target page); glossary links follow the new title and anchor.

## Related Issue(s)

Fixes DOC-586
