### PR TITLE
fix(core): create external nodes for out-of-workspace link dependencies

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -3045,10 +3045,23 @@ importers:
       );
     });
 
-    it('should produce no external nodes', () => {
+    it('should produce a node only for the out-of-workspace link', () => {
       const result = getPnpmLockfileNodes(lockFile, '__workspace_only__');
 
-      expect(result.nodes).toEqual({});
+      // `link:../my-plugin` escapes the workspace, so it is an external
+      // dependency even though the lockfile has no packages block; a task
+      // input naming it must resolve to a node instead of failing the hasher.
+      expect(result.nodes).toEqual({
+        'npm:my-plugin': {
+          type: 'npm',
+          name: 'npm:my-plugin',
+          data: {
+            version: 'link:../my-plugin',
+            packageName: 'my-plugin',
+            hash: expect.any(String),
+          },
+        },
+      });
     });
 
     it('should produce no dependencies', () => {
@@ -3065,6 +3078,90 @@ importers:
       expect(
         getPnpmLockfileDependencies(lockFile, '__workspace_only__', ctx, keyMap)
       ).toEqual([]);
+    });
+  });
+
+  describe('linked dependencies', () => {
+    // A `link:` outside the workspace has no packages-section entry, so no
+    // node used to exist for it and `externalDependencies: ['<name>']` on any
+    // task failed hashing with "could not be found" (seen with a linked
+    // @nx/oxlint whose config names it via jsPlugins). Links inside the
+    // workspace are workspace projects and must NOT become external nodes.
+    const lockFile = `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-even:
+        specifier: ^1.0.0
+        version: 1.0.0
+    devDependencies:
+      '@scoped/linked-out':
+        specifier: link:../../elsewhere/plugin
+        version: link:../../elsewhere/plugin
+      linked-in:
+        specifier: link:packages/local
+        version: link:packages/local
+
+  packages/local: {}
+
+packages:
+
+  is-even@1.0.0:
+    resolution: {integrity: sha512-LEhnkAdJqic4Dbqn58A0y52IXoHWlsueqQkKfMfdEnIYG8A1sm/GHidKkS6yvXlMoRrkM34csHnXQtOqcb+Jzg==}
+
+snapshots:
+
+  is-even@1.0.0: {}
+`;
+
+    beforeEach(() => {
+      vol.fromJSON(
+        { 'node_modules/.modules.yaml': 'hoistedDependencies: {}\n' },
+        '/root'
+      );
+    });
+
+    it('should create a node for an out-of-workspace link but not an in-workspace one', () => {
+      const { nodes } = getPnpmLockfileNodes(lockFile, '__linked_deps__');
+
+      expect(nodes['npm:@scoped/linked-out']).toEqual({
+        type: 'npm',
+        name: 'npm:@scoped/linked-out',
+        data: {
+          version: 'link:../../elsewhere/plugin',
+          packageName: '@scoped/linked-out',
+          hash: expect.any(String),
+        },
+      });
+      expect(nodes['npm:linked-in']).toBeUndefined();
+      expect(Object.keys(nodes).filter((n) => n.includes('linked-in'))).toEqual(
+        []
+      );
+      // Registry packages are untouched.
+      expect(nodes['npm:is-even']).toBeDefined();
+    });
+
+    it('should not shadow a hoisted registry package with a link from a nested importer', () => {
+      const withNestedLink = lockFile.replace(
+        '  packages/local: {}',
+        `  packages/local:
+    dependencies:
+      is-even:
+        specifier: link:../../../other/is-even
+        version: link:../../../other/is-even`
+      );
+
+      const { nodes } = getPnpmLockfileNodes(withNestedLink, '__linked_dup__');
+
+      // npm:is-even already names the hoisted registry version; the link from
+      // the nested importer must not replace it.
+      expect(nodes['npm:is-even'].data.version).toBe('1.0.0');
     });
   });
 });

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -15,6 +15,7 @@ import {
   RawProjectGraphDependency,
 } from '../../../project-graph/project-graph-builder';
 import { CreateDependenciesContext } from '../../../project-graph/plugins';
+import { hashArray } from '../../../hasher/file-hasher';
 
 jest.mock('node:fs', () => {
   const memFs = require('memfs').fs;
@@ -3058,7 +3059,7 @@ importers:
           data: {
             version: 'link:../my-plugin',
             packageName: 'my-plugin',
-            hash: expect.any(String),
+            hash: hashArray(['my-plugin', 'link:../my-plugin']),
           },
         },
       });
@@ -3104,6 +3105,15 @@ importers:
       '@scoped/linked-out':
         specifier: link:../../elsewhere/plugin
         version: link:../../elsewhere/plugin
+      abs-in:
+        specifier: link:/root/packages/local
+        version: link:/root/packages/local
+      abs-out:
+        specifier: link:/elsewhere/abs-plugin
+        version: link:/elsewhere/abs-plugin
+      dot-named:
+        specifier: link:..cache/plugin
+        version: link:..cache/plugin
       linked-in:
         specifier: link:packages/local
         version: link:packages/local
@@ -3136,15 +3146,39 @@ snapshots:
         data: {
           version: 'link:../../elsewhere/plugin',
           packageName: '@scoped/linked-out',
-          hash: expect.any(String),
+          hash: hashArray([
+            '@scoped/linked-out',
+            'link:../../elsewhere/plugin',
+          ]),
         },
       });
       expect(nodes['npm:linked-in']).toBeUndefined();
       expect(Object.keys(nodes).filter((n) => n.includes('linked-in'))).toEqual(
         []
       );
-      // Registry packages are untouched.
       expect(nodes['npm:is-even']).toBeDefined();
+    });
+
+    it('should resolve absolute link targets against the workspace root', () => {
+      const { nodes } = getPnpmLockfileNodes(lockFile, '__linked_abs__');
+
+      expect(nodes['npm:abs-out']).toEqual({
+        type: 'npm',
+        name: 'npm:abs-out',
+        data: {
+          version: 'link:/elsewhere/abs-plugin',
+          packageName: 'abs-out',
+          hash: hashArray(['abs-out', 'link:/elsewhere/abs-plugin']),
+        },
+      });
+      expect(nodes['npm:abs-in']).toBeUndefined();
+    });
+
+    it('should not treat a dot-prefixed directory name as an escape', () => {
+      const { nodes } = getPnpmLockfileNodes(lockFile, '__linked_dotname__');
+
+      // `..cache` is a directory inside the workspace, not a `../` traversal.
+      expect(nodes['npm:dot-named']).toBeUndefined();
     });
 
     it('should not shadow a hoisted registry package with a link from a nested importer', () => {

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -3021,7 +3021,8 @@ snapshots:
 
   describe('workspace-only lockfile', () => {
     // pnpm omits the `packages` block entirely when every dependency resolves
-    // to a `link:`/`workspace:` reference, so there is nothing external to lock.
+    // to a `link:`/`workspace:` reference; out-of-workspace links still mint
+    // external nodes.
     const lockFile = `lockfileVersion: '9.0'
 
 settings:
@@ -3038,8 +3039,8 @@ importers:
 `;
 
     beforeEach(() => {
-      // The parser requires `.modules.yaml` to exist; a workspace with no
-      // external packages hoists nothing.
+      // The parser requires `.modules.yaml` to exist; nothing is hoisted
+      // when the lockfile has no packages block.
       vol.fromJSON(
         { 'node_modules/.modules.yaml': 'hoistedDependencies: {}\n' },
         '/root'
@@ -3049,9 +3050,6 @@ importers:
     it('should produce a node only for the out-of-workspace link', () => {
       const result = getPnpmLockfileNodes(lockFile, '__workspace_only__');
 
-      // `link:../my-plugin` escapes the workspace, so it is an external
-      // dependency even though the lockfile has no packages block; a task
-      // input naming it must resolve to a node instead of failing the hasher.
       expect(result.nodes).toEqual({
         'npm:my-plugin': {
           type: 'npm',
@@ -3083,11 +3081,8 @@ importers:
   });
 
   describe('linked dependencies', () => {
-    // A `link:` outside the workspace has no packages-section entry, so no
-    // node used to exist for it and `externalDependencies: ['<name>']` on any
-    // task failed hashing with "could not be found" (seen with a linked
-    // @nx/oxlint whose config names it via jsPlugins). Links inside the
-    // workspace are workspace projects and must NOT become external nodes.
+    // Out-of-workspace `link:` targets mint external nodes; links inside the
+    // workspace are workspace projects and must not.
     const lockFile = `lockfileVersion: '9.0'
 
 settings:
@@ -3098,9 +3093,15 @@ importers:
 
   .:
     dependencies:
+      abs-out:
+        specifier: link:/elsewhere/abs-plugin
+        version: link:/elsewhere/abs-plugin
       is-even:
         specifier: ^1.0.0
         version: 1.0.0
+      multi-target:
+        specifier: link:../elsewhere/root-target
+        version: link:../elsewhere/root-target
     devDependencies:
       '@scoped/linked-out':
         specifier: link:../../elsewhere/plugin
@@ -3108,17 +3109,22 @@ importers:
       abs-in:
         specifier: link:/root/packages/local
         version: link:/root/packages/local
-      abs-out:
-        specifier: link:/elsewhere/abs-plugin
-        version: link:/elsewhere/abs-plugin
       dot-named:
         specifier: link:..cache/plugin
         version: link:..cache/plugin
       linked-in:
         specifier: link:packages/local
         version: link:packages/local
+    optionalDependencies:
+      opt-linked:
+        specifier: link:../elsewhere/opt-plugin
+        version: link:../elsewhere/opt-plugin
 
-  packages/local: {}
+  packages/local:
+    dependencies:
+      multi-target:
+        specifier: link:../../elsewhere/nested-target
+        version: link:../../elsewhere/nested-target
 
 packages:
 
@@ -3159,6 +3165,23 @@ snapshots:
       expect(nodes['npm:is-even']).toBeDefined();
     });
 
+    it('should mint nodes for outside links in dependencies and optionalDependencies', () => {
+      const { nodes } = getPnpmLockfileNodes(lockFile, '__linked_dep_types__');
+
+      expect(nodes['npm:abs-out']).toBeDefined();
+      expect(nodes['npm:opt-linked'].data.version).toBe(
+        'link:../elsewhere/opt-plugin'
+      );
+    });
+
+    it('should let the root importer win when several importers link the same name', () => {
+      const { nodes } = getPnpmLockfileNodes(lockFile, '__linked_competing__');
+
+      expect(nodes['npm:multi-target'].data.version).toBe(
+        'link:../elsewhere/root-target'
+      );
+    });
+
     it('should resolve absolute link targets against the workspace root', () => {
       const { nodes } = getPnpmLockfileNodes(lockFile, '__linked_abs__');
 
@@ -3177,7 +3200,6 @@ snapshots:
     it('should not treat a dot-prefixed directory name as an escape', () => {
       const { nodes } = getPnpmLockfileNodes(lockFile, '__linked_dotname__');
 
-      // `..cache` is a directory inside the workspace, not a `../` traversal.
       expect(nodes['npm:dot-named']).toBeUndefined();
     });
 
@@ -3193,8 +3215,6 @@ snapshots:
 
       const { nodes } = getPnpmLockfileNodes(withNestedLink, '__linked_dup__');
 
-      // npm:is-even already names the hoisted registry version; the link from
-      // the nested importer must not replace it.
       expect(nodes['npm:is-even'].data.version).toBe('1.0.0');
     });
   });

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -28,7 +28,8 @@ import { hashArray } from '../../../hasher/file-hasher';
 import { CreateDependenciesContext } from '../../../project-graph/plugins';
 import { getCatalogManager } from '../../../utils/catalog';
 import { findNodeMatchingVersion } from './project-graph-pruning';
-import { join, posix, relative, sep } from 'path';
+import { isAbsolute, join, posix, relative, sep } from 'path';
+import { workspaceRoot } from '../../../utils/workspace-root';
 import { getWorkspacePackagesFromGraph } from '../utils/get-workspace-packages-from-graph';
 import { satisfies, validRange } from 'semver';
 
@@ -226,6 +227,23 @@ function findPatchHash(
     (entry) => entry.versionSpecifier === null
   );
   return nameOnlyMatch?.hash;
+}
+
+// Segment-aware: `..` and `../x` escape, a directory literally named `..cache`
+// does not. Absolute targets are resolved against the workspace root.
+function linkTargetEscapesWorkspace(
+  importerPath: string,
+  depVersion: string
+): boolean {
+  const rawTarget = depVersion.slice('link:'.length);
+  if (posix.isAbsolute(rawTarget) || isAbsolute(rawTarget)) {
+    const rel = relative(workspaceRoot, rawTarget);
+    return rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel);
+  }
+  const combined = posix.normalize(
+    posix.join(importerPath === '.' ? '' : importerPath, rawTarget)
+  );
+  return combined === '..' || combined.startsWith('../');
 }
 
 function getNodes(
@@ -512,11 +530,21 @@ function getNodes(
   // `link:` dependencies pointing outside the workspace never appear in the
   // packages section, so nothing above minted a node for them — and a task
   // input naming one via `externalDependencies` fails hashing with "could not
-  // be found". Mint a node keyed on the link path. Its hash changes only when
-  // the path does, not when the linked content does, which is how linked
-  // dependencies behave everywhere else in Nx. Links that resolve inside the
-  // workspace are workspace projects, not externals, and are skipped.
-  for (const [importerPath, importer] of Object.entries(data.importers ?? {})) {
+  // be found". Mint a node under the bare `npm:<name>`, hashed on the link
+  // path: the hash changes only when the path does, not when the linked
+  // content does, which is how linked dependencies behave everywhere else in
+  // Nx. Links that resolve inside the workspace are workspace projects, not
+  // externals, and are skipped.
+  //
+  // Importers are visited root-first, then lexicographically, so when several
+  // importers link the same package name to different targets the choice of
+  // the surviving node is deterministic — the bare name is the only name
+  // `externalDependencies` can reference, so only one node is minted per name.
+  const importerPaths = Object.keys(data.importers ?? {}).sort((a, b) =>
+    a === '.' ? -1 : b === '.' ? 1 : a.localeCompare(b)
+  );
+  for (const importerPath of importerPaths) {
+    const importer = data.importers[importerPath];
     for (const depType of [
       'dependencies',
       'devDependencies',
@@ -530,18 +558,12 @@ function getNodes(
         if (typeof depVersion !== 'string' || !depVersion.startsWith('link:')) {
           continue;
         }
-        const linkTarget = posix.normalize(
-          posix.join(
-            importerPath === '.' ? '' : importerPath,
-            depVersion.slice('link:'.length)
-          )
-        );
-        if (!linkTarget.startsWith('..')) {
+        if (!linkTargetEscapesWorkspace(importerPath, depVersion)) {
           continue; // inside the workspace -> a workspace project
         }
         const bareName = `npm:${depName}`;
         if (results[bareName]) {
-          continue; // a registry version is hoisted under this name
+          continue; // a hoisted registry version or an earlier link wins
         }
         results[bareName] = {
           type: 'npm',

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -536,10 +536,10 @@ function getNodes(
   // Nx. Links that resolve inside the workspace are workspace projects, not
   // externals, and are skipped.
   //
-  // Importers are visited root-first, then lexicographically, so when several
-  // importers link the same package name to different targets the choice of
-  // the surviving node is deterministic — the bare name is the only name
-  // `externalDependencies` can reference, so only one node is minted per name.
+  // One node per package name, chosen deterministically by visiting importers
+  // root-first, then lexicographically. An `externalDependencies` input names
+  // a package, not a link target, so it could not distinguish two linked
+  // targets anyway.
   const importerPaths = Object.keys(data.importers ?? {}).sort((a, b) =>
     a === '.' ? -1 : b === '.' ? 1 : a.localeCompare(b)
   );

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -28,7 +28,7 @@ import { hashArray } from '../../../hasher/file-hasher';
 import { CreateDependenciesContext } from '../../../project-graph/plugins';
 import { getCatalogManager } from '../../../utils/catalog';
 import { findNodeMatchingVersion } from './project-graph-pruning';
-import { join, relative, sep } from 'path';
+import { join, posix, relative, sep } from 'path';
 import { getWorkspacePackagesFromGraph } from '../utils/get-workspace-packages-from-graph';
 import { satisfies, validRange } from 'semver';
 
@@ -508,6 +508,54 @@ function getNodes(
       results[node.name] = node;
     });
   }
+
+  // `link:` dependencies pointing outside the workspace never appear in the
+  // packages section, so nothing above minted a node for them — and a task
+  // input naming one via `externalDependencies` fails hashing with "could not
+  // be found". Mint a node keyed on the link path. Its hash changes only when
+  // the path does, not when the linked content does, which is how linked
+  // dependencies behave everywhere else in Nx. Links that resolve inside the
+  // workspace are workspace projects, not externals, and are skipped.
+  for (const [importerPath, importer] of Object.entries(data.importers ?? {})) {
+    for (const depType of [
+      'dependencies',
+      'devDependencies',
+      'optionalDependencies',
+    ] as const) {
+      const deps = importer[depType] as Record<string, string> | undefined;
+      if (!deps) {
+        continue;
+      }
+      for (const [depName, depVersion] of Object.entries(deps)) {
+        if (typeof depVersion !== 'string' || !depVersion.startsWith('link:')) {
+          continue;
+        }
+        const linkTarget = posix.normalize(
+          posix.join(
+            importerPath === '.' ? '' : importerPath,
+            depVersion.slice('link:'.length)
+          )
+        );
+        if (!linkTarget.startsWith('..')) {
+          continue; // inside the workspace -> a workspace project
+        }
+        const bareName = `npm:${depName}`;
+        if (results[bareName]) {
+          continue; // a registry version is hoisted under this name
+        }
+        results[bareName] = {
+          type: 'npm',
+          name: bareName,
+          data: {
+            version: depVersion,
+            packageName: depName,
+            hash: hashArray([depName, depVersion]),
+          },
+        };
+      }
+    }
+  }
+
   return { nodes: results, keyMap };
 }
 


### PR DESCRIPTION
## Current Behavior

A `link:` dependency has no entry in the lockfile's `packages:` section (it only appears under `importers`, with no version or integrity), so the pnpm parser mints no external node for it. Any task input naming such a package via `externalDependencies` fails the whole run at hash-planning time:

```
NX  The externalDependency '@nx/oxlint' for 'examples-react-basic:lint' could not be found
```

Hit by workspaces that link a plugin to a local checkout while an inferred target (or targetDefaults) declares that plugin as an external dependency — e.g. `@nx/oxlint`'s inferred inputs naming the packages that a config's `jsPlugins` loads.

## Expected Behavior

`getPnpmLockfileNodes` mints an external node for each importer dependency whose `link:` target escapes the workspace root — `npm:<name>` with `version: "link:<path>"`, hashed on name + path. Two deliberate boundaries:

- **Links that resolve inside the workspace stay excluded** — they are workspace projects, and a node would shadow them.
- **A hoisted registry version keeps the bare `npm:` name** over a nested importer's link, so a linked dev copy cannot hijack an identity the real dependency holds.

Known limits, stated rather than hidden: the node's identity is the link *path*, so content changes to the linked directory do not re-hash it (consistent with how linked dependencies behave everywhere else in Nx — content-hashed nodes would be a separate enhancement), and the npm/yarn/bun parsers still skip linked entries (the same fix can follow there).

Performance: the added importers walk costs ~0.4ms on nx's own 2.1MB lockfile (121 importers, 1141 dependency entries) — 0.4% of the YAML parse it follows, and it only runs when the lockfile hash changes.

Covered by two new parser cases (out-of-workspace minted / in-workspace excluded / no shadowing) plus one deliberately updated existing test that had documented the old zero-node behavior.

## Related Issue(s)

Split out of #36733, whose examples-workspace CI surfaced the failure; that branch carries an interim plugin-side filter it can drop once this lands.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Move-eslint-import-rules-to-oxlint-4118407a">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->