### PR TITLE
docs(nx-cloud): update checkout action examples and document apply-locally syntax

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
@@ -56,7 +56,7 @@ jobs:
       # Your existing steps which check out the repo, start-ci-run, install
       # dependencies, etc.
       # These are just illustrative examples...
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
       - run: npx nx start-ci-run
       - run: npm ci
@@ -310,6 +310,12 @@ If a fix is 90% correct but needs minor adjustments:
 1. Click "Apply Locally" in the GitHub comment or Nx Cloud UI
 2. Run the provided command in your terminal
 3. Make your adjustments and commit
+
+The provided command takes the form below. The fix identifier is shown in the Nx Cloud UI and in the PR/MR comment. Pass `--no-interactive` to disable prompting.
+
+```shell
+nx apply-locally <fix-identifier>
+```
 
 ![Apply Self-Healing Fixes Locally](../../../../assets/features/self-healing-apply-locally.avif)
 

--- a/astro-docs/src/content/docs/kb/nx-vs-blacksmith.mdoc
+++ b/astro-docs/src/content/docs/kb/nx-vs-blacksmith.mdoc
@@ -58,7 +58,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - run: npm ci
       - run: npx nx-cloud start-ci-run --distribute-on="8 linux-medium-js"
       - run: npx nx run-many -t lint test build e2e
@@ -72,19 +72,19 @@ jobs:
   lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - run: npm ci
       - run: npx eslint .
   test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - run: npm ci
       - run: npx jest
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - run: npm ci
       - run: npm run build
   e2e:
@@ -93,7 +93,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4] # shard count fixed before the run, rebalanced by hand
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - run: npm ci
       - run: npx playwright test --shard=${{ matrix.shard }}/4
 ```

--- a/astro-docs/src/content/docs/kb/use-bun.mdoc
+++ b/astro-docs/src/content/docs/kb/use-bun.mdoc
@@ -80,7 +80,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: tree:0


### PR DESCRIPTION
## Current Behavior

Three pages pin `actions/checkout` one or two majors behind the sitewide `@v7` baseline, and the self-healing CI page points at the Apply Locally button without ever giving the command syntax.

## Expected Behavior

All checkout examples are on `@v7`, and the `nx-cloud apply-locally <fix-identifier>` syntax is stated inline.

## Related Issue(s)

DOC-618
DOC-619
DOC-621
