### PR TITLE
docs(nx-cloud): show complete ci pipeline examples with task distribution enabled

### DIFF
--- a/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
@@ -36,6 +36,7 @@ Page: {pageUrl}
 {% /llm_copy_prompt %}
 
 Connect your workspace to Nx Cloud and run your CI tasks through `nx`. That turns on remote caching, affected, distribution, and self-healing CI.
+Each section below covers one of those in isolation. If you would rather start from a working pipeline, jump to the [complete example](#complete-example).
 
 {% call_to_action variant="default" title="Tour an Nx Cloud workspace" url="https://cloud.nx.app/demo/intro?utm_source=nx-dev&utm_medium=ci-tutorial&utm_campaign=workspace-tour" description="See distributed task execution, caching, and run analytics on a live workspace before you wire up your own CI." /%}
 
@@ -122,6 +123,7 @@ dte:
 
 Distribution works with [remote caching](#remote-caching) and enables [task splitting](/docs/features/ci-features/split-e2e-tasks) for Playwright, Vitest, and other tools across machines.
 For every configuration option, see the [CI configuration file reference](/docs/reference/nx-cloud/ci-config).
+For the same setup on CircleCI, GitLab, Azure Pipelines, Jenkins, or Bitbucket, see [Setting up CI for Nx Cloud](/docs/kb/setup-ci).
 
 ## Self-healing CI
 
@@ -137,6 +139,68 @@ Add `npx nx fix-ci` as the final step in your workflow. When a task fails, Nx Cl
 The `if: always()` ensures `fix-ci` runs even when prior steps fail. It catches flaky tests, configuration drift, and other issues Nx Cloud can fix without manual debugging.
 
 See [Self-healing CI](/docs/features/ci-features/self-healing-ci) for the trigger model.
+
+## Complete example
+
+The sections above each show one piece. Here they are together as a single GitHub Actions pipeline with remote caching, affected, distribution, and self-healing all enabled.
+
+```yaml
+// .nx/ci-config.yaml
+dte:
+  # Distribute across 3 agents using the linux-medium-js launch template
+  distribute-on: 3 linux-medium-js
+lifecycle:
+  # Shut idle agents down once every build task has been requested
+  stop-after:
+    - build
+```
+
+```yaml
+// .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 gives Nx the full history it needs to work out what changed
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      # Provisions the agents declared in .nx/ci-config.yaml.
+      # Run it before installing dependencies so agents boot while this job installs.
+      - run: npx nx-cloud start-nx-agents
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - run: npm ci
+
+      # Runs lint, test, and build only for projects affected by this change.
+      # Nx Cloud distributes these tasks across the agents started above.
+      - run: npx nx affected -t lint test build
+
+      # Analyzes any failure above and proposes a fix.
+      # if: always() so it still runs when a task fails, which is the case it exists for.
+      - run: npx nx fix-ci
+        if: always()
+```
+
+For the same pipeline on another CI provider, and for provider-specific details such as shallow-clone handling and branch variables, see [Setting up CI for Nx Cloud](/docs/kb/setup-ci).
 
 ## Resources
 

--- a/astro-docs/src/content/docs/kb/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/kb/setup-ci.mdoc
@@ -21,12 +21,25 @@ Each platform has specific configurations and optimizations that help you build 
 
 ## CI configuration
 
+Each example combines a `.nx/ci-config.yaml` file that configures task distribution across [Nx Agents](/docs/features/ci-features/distribute-task-execution) with a provider workflow that starts those agents by running `nx-cloud start-nx-agents`. See the [CI configuration file reference](/docs/reference/nx-cloud/ci-config) for every key you can set.
+
 {% tabs syncKey="ci-provider" %}
 {% tabitem label="GitHub" %}
 Need a starting point? Generate a new workflow file with the following command:
 
 ```shell
 nx g ci-workflow --ci=github
+```
+
+Add a `.nx/ci-config.yaml` file to configure task distribution:
+
+```yaml
+// .nx/ci-config.yaml
+dte:
+  distribute-on: 3 linux-medium-js
+lifecycle:
+  stop-after:
+    - build
 ```
 
 Below is an example of a GitHub Actions setup, building, and testing only what is affected.
@@ -56,9 +69,7 @@ jobs:
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+      - run: npx nx-cloud start-nx-agents
 
       # Cache node_modules
       - uses: actions/setup-node@v6
@@ -87,6 +98,17 @@ Need a starting point? Generate a new workflow file with the following command:
 nx g ci-workflow --ci=circleci
 ```
 
+Add a `.nx/ci-config.yaml` file to configure task distribution:
+
+```yaml
+// .nx/ci-config.yaml
+dte:
+  distribute-on: 3 linux-medium-js
+lifecycle:
+  stop-after:
+    - build
+```
+
 Below is an example of a Circle CI setup, building, and testing only what is affected.
 
 ```yaml
@@ -105,9 +127,7 @@ jobs:
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+      - run: npx nx-cloud start-nx-agents
 
       - run: npm ci
       - nx/set-shas:
@@ -139,6 +159,17 @@ Need a starting point? Generate a new workflow file with the following command:
 nx g ci-workflow --ci=gitlab
 ```
 
+Add a `.nx/ci-config.yaml` file to configure task distribution:
+
+```yaml
+// .nx/ci-config.yaml
+dte:
+  distribute-on: 3 linux-medium-js
+lifecycle:
+  stop-after:
+    - build
+```
+
 Below is an example of a GitLab setup, building and testing only what is affected.
 
 ```yaml
@@ -156,9 +187,7 @@ CI:
   script:
     # This enables task distribution via Nx Cloud
     # Run this command as early as possible, before dependencies are installed
-    # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-    # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-    # - npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+    - npx nx-cloud start-nx-agents
 
     - npm ci
     - NX_HEAD=$CI_COMMIT_SHA
@@ -181,6 +210,17 @@ Need a starting point? Generate a new workflow file with the following command:
 
 ```shell
 nx g ci-workflow --ci=azure-pipelines
+```
+
+Add a `.nx/ci-config.yaml` file to configure task distribution:
+
+```yaml
+// .nx/ci-config.yaml
+dte:
+  distribute-on: 3 linux-medium-js
+lifecycle:
+  stop-after:
+    - build
 ```
 
 Below is an example of an Azure Pipelines setup building and testing only what is affected.
@@ -233,9 +273,7 @@ jobs:
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-      # - script: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+      - script: npx nx-cloud start-nx-agents
 
       - script: npm ci
       - script: git branch --track main origin/main
@@ -252,6 +290,17 @@ jobs:
 {% /tabitem %}
 
 {% tabitem label="Jenkins" %}
+
+Add a `.nx/ci-config.yaml` file to configure task distribution:
+
+```yaml
+// .nx/ci-config.yaml
+dte:
+  distribute-on: 3 linux-medium-js
+lifecycle:
+  stop-after:
+    - e2e-ci
+```
 
 Below is an example of a Jenkins setup, building and testing only what is affected.
 
@@ -271,8 +320,7 @@ pipeline {
                     agent any
                     steps {
                         // This line enables distribution
-                        // The "--stop-agents-after" is optional, but allows idle agents to shut down once the "e2e-ci" targets have been requested
-                        // sh "npx nx start-ci-run --distribute-on='3 linux-medium-js' --stop-agents-after='e2e-ci'"
+                        sh "npx nx-cloud start-nx-agents"
                         sh "npm ci"
 
                         // Prepend any command with "nx record --" to record its logs to Nx Cloud
@@ -291,8 +339,7 @@ pipeline {
                     agent any
                     steps {
                         // This line enables distribution
-                        // The "--stop-agents-after" is optional, but allows idle agents to shut down once the "e2e-ci" targets have been requested
-                        // sh "npx nx start-ci-run --distribute-on='3 linux-medium-js' --stop-agents-after='e2e-ci'"
+                        sh "npx nx-cloud start-nx-agents"
                         sh "npm ci"
 
                         // Prepend any command with "nx record --" to record its logs to Nx Cloud
@@ -320,6 +367,17 @@ Need a starting point? Generate a new workflow file with the following command:
 nx g ci-workflow --ci=bitbucket-pipelines
 ```
 
+Add a `.nx/ci-config.yaml` file to configure task distribution:
+
+```yaml
+// .nx/ci-config.yaml
+dte:
+  distribute-on: 3 linux-medium-js
+lifecycle:
+  stop-after:
+    - build
+```
+
 Below is an example of a Bitbucket Pipelines, building and testing only what is affected.
 
 ```yaml
@@ -339,9 +397,7 @@ pipelines:
 
             # This enables task distribution via Nx Cloud
             # Run this command as early as possible, before dependencies are installed
-            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-            # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
-            # - npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+            - npx nx-cloud start-nx-agents
 
             - npm ci
 
@@ -361,9 +417,7 @@ pipelines:
             - export NX_BRANCH=$BITBUCKET_BRANCH
             # This enables task distribution via Nx Cloud
             # Run this command as early as possible, before dependencies are installed
-            # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-            # Connect your workspace by running "nx connect" and uncomment this
-            # - npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+            - npx nx-cloud start-nx-agents
 
             - npm ci
 
@@ -472,10 +526,10 @@ We also have to set `NX_BRANCH` explicitly.
 All CI platforms support task distribution via Nx Cloud. To enable it:
 
 1. Connect your workspace by running `nx connect`
-2. Uncomment the `npx nx start-ci-run` command in your CI configuration
-3. Configure the distribution settings based on your needs
+2. Commit a `.nx/ci-config.yaml` file with your distribution and stop conditions
+3. Run `npx nx-cloud start-nx-agents` at the start of your main job
 
-Learn more at [Nx Cloud CI Reference](https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun).
+Learn more in the [CI configuration file reference](/docs/reference/nx-cloud/ci-config).
 
 ### Self-healing CI
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/ci-config.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/ci-config.mdoc
@@ -49,6 +49,8 @@ The file has five top-level sections. All are optional, and each falls back to i
 | `nx-agents` | Configuration for the Nx Agents themselves.                         |
 | `overrides` | Per-environment overrides keyed by `NX_CI_EXECUTION_ENV`.           |
 
+For complete pipelines that pair this file with a provider workflow, see [Setting up CI for Nx Cloud](/docs/kb/setup-ci).
+
 ## `lifecycle`
 
 Stop conditions and stall detection for the run group.


### PR DESCRIPTION
## Current Behavior

`kb/setup-ci.mdoc` holds the only complete per-provider pipelines, but they use the superseded `start-ci-run` form with the distribution line commented out. The pages that teach the current `.nx/ci-config.yaml` + `start-nx-agents` form only show fragments, and they link readers here.

The two forms cannot be combined - once `.nx/ci-config.yaml` exists, `start-ci-run` errors out.

## Expected Behavior

All six provider examples show an active `nx-cloud start-nx-agents` call plus the `.nx/ci-config.yaml` beside it, so each is a complete working pipeline with distribution enabled. Set up CI carries a full single-provider pipeline of its own and links here for the other providers.

### Page previews

Largest change first:

- [Setting up CI for Nx Cloud](https://deploy-preview-36747--nx-docs.netlify.app/docs/kb/setup-ci#ci-configuration) - 104 lines (+79/-25). All six provider tabs gain a `.nx/ci-config.yaml` block, and eight commented `start-ci-run` call sites become active `nx-cloud start-nx-agents` calls in each provider's own syntax. The summary section no longer tells you to uncomment a line that is no longer commented.
- [Setting Up CI](https://deploy-preview-36747--nx-docs.netlify.app/docs/getting-started/setup-ci#complete-example) - 64 lines (+64/-0). New `## Complete example` section at the end: the `.nx/ci-config.yaml` plus a full GitHub Actions workflow with remote caching, affected, distribution, and self-healing all enabled, commented on the lines that need explaining. Intro points at it, and the distribution section links to the KB page for the other providers.
- [CI config reference](https://deploy-preview-36747--nx-docs.netlify.app/docs/reference/nx-cloud/ci-config#top-level-structure) - 2 lines (+2/-0). Link to the complete pipelines.

## Related Issue(s)

DOC-633
