### PR TITLE
fix(misc): de-flake the nx watch e2e suite

### DIFF
--- a/e2e/nx/src/watch.test.ts
+++ b/e2e/nx/src/watch.test.ts
@@ -42,21 +42,22 @@ const ranFor =
   (lines: string[]): boolean =>
     expected.every((e) => lines.includes(e));
 
-/** One NX_FILE_CHANGES batch carries every file in `expected`. */
-const batchedAll =
-  (expected: string[]) =>
-  (lines: string[]): boolean =>
-    lines.some((line) => expected.every((f) => line.split(' ').includes(f)));
-
-// '' when the watcher emitted nothing, so the assertion diffs readably instead of
-// throwing on undefined.
-function matchingBatch(lines: string[], expected: string[]): string {
-  return (
-    lines.find((line) => expected.every((f) => line.split(' ').includes(f))) ??
-    lines[0] ??
-    ''
-  );
+/** Unique paths across every NX_FILE_CHANGES batch, sorted. */
+function reportedFiles(lines: string[]): string[] {
+  return [
+    ...new Set(lines.flatMap((line) => line.split(' ')).filter(Boolean)),
+  ].sort();
 }
+
+// Across batches, not within one: the writes are 10ms apart and the watcher
+// coalesces on a 100ms idle window, so a loaded machine splits one burst into
+// several batches. Observed on CI as three.
+const receivedAll =
+  (expected: string[]) =>
+  (lines: string[]): boolean => {
+    const received = reportedFiles(lines);
+    return expected.every((e) => received.includes(e));
+  };
 
 // The parsed lines drop every NX-prefixed line, which is where `nx watch`
 // reports errors. Keep the raw stream so afterEach can show it.
@@ -157,10 +158,9 @@ describe('Nx Watch', () => {
       `libs/${proj1}/newfile2.txt`,
       `libs/${proj2}/newfile.txt`,
     ];
-    const lines = await getOutput(batchedAll(expected));
-    let results = matchingBatch(lines, expected).split(' ').sort();
+    const lines = await getOutput(receivedAll(expected));
 
-    expect(results).toEqual(expected);
+    expect(reportedFiles(lines)).toEqual([...expected].sort());
   }, 50000);
 
   it('should watch for global workspace file changes', async () => {
@@ -178,10 +178,9 @@ describe('Nx Watch', () => {
       `libs/${proj2}/newfile.txt`,
       'newfile2.txt',
     ];
-    const lines = await getOutput(batchedAll(expected));
-    let results = matchingBatch(lines, expected).split(' ').sort();
+    const lines = await getOutput(receivedAll(expected));
 
-    expect(results).toEqual(expected);
+    expect(reportedFiles(lines)).toEqual([...expected].sort());
   }, 50000);
 
   it('should watch selected projects only', async () => {
@@ -236,10 +235,11 @@ describe('Nx Watch', () => {
     );
 
     const expected = [`libs/${proj1}/src/newsubdir/newfile.ts`];
-    const lines = await getOutput(batchedAll(expected));
-    let results = matchingBatch(lines, expected).split(' ').sort();
+    const lines = await getOutput(receivedAll(expected));
 
-    expect(results).toContain(`libs/${proj1}/src/newsubdir/newfile.ts`);
+    expect(reportedFiles(lines)).toContain(
+      `libs/${proj1}/src/newsubdir/newfile.ts`
+    );
   }, 50000);
 
   it('should reconnect after daemon restart', async () => {
@@ -304,13 +304,16 @@ function createGetOutput(
       await wait(50);
     }
 
+    // Sampled before the kill below, which would otherwise set `exited` too and
+    // make every timeout look like the process had died on its own.
+    const exitedOnItsOwn = exited;
     if (!exited) {
       await wait(settleMs);
       treeKill(p.pid);
     }
     await closed;
 
-    if (exited && !until(lines())) {
+    if (exitedOnItsOwn && !until(lines())) {
       // `nx watch` exits on a fatal daemon error. Reporting that beats letting
       // the caller assert on an empty array and show `Received: []`.
       throw new Error(

--- a/e2e/nx/src/watch.test.ts
+++ b/e2e/nx/src/watch.test.ts
@@ -19,6 +19,45 @@ import { tmpdir } from 'os';
 let cacheDirectory = mkdtempSync(join(tmpdir(), 'daemon'));
 console.log('cache directory', cacheDirectory);
 
+// getStrippedEnvironmentVariables drops NX_PROJECT_GRAPH_CACHE_DIRECTORY, so every
+// nx invocation here must re-add it or it talks to a second daemon in the default
+// cache dir — not the one afterEach dumps the log of.
+const daemonEnv = {
+  NX_DAEMON: 'true',
+  NX_PROJECT_GRAPH_CACHE_DIRECTORY: cacheDirectory,
+};
+
+// Kept out of daemonEnv: in the daemon this lands in its log file, but the `nx watch`
+// client shares stdout with the command output these tests parse.
+const daemonStartEnv = { ...daemonEnv, NX_NATIVE_LOGGING: 'nx' };
+
+const OUTPUT_TIMEOUT_MS = 15000;
+// Read on past the match: the suite also asserts that unwatched projects did NOT
+// run, which a late straggler would otherwise slip past.
+const OUTPUT_SETTLE_MS = 500;
+
+/** Every project in `expected` has run the command at least once. */
+const ranFor =
+  (expected: string[]) =>
+  (lines: string[]): boolean =>
+    expected.every((e) => lines.includes(e));
+
+/** One NX_FILE_CHANGES batch carries every file in `expected`. */
+const batchedAll =
+  (expected: string[]) =>
+  (lines: string[]): boolean =>
+    lines.some((line) => expected.every((f) => line.split(' ').includes(f)));
+
+// '' when the watcher emitted nothing, so the assertion diffs readably instead of
+// throwing on undefined.
+function matchingBatch(lines: string[], expected: string[]): string {
+  return (
+    lines.find((line) => expected.every((f) => line.split(' ').includes(f))) ??
+    lines[0] ??
+    ''
+  );
+}
+
 let writeSeq = 0;
 function uniqueFileContent() {
   return `content-${Date.now()}-${++writeSeq}`;
@@ -46,16 +85,10 @@ describe('Nx Watch', () => {
   let proj3 = uniq('proj3');
   beforeAll(() => {
     newProject({ packages: ['@nx/js'] });
-    runCLI(`generate @nx/js:lib libs/${proj1}`);
-    runCLI(`generate @nx/js:lib libs/${proj2}`);
-    runCLI(`generate @nx/js:lib libs/${proj3}`);
-    runCLI('daemon --start', {
-      env: {
-        NX_DAEMON: 'true',
-        NX_NATIVE_LOGGING: 'nx',
-        NX_PROJECT_GRAPH_CACHE_DIRECTORY: cacheDirectory,
-      },
-    });
+    runCLI(`generate @nx/js:lib libs/${proj1}`, { env: daemonEnv });
+    runCLI(`generate @nx/js:lib libs/${proj2}`, { env: daemonEnv });
+    runCLI(`generate @nx/js:lib libs/${proj3}`, { env: daemonEnv });
+    runCLI('daemon --start', { env: daemonStartEnv });
   });
 
   afterEach(() => {
@@ -75,7 +108,7 @@ describe('Nx Watch', () => {
     } catch (e) {
       console.log(`[watch-debug] failed to read daemon log: ${e}`);
     }
-    runCLI('reset');
+    runCLI('reset', { env: daemonEnv });
   });
 
   afterAll(() => cleanupProject());
@@ -90,7 +123,7 @@ describe('Nx Watch', () => {
     await writeFileForWatcher(`libs/${proj3}/newfile2.txt`);
     await writeFileForWatcher(`newfile2.txt`);
 
-    expect(await getOutput()).toEqual([proj1]);
+    expect(await getOutput(ranFor([proj1]))).toEqual([proj1]);
   }, 50000);
 
   it('should watch for all projects and output the project name', async () => {
@@ -101,7 +134,7 @@ describe('Nx Watch', () => {
     await writeFileForWatcher(`libs/${proj3}/newfile2.txt`);
     await writeFileForWatcher(`newfile2.txt`);
 
-    let content = await getOutput();
+    let content = await getOutput(ranFor([proj1, proj2, proj3]));
     let results = content.sort();
 
     expect(results).toEqual([proj1, proj2, proj3]);
@@ -114,14 +147,15 @@ describe('Nx Watch', () => {
     await writeFileForWatcher(`libs/${proj1}/newfile2.txt`);
     await writeFileForWatcher(`newfile2.txt`);
 
-    let output = (await getOutput())[0];
-    let results = output.split(' ').sort();
-
-    expect(results).toEqual([
+    const expected = [
       `libs/${proj1}/newfile.txt`,
       `libs/${proj1}/newfile2.txt`,
       `libs/${proj2}/newfile.txt`,
-    ]);
+    ];
+    const lines = await getOutput(batchedAll(expected));
+    let results = matchingBatch(lines, expected).split(' ').sort();
+
+    expect(results).toEqual(expected);
   }, 50000);
 
   it('should watch for global workspace file changes', async () => {
@@ -133,15 +167,16 @@ describe('Nx Watch', () => {
     await writeFileForWatcher(`libs/${proj1}/newfile2.txt`);
     await writeFileForWatcher(`newfile2.txt`);
 
-    let output = (await getOutput())[0];
-    let results = output.split(' ').sort();
-
-    expect(results).toEqual([
+    const expected = [
       `libs/${proj1}/newfile.txt`,
       `libs/${proj1}/newfile2.txt`,
       `libs/${proj2}/newfile.txt`,
       'newfile2.txt',
-    ]);
+    ];
+    const lines = await getOutput(batchedAll(expected));
+    let results = matchingBatch(lines, expected).split(' ').sort();
+
+    expect(results).toEqual(expected);
   }, 50000);
 
   it('should watch selected projects only', async () => {
@@ -154,7 +189,7 @@ describe('Nx Watch', () => {
     await writeFileForWatcher(`libs/${proj3}/newfile2.txt`);
     await writeFileForWatcher(`newfile2.txt`);
 
-    let output = await getOutput();
+    let output = await getOutput(ranFor([proj1, proj3]));
     let results = output.sort();
 
     expect(results).toEqual([proj1, proj3]);
@@ -175,7 +210,7 @@ describe('Nx Watch', () => {
     await writeFileForWatcher(`libs/${proj3}/newfile2.txt`);
     await writeFileForWatcher(`newfile2.txt`);
 
-    let output = await getOutput();
+    let output = await getOutput(ranFor([proj1, proj3]));
     let results = output.sort();
 
     expect(results).toEqual([proj1, proj3]);
@@ -195,8 +230,9 @@ describe('Nx Watch', () => {
       'export const x = 1;'
     );
 
-    let output = (await getOutput())[0];
-    let results = output.split(' ').sort();
+    const expected = [`libs/${proj1}/src/newsubdir/newfile.ts`];
+    const lines = await getOutput(batchedAll(expected));
+    let results = matchingBatch(lines, expected).split(' ').sort();
 
     expect(results).toContain(`libs/${proj1}/src/newsubdir/newfile.ts`);
   }, 50000);
@@ -211,12 +247,7 @@ describe('Nx Watch', () => {
     await wait(1000);
 
     // Kill the daemon
-    runCLI('daemon --stop', {
-      env: {
-        NX_DAEMON: 'true',
-        NX_PROJECT_GRAPH_CACHE_DIRECTORY: cacheDirectory,
-      },
-    });
+    runCLI('daemon --stop', { env: daemonEnv });
 
     // Wait for reconnection to happen (exponential backoff)
     await wait(3000);
@@ -224,10 +255,41 @@ describe('Nx Watch', () => {
     // Write file after daemon restart - watch should reconnect and receive this
     await writeFileForWatcher(`libs/${proj1}/after-restart.txt`);
 
-    const output = await getOutput();
+    const output = await getOutput(ranFor([proj1]));
     expect(output).toContain(proj1);
   }, 60000);
 });
+
+type GetOutput = (
+  until?: (lines: string[]) => boolean,
+  opts?: { settleMs?: number; timeout?: number }
+) => Promise<string[]>;
+
+// Waits for `until` rather than a fixed window, so a slow-but-correct watcher
+// passes while a silent one still fails.
+function createGetOutput(p: ReturnType<typeof spawn>, readRaw: () => string) {
+  const lines = () =>
+    readRaw()
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.includes('NX'));
+
+  const getOutput: GetOutput = async (
+    until = (l) => l.length > 0,
+    { settleMs = OUTPUT_SETTLE_MS, timeout = OUTPUT_TIMEOUT_MS } = {}
+  ) => {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline && !until(lines())) {
+      await wait(50);
+    }
+    await wait(settleMs);
+    treeKill(p.pid);
+    await new Promise<void>((res) => p.on('close', res));
+    return lines();
+  };
+
+  return getOutput;
+}
 
 async function wait(timeout = 200) {
   return new Promise<void>((res) => {
@@ -240,34 +302,28 @@ async function wait(timeout = 200) {
 async function runWatch(command: string) {
   const runCommand = `npx -c 'nx watch --verbose ${command}'`;
   isVerboseE2ERun() && console.log(runCommand);
-  return new Promise<(timeout?: number) => Promise<string[]>>((resolve) => {
+  return new Promise<GetOutput>((resolve) => {
     const p = spawn(runCommand, {
       cwd: tmpProjPath(),
       env: {
         CI: 'true',
         ...getStrippedEnvironmentVariables(),
         FORCE_COLOR: 'false',
-        NX_DAEMON: 'true',
+        ...daemonEnv,
       },
       shell: true,
       stdio: 'pipe',
     });
 
     let output = '';
+    let resolved = false;
     p.stdout?.on('data', (data) => {
       output += data;
       const s = data.toString().trim();
       isVerboseE2ERun() && console.log(s);
-      if (s.includes('watch process waiting')) {
-        resolve(async (timeout = 1000) => {
-          await wait(timeout);
-          treeKill(p.pid);
-          // Wait for process tree to fully exit before returning
-          await new Promise<void>((res) => p.on('close', res));
-          return output
-            .split('\n')
-            .filter((line) => line.length > 0 && !line.includes('NX'));
-        });
+      if (s.includes('watch process waiting') && !resolved) {
+        resolved = true;
+        resolve(createGetOutput(p, () => output));
       }
     });
   });
@@ -276,15 +332,14 @@ async function runWatch(command: string) {
 async function runWatchWithReconnect(command: string) {
   const runCommand = `npx -c 'nx watch --verbose ${command}'`;
   isVerboseE2ERun() && console.log(runCommand);
-  return new Promise<(timeout?: number) => Promise<string[]>>((resolve) => {
+  return new Promise<GetOutput>((resolve) => {
     const p = spawn(runCommand, {
       cwd: tmpProjPath(),
       env: {
         CI: 'true',
         ...getStrippedEnvironmentVariables(),
         FORCE_COLOR: 'false',
-        NX_DAEMON: 'true',
-        NX_PROJECT_GRAPH_CACHE_DIRECTORY: cacheDirectory,
+        ...daemonEnv,
       },
       shell: true,
       stdio: 'pipe',
@@ -299,15 +354,7 @@ async function runWatchWithReconnect(command: string) {
       // Resolve once we see the watch is ready, but don't kill the process yet
       if (s.includes('watch process waiting') && !resolved) {
         resolved = true;
-        resolve(async (timeout = 2000) => {
-          await wait(timeout);
-          treeKill(p.pid);
-          // Wait for process tree to fully exit before returning
-          await new Promise<void>((res) => p.on('close', res));
-          return output
-            .split('\n')
-            .filter((line) => line.length > 0 && !line.includes('NX'));
-        });
+        resolve(createGetOutput(p, () => output));
       }
     });
 

--- a/e2e/nx/src/watch.test.ts
+++ b/e2e/nx/src/watch.test.ts
@@ -58,6 +58,10 @@ function matchingBatch(lines: string[], expected: string[]): string {
   );
 }
 
+// The parsed lines drop every NX-prefixed line, which is where `nx watch`
+// reports errors. Keep the raw stream so afterEach can show it.
+let lastWatchOutput = '';
+
 let writeSeq = 0;
 function uniqueFileContent() {
   return `content-${Date.now()}-${++writeSeq}`;
@@ -108,6 +112,7 @@ describe('Nx Watch', () => {
     } catch (e) {
       console.log(`[watch-debug] failed to read daemon log: ${e}`);
     }
+    console.log(`[watch-debug] nx watch output: \n${lastWatchOutput}`);
     runCLI('reset', { env: daemonEnv });
   });
 
@@ -267,9 +272,25 @@ type GetOutput = (
 
 // Waits for `until` rather than a fixed window, so a slow-but-correct watcher
 // passes while a silent one still fails.
-function createGetOutput(p: ReturnType<typeof spawn>, readRaw: () => string) {
+function createGetOutput(
+  p: ReturnType<typeof spawn>,
+  readStdout: () => string,
+  readAll: () => string = readStdout
+) {
+  // Registered while handling the process's own stdout, so it cannot have
+  // closed yet. Awaiting a promise created here -- rather than attaching a
+  // listener after the kill -- also covers the process exiting on its own,
+  // where a late `once('close')` would never fire and hang the test.
+  let exited = false;
+  const closed = new Promise<void>((res) =>
+    p.on('close', () => {
+      exited = true;
+      res();
+    })
+  );
+
   const lines = () =>
-    readRaw()
+    readStdout()
       .split('\n')
       .map((line) => line.trim())
       .filter((line) => line.length > 0 && !line.includes('NX'));
@@ -279,12 +300,23 @@ function createGetOutput(p: ReturnType<typeof spawn>, readRaw: () => string) {
     { settleMs = OUTPUT_SETTLE_MS, timeout = OUTPUT_TIMEOUT_MS } = {}
   ) => {
     const deadline = Date.now() + timeout;
-    while (Date.now() < deadline && !until(lines())) {
+    while (Date.now() < deadline && !exited && !until(lines())) {
       await wait(50);
     }
-    await wait(settleMs);
-    treeKill(p.pid);
-    await new Promise<void>((res) => p.on('close', res));
+
+    if (!exited) {
+      await wait(settleMs);
+      treeKill(p.pid);
+    }
+    await closed;
+
+    if (exited && !until(lines())) {
+      // `nx watch` exits on a fatal daemon error. Reporting that beats letting
+      // the caller assert on an empty array and show `Received: []`.
+      throw new Error(
+        `nx watch exited before producing the expected output:\n${readAll()}`
+      );
+    }
     return lines();
   };
 
@@ -316,15 +348,31 @@ async function runWatch(command: string) {
     });
 
     let output = '';
+    let all = '';
+    lastWatchOutput = '';
     let resolved = false;
     p.stdout?.on('data', (data) => {
       output += data;
+      all += data;
+      lastWatchOutput = all;
       const s = data.toString().trim();
       isVerboseE2ERun() && console.log(s);
       if (s.includes('watch process waiting') && !resolved) {
         resolved = true;
-        resolve(createGetOutput(p, () => output));
+        resolve(
+          createGetOutput(
+            p,
+            () => output,
+            () => all
+          )
+        );
       }
+    });
+
+    p.stderr?.on('data', (data) => {
+      all += data;
+      lastWatchOutput = all;
+      isVerboseE2ERun() && console.log('stderr:', data.toString().trim());
     });
   });
 }
@@ -346,19 +394,31 @@ async function runWatchWithReconnect(command: string) {
     });
 
     let output = '';
+    let all = '';
+    lastWatchOutput = '';
     let resolved = false;
     p.stdout?.on('data', (data) => {
       output += data;
+      all += data;
+      lastWatchOutput = all;
       const s = data.toString().trim();
       isVerboseE2ERun() && console.log(s);
       // Resolve once we see the watch is ready, but don't kill the process yet
       if (s.includes('watch process waiting') && !resolved) {
         resolved = true;
-        resolve(createGetOutput(p, () => output));
+        resolve(
+          createGetOutput(
+            p,
+            () => output,
+            () => all
+          )
+        );
       }
     });
 
     p.stderr?.on('data', (data) => {
+      all += data;
+      lastWatchOutput = all;
       const s = data.toString().trim();
       isVerboseE2ERun() && console.log('stderr:', s);
     });

--- a/e2e/nx/src/watch.test.ts
+++ b/e2e/nx/src/watch.test.ts
@@ -280,7 +280,7 @@ function createGetOutput(
   // Registered while handling the process's own stdout, so it cannot have
   // closed yet. Awaiting a promise created here -- rather than attaching a
   // listener after the kill -- also covers the process exiting on its own,
-  // where a late `once('close')` would never fire and hang the test.
+  // where a listener added after 'close' already fired would hang the test.
   let exited = false;
   const closed = new Promise<void>((res) =>
     p.on('close', () => {

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -1,5 +1,9 @@
 import { spawn } from 'child_process';
-import { ChangedFile, daemonClient } from '../../daemon/client/client';
+import {
+  ChangedFile,
+  daemonClient,
+  WatcherFailedError,
+} from '../../daemon/client/client';
 import { VersionMismatchError } from '../../daemon/client/daemon-socket-messenger';
 import { output } from '../../utils/output';
 
@@ -237,6 +241,16 @@ export async function watch(args: WatchArguments) {
           title: 'Nx version changed. Please restart your command.',
         });
         process.exit(1);
+      } else if (err instanceof WatcherFailedError) {
+        output.error({
+          title: 'The Nx Daemon stopped watching for file changes',
+          bodyLines: [
+            err.message,
+            'On Linux this is usually the inotify watch limit. See https://askubuntu.com/questions/1088272/inotify-add-watch-failed-no-space-left-on-device',
+            'Please restart your watch command.',
+          ],
+        });
+        process.exit(1);
       } else if (err !== null) {
         output.error({
           title: 'Watch error',
@@ -245,6 +259,8 @@ export async function watch(args: WatchArguments) {
             err.message,
           ],
         });
+        // `data` is null on the error path; falling through dereferences it.
+        return;
       }
 
       // Only pass the projects to the queue if the command has a replacement for projects

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -153,6 +153,18 @@ const WAIT_FOR_SERVER_CONFIG = {
   maxAttempts: 6000, // 6000 * 10ms = 60 seconds
 };
 
+/**
+ * The daemon's workspace watcher died. Nothing it serves will see file changes
+ * again, so a watching client has to restart rather than keep waiting.
+ */
+export class WatcherFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WatcherFailedError';
+    Object.setPrototypeOf(this, WatcherFailedError.prototype);
+  }
+}
+
 export class DaemonClient {
   private readonly nxJson: NxJsonConfiguration | null;
 
@@ -426,6 +438,13 @@ export class DaemonClient {
         (message) => {
           try {
             const parsedMessage = parseMessage<any>(message);
+            if (parsedMessage?.watcherError) {
+              const error = new WatcherFailedError(parsedMessage.watcherError);
+              for (const cb of this.fileWatcherCallbacks.values()) {
+                cb(error, null);
+              }
+              return;
+            }
             // Notify all callbacks
             for (const cb of this.fileWatcherCallbacks.values()) {
               cb(null, parsedMessage);

--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.spec.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.spec.ts
@@ -5,6 +5,7 @@ jest.mock('../project-graph-incremental-recomputation', () => ({
   currentProjectGraph: undefined,
 }));
 
+import { parseMessage } from '../../../utils/consume-messages-from-socket';
 import { handleResult } from '../server';
 import {
   notifyFileWatcherSocketsOfError,
@@ -67,6 +68,22 @@ describe('notifyFileWatcherSocketsOfError', () => {
     expect(JSON.parse(response)).toEqual({
       watcherError: 'inotify_add_watch failed',
     });
+  });
+
+  // The client decides between a change event and a failure by reading
+  // `watcherError` off the parsed message, so the payload has to survive
+  // parseMessage's JSON-vs-v8 detection with that key intact.
+  it('survives the client-side parse the daemon client actually uses', async () => {
+    registerSocket({} as Socket);
+
+    notifyFileWatcherSocketsOfError(new Error('inotify_add_watch failed'));
+    await flushQueue();
+
+    const [, , buildResult] = handleResultMock.mock.calls[0];
+    const { response } = await buildResult();
+
+    const parsed = parseMessage<{ watcherError?: string }>(response);
+    expect(parsed.watcherError).toEqual('inotify_add_watch failed');
   });
 
   it('does nothing when no client is watching', async () => {

--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.spec.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.spec.ts
@@ -1,0 +1,78 @@
+import type { Socket } from 'net';
+
+jest.mock('../server', () => ({ handleResult: jest.fn() }));
+jest.mock('../project-graph-incremental-recomputation', () => ({
+  currentProjectGraph: undefined,
+}));
+
+import { handleResult } from '../server';
+import {
+  notifyFileWatcherSocketsOfError,
+  registeredFileWatcherSockets,
+  removeRegisteredFileWatcherSocket,
+} from './file-watcher-sockets';
+
+const handleResultMock = handleResult as jest.Mock;
+
+function registerSocket(socket: Socket) {
+  registeredFileWatcherSockets.push({
+    socket,
+    config: {
+      watchProjects: 'all',
+      includeGlobalWorkspaceFiles: false,
+      includeDependencies: false,
+    },
+  });
+}
+
+/** The notify helpers dispatch through a queue rather than awaiting inline. */
+async function flushQueue() {
+  await new Promise((res) => setImmediate(res));
+  await new Promise((res) => setImmediate(res));
+}
+
+describe('notifyFileWatcherSocketsOfError', () => {
+  beforeEach(() => {
+    handleResultMock.mockReset();
+    for (const { socket } of [...registeredFileWatcherSockets]) {
+      removeRegisteredFileWatcherSocket(socket);
+    }
+  });
+
+  it('pushes the error to every registered socket', async () => {
+    const first = {} as Socket;
+    const second = {} as Socket;
+    registerSocket(first);
+    registerSocket(second);
+
+    notifyFileWatcherSocketsOfError(new Error('inotify_add_watch failed'));
+    await flushQueue();
+
+    expect(handleResultMock).toHaveBeenCalledTimes(2);
+    expect(handleResultMock.mock.calls.map(([socket]) => socket)).toEqual([
+      first,
+      second,
+    ]);
+  });
+
+  it('sends a payload the client can distinguish from a change event', async () => {
+    registerSocket({} as Socket);
+
+    notifyFileWatcherSocketsOfError(new Error('inotify_add_watch failed'));
+    await flushQueue();
+
+    const [, , buildResult] = handleResultMock.mock.calls[0];
+    const { response } = await buildResult();
+
+    expect(JSON.parse(response)).toEqual({
+      watcherError: 'inotify_add_watch failed',
+    });
+  });
+
+  it('does nothing when no client is watching', async () => {
+    notifyFileWatcherSocketsOfError(new Error('inotify_add_watch failed'));
+    await flushQueue();
+
+    expect(handleResultMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
@@ -27,6 +27,33 @@ export function hasRegisteredFileWatcherSockets() {
   return registeredFileWatcherSockets.length > 0;
 }
 
+/**
+ * The workspace watcher has died; no further change events will ever arrive.
+ * Registered clients are passive, so without this push they wait forever.
+ */
+export function notifyFileWatcherSocketsOfError(error: Error) {
+  if (!hasRegisteredFileWatcherSockets()) {
+    return;
+  }
+
+  queue.sendToQueue(async () => {
+    await Promise.all(
+      registeredFileWatcherSockets.map(({ socket }) =>
+        handleResult(
+          socket,
+          'FILE-WATCH-CHANGED',
+          () =>
+            Promise.resolve({
+              description: 'File watch error',
+              response: JSON.stringify({ watcherError: error.message }),
+            }),
+          'json'
+        )
+      )
+    );
+  });
+}
+
 export function notifyFileWatcherSockets(
   createdFiles: string[] | null,
   updatedFiles: string[],

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -100,6 +100,7 @@ import { registerFileChangeListener } from './file-watching/file-change-events';
 import { routeWorkspaceChanges } from './file-watching/route-workspace-changes';
 import {
   hasRegisteredFileWatcherSockets,
+  notifyFileWatcherSocketsOfError,
   registeredFileWatcherSockets,
   removeRegisteredFileWatcherSocket,
 } from './file-watching/file-watcher-sockets';
@@ -639,6 +640,7 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
       );
       console.error(error);
       workspaceWatcherError = error;
+      notifyFileWatcherSocketsOfError(error);
       return;
     }
 
@@ -648,6 +650,7 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
     serverLogger.watcherLog(`Unexpected workspace error`, err.message);
     console.error(err);
     workspaceWatcherError = err;
+    notifyFileWatcherSocketsOfError(err);
   }
 };
 


### PR DESCRIPTION
## Current Behavior

`e2e/nx/src/watch.test.ts` fails nondeterministically on CI. The same source tree produced 1 failure in one run and 4 in the next, and it rotates which tests it hits. Failures show up as `Received: Array []` or `TypeError: Cannot read properties of undefined (reading 'split')`.

Two timing assumptions in the suite cause it, and both are properties of an idle machine rather than invariants:

1. **`getOutput()` slept a flat 1000ms and then looked exactly once.** In a local fixture driving the real daemon and watcher (3 trivial projects, no plugins), write→output latency measures 100–116ms, with the floor set by the native watcher's 100ms `IDLE_WINDOW`. CI latency was not measured directly — each test there cold-starts a daemon and loads plugins (~800–1000ms in the logs) — but CI shows the 1000ms window is missed often enough to fail, producing an empty array with no diagnostic.
2. **The file-change assertions required every expected file in one `NX_FILE_CHANGES` batch**, because they read `output[0]`. The writes are 10ms apart against a 100ms idle window, so under load the writes themselves get descheduled past the window and the watcher flushes them separately — exactly as designed.

Both were observed directly. A failing CI run reported all four expected files, split across three batches:

```
libs/<p1>/newfile.txt
libs/<p2>/newfile.txt libs/<p1>/newfile2.txt
newfile2.txt
```

That run's agent was moderately slower than its neighbours — median per-test 10.3s against 6.7s and 7.4s on the green runs either side. (The failing test's own 25.8s is mostly this PR's 15s wait expiring, not machine load, so it is not cited as evidence of it.)

Separately, the suite talked to **two different daemons**. `runWatch` never re-added `NX_PROJECT_GRAPH_CACHE_DIRECTORY`, which `getStrippedEnvironmentVariables` drops, while `beforeAll`, `runWatchWithReconnect` and the `afterEach` log dump all did. Seven of the eight tests therefore ran against a daemon other than the one whose log CI printed, so the diagnostic added in #36421 has been pointed at a daemon that never saw the events.

## Expected Behavior

- **Wait for the expected output** (15s ceiling) instead of a fixed window. A slow-but-correct watcher passes; a silent one still fails.
- **Keep reading for 500ms after the match.** Several of these tests also assert that *unwatched* projects did **not** run, and returning the instant the positive expectation is met would silently stop checking that.
- **Assert the union of files across batches** rather than requiring one coalesced batch. A global file leaking into a project-scoped run still breaks equality, so the negative assertions survive.
- **One cache directory for every nx invocation in the suite**, so `afterEach` dumps the daemon that actually served the watch. The raw `nx watch` stream (stdout and stderr) is dumped on failure, since `output.error` is NX-prefixed and dropped by the line filter.

### Verification

- **Control:** `master` failed this suite 2/8 with both original symptoms (`Received: []` and the `TypeError`) at a median per-test of 7.7s — squarely among the runs where this branch passed 8/8 (6.7s and 7.4s). So the flake does not require an unusually loaded agent; an ordinary one misses the 1000ms window often enough to fail.
- **Deterministic repro:** driving the real daemon and native watcher, writes spaced past the idle window split into 4 batches — the old predicate rejects them, the new one accepts with an exact union. The 10ms control coalesces into 1 batch.
- New unit coverage for the daemon change below; `nx lint nx` clean, both typechecks clean, all daemon specs pass.

## Also in this PR — a real bug, but **not** the cause of the flake

`fix(core): tell nx watch when the daemon stops watching`

When the native workspace watcher dies, `workspaceWatcherError` latches write-once and `handleWorkspaceChanges` returns early for the rest of the process's life. That error only ever reached clients that send a *new* message, and `nx watch` never sends one — it registers a socket and waits. The command therefore kept running and silently never fired again. It now pushes the failure to registered file-watcher sockets, the client raises `WatcherFailedError`, and `nx watch` reports it and exits. Also fixes a latent crash next to it: the generic watch error branch fell through to `data.changedProjects` with `data === null`.

This was the original hypothesis for the flake — inotify watch exhaustion killing the watch loop on Linux CI. **CI evidence falsified it:** in the failing run the watcher was alive and reporting throughout, and this error path never fired. It is kept here because it is a genuine bug found during the investigation, not because it explains the flakiness. Happy to split it into its own PR if reviewers would rather keep this one to the e2e fix.

## Related Issue(s)

Tracked internally in NXC-4840. No public issue.
