### PR TITLE
docs(core): document json input type and dependsOn options

### DIFF
--- a/astro-docs/src/content/docs/reference/inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/inputs.mdoc
@@ -108,6 +108,29 @@ This may cause Nx to rerun some tasks even when files irrelevant to the task hav
 
 To get a better idea of how to use inputs, you can browse some [common input sets](/docs/kb/configure-inputs#common-inputs).
 
+### JSON files
+
+Configuration files such as `package.json` or `tsconfig.base.json` hold fields that are irrelevant to most tasks. Nx can hash a subset of a JSON file so that edits to the remaining fields do not invalidate the cache. JSON inputs are defined like this:
+
+```jsonc
+{
+  "inputs": [
+    { "json": "{projectRoot}/package.json" }, // The whole file
+    { "json": "{projectRoot}/package.json", "fields": ["dependencies"] }, // Only the listed fields
+    {
+      "json": "{workspaceRoot}/tsconfig.base.json",
+      "excludeFields": ["compilerOptions.paths"], // Everything except the listed fields
+    },
+  ],
+}
+```
+
+The `json` path must be prefixed with `{workspaceRoot}` or `{projectRoot}`, the same as a source file input, and it can be a glob pattern that matches several files.
+
+Both `fields` and `excludeFields` accept dot notation to reach nested values, such as `compilerOptions.target`. Fields that a file does not contain are skipped. When both properties are set, `fields` selects first and `excludeFields` then removes from that selection.
+
+A JSON input hashes the parsed contents of the file rather than its raw bytes, so reformatting the file or reordering its keys does not invalidate the cache. Files that parse as neither JSON nor JSONC fall back to hashing the raw contents, and the field filters do not apply to them.
+
 ### Environment variables
 
 Tools and scripts will often use some environment variables to change their behavior. Nx can consider the value of environment variables when calculating the computation hash in order to invalidate the cache if the environment variable value changes. Environment variable inputs are defined like this:

--- a/astro-docs/src/content/docs/reference/project-configuration.mdoc
+++ b/astro-docs/src/content/docs/reference/project-configuration.mdoc
@@ -530,6 +530,22 @@ This also works when defining a relation for the target of the project itself us
 }
 ```
 
+The expanded syntax also accepts an `options` property, which controls whether the options configured on this target are forwarded to the dependency targets. Like `params`, it can be set to `"forward"` or `"ignore"` and defaults to `"ignore"`.
+
+```json
+{
+  "targets": {
+    "build": {
+      "options": { "out": "dist/mylib" },
+      // forward the options of this target to the dependency target
+      "dependsOn": [{ "target": "pre-build", "options": "forward" }]
+    }
+  }
+}
+```
+
+When the target runs with a configuration, the options of that configuration are merged over the target options before they are forwarded. `params` and `options` are set independently of each other, and when both are forwarded, the params passed on the command line take precedence over the forwarded options.
+
 Additionally, when using the expanded object syntax, you can specify individual projects in version 16 or greater.
 
 ```json


### PR DESCRIPTION
## Current Behavior

The inputs reference omits the `json` input type entirely, and the project configuration reference never mentions `dependsOn[].options`.

## Expected Behavior

Both are documented, grounded in the schema, the TypeScript types, and the Rust hasher.

## Related Issue(s)

DOC-614
DOC-617
