### PR TITLE
docs(nx-cloud): align github app permission levels with the granted app scopes

### DIFF
--- a/astro-docs/src/content/docs/enterprise/conformance.mdoc
+++ b/astro-docs/src/content/docs/enterprise/conformance.mdoc
@@ -108,6 +108,8 @@ Here we are using the `nx-cloud` CLI to run the `conformance:check` command so t
 
 If a valid license is not available to the workspace (either locally or via Nx Cloud), the `conformance` and `conformance:check` commands will fail without checking any rules.
 
+Pass `--printConfig` to either command to print the resolved conformance configuration for the workspace.
+
 ## Taking things further with Nx Cloud Enterprise
 
 Organizations on the Nx Cloud Enterprise plan can [publish custom conformance rules](/docs/enterprise/publish-conformance-rules-to-nx-cloud) to their Nx Cloud organization without the friction of a custom registry, and then [configure the rules](/docs/enterprise/configure-conformance-rules-in-nx-cloud) to apply to the workspaces in their organization automatically when `nx-cloud conformance` or `nx-cloud conformance:check` is run (note that the `nx-cloud` CLI is used in this case in order to handle the authentication with Nx Cloud).

--- a/astro-docs/src/content/docs/kb/github-app-permissions.mdoc
+++ b/astro-docs/src/content/docs/kb/github-app-permissions.mdoc
@@ -36,7 +36,7 @@ Organization permissions:
 
 ## Permission details
 
-### Checks (write)
+### Checks (read & write)
 
 **Used for:** Updating CI run statuses so you can see the progress and results of your Nx Cloud pipeline executions directly in GitHub. Also used for Self-Healing CI status check runs in PRs.
 
@@ -62,7 +62,7 @@ Organization permissions:
 
 ### Issues (read & write)
 
-**Used for:** PR comments (GitHub uses the Issues API for PR comments — see "Pull requests" below for more detail).
+**Used for:** PR comments (GitHub uses the Issues API for PR comments - see "Pull requests" below for more detail). Also used to write labels on pull requests, which GitHub exposes through the same Issues API.
 
 **When it's used:** During CI runs and when posting status comments.
 
@@ -79,7 +79,7 @@ Organization permissions:
 
 **When it's used:** Read operations occur during CI runs. Write operations occur during setup and when posting status comments.
 
-### Workflows (write)
+### Workflows (read & write)
 
 **Used for:** Automatically configuring GitHub Actions workflow files when you opt in to features like Self-Healing CI and distributed task execution.
 


### PR DESCRIPTION
## Current Behavior

The GitHub app permissions page heads the Checks and Workflows sections `(write)` while the app grants read and write on both. The Issues section does not mention label writes, and no conformance page documents `--printConfig`.

## Expected Behavior

Heading levels match the scopes the installed app actually grants, label writes are noted, and `--printConfig` is documented.

## Related Issue(s)

DOC-620
DOC-622
