### PR TITLE
fix(core): restamp the migrate-runs gitignore migration so beta-train workspaces run it

### DIFF
--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -181,7 +181,7 @@
       "implementation": "./dist/src/migrations/update-23-0-0/consolidate-release-tag-config"
     },
     "23-0-0-add-migrate-runs-to-git-ignore": {
-      "version": "23.0.0-beta.18",
+      "version": "23.2.0-beta.10",
       "description": "Adds .nx/migrate-runs to .gitignore",
       "implementation": "./dist/src/migrations/update-23-0-0/add-migrate-runs-to-git-ignore"
     },

--- a/packages/nx/src/command-line/migrate/agentic/handoff-gitignore.spec.ts
+++ b/packages/nx/src/command-line/migrate/agentic/handoff-gitignore.spec.ts
@@ -24,7 +24,7 @@ const mockInfo = logger.info as jest.Mock;
 const HANDOFF_GITIGNORE_MIGRATION = {
   package: 'nx',
   name: '23-0-0-add-migrate-runs-to-git-ignore',
-  version: '23.0.0-beta.18',
+  version: '23.2.0-beta.10',
 };
 
 const COMMIT_PREFIX = 'chore: [nx migration] ';


### PR DESCRIPTION
## Current Behavior

`23-0-0-add-migrate-runs-to-git-ignore` is declared at `23.0.0-beta.18`. Migrations only run when `installed < version <= target`, so any workspace that crossed v23 before beta.18 shipped (the whole early-beta cohort, including the nrwl repos) never gets it selected on any later upgrade. The agentic/orchestrated gitignore fallback then reads the missing entry as a deliberate removal and refuses commit-creating runs until the user hand-edits `.gitignore` — which is exactly what happened in this session's five-repo `23.2.0-beta.9` migration.

## Expected Behavior

The entry is re-stamped to `23.2.0-beta.10` (the active train's next prerelease). The migration is idempotent, so workspaces that already have the entry re-run it as a no-op, and the stranded beta cohort finally gets `.nx/migrate-runs` ignored on their next migrate. The entry key is unchanged, so `isHandoffGitignoreMigration` (which matches on package + name only) keeps hoisting it to run first, and the inline pre-v23 fallback is unaffected. The `handoff-gitignore.spec.ts` fixture mirrors the new version.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Use-the-orchestrated-migrate-loop-in-the-multi-repo-migrate-skill-a479908d">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->