### PR TITLE
docs(nx-cloud): explain multi-GitHub organization setup

### DIFF
--- a/astro-docs/src/content/docs/getting-started/nx-cloud.mdoc
+++ b/astro-docs/src/content/docs/getting-started/nx-cloud.mdoc
@@ -29,6 +29,8 @@ nx connect
 
 For more details, [follow our in-depth guide](/docs/kb/setup-ci) for setting up CI with Nx.
 
+If your repositories span multiple GitHub organizations, review the [Nx Cloud organization and repository-scoped access options](/docs/kb/multiple-github-organizations) before connecting them.
+
 ## How Nx Cloud improves CI
 
 In traditional CI models, the work required is statically assigned to CI machines. Statically defining work to machines creates inefficiencies which many teams become familiar with at scale.

--- a/astro-docs/src/content/docs/kb/github-app-permissions.mdoc
+++ b/astro-docs/src/content/docs/kb/github-app-permissions.mdoc
@@ -8,6 +8,8 @@ topics:
 
 The Nx Cloud GitHub App requires the following permissions to provide CI/CD integration and setup experiences. Most information is used transiently during operations and not stored in our systems.
 
+If your workspaces use repositories from more than one GitHub organization, see how to [configure a standard Nx Cloud organization with repository-scoped access](/docs/kb/multiple-github-organizations).
+
 {% callout type="note" title="Administration (read & write) permission removed." %}
 The Nx Cloud GitHub App no longer requests the `Administration` (read & write) permission. It was previously required to generate new workspaces from the browser; that feature has since been removed, so we've dropped the permission to reduce the access we request.
 {% /callout %}

--- a/astro-docs/src/content/docs/kb/multiple-github-organizations.mdoc
+++ b/astro-docs/src/content/docs/kb/multiple-github-organizations.mdoc
@@ -1,0 +1,42 @@
+---
+title: Use Repositories from Multiple GitHub Organizations in Nx Cloud
+description: Choose an access model and connect repositories from multiple GitHub organizations to one Nx Cloud organization
+filter: 'type:Guides'
+topics:
+  - 'Continuous integration'
+---
+
+A GitHub-connected Nx Cloud organization can only connect repositories from the GitHub organization it is connected to. If your repositories span multiple GitHub organizations, choose an Nx Cloud access model based on how you want to manage users.
+
+## Choose an access model
+
+| Access model                                                | Use when                                                                            | Nx Cloud organization and licensing impact                                                                                                      |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| SAML and SCIM                                               | Your identity provider should control access to every workspace centrally.          | Use one organization and one license for all workspaces.                                                                                        |
+| Multiple GitHub-connected organizations                     | Each GitHub organization must remain a separate administration and access boundary. | Create one Nx Cloud organization and license for each GitHub organization. Usage reporting is also split between them.                          |
+| One standard organization with repository-scoped workspaces | Workspace access should mirror each repository's GitHub contributors.               | Use one Nx Cloud organization and license for repositories from any number of GitHub organizations. This is the recommended GitHub-based model. |
+
+## Configure repository-scoped access
+
+1. Create a standard Nx Cloud organization without connecting it to a GitHub organization. Use the manual organization setup flow. The warnings shown during this flow are expected.
+2. Add a workspace for each repository. The add-workspace flow connects the repository to Nx Cloud through the GitHub App.
+3. Grant the Nx Cloud GitHub App access to every repository you add. You can authorize repositories from different GitHub organizations.
+4. In each workspace's access settings, select the repository-scoped access type.
+5. Ask each user to connect their GitHub account to Nx Cloud through OAuth. Nx Cloud uses their GitHub identity to verify that they are a contributor to the connected repository.
+
+Nx Cloud then synchronizes workspace access from the repository's GitHub contributors. Adding or removing access in GitHub updates who can access that workspace without requiring Nx Cloud organization membership.
+
+{% aside type="note" title="Existing GitHub-connected organization" %}
+Changing an existing GitHub-connected organization to a standard organization is not a self-service operation. [Contact Nx Cloud support](/contact) to assess converting it without creating a new organization.
+{% /aside %}
+
+## Understand the access limitations
+
+- Organization administrator access is managed manually in a standard organization.
+- Users with only repository-scoped workspace access do not see the organization in their organization list. They must open the workspace from a direct link, such as a CI Pipeline Execution link in a GitHub pull request comment.
+- Signing in with GitHub is not sufficient by itself. Each user must also connect their GitHub account to Nx Cloud so their GitHub identity can be matched to repository access.
+
+## Related configuration
+
+- Review the [Nx Cloud GitHub App permissions](/docs/kb/github-app-permissions) before granting repository access.
+- To manage access centrally instead of mirroring GitHub repositories, configure [Okta SAML and SCIM](/docs/enterprise/single-tenant/okta-saml) or [Azure SAML](/docs/enterprise/single-tenant/azure-saml).

--- a/astro-docs/src/content/docs/kb/multiple-github-organizations.mdoc
+++ b/astro-docs/src/content/docs/kb/multiple-github-organizations.mdoc
@@ -24,7 +24,7 @@ The licensing details below apply only to Nx Cloud Enterprise customers.
 2. Add a workspace for each repository. The add-workspace flow connects the repository to Nx Cloud through the GitHub App.
 3. Grant the Nx Cloud GitHub App access to every repository you add. You can authorize repositories from different GitHub organizations.
 4. In each workspace's access settings, select the repository-scoped access type.
-5. Ask each user to connect their GitHub account to Nx Cloud through OAuth. Nx Cloud uses their GitHub identity to verify that they are a contributor to the connected repository.
+5. Ask each user to complete the separate GitHub account connection when Nx Cloud prompts them. Signing in to Nx Cloud with GitHub does not complete this connection. Nx Cloud needs the connection to obtain their GitHub ID and verify that they are a contributor to the connected repository.
 
 Nx Cloud then synchronizes workspace access from the repository's GitHub contributors. Adding or removing access in GitHub updates who can access that workspace without requiring Nx Cloud organization membership.
 
@@ -36,7 +36,7 @@ Changing an existing GitHub-connected organization to a standard organization is
 
 - Organization administrator access is managed manually in a standard organization.
 - Users with only repository-scoped workspace access do not see the organization in their organization list. They must open the workspace from a direct link, such as a CI Pipeline Execution link in a GitHub pull request comment.
-- Signing in with GitHub is not sufficient by itself. Each user must also connect their GitHub account to Nx Cloud so their GitHub identity can be matched to repository access.
+- Nx Cloud normally directs users to the GitHub account connection when it is required. If repository-scoped access does not resolve, confirm that the user completed this connection; signing in with GitHub alone is not sufficient.
 
 ## Related configuration
 

--- a/astro-docs/src/content/docs/kb/multiple-github-organizations.mdoc
+++ b/astro-docs/src/content/docs/kb/multiple-github-organizations.mdoc
@@ -10,11 +10,13 @@ A GitHub-connected Nx Cloud organization can only connect repositories from the 
 
 ## Choose an access model
 
-| Access model                                                | Use when                                                                            | Nx Cloud organization and licensing impact                                                                                                      |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| SAML and SCIM                                               | Your identity provider should control access to every workspace centrally.          | Use one organization and one license for all workspaces.                                                                                        |
-| Multiple GitHub-connected organizations                     | Each GitHub organization must remain a separate administration and access boundary. | Create one Nx Cloud organization and license for each GitHub organization. Usage reporting is also split between them.                          |
-| One standard organization with repository-scoped workspaces | Workspace access should mirror each repository's GitHub contributors.               | Use one Nx Cloud organization and license for repositories from any number of GitHub organizations. This is the recommended GitHub-based model. |
+The licensing details below apply only to Nx Cloud Enterprise customers.
+
+| Access model                                                | Use when                                                                            | Organization setup and Enterprise licensing                                                                                                                          |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SAML and SCIM                                               | Your identity provider should control access to every workspace centrally.          | Use one organization for all workspaces. Enterprise customers need one license.                                                                                      |
+| Multiple GitHub-connected organizations                     | Each GitHub organization must remain a separate administration and access boundary. | Create one Nx Cloud organization for each GitHub organization. Enterprise customers need one license per Nx Cloud organization. Usage reporting is also split.       |
+| One standard organization with repository-scoped workspaces | Workspace access should mirror each repository's GitHub contributors.               | Use one Nx Cloud organization for repositories from any number of GitHub organizations. Enterprise customers need one license. This is the recommended GitHub model. |
 
 ## Configure repository-scoped access
 

--- a/astro-docs/src/content/docs/kb/multiple-github-organizations.mdoc
+++ b/astro-docs/src/content/docs/kb/multiple-github-organizations.mdoc
@@ -3,7 +3,7 @@ title: Use Repositories from Multiple GitHub Organizations in Nx Cloud
 description: Choose an access model and connect repositories from multiple GitHub organizations to one Nx Cloud organization
 filter: 'type:Guides'
 topics:
-  - 'Continuous integration'
+  - 'Nx Cloud'
 ---
 
 A GitHub-connected Nx Cloud organization can only connect repositories from the GitHub organization it is connected to. If your repositories span multiple GitHub organizations, choose an Nx Cloud access model based on how you want to manage users.


### PR DESCRIPTION
## Current Behavior

Nx Cloud documentation does not explain that a GitHub-connected Nx Cloud organization is limited to repositories from one GitHub organization or how enterprises should organize repositories that span multiple GitHub organizations.

## Expected Behavior

The knowledge base explains the three available access models and recommends a standard Nx Cloud organization with repository-scoped workspaces when GitHub repository permissions should control access. It documents setup, licensing, OAuth, administration, navigation, and conversion caveats, with links from the related Nx Cloud and GitHub App pages.

## Related Issue(s)

[Linear CS-283](https://linear.app/nxdev/issue/CS-283/kb-article-using-repos-from-multiple-github-orgs-under-one-nx-cloud)

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/calm-wombat-1dba8bb6">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->