### PR TITLE
fix(core): point duplicate project names from worktrees at the fix

### DIFF
--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -3,6 +3,7 @@ import { ProjectConfiguration } from '../config/workspace-json-project-json';
 import { CreateNodesFunction } from './plugins/public-api';
 import { ConfigurationResult } from './utils/project-configuration-utils';
 import type { ConfigurationSourceMaps } from './utils/project-configuration/source-maps';
+import type { WorktreeConflictAdvice } from '../utils/git-worktrees';
 
 export type ProjectGraphErrorTypes =
   | AggregateCreateNodesError
@@ -110,10 +111,10 @@ export class MultipleProjectsWithSameNameError extends Error {
     public conflicts: Map<string, string[]>,
     public projects: Record<string, ProjectConfiguration>,
     /**
-     * Paths to ignore when the duplicates come from git worktrees nested in
-     * the workspace, which is a different fix than renaming them.
+     * Set when some of the duplicates come from git worktrees nested in the
+     * workspace, which is a different fix than renaming them.
      */
-    public worktreeIgnoreTargets?: string[]
+    public worktreeAdvice?: WorktreeConflictAdvice
   ) {
     super(
       [
@@ -122,21 +123,30 @@ export class MultipleProjectsWithSameNameError extends Error {
           [`- ${project}: `, ...roots.map((r) => `  - ${r}`)].join('\n')
         ),
         '',
-        ...(worktreeIgnoreTargets?.length
+        ...(worktreeAdvice?.ignoreTargets.length
           ? [
               'Some of these are inside git worktrees nested in this workspace. A worktree is a full checkout, so every project in it collides with the one it was checked out from.',
               '',
-              `To fix this, add the following to .gitignore:`,
-              ...worktreeIgnoreTargets.map((target) => `  ${target}`),
+              'To fix those, add the following to .gitignore:',
+              ...worktreeAdvice.ignoreTargets.map((target) => `  ${target}`),
+              // Ignoring the worktrees settles only the duplicates they
+              // explain; anything left is an ordinary name collision and still
+              // needs the ordinary answer.
+              ...(worktreeAdvice.explainsAllConflicts
+                ? []
+                : ['', `The rest are not from worktrees. ${RENAME_ADVICE}`]),
             ]
           : [
-              "To fix this, set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name.",
+              `To fix this, ${RENAME_ADVICE[0].toLowerCase()}${RENAME_ADVICE.slice(1)}`,
             ]),
       ].join('\n')
     );
     this.name = this.constructor.name;
   }
 }
+
+const RENAME_ADVICE =
+  "Set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name.";
 
 export class ProjectWithExistingNameError extends Error {
   constructor(

--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -127,7 +127,10 @@ export class MultipleProjectsWithSameNameError extends Error {
           ? [
               'Some of these are inside git worktrees nested in this workspace. A worktree is a full checkout, so every project in it collides with the one it was checked out from.',
               '',
-              'To fix those, add the following to .gitignore:',
+              // Which `.gitignore` matters: a leading slash anchors to the
+              // directory holding the file, and these paths are relative to
+              // the workspace, which is not always the repository root.
+              'To fix those, add the following to the .gitignore in the workspace root:',
               ...worktreeAdvice.ignoreTargets.map((target) => `  ${target}`),
               // Ignoring the worktrees settles only the duplicates they
               // explain; anything left is an ordinary name collision and still

--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -108,7 +108,12 @@ export class ProjectGraphError extends Error {
 export class MultipleProjectsWithSameNameError extends Error {
   constructor(
     public conflicts: Map<string, string[]>,
-    public projects: Record<string, ProjectConfiguration>
+    public projects: Record<string, ProjectConfiguration>,
+    /**
+     * Paths to ignore when the duplicates come from git worktrees nested in
+     * the workspace, which is a different fix than renaming them.
+     */
+    public worktreeIgnoreTargets?: string[]
   ) {
     super(
       [
@@ -117,7 +122,16 @@ export class MultipleProjectsWithSameNameError extends Error {
           [`- ${project}: `, ...roots.map((r) => `  - ${r}`)].join('\n')
         ),
         '',
-        "To fix this, set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name.",
+        ...(worktreeIgnoreTargets?.length
+          ? [
+              'Some of these are inside git worktrees nested in this workspace. A worktree is a full checkout, so every project in it collides with the one it was checked out from.',
+              '',
+              `To fix this, add the following to .gitignore:`,
+              ...worktreeIgnoreTargets.map((target) => `  ${target}`),
+            ]
+          : [
+              "To fix this, set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name.",
+            ]),
       ].join('\n')
     );
     this.name = this.constructor.name;

--- a/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
@@ -11,6 +11,8 @@ import {
   resolveCommandSyntacticSugar,
 } from './target-merging';
 import { validateProject } from './target-normalization';
+import { analyzeWorktreeConflicts } from '../../../utils/git-worktrees';
+import { workspaceRoot as workspaceRootDefault } from '../../../utils/workspace-root';
 import { ProjectNameInNodePropsManager } from './name-substitution-manager';
 import type { ConfigurationSourceMaps, SourceInformation } from './source-maps';
 import {
@@ -229,7 +231,8 @@ export function mergeProjectConfigurationIntoRootMap(
 }
 
 export function readProjectConfigurationsFromRootMap(
-  projectRootMap: Record<string, ProjectConfiguration>
+  projectRootMap: Record<string, ProjectConfiguration>,
+  workspaceRoot: string = workspaceRootDefault
 ) {
   const projects: Record<string, ProjectConfiguration> = {};
   // If there are projects that have the same name, that is an error.
@@ -263,7 +266,13 @@ export function readProjectConfigurationsFromRootMap(
   }
 
   if (conflicts.size > 0) {
-    throw new MultipleProjectsWithSameNameError(conflicts, projects);
+    // Only on the way to throwing, so a workspace without duplicates never
+    // pays for reading git's worktree registry.
+    throw new MultipleProjectsWithSameNameError(
+      conflicts,
+      projects,
+      analyzeWorktreeConflicts(workspaceRoot, conflicts) ?? undefined
+    );
   }
   if (projectRootsWithNoName.length > 0) {
     throw new ProjectsWithNoNameError(projectRootsWithNoName, projects);

--- a/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
@@ -12,7 +12,7 @@ import {
 } from './target-merging';
 import { validateProject } from './target-normalization';
 import { analyzeWorktreeConflicts } from '../../../utils/git-worktrees';
-import { workspaceRoot as workspaceRootDefault } from '../../../utils/workspace-root';
+import { workspaceRoot } from '../../../utils/workspace-root';
 import { ProjectNameInNodePropsManager } from './name-substitution-manager';
 import type { ConfigurationSourceMaps, SourceInformation } from './source-maps';
 import {
@@ -231,8 +231,7 @@ export function mergeProjectConfigurationIntoRootMap(
 }
 
 export function readProjectConfigurationsFromRootMap(
-  projectRootMap: Record<string, ProjectConfiguration>,
-  workspaceRoot: string = workspaceRootDefault
+  projectRootMap: Record<string, ProjectConfiguration>
 ) {
   const projects: Record<string, ProjectConfiguration> = {};
   // If there are projects that have the same name, that is an error.

--- a/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { TempFs } from '../../../internal-testing-utils/temp-fs';
 import * as executorUtils from '../../../command-line/run/executor-utils';
 import type { NxJsonConfiguration } from '../../../config/nx-json';
@@ -141,6 +144,36 @@ describe('validateAndNormalizeProjectRootMap', () => {
     expect(() =>
       validateAndNormalizeProjectRootMap(tempFs.tempDir, projectRootMap, {})
     ).toThrow(AggregateError);
+  });
+
+  it('should point a duplicate coming from a worktree at the directory to ignore', () => {
+    // A worktree is a full checkout, so every project in it duplicates the one
+    // it came from. Renaming is the wrong advice - the copy shouldn't be walked.
+    const metadataDir = join(tempFs.tempDir, '.git', 'worktrees', 'wt');
+    const checkout = join(tempFs.tempDir, '.claude', 'worktrees', 'wt');
+    mkdirSync(metadataDir, { recursive: true });
+    mkdirSync(checkout, { recursive: true });
+    writeFileSync(join(metadataDir, 'gitdir'), `${join(checkout, '.git')}\n`);
+    writeFileSync(join(checkout, '.git'), `gitdir: ${metadataDir}\n`);
+
+    const projectRootMap = {
+      'libs/ui': { name: 'ui', root: 'libs/ui' },
+      '.claude/worktrees/wt/libs/ui': {
+        name: 'ui',
+        root: '.claude/worktrees/wt/libs/ui',
+      },
+    };
+
+    let message = '';
+    try {
+      validateAndNormalizeProjectRootMap(tempFs.tempDir, projectRootMap, {});
+    } catch (e) {
+      message = (e as AggregateError).errors[0].message;
+    }
+
+    expect(message).toContain('git worktrees nested in this workspace');
+    expect(message).toContain('.claude/worktrees');
+    expect(message).not.toContain('set a unique name');
   });
 });
 

--- a/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
@@ -175,7 +175,7 @@ describe('validateAndNormalizeProjectRootMap', () => {
     // pin the advice line itself - matching the path alone passes with the
     // advice deleted entirely.
     expect(message).toContain(
-      'To fix those, add the following to .gitignore:\n  /.claude/worktrees/wt'
+      'add the following to the .gitignore in the workspace root:\n  /.claude/worktrees/wt'
     );
     expect(message).toContain('git worktrees nested in this workspace');
     // Nothing is left over, so the reader is not also told to rename anything.

--- a/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
@@ -175,7 +175,7 @@ describe('validateAndNormalizeProjectRootMap', () => {
     // pin the advice line itself - matching the path alone passes with the
     // advice deleted entirely.
     expect(message).toContain(
-      'To fix those, add the following to .gitignore:\n  .claude/worktrees/wt'
+      'To fix those, add the following to .gitignore:\n  /.claude/worktrees/wt'
     );
     expect(message).toContain('git worktrees nested in this workspace');
     // Nothing is left over, so the reader is not also told to rename anything.

--- a/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
@@ -171,9 +171,47 @@ describe('validateAndNormalizeProjectRootMap', () => {
       message = (e as AggregateError).errors[0].message;
     }
 
+    // The bare path also appears in the list of conflicting roots above, so
+    // pin the advice line itself - matching the path alone passes with the
+    // advice deleted entirely.
+    expect(message).toContain(
+      'To fix those, add the following to .gitignore:\n  .claude/worktrees/wt'
+    );
     expect(message).toContain('git worktrees nested in this workspace');
-    expect(message).toContain('.claude/worktrees');
-    expect(message).not.toContain('set a unique name');
+    // Nothing is left over, so the reader is not also told to rename anything.
+    expect(message).not.toContain('Set a unique name');
+  });
+
+  it('should still ask for a rename for the duplicates a worktree does not explain', () => {
+    const metadataDir = join(tempFs.tempDir, '.git', 'worktrees', 'wt');
+    const checkout = join(tempFs.tempDir, '.claude', 'worktrees', 'wt');
+    mkdirSync(metadataDir, { recursive: true });
+    mkdirSync(checkout, { recursive: true });
+    writeFileSync(join(metadataDir, 'gitdir'), `${join(checkout, '.git')}\n`);
+    writeFileSync(join(checkout, '.git'), `gitdir: ${metadataDir}\n`);
+
+    const projectRootMap = {
+      'libs/ui': { name: 'ui', root: 'libs/ui' },
+      '.claude/worktrees/wt/libs/ui': {
+        name: 'ui',
+        root: '.claude/worktrees/wt/libs/ui',
+      },
+      'apps/a': { name: 'dup', root: 'apps/a' },
+      'apps/b': { name: 'dup', root: 'apps/b' },
+    };
+
+    let message = '';
+    try {
+      validateAndNormalizeProjectRootMap(tempFs.tempDir, projectRootMap, {});
+    } catch (e) {
+      message = (e as AggregateError).errors[0].message;
+    }
+
+    // `dup` is an ordinary collision listed alongside the worktree one, and
+    // would otherwise be named and then left with no remedy.
+    expect(message).toContain('git worktrees nested in this workspace');
+    expect(message).toContain('The rest are not from worktrees.');
+    expect(message).toContain('Set a unique name');
   });
 });
 

--- a/packages/nx/src/project-graph/utils/project-configuration/target-normalization.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-normalization.ts
@@ -32,6 +32,7 @@ import {
 import type { ConfigurationSourceMaps } from './source-maps';
 
 import { existsSync } from 'node:fs';
+import { worktreeIgnoreTarget } from '../../../utils/git-worktrees';
 import { join } from 'path';
 
 export function validateProject(
@@ -409,7 +410,19 @@ export function validateAndNormalizeProjectRootMap(
   const errors: Error[] = [];
 
   if (conflicts.size > 0) {
-    errors.push(new MultipleProjectsWithSameNameError(conflicts, projects));
+    // Only on the way to throwing, so a workspace without duplicates never
+    // pays for reading git's worktree registry.
+    const worktreeIgnoreTargets = worktreeIgnoreTarget(
+      workspaceRoot,
+      Array.from(conflicts.values()).flat()
+    );
+    errors.push(
+      new MultipleProjectsWithSameNameError(
+        conflicts,
+        projects,
+        worktreeIgnoreTargets ?? undefined
+      )
+    );
   }
   if (projectRootsWithNoName.length > 0) {
     errors.push(new ProjectsWithNoNameError(projectRootsWithNoName, projects));

--- a/packages/nx/src/project-graph/utils/project-configuration/target-normalization.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-normalization.ts
@@ -32,7 +32,7 @@ import {
 import type { ConfigurationSourceMaps } from './source-maps';
 
 import { existsSync } from 'node:fs';
-import { worktreeIgnoreTarget } from '../../../utils/git-worktrees';
+import { analyzeWorktreeConflicts } from '../../../utils/git-worktrees';
 import { join } from 'path';
 
 export function validateProject(
@@ -412,15 +412,12 @@ export function validateAndNormalizeProjectRootMap(
   if (conflicts.size > 0) {
     // Only on the way to throwing, so a workspace without duplicates never
     // pays for reading git's worktree registry.
-    const worktreeIgnoreTargets = worktreeIgnoreTarget(
-      workspaceRoot,
-      Array.from(conflicts.values()).flat()
-    );
+    const worktreeAdvice = analyzeWorktreeConflicts(workspaceRoot, conflicts);
     errors.push(
       new MultipleProjectsWithSameNameError(
         conflicts,
         projects,
-        worktreeIgnoreTargets ?? undefined
+        worktreeAdvice ?? undefined
       )
     );
   }

--- a/packages/nx/src/utils/git-worktrees.spec.ts
+++ b/packages/nx/src/utils/git-worktrees.spec.ts
@@ -51,6 +51,57 @@ describe('git worktrees', () => {
     });
   });
 
+  describe('when the workspace sits below the git root', () => {
+    // An Nx workspace nested in a larger repository is ordinary. Its worktrees
+    // are registered against the repository, so looking only at
+    // `<workspace>/.git` finds no registry and the reader gets the base
+    // message with no mention of worktrees.
+    let repoRoot: string;
+    let workspace: string;
+
+    beforeEach(() => {
+      repoRoot = mkdtempSync(join(tmpdir(), 'nx-repo-'));
+      mkdirSync(join(repoRoot, '.git'), { recursive: true });
+      workspace = join(repoRoot, 'tools', 'workspace');
+      mkdirSync(workspace, { recursive: true });
+    });
+
+    function registerAt(name: string, absoluteRoot: string) {
+      const metadataDir = join(repoRoot, '.git', 'worktrees', name);
+      mkdirSync(metadataDir, { recursive: true });
+      mkdirSync(absoluteRoot, { recursive: true });
+      writeFileSync(
+        join(metadataDir, 'gitdir'),
+        `${join(absoluteRoot, '.git')}\n`
+      );
+      writeFileSync(join(absoluteRoot, '.git'), `gitdir: ${metadataDir}\n`);
+    }
+
+    it('finds a worktree nested inside the workspace', () => {
+      registerAt('wt', join(workspace, '.claude', 'worktrees', 'wt'));
+
+      expect(nestedWorktreeRoots(workspace)).toEqual(['.claude/worktrees/wt']);
+    });
+
+    it('drops a worktree that is in the repo but outside the workspace', () => {
+      // The walker never reaches it, so it cannot be causing the duplicate.
+      registerAt('elsewhere', join(repoRoot, 'other', 'wt'));
+
+      expect(nestedWorktreeRoots(workspace)).toEqual([]);
+    });
+
+    it('advises on a duplicate coming from the nested worktree', () => {
+      registerAt('wt', join(workspace, '.claude', 'worktrees', 'wt'));
+
+      expect(
+        analyzeWorktreeConflicts(
+          workspace,
+          new Map([['ui', ['libs/ui', '.claude/worktrees/wt/libs/ui']]])
+        )!.ignoreTargets
+      ).toEqual(['/.claude/worktrees/wt']);
+    });
+  });
+
   describe('when the workspace is itself a linked worktree', () => {
     // Real layout: someone opens an agent worktree and runs Nx there, then
     // tooling makes more worktrees inside it. `.git` is a gitfile, so the

--- a/packages/nx/src/utils/git-worktrees.spec.ts
+++ b/packages/nx/src/utils/git-worktrees.spec.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { nestedWorktreeRoots, worktreeIgnoreTarget } from './git-worktrees';
+
+describe('git worktrees', () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'nx-worktrees-'));
+    mkdirSync(join(workspaceRoot, '.git'), { recursive: true });
+  });
+
+  /**
+   * Lays out a linked worktree the way `git worktree add` does: a registration
+   * naming the checkout, and a gitfile in the checkout naming it back.
+   */
+  function registerWorktree(name: string, root: string) {
+    const metadataDir = join(workspaceRoot, '.git', 'worktrees', name);
+    const checkout = join(workspaceRoot, root);
+    mkdirSync(metadataDir, { recursive: true });
+    mkdirSync(checkout, { recursive: true });
+    writeFileSync(join(metadataDir, 'gitdir'), `${join(checkout, '.git')}\n`);
+    writeFileSync(join(checkout, '.git'), `gitdir: ${metadataDir}\n`);
+  }
+
+  describe('nestedWorktreeRoots', () => {
+    it('finds worktrees registered inside the workspace', () => {
+      registerWorktree('wt', '.claude/worktrees/wt');
+
+      expect(nestedWorktreeRoots(workspaceRoot)).toEqual([
+        '.claude/worktrees/wt',
+      ]);
+    });
+
+    it('returns nothing when the repo has no worktrees', () => {
+      expect(nestedWorktreeRoots(workspaceRoot)).toEqual([]);
+    });
+
+    it('drops a worktree checked out beside the workspace', () => {
+      // `git worktree add ../elsewhere` is ordinary, and nothing walks it.
+      const metadataDir = join(workspaceRoot, '.git', 'worktrees', 'outside');
+      const checkout = join(workspaceRoot, '..', 'outside-wt');
+      mkdirSync(metadataDir, { recursive: true });
+      mkdirSync(checkout, { recursive: true });
+      writeFileSync(join(metadataDir, 'gitdir'), `${join(checkout, '.git')}\n`);
+      writeFileSync(join(checkout, '.git'), `gitdir: ${metadataDir}\n`);
+
+      expect(nestedWorktreeRoots(workspaceRoot)).toEqual([]);
+    });
+  });
+
+  describe('worktreeIgnoreTarget', () => {
+    it('names the directory holding the worktrees', () => {
+      registerWorktree('one', '.claude/worktrees/one');
+      registerWorktree('two', '.claude/worktrees/two');
+
+      expect(
+        worktreeIgnoreTarget(workspaceRoot, [
+          'packages/app',
+          '.claude/worktrees/one/packages/app',
+        ])
+      ).toEqual(['.claude/worktrees']);
+    });
+
+    it('names the worktrees themselves when their directory holds anything else', () => {
+      // Ignoring the directory would drop `notes` from the graph too.
+      registerWorktree('one', 'trees/one');
+      mkdirSync(join(workspaceRoot, 'trees/notes'), { recursive: true });
+
+      expect(
+        worktreeIgnoreTarget(workspaceRoot, ['libs/a', 'trees/one/libs/a'])
+      ).toEqual(['trees/one']);
+    });
+
+    it('names the worktrees themselves when they share no directory', () => {
+      // Their common parent is the workspace root, which is never the answer.
+      registerWorktree('one', 'wt1');
+      registerWorktree('two', 'nested/wt2');
+
+      expect(
+        worktreeIgnoreTarget(workspaceRoot, ['wt1/libs/a', 'nested/wt2/libs/a'])
+      ).toEqual(['wt1', 'nested/wt2']);
+    });
+
+    it('stays out of the way when the duplicates are not from worktrees', () => {
+      registerWorktree('one', '.claude/worktrees/one');
+
+      expect(
+        worktreeIgnoreTarget(workspaceRoot, ['packages/a', 'packages/b'])
+      ).toBeNull();
+    });
+
+    it('stays out of the way when there are no worktrees at all', () => {
+      expect(
+        worktreeIgnoreTarget(workspaceRoot, ['packages/a', 'packages/b'])
+      ).toBeNull();
+    });
+
+    it('does not read a sibling whose name merely starts the same', () => {
+      registerWorktree('one', 'trees/wt');
+      mkdirSync(join(workspaceRoot, 'trees/wt-other'), { recursive: true });
+
+      expect(
+        worktreeIgnoreTarget(workspaceRoot, ['trees/wt-other/libs/a'])
+      ).toBeNull();
+    });
+  });
+});

--- a/packages/nx/src/utils/git-worktrees.spec.ts
+++ b/packages/nx/src/utils/git-worktrees.spec.ts
@@ -34,6 +34,14 @@ describe('git worktrees', () => {
       ]);
     });
 
+    it('keeps a directory whose name merely begins with dots', () => {
+      // `..hidden` is an ordinary directory inside the workspace. Only a
+      // leading `..` *segment* means the path climbed out of it.
+      registerWorktree('dots', '..hidden/wt');
+
+      expect(nestedWorktreeRoots(workspaceRoot)).toEqual(['..hidden/wt']);
+    });
+
     it('returns nothing when the repo has no worktrees', () => {
       expect(nestedWorktreeRoots(workspaceRoot)).toEqual([]);
     });

--- a/packages/nx/src/utils/git-worktrees.spec.ts
+++ b/packages/nx/src/utils/git-worktrees.spec.ts
@@ -51,6 +51,73 @@ describe('git worktrees', () => {
     });
   });
 
+  describe('when the workspace is itself a linked worktree', () => {
+    // Real layout: someone opens an agent worktree and runs Nx there, then
+    // tooling makes more worktrees inside it. `.git` is a gitfile, so the
+    // registry is only reachable by following `commondir` back to the main
+    // repository - every worktree of a repo shares one registry.
+    let mainRepo: string;
+    let nestedWorkspace: string;
+
+    beforeEach(() => {
+      mainRepo = mkdtempSync(join(tmpdir(), 'nx-main-'));
+      const mainGitDir = join(mainRepo, '.git');
+      mkdirSync(mainGitDir, { recursive: true });
+
+      // The workspace we run in is a worktree of `mainRepo`.
+      nestedWorkspace = join(mainRepo, 'checkouts', 'workspace');
+      const workspaceMeta = join(mainGitDir, 'worktrees', 'workspace');
+      mkdirSync(workspaceMeta, { recursive: true });
+      mkdirSync(nestedWorkspace, { recursive: true });
+      writeFileSync(
+        join(workspaceMeta, 'gitdir'),
+        `${join(nestedWorkspace, '.git')}\n`
+      );
+      writeFileSync(
+        join(nestedWorkspace, '.git'),
+        `gitdir: ${workspaceMeta}\n`
+      );
+      writeFileSync(join(workspaceMeta, 'commondir'), '../..\n');
+
+      // And an agent worktree nested inside that workspace.
+      const agentMeta = join(mainGitDir, 'worktrees', 'agent');
+      const agentCheckout = join(
+        nestedWorkspace,
+        '.claude',
+        'worktrees',
+        'agent'
+      );
+      mkdirSync(agentMeta, { recursive: true });
+      mkdirSync(agentCheckout, { recursive: true });
+      writeFileSync(
+        join(agentMeta, 'gitdir'),
+        `${join(agentCheckout, '.git')}\n`
+      );
+      writeFileSync(join(agentCheckout, '.git'), `gitdir: ${agentMeta}\n`);
+      writeFileSync(join(agentMeta, 'commondir'), '../..\n');
+    });
+
+    it('follows commondir to find worktrees nested inside it', () => {
+      expect(nestedWorktreeRoots(nestedWorkspace)).toEqual([
+        '.claude/worktrees/agent',
+      ]);
+    });
+
+    it('does not report the workspace itself', () => {
+      // Its own registration resolves to the walk root, which is not nested.
+      expect(nestedWorktreeRoots(nestedWorkspace)).not.toContain('');
+    });
+
+    it('advises on a duplicate coming from the nested worktree', () => {
+      expect(
+        analyzeWorktreeConflicts(
+          nestedWorkspace,
+          new Map([['ui', ['libs/ui', '.claude/worktrees/agent/libs/ui']]])
+        )!.ignoreTargets
+      ).toEqual(['/.claude/worktrees/agent']);
+    });
+  });
+
   describe('analyzeWorktreeConflicts', () => {
     function analyze(conflicts: Record<string, string[]>) {
       return analyzeWorktreeConflicts(
@@ -69,9 +136,18 @@ describe('git worktrees', () => {
           api: ['apps/api', '.claude/worktrees/two/apps/api'],
         })
       ).toEqual({
-        ignoreTargets: ['.claude/worktrees'],
+        ignoreTargets: ['/.claude/worktrees'],
         explainsAllConflicts: true,
       });
+    });
+
+    it('anchors a top-level worktree so it is a location, not a name', () => {
+      // Bare `wt1` in a .gitignore matches any `wt1` at any depth.
+      registerWorktree('one', 'wt1');
+
+      expect(
+        analyze({ ui: ['libs/ui', 'wt1/libs/ui'] })!.ignoreTargets
+      ).toEqual(['/wt1']);
     });
 
     it('names a lone worktree rather than the directory holding it', () => {
@@ -80,7 +156,7 @@ describe('git worktrees', () => {
       registerWorktree('one', 'apps/wt');
 
       expect(analyze({ ui: ['libs/ui', 'apps/wt/libs/ui'] })).toEqual({
-        ignoreTargets: ['apps/wt'],
+        ignoreTargets: ['/apps/wt'],
         explainsAllConflicts: true,
       });
     });
@@ -96,7 +172,7 @@ describe('git worktrees', () => {
           a: ['libs/a', 'trees/one/libs/a'],
           b: ['libs/b', 'trees/two/libs/b'],
         })!.ignoreTargets
-      ).toEqual(['trees/one', 'trees/two']);
+      ).toEqual(['/trees/one', '/trees/two']);
     });
 
     it('names the worktrees themselves when they share no directory', () => {
@@ -109,7 +185,7 @@ describe('git worktrees', () => {
           a: ['libs/a', 'wt1/libs/a'],
           b: ['libs/b', 'nested/wt2/libs/b'],
         })!.ignoreTargets
-      ).toEqual(['wt1', 'nested/wt2']);
+      ).toEqual(['/wt1', '/nested/wt2']);
     });
 
     it('reports that ignoring them leaves duplicates the reader still owns', () => {

--- a/packages/nx/src/utils/git-worktrees.spec.ts
+++ b/packages/nx/src/utils/git-worktrees.spec.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { nestedWorktreeRoots, worktreeIgnoreTarget } from './git-worktrees';
+import { analyzeWorktreeConflicts, nestedWorktreeRoots } from './git-worktrees';
 
 describe('git worktrees', () => {
   let workspaceRoot: string;
@@ -51,27 +51,52 @@ describe('git worktrees', () => {
     });
   });
 
-  describe('worktreeIgnoreTarget', () => {
-    it('names the directory holding the worktrees', () => {
+  describe('analyzeWorktreeConflicts', () => {
+    function analyze(conflicts: Record<string, string[]>) {
+      return analyzeWorktreeConflicts(
+        workspaceRoot,
+        new Map(Object.entries(conflicts))
+      );
+    }
+
+    it('names the directory holding the worktrees once there is more than one', () => {
       registerWorktree('one', '.claude/worktrees/one');
       registerWorktree('two', '.claude/worktrees/two');
 
       expect(
-        worktreeIgnoreTarget(workspaceRoot, [
-          'packages/app',
-          '.claude/worktrees/one/packages/app',
-        ])
-      ).toEqual(['.claude/worktrees']);
+        analyze({
+          ui: ['libs/ui', '.claude/worktrees/one/libs/ui'],
+          api: ['apps/api', '.claude/worktrees/two/apps/api'],
+        })
+      ).toEqual({
+        ignoreTargets: ['.claude/worktrees'],
+        explainsAllConflicts: true,
+      });
+    });
+
+    it('names a lone worktree rather than the directory holding it', () => {
+      // `apps/` holds only the worktree today and is where the reader will put
+      // projects tomorrow. Collapsing saves no lines here and risks all of them.
+      registerWorktree('one', 'apps/wt');
+
+      expect(analyze({ ui: ['libs/ui', 'apps/wt/libs/ui'] })).toEqual({
+        ignoreTargets: ['apps/wt'],
+        explainsAllConflicts: true,
+      });
     });
 
     it('names the worktrees themselves when their directory holds anything else', () => {
       // Ignoring the directory would drop `notes` from the graph too.
       registerWorktree('one', 'trees/one');
+      registerWorktree('two', 'trees/two');
       mkdirSync(join(workspaceRoot, 'trees/notes'), { recursive: true });
 
       expect(
-        worktreeIgnoreTarget(workspaceRoot, ['libs/a', 'trees/one/libs/a'])
-      ).toEqual(['trees/one']);
+        analyze({
+          a: ['libs/a', 'trees/one/libs/a'],
+          b: ['libs/b', 'trees/two/libs/b'],
+        })!.ignoreTargets
+      ).toEqual(['trees/one', 'trees/two']);
     });
 
     it('names the worktrees themselves when they share no directory', () => {
@@ -80,31 +105,50 @@ describe('git worktrees', () => {
       registerWorktree('two', 'nested/wt2');
 
       expect(
-        worktreeIgnoreTarget(workspaceRoot, ['wt1/libs/a', 'nested/wt2/libs/a'])
+        analyze({
+          a: ['libs/a', 'wt1/libs/a'],
+          b: ['libs/b', 'nested/wt2/libs/b'],
+        })!.ignoreTargets
       ).toEqual(['wt1', 'nested/wt2']);
+    });
+
+    it('reports that ignoring them leaves duplicates the reader still owns', () => {
+      registerWorktree('one', '.claude/worktrees/one');
+
+      expect(
+        analyze({
+          ui: ['libs/ui', '.claude/worktrees/one/libs/ui'],
+          dup: ['apps/a', 'apps/b'],
+        })!.explainsAllConflicts
+      ).toBe(false);
+    });
+
+    it('reports a duplicate that survives dropping the worktree copy', () => {
+      // Three roots, one of them a worktree copy: the other two still collide.
+      registerWorktree('one', '.claude/worktrees/one');
+
+      expect(
+        analyze({
+          ui: ['libs/ui', 'apps/ui', '.claude/worktrees/one/libs/ui'],
+        })!.explainsAllConflicts
+      ).toBe(false);
     });
 
     it('stays out of the way when the duplicates are not from worktrees', () => {
       registerWorktree('one', '.claude/worktrees/one');
 
-      expect(
-        worktreeIgnoreTarget(workspaceRoot, ['packages/a', 'packages/b'])
-      ).toBeNull();
+      expect(analyze({ dup: ['packages/a', 'packages/b'] })).toBeNull();
     });
 
     it('stays out of the way when there are no worktrees at all', () => {
-      expect(
-        worktreeIgnoreTarget(workspaceRoot, ['packages/a', 'packages/b'])
-      ).toBeNull();
+      expect(analyze({ dup: ['packages/a', 'packages/b'] })).toBeNull();
     });
 
     it('does not read a sibling whose name merely starts the same', () => {
       registerWorktree('one', 'trees/wt');
       mkdirSync(join(workspaceRoot, 'trees/wt-other'), { recursive: true });
 
-      expect(
-        worktreeIgnoreTarget(workspaceRoot, ['trees/wt-other/libs/a'])
-      ).toBeNull();
+      expect(analyze({ a: ['libs/a', 'trees/wt-other/libs/a'] })).toBeNull();
     });
   });
 });

--- a/packages/nx/src/utils/git-worktrees.spec.ts
+++ b/packages/nx/src/utils/git-worktrees.spec.ts
@@ -51,6 +51,31 @@ describe('git worktrees', () => {
     });
   });
 
+  it('falls back to the git dir when commondir names something that is not a directory', () => {
+    // Pointing `commondir` at a file has to give a different answer from
+    // following it, or this pins nothing: following a file yields a
+    // `worktrees` path underneath it, which reads as empty either way. So the
+    // registration lives beside `commondir`, where only the fallback finds it.
+    const metadataDir = join(workspaceRoot, '.git', 'worktrees', 'self');
+    const notADirectory = join(workspaceRoot, '.git', 'not-a-dir');
+    mkdirSync(metadataDir, { recursive: true });
+    writeFileSync(notADirectory, 'x\n');
+    writeFileSync(join(metadataDir, 'commondir'), `${notADirectory}\n`);
+
+    // A workspace that is itself a linked worktree, so `commondir` is read.
+    const workspace = mkdtempSync(join(tmpdir(), 'nx-fallback-'));
+    writeFileSync(join(workspace, '.git'), `gitdir: ${metadataDir}\n`);
+
+    const checkout = join(workspace, 'nested', 'wt');
+    const innerMeta = join(metadataDir, 'worktrees', 'inner');
+    mkdirSync(innerMeta, { recursive: true });
+    mkdirSync(checkout, { recursive: true });
+    writeFileSync(join(innerMeta, 'gitdir'), `${join(checkout, '.git')}\n`);
+    writeFileSync(join(checkout, '.git'), `gitdir: ${innerMeta}\n`);
+
+    expect(nestedWorktreeRoots(workspace)).toEqual(['nested/wt']);
+  });
+
   describe('when the workspace sits below the git root', () => {
     // An Nx workspace nested in a larger repository is ordinary. Its worktrees
     // are registered against the repository, so looking only at

--- a/packages/nx/src/utils/git-worktrees.ts
+++ b/packages/nx/src/utils/git-worktrees.ts
@@ -20,7 +20,8 @@ function readRecordedPath(file: string, base: string): string | null {
 
 /**
  * `<git-dir>/worktrees`, where git registers every linked worktree of the
- * repository `workspaceRoot` belongs to. Null when there is no `.git`, or when
+ * repository `workspaceRoot` belongs to - found by walking up, since the
+ * workspace need not be the repository root. Null when there is no `.git`, or when
  * it is a gitfile that names nothing. The registry itself is not checked -
  * reading it is what tells us whether anything is registered.
  */
@@ -32,14 +33,41 @@ function isDirectory(path: string): boolean {
   }
 }
 
+/**
+ * The nearest directory at or above `from` holding a `.git`, or null when
+ * there is no repository above it.
+ *
+ * The workspace root and the repository root are often the same directory, but
+ * a workspace nested in a larger repo is ordinary - and its worktrees are
+ * registered against the repository, not against the workspace.
+ */
+function findGitRoot(from: string): string | null {
+  let current = resolve(from);
+
+  while (!existsSync(join(current, '.git'))) {
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+
+  return current;
+}
+
 function worktreeRegistry(workspaceRoot: string): string | null {
-  const dotGit = join(workspaceRoot, '.git');
+  const gitRoot = findGitRoot(workspaceRoot);
+  if (!gitRoot) {
+    return null;
+  }
+
+  const dotGit = join(gitRoot, '.git');
 
   let gitDir: string | null;
   try {
     gitDir = statSync(dotGit).isDirectory()
       ? dotGit
-      : readRecordedPath(dotGit, workspaceRoot);
+      : readRecordedPath(dotGit, gitRoot);
   } catch {
     return null;
   }

--- a/packages/nx/src/utils/git-worktrees.ts
+++ b/packages/nx/src/utils/git-worktrees.ts
@@ -1,0 +1,166 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+
+const GITDIR_PREFIX = 'gitdir:';
+
+function readRecordedPath(file: string, base: string): string | null {
+  let contents: string;
+  try {
+    contents = readFileSync(file, 'utf-8').trim();
+  } catch {
+    return null;
+  }
+
+  const raw = contents.startsWith(GITDIR_PREFIX)
+    ? contents.slice(GITDIR_PREFIX.length).trim()
+    : contents;
+
+  return raw ? resolve(base, raw) : null;
+}
+
+/**
+ * `<git-dir>/worktrees`, where git registers every linked worktree of the
+ * repository `workspaceRoot` belongs to. Null when there is no repository, or
+ * when `.git` is a gitfile naming a directory that isn't there.
+ */
+function worktreeRegistry(workspaceRoot: string): string | null {
+  const dotGit = join(workspaceRoot, '.git');
+
+  let gitDir: string | null;
+  try {
+    gitDir = statSync(dotGit).isDirectory()
+      ? dotGit
+      : readRecordedPath(dotGit, workspaceRoot);
+  } catch {
+    return null;
+  }
+  if (!gitDir) {
+    return null;
+  }
+
+  // Running from inside a linked worktree lands on
+  // `<main>/.git/worktrees/<name>`, whose `commondir` names the real git dir.
+  const commonDir =
+    readRecordedPath(join(gitDir, 'commondir'), gitDir) ?? gitDir;
+  return join(commonDir, 'worktrees');
+}
+
+/**
+ * Roots of the git linked worktrees that live inside `workspaceRoot`,
+ * relative to it and separator-normalized.
+ *
+ * Reads git's own registry rather than probing the workspace, so it costs one
+ * `readdir` plus a small file per worktree. Worktrees outside the workspace
+ * are dropped - nothing walks them. Submodules use the same gitfile mechanism
+ * but register under `<git-dir>/modules`, so they never appear here.
+ */
+export function nestedWorktreeRoots(workspaceRoot: string): string[] {
+  const registry = worktreeRegistry(workspaceRoot);
+  if (!registry) {
+    return [];
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(registry);
+  } catch {
+    return [];
+  }
+
+  const roots: string[] = [];
+  for (const entry of entries) {
+    // Points at the worktree's own `.git` gitfile, so its parent is the root.
+    const gitfile = readRecordedPath(
+      join(registry, entry, 'gitdir'),
+      join(registry, entry)
+    );
+    if (!gitfile || !existsSync(gitfile)) {
+      continue;
+    }
+
+    const root = relative(workspaceRoot, dirname(gitfile));
+    // Outside the workspace, or the workspace itself - neither is a nested
+    // worktree that Nx would walk into.
+    if (
+      !root ||
+      root.startsWith('..') ||
+      resolve(workspaceRoot, root) === resolve(workspaceRoot)
+    ) {
+      continue;
+    }
+
+    roots.push(root.split(sep).join('/'));
+  }
+
+  return roots;
+}
+
+/**
+ * Whether `path` sits inside `root`, comparing whole path segments so that
+ * `wt-other` is not read as living inside `wt`.
+ */
+export function isInside(path: string, root: string): boolean {
+  return path === root || path.startsWith(`${root}/`);
+}
+
+/**
+ * The path to suggest ignoring when duplicate project names come from git
+ * worktrees nested in the workspace, or null when they don't.
+ *
+ * Prefers the directory holding the worktrees - agent tooling keeps them under
+ * one (`.claude/worktrees`), and one entry beats one per worktree. Only when
+ * that directory holds nothing else, though: ignoring a directory that also
+ * holds real projects would drop them from the graph.
+ */
+export function worktreeIgnoreTarget(
+  workspaceRoot: string,
+  conflictingRoots: string[]
+): string[] | null {
+  const worktrees = nestedWorktreeRoots(workspaceRoot);
+  if (!worktrees.length) {
+    return null;
+  }
+
+  const offending = worktrees.filter((worktree) =>
+    conflictingRoots.some((root) => isInside(root, worktree))
+  );
+  if (!offending.length) {
+    return null;
+  }
+
+  const parent = commonParent(offending);
+  return parent && holdsOnlyWorktrees(workspaceRoot, parent, worktrees)
+    ? [parent]
+    : offending;
+}
+
+/**
+ * The directory every one of `roots` sits directly inside, or null when they
+ * don't share one - including when it would be the workspace root, which is
+ * never something to ignore.
+ */
+function commonParent(roots: string[]): string | null {
+  const parents = new Set(
+    roots.map((root) => root.split('/').slice(0, -1).join('/'))
+  );
+  const [parent] = parents;
+  return parents.size === 1 && parent ? parent : null;
+}
+
+function holdsOnlyWorktrees(
+  workspaceRoot: string,
+  directory: string,
+  worktrees: string[]
+): boolean {
+  let entries: string[];
+  try {
+    entries = readdirSync(join(workspaceRoot, directory));
+  } catch {
+    return false;
+  }
+
+  return (
+    entries.length > 0 &&
+    entries.every((entry) => worktrees.includes(`${directory}/${entry}`))
+  );
+}

--- a/packages/nx/src/utils/git-worktrees.ts
+++ b/packages/nx/src/utils/git-worktrees.ts
@@ -21,9 +21,17 @@ function readRecordedPath(file: string, base: string): string | null {
 /**
  * `<git-dir>/worktrees`, where git registers every linked worktree of the
  * repository `workspaceRoot` belongs to. Null when there is no `.git`, or when
- * it is a gitfile that names nothing. The directory it names is not checked -
+ * it is a gitfile that names nothing. The registry itself is not checked -
  * reading it is what tells us whether anything is registered.
  */
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 function worktreeRegistry(workspaceRoot: string): string | null {
   const dotGit = join(workspaceRoot, '.git');
 
@@ -41,9 +49,14 @@ function worktreeRegistry(workspaceRoot: string): string | null {
 
   // Running from inside a linked worktree lands on
   // `<main>/.git/worktrees/<name>`, whose `commondir` names the real git dir.
-  const commonDir =
-    readRecordedPath(join(gitDir, 'commondir'), gitDir) ?? gitDir;
-  return join(commonDir, 'worktrees');
+  // Followed only when it names a directory that is there: `commondir` is a
+  // path out of a file we did not write, and everything downstream reads
+  // whatever it points at.
+  const commonDir = readRecordedPath(join(gitDir, 'commondir'), gitDir);
+  return join(
+    commonDir && isDirectory(commonDir) ? commonDir : gitDir,
+    'worktrees'
+  );
 }
 
 /**
@@ -178,13 +191,26 @@ function ignoreTargetsFor(
   worktrees: string[]
 ): string[] {
   if (offending.length < 2) {
-    return offending;
+    return offending.map(anchored);
   }
 
   const parent = commonParent(offending);
-  return parent && holdsOnlyWorktrees(workspaceRoot, parent, worktrees)
-    ? [parent]
-    : offending;
+  return (
+    parent && holdsOnlyWorktrees(workspaceRoot, parent, worktrees)
+      ? [parent]
+      : offending
+  ).map(anchored);
+}
+
+/**
+ * A gitignore pattern rooted at the workspace rather than matched anywhere.
+ *
+ * Without the leading slash a single-segment path like `wt1` is a name, not a
+ * location - it would ignore every `wt1` at any depth. Applied to all of them
+ * so the emitted line reads the same way wherever it came from.
+ */
+function anchored(root: string): string {
+  return `/${root}`;
 }
 
 /**

--- a/packages/nx/src/utils/git-worktrees.ts
+++ b/packages/nx/src/utils/git-worktrees.ts
@@ -18,13 +18,6 @@ function readRecordedPath(file: string, base: string): string | null {
   return raw ? resolve(base, raw) : null;
 }
 
-/**
- * `<git-dir>/worktrees`, where git registers every linked worktree of the
- * repository `workspaceRoot` belongs to - found by walking up, since the
- * workspace need not be the repository root. Null when there is no `.git`, or when
- * it is a gitfile that names nothing. The registry itself is not checked -
- * reading it is what tells us whether anything is registered.
- */
 function isDirectory(path: string): boolean {
   try {
     return statSync(path).isDirectory();
@@ -55,6 +48,13 @@ function findGitRoot(from: string): string | null {
   return current;
 }
 
+/**
+ * `<git-dir>/worktrees`, where git registers every linked worktree of the
+ * repository `workspaceRoot` belongs to - found by walking up, since the
+ * workspace need not be the repository root. Null when there is no `.git`, or
+ * when it is a gitfile that names nothing. The registry itself is not checked -
+ * reading it is what tells us whether anything is registered.
+ */
 function worktreeRegistry(workspaceRoot: string): string | null {
   const gitRoot = findGitRoot(workspaceRoot);
   if (!gitRoot) {
@@ -77,9 +77,9 @@ function worktreeRegistry(workspaceRoot: string): string | null {
 
   // Running from inside a linked worktree lands on
   // `<main>/.git/worktrees/<name>`, whose `commondir` names the real git dir.
-  // Followed only when it names a directory that is there: `commondir` is a
-  // path out of a file we did not write, and everything downstream reads
-  // whatever it points at.
+  // Ignored unless it names a directory that exists. That is a sanity check
+  // on a path out of a file we did not write, not a bound on where it may
+  // point - it can still name any directory on the machine.
   const commonDir = readRecordedPath(join(gitDir, 'commondir'), gitDir);
   return join(
     commonDir && isDirectory(commonDir) ? commonDir : gitDir,

--- a/packages/nx/src/utils/git-worktrees.ts
+++ b/packages/nx/src/utils/git-worktrees.ts
@@ -20,8 +20,9 @@ function readRecordedPath(file: string, base: string): string | null {
 
 /**
  * `<git-dir>/worktrees`, where git registers every linked worktree of the
- * repository `workspaceRoot` belongs to. Null when there is no repository, or
- * when `.git` is a gitfile naming a directory that isn't there.
+ * repository `workspaceRoot` belongs to. Null when there is no `.git`, or when
+ * it is a gitfile that names nothing. The directory it names is not checked -
+ * reading it is what tells us whether anything is registered.
  */
 function worktreeRegistry(workspaceRoot: string): string | null {
   const dotGit = join(workspaceRoot, '.git');
@@ -103,29 +104,81 @@ export function isInside(path: string, root: string): boolean {
   return path === root || path.startsWith(`${root}/`);
 }
 
+/** Advice for duplicate project names that come from nested git worktrees. */
+export interface WorktreeConflictAdvice {
+  /** Paths to add to `.gitignore`. */
+  ignoreTargets: string[];
+  /**
+   * Whether ignoring them settles every duplicate. When false the caller still
+   * owes the reader the ordinary advice for the ones left over.
+   */
+  explainsAllConflicts: boolean;
+}
+
 /**
- * The path to suggest ignoring when duplicate project names come from git
- * worktrees nested in the workspace, or null when they don't.
- *
- * Prefers the directory holding the worktrees - agent tooling keeps them under
- * one (`.claude/worktrees`), and one entry beats one per worktree. Only when
- * that directory holds nothing else, though: ignoring a directory that also
- * holds real projects would drop them from the graph.
+ * What to tell someone whose duplicate project names come from git worktrees
+ * nested in the workspace, or null when none of them do.
  */
-export function worktreeIgnoreTarget(
+export function analyzeWorktreeConflicts(
   workspaceRoot: string,
-  conflictingRoots: string[]
-): string[] | null {
+  conflicts: Map<string, string[]>
+): WorktreeConflictAdvice | null {
   const worktrees = nestedWorktreeRoots(workspaceRoot);
   if (!worktrees.length) {
     return null;
   }
 
-  const offending = worktrees.filter((worktree) =>
-    conflictingRoots.some((root) => isInside(root, worktree))
-  );
+  const offending: string[] = [];
+  let explainsAllConflicts = true;
+
+  for (const roots of conflicts.values()) {
+    const fromWorktrees = worktrees.filter((worktree) =>
+      roots.some((root) => isInside(root, worktree))
+    );
+    // What would still be defined twice once the worktrees are out of the way.
+    const remaining = roots.filter(
+      (root) => !worktrees.some((worktree) => isInside(root, worktree))
+    );
+
+    // Worth naming whenever a worktree is involved, even if ignoring it
+    // doesn't settle the whole conflict.
+    for (const worktree of fromWorktrees) {
+      if (!offending.includes(worktree)) {
+        offending.push(worktree);
+      }
+    }
+
+    if (!fromWorktrees.length || remaining.length > 1) {
+      explainsAllConflicts = false;
+    }
+  }
+
   if (!offending.length) {
     return null;
+  }
+
+  return {
+    ignoreTargets: ignoreTargetsFor(workspaceRoot, offending, worktrees),
+    explainsAllConflicts,
+  };
+}
+
+/**
+ * The worktree roots themselves, or the one directory holding them.
+ *
+ * Collapsing to the directory is only worth anything when it saves lines, and
+ * only safe when it holds nothing else. With a single worktree it saves
+ * nothing and risks everything: a lone worktree in `apps/` would have us name
+ * `apps/`, which holds only that worktree today and is where the reader will
+ * put projects tomorrow.
+ */
+function ignoreTargetsFor(
+  workspaceRoot: string,
+  offending: string[],
+  worktrees: string[]
+): string[] {
+  if (offending.length < 2) {
+    return offending;
   }
 
   const parent = commonParent(offending);

--- a/packages/nx/src/utils/git-worktrees.ts
+++ b/packages/nx/src/utils/git-worktrees.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { dirname, join, relative, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 const GITDIR_PREFIX = 'gitdir:';
 
@@ -121,13 +121,12 @@ export function nestedWorktreeRoots(workspaceRoot: string): string[] {
     }
 
     const root = relative(workspaceRoot, dirname(gitfile));
-    // Outside the workspace, or the workspace itself - neither is a nested
-    // worktree that Nx would walk into.
-    if (
-      !root ||
-      root.startsWith('..') ||
-      resolve(workspaceRoot, root) === resolve(workspaceRoot)
-    ) {
+    // Neither the workspace itself nor anything outside it is a nested
+    // worktree Nx would walk into. Compared by whole segments, because `..` is
+    // a traversal and `..hidden` is an ordinary directory name; and by
+    // absoluteness, because `relative` across Windows drives returns its
+    // second argument, which is outside by definition and carries no `..`.
+    if (!root || isAbsolute(root) || root.split(sep)[0] === '..') {
       continue;
     }
 


### PR DESCRIPTION
## Current Behavior

A git worktree checked out inside the workspace is a full copy of it, so Nx walks it and every project in it collides with the project it was checked out from. This happens routinely with agent tooling that keeps worktrees under a fixed path such as `.claude/worktrees`.

The resulting error tells the reader to give the projects unique names:

```
The following projects are defined in multiple locations:
- ui:
  - libs/ui
  - .claude/worktrees/wt/libs/ui

To fix this, set a unique name for each project in a project.json inside the project's root. [...]
```

That is the wrong fix. Renaming the copy inside the worktree makes no sense — the copy should not be in the graph at all. An agent following this advice will either rename real projects or get stuck.

## Expected Behavior

When the conflicting roots sit inside a linked worktree, the error says so and names the path to gitignore:

```
The following projects are defined in multiple locations:
- ui:
  - libs/ui
  - .claude/worktrees/wt/libs/ui

Some of these are inside git worktrees nested in this workspace. A worktree is a
full checkout, so every project in it collides with the one it was checked out from.

To fix those, add the following to .gitignore:
  /.claude/worktrees/wt
```

Duplicates that are *not* from worktrees keep the existing "set a unique name" guidance. A mixed set gets both: the gitignore advice for the worktree copies, then `The rest are not from worktrees.` followed by the rename advice for what is left.

### How the suggested path is chosen

The directory holding the worktrees is preferred over listing each one — but only with **two or more** worktrees, and only when that directory holds nothing else. With a single worktree, collapsing saves nothing and risks everything: a lone worktree in `apps/` would have us name `apps/`, which holds only that worktree today and is where the reader will put projects tomorrow. So a single worktree is always named directly, as in the sample above.

Fallbacks to the exact worktree roots:

- there is only one offending worktree
- the shared directory contains anything that is not a worktree
- the worktrees share no directory, so their common ancestor is the workspace root

Every emitted path is anchored with a leading `/`. Without it a single-segment path like `wt1` is a name rather than a location, and would ignore every `wt1` at any depth.

### Cost

The check runs inside the `conflicts.size > 0` branch, on the way to throwing. A workspace without duplicate project names never reads git's worktree registry.

### Implementation notes

Worktrees are read from git's own registry (`<git-dir>/worktrees/*/gitdir`) rather than by probing directories: one `readdir` plus a small file per worktree. The repository root is found by walking up, since an Nx workspace nested inside a larger repo is ordinary and its worktrees are registered against the repo; what counts as *nested* is still measured from the workspace, so a worktree elsewhere in the repository is dropped. `commondir` is followed so this works when the workspace is itself a linked worktree with agent worktrees nested inside it — every worktree of a repository shares one registry — and only when it names a directory that exists, since it is a path out of a file we did not write. Submodules use the same gitfile mechanism but register under `<git-dir>/modules`, so they are never mistaken for worktrees.

This is deliberately TypeScript rather than a binding to the Rust worktree helpers — a new `#[napi]` function requires four regenerated committed artifacts and a nightly toolchain for the wasm arm, which is a poor trade for a check that only runs on an error path.

It also teaches the remedy Nx already ships: the `update-22-6-0/add-claude-worktrees-to-git-ignore` migration writes `.claude/worktrees` into `.gitignore`, and this covers the workspaces and paths that migration cannot reach.

### Known gap

A plain `cp -r` copy of the workspace gets no worktree advice, because git has no registry entry for it. Detecting that would mean probing directories rather than reading the registry, which is the cost this deliberately avoids.

### Tests

- 19 unit tests covering registry reading, the `commondir` layout, a workspace below the git root, the path-shortening rule and both fallbacks, anchoring, and a `wt-other`-style prefix case
- integration tests through `validateAndNormalizeProjectRootMap` for both the worktree-only and mixed-conflict messages

Each was verified to fail when the code under it is broken.

## Related Issue(s)

Linear: [NXC-4730](https://linear.app/nxdev/issue/NXC-4730/fix-duplicate-project-name-errors-from-git-worktrees)

Supersedes #36465, which pruned worktrees from every workspace walk and from the file watcher. That approach worked but kept growing edge cases (event-ordering races, registry-cache invalidation, a self-feeding `.git` event loop), and the discussion concluded a good error is the better trade for a situation users should avoid in the first place.
