### PR TITLE
chore(repo): bump pnpm to 11.22.0

### DIFF
--- a/.github/workflows/generate-embeddings.yml
+++ b/.github/workflows/generate-embeddings.yml
@@ -26,7 +26,7 @@ jobs:
         uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         id: pnpm-install
         with:
-          version: 11.2.2
+          version: 11.22.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         with:
-          version: 11.2.2
+          version: 11.22.0
 
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ env:
   NX_RUN_GROUP: ${{ github.run_id }}-${{ github.run_attempt }}
   CYPRESS_INSTALL_BINARY: 0
   NODE_VERSION: 26.7.0
-  PNPM_VERSION: 11.2.2 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
+  PNPM_VERSION: 11.22.0 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
   NX_GRADLE_PROJECT_GRAPH_TIMEOUT: 600
 
 jobs:
@@ -448,7 +448,7 @@ jobs:
             env
             whoami
             sudo pkg install -y -f node libnghttp2 www/npm git ca_root_nss
-            sudo npm install --location=global --ignore-scripts pnpm@11.2.2
+            sudo npm install --location=global --ignore-scripts pnpm@11.22.0
             curl https://sh.rustup.rs -sSf --output rustup.sh
             sh rustup.sh -y --profile minimal --default-toolchain stable
             source "$HOME/.cargo/env"

--- a/nx.json
+++ b/nx.json
@@ -389,7 +389,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 3237,
+  "bust": 3238,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Smart Monorepos · Fast Builds",
   "homepage": "https://nx.dev",
   "private": true,
-  "packageManager": "pnpm@11.2.2",
+  "packageManager": "pnpm@11.22.0",
   "scripts": {
     "build": "nx run-many --target build --parallel 8 --exclude nx-dev,tools-documentation-create-embeddings,nx-dev-util-ai,astro-docs",
     "commit": "czg",

--- a/packages/eslint-plugin/internal.ts
+++ b/packages/eslint-plugin/internal.ts
@@ -7,4 +7,6 @@
 // explains why.
 import enforceModuleBoundariesRule from './src/rules/enforce-module-boundaries';
 
-export const enforceModuleBoundaries = enforceModuleBoundariesRule;
+// Keep the annotation: the inferred type names RuleModule via a pnpm store path (TS2883).
+export const enforceModuleBoundaries: typeof enforceModuleBoundariesRule =
+  enforceModuleBoundariesRule;

--- a/packages/eslint-plugin/nx.ts
+++ b/packages/eslint-plugin/nx.ts
@@ -1,3 +1,4 @@
+import type { TSESLint } from '@typescript-eslint/utils';
 import { workspaceRules } from './src/resolve-workspace-rules';
 import dependencyChecks, {
   RULE_NAME as dependencyChecksRuleName,
@@ -9,7 +10,11 @@ import nxPluginChecksRule, {
   RULE_NAME as nxPluginChecksRuleName,
 } from './src/rules/nx-plugin-checks';
 
-const plugin = {
+// Keep the annotation: the inferred type names RuleModule via a pnpm store path (TS2883).
+const plugin: {
+  configs: Record<string, unknown>;
+  rules: Record<string, TSESLint.RuleModule<string, unknown[]>>;
+} = {
   configs: {},
   rules: {
     [enforceModuleBoundariesRuleName]: enforceModuleBoundaries,

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,3 +1,4 @@
+import type { TSESLint } from '@typescript-eslint/utils';
 import typescript from './configs/typescript';
 import javascript from './configs/javascript';
 import reactTmp from './configs/react-tmp';
@@ -64,7 +65,8 @@ const configs = {
   },
 };
 
-const rules = {
+// Keep the annotation: the inferred type names RuleModule via a pnpm store path (TS2883).
+const rules: Record<string, TSESLint.RuleModule<string, unknown[]>> = {
   [enforceModuleBoundariesRuleName]: enforceModuleBoundaries,
   [nxPluginChecksRuleName]: nxPluginChecksRule,
   [dependencyChecksRuleName]: dependencyChecks,


### PR DESCRIPTION
## Current Behavior

The repo pins pnpm `11.2.2`, which is ~20 minor releases behind the current `11.22.0`. The version is pinned in four places that must stay in sync:

- `package.json` `packageManager`
- `.github/workflows/publish.yml` (`PNPM_VERSION` env + a hardcoded global install)
- `.github/workflows/issue-notifier.yml` (`pnpm/action-setup` version)
- `.github/workflows/generate-embeddings.yml` (`pnpm/action-setup` version)

## Expected Behavior

All four pins move to pnpm `11.22.0`. This stays within the same major, so no lockfile or config migration is involved — `pnpm install --frozen-lockfile` was verified to pass unchanged on 11.22.0 locally (all 121 workspace projects, `lockfileVersion: 9.0` untouched, supply-chain policy check green).

Other `11.2.2` occurrences in the repo are unrelated unit-test fixtures and version strings tied to specific documented pnpm behaviors, so they are intentionally left alone.

## Related Issue(s)

N/A — routine toolchain maintenance.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Bump-pnpm-to-11.22.0-b99b3cf2">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->