### PR TITLE
docs(misc): refresh stale node and yarn versions in knowledge base examples

### DIFF
--- a/astro-docs/src/content/docs/getting-started/installation.mdoc
+++ b/astro-docs/src/content/docs/getting-started/installation.mdoc
@@ -53,7 +53,7 @@ sudo apt install nx
 nx --version
 ```
 
-You should see a version number like `22.5.0`.
+You should see a version number like `23.1.1`.
 
 ### Update global installation
 

--- a/astro-docs/src/content/docs/kb/bundling-node-projects.mdoc
+++ b/astro-docs/src/content/docs/kb/bundling-node-projects.mdoc
@@ -112,7 +112,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   build: {
-    target: 'node18',
+    target: 'node22',
     outDir: 'dist',
     lib: {
       entry: 'src/main.ts',

--- a/astro-docs/src/content/docs/kb/launch-template-examples.mdoc
+++ b/astro-docs/src/content/docs/kb/launch-template-examples.mdoc
@@ -194,7 +194,7 @@ You can use [mise](#install-tools-with-mise) to manage node versions alongside o
 ```yaml
 // .nx/workflows/agents.yaml
 launch-templates:
-  node-21:
+  node-22:
     resource-class: 'docker_linux_amd64/medium'
     image: 'ubuntu22.04-node24.14-v1'
     init-steps:
@@ -205,7 +205,7 @@ launch-templates:
         inputs:
           # you can also define a mise.toml in your repo instead of inline tools
           tools: |
-            node=21
+            node=22
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
 ```
@@ -226,7 +226,7 @@ If none of these are set, the agent keeps the node version that ships with the i
 ```yaml
 // .nx/workflows/agents.yaml
 launch-templates:
-  node-21:
+  node-22:
     resource-class: 'docker_linux_amd64/medium'
     # note the image version of v9,
     # earlier versions of the base image will not work
@@ -240,7 +240,7 @@ launch-templates:
         inputs:
           # omit this input to read the version from a '.nvmrc'
           # file or the 'volta.node' field in package.json
-          node_version: '21'
+          node_version: '22'
 ```
 
 {% /tabitem %}
@@ -257,7 +257,7 @@ The steps follow the general pattern of:
 ```yaml
 // .nx/workflows/agents.yaml
 launch-templates:
-  node-21:
+  node-22:
     resource-class: 'docker_linux_amd64/medium'
     image: 'ubuntu22.04-node24.14-v1'
     init-steps:
@@ -270,7 +270,7 @@ launch-templates:
           # source the updated profile to get the nvm command available
           source ~/.profile
           # install the needed version of node via nvm
-          nvm install 21.7.3
+          nvm install 22.23.2
           # echo the current path (which now includes the nvm-provided version of node) to NX_CLOUD_ENV
           echo "PATH=$PATH" >> $NX_CLOUD_ENV
       - name: Print node version

--- a/astro-docs/src/content/docs/kb/yarn-pnp.mdoc
+++ b/astro-docs/src/content/docs/kb/yarn-pnp.mdoc
@@ -31,13 +31,13 @@ If the version is in the `1.x.x` range, the workspace will be created with yarn 
  yarn set version stable
 ```
 
-This command will update `.yarnrc.yml` with the path to the local yarn `bin` of the correct version and will set the `packageManager` property in the root `package.json`:
+This command will update `.yarnrc.yml` with the path to the local yarn `bin` of the correct version and will set the `packageManager` property in the root `package.json`. The exact version depends on the current stable release of yarn:
 
 ```jsonc
 // package.json
 {
   // ...
-  "packageManager": "yarn@3.6.1",
+  "packageManager": "yarn@4.x.y",
 }
 ```
 


### PR DESCRIPTION
## Current Behavior

Knowledge base examples target EOL Node 18 and Node 21, present `yarn@3.6.1` as the current output of `yarn set version stable`, and advertise a superseded Nx major in the installation check.

## Expected Behavior

Versions match the supported lines in the Nx 23 compatibility table, and the yarn snippet is genericized so it does not rot again.

## Related Issue(s)

DOC-623
DOC-624
DOC-625
DOC-626
