### PR TITLE
fix(core): ignore bundled snapshots when pruning npm lockfiles

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
@@ -766,6 +766,116 @@ describe('NPM lock file utility', () => {
     });
   });
 
+  describe('bundled dependencies', () => {
+    it('should never use bundled snapshots when pruning', () => {
+      const rootLockFile = {
+        name: 'test-app',
+        version: '1.0.0',
+        lockfileVersion: 3,
+        packages: {
+          '': {
+            name: 'test-app',
+            version: '1.0.0',
+            dependencies: { socks: '2.8.9' },
+          },
+          'node_modules/npm': {
+            version: '11.6.2',
+            resolved: 'https://registry.npmjs.org/npm/-/npm-11.6.2.tgz',
+            integrity: 'sha512-registry-npm',
+            dependencies: { socks: '2.8.9' },
+          },
+          'node_modules/npm/node_modules/socks': {
+            version: '2.8.9',
+            inBundle: true,
+            dependencies: { 'ip-address': '^10.0.0' },
+          },
+          'node_modules/npm/node_modules/socks/node_modules/ip-address': {
+            version: '10.2.0',
+            inBundle: true,
+          },
+          'node_modules/socks': {
+            version: '2.8.9',
+            resolved: 'https://registry.npmjs.org/socks/-/socks-2.8.9.tgz',
+            integrity: 'sha512-registry-socks',
+            dependencies: { 'ip-address': '^10.0.0' },
+          },
+          'node_modules/ip-address': {
+            version: '10.4.0',
+            resolved:
+              'https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz',
+            integrity: 'sha512-registry-ip-address',
+          },
+        },
+      };
+      const packageJson = {
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: { socks: '2.8.9' },
+      };
+      const hash = uniq('mock-hash');
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
+        JSON.stringify(rootLockFile),
+        hash
+      );
+      const ctx: CreateDependenciesContext = {
+        projects: {},
+        externalNodes,
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        nxJsonConfiguration: null,
+        workspaceRoot: '/virtual',
+      };
+      const dependencies = getNpmLockfileDependencies(
+        JSON.stringify(rootLockFile),
+        hash,
+        ctx,
+        keyMap
+      );
+      const builder = new ProjectGraphBuilder({
+        nodes: {},
+        dependencies: {},
+        externalNodes,
+      });
+      for (const dep of dependencies) {
+        builder.addDependency(
+          dep.source,
+          dep.target,
+          dep.type,
+          'sourceFile' in dep ? dep.sourceFile : null
+        );
+      }
+
+      const graph = builder.getUpdatedProjectGraph();
+      const prunedGraph = pruneProjectGraph(graph, packageJson);
+      const result = JSON.parse(
+        stringifyNpmLockfile(
+          prunedGraph,
+          JSON.stringify(rootLockFile),
+          packageJson
+        )
+      );
+
+      expect(result.packages['node_modules/socks'].resolved).toBe(
+        'https://registry.npmjs.org/socks/-/socks-2.8.9.tgz'
+      );
+      expect(externalNodes['npm:socks'].data.hash).toBe(
+        'sha512-registry-socks'
+      );
+      expect(externalNodes).not.toHaveProperty('npm:ip-address@10.2.0');
+      expect(
+        Object.values(result.packages).some(
+          (snapshot: Record<string, unknown>) => snapshot?.inBundle
+        )
+      ).toBe(false);
+    });
+  });
+
   describe('pruning', () => {
     let rootLockFile;
 

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.ts
@@ -35,6 +35,7 @@ type NpmDependency = {
 };
 
 type NpmDependencyV3 = NpmDependency & {
+  inBundle?: boolean;
   dependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
@@ -110,8 +111,13 @@ function getNodes(data: NpmLockFile): {
 
   if (data.lockfileVersion > 1) {
     Object.entries(data.packages).forEach(([path, snapshot]) => {
-      // skip workspaces packages
-      if (path === '' || !path.includes('node_modules') || snapshot.link) {
+      // skip workspaces and snapshots bundled into their parent package
+      if (
+        path === '' ||
+        !path.includes('node_modules') ||
+        snapshot.link ||
+        snapshot.inBundle
+      ) {
         return;
       }
 
@@ -850,12 +856,15 @@ function buildV3Index(
   if (!packages) return index;
   const marker = 'node_modules/';
   for (const key of Object.keys(packages)) {
+    const snapshot = packages[key];
+    // Bundled snapshots are not independently installable package candidates.
+    if (snapshot.inBundle) continue;
     const i = key.lastIndexOf(marker);
     if (i === -1) continue; // root "" / workspace paths never matched endsWith
     const name = key.slice(i + marker.length);
     let bucket = index.get(name);
     if (!bucket) index.set(name, (bucket = []));
-    bucket.push(packages[key]);
+    bucket.push(snapshot);
   }
   return index;
 }


### PR DESCRIPTION
## Current Behavior

The npm lockfile parser treats `inBundle` package snapshots as independently installable packages. When a bundled snapshot and a registry snapshot have the same package name and version, the bundled copy can supply the graph node and pruned lockfile entry. Because bundled snapshots omit registry resolution metadata, the resulting lockfile can lose `resolved` and `integrity` and retain dependencies that only exist inside the parent package bundle.

## Expected Behavior

Bundled snapshots should not participate in the external package graph or in registry snapshot selection. Pruned lockfiles should use the installable registry snapshot, preserve its resolution metadata, and exclude bundle-only dependency versions. The regression test covers equal-version bundled and registry copies and exercises parsing, graph pruning, and npm lockfile serialization together.

## Related Issue(s)

Fixes #36672