### PR TITLE
chore(nx-dev): align site analytics setup with other web properties

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -116,6 +116,60 @@ export default defineConfig({
               },
             ]
           : []),
+        // PostHog analytics, consent-gated via Cookiebot and served through the
+        // first-party reverse proxy. Deliberately code-owned (not in the GTM
+        // container) so adblockers that block googletagmanager.com don't also
+        // take PostHog down. Loaded before GTM; the hostname guard keeps it
+        // inert in dev and preview deploys.
+        {
+          tag: 'script',
+          attrs: { 'data-cookieconsent': 'ignore' },
+          content: `!function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.setAttribute("data-cookieconsent","ignore"),p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="an ln init xn Cn Br kn In capture Fn nn calculateEventProperties On register register_once register_for_session unregister unregister_for_session Ln getFeatureFlag getFeatureFlagPayload getFeatureFlagResult getAllFeatureFlags isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Dn identify setPersonProperties unsetPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset shutdown setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty An Rn createPersonProfile setInternalOrTestUser $n yn jn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Tn debug Ur Rt getPageViewId captureTraceFeedback captureTraceMetric pn".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+
+// Only run on the production hostname (inert in dev/preview)
+var h = window.location.hostname;
+if (h === "nx.dev") {
+  posthog.init('phc_eTmACxF0EKeNRjAZbfpdszbHYumyKhWqsIpMU4Wi53c', {
+    api_host: 'https://pha-prx.ops.cloud.nx.app',
+    ui_host: 'https://us.posthog.com',
+    defaults: '2026-05-30',
+    person_profiles: 'identified_only',
+    cookieless_mode: 'on_reject',
+  });
+
+  // Sync PostHog consent state with Cookiebot.
+  // Cookiebot is delivered via the GTM container (GTM-KW8423B6);
+  // data-cookieconsent="ignore" above is inert with GTM delivery (no
+  // auto-blocking) but protects against a future inline Cookiebot setup.
+  // Guards ensure state transitions (and the "Opt in" event) fire once
+  // per genuine consent change, not on every page load.
+  var syncConsent = function () {
+    if (window.Cookiebot && Cookiebot.consent && Cookiebot.consent.statistics) {
+      if (!posthog.has_opted_in_capturing()) {
+        posthog.opt_in_capturing();
+      }
+    } else if (!posthog.has_opted_out_capturing()) {
+      posthog.opt_out_capturing();
+    }
+  };
+
+  // OnAccept/OnDecline fire both on the consent click and on every page
+  // load for returning visitors with stored consent, so these two cover
+  // new choices and returning sessions alike.
+  window.addEventListener('CookiebotOnAccept', syncConsent);
+  window.addEventListener('CookiebotOnDecline', syncConsent);
+
+  // Fallback: if Cookiebot never loads (adblocker kills GTM), treat as
+  // declined — counts the user via the anonymous cookieless hash, stores
+  // nothing client-side. Cookiebot-present-but-unclicked stays pending,
+  // so the banner flow remains authoritative.
+  setTimeout(function () {
+    if (!window.Cookiebot && posthog.get_explicit_consent_status && posthog.get_explicit_consent_status() === 'pending') {
+      posthog.opt_out_capturing();
+    }
+  }, 3000);
+}`,
+        },
         {
           tag: 'script',
           content: `window.__CONFIG = ${JSON.stringify(PUBLIC_CONFIG)};`,

--- a/nx-dev/feature-analytics/src/index.ts
+++ b/nx-dev/feature-analytics/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/google-analytics';
+export * from './lib/posthog-snippet';
 export * from './lib/use-window-scroll-depth';

--- a/nx-dev/feature-analytics/src/lib/posthog-snippet.ts
+++ b/nx-dev/feature-analytics/src/lib/posthog-snippet.ts
@@ -1,0 +1,52 @@
+// PostHog analytics, consent-gated via Cookiebot and served through the
+// first-party reverse proxy. Deliberately code-owned (not in the GTM
+// container) so adblockers that block googletagmanager.com don't also
+// take PostHog down. Loaded before GTM; the hostname guard keeps it
+// inert in dev and preview deploys. Rendered inline (with
+// data-cookieconsent="ignore") in both the pages-router _document and
+// the app-router root layout.
+export const POSTHOG_SNIPPET = `!function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.setAttribute("data-cookieconsent","ignore"),p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="an ln init xn Cn Br kn In capture Fn nn calculateEventProperties On register register_once register_for_session unregister unregister_for_session Ln getFeatureFlag getFeatureFlagPayload getFeatureFlagResult getAllFeatureFlags isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Dn identify setPersonProperties unsetPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset shutdown setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty An Rn createPersonProfile setInternalOrTestUser $n yn jn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Tn debug Ur Rt getPageViewId captureTraceFeedback captureTraceMetric pn".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+
+// Only run on the production hostname (inert in dev/preview)
+var h = window.location.hostname;
+if (h === "nx.dev") {
+  posthog.init('phc_eTmACxF0EKeNRjAZbfpdszbHYumyKhWqsIpMU4Wi53c', {
+    api_host: 'https://pha-prx.ops.cloud.nx.app',
+    ui_host: 'https://us.posthog.com',
+    defaults: '2026-05-30',
+    person_profiles: 'identified_only',
+    cookieless_mode: 'on_reject',
+  });
+
+  // Sync PostHog consent state with Cookiebot.
+  // Cookiebot is delivered via the GTM container (GTM-KW8423B6);
+  // data-cookieconsent="ignore" above is inert with GTM delivery (no
+  // auto-blocking) but protects against a future inline Cookiebot setup.
+  // Guards ensure state transitions (and the "Opt in" event) fire once
+  // per genuine consent change, not on every page load.
+  var syncConsent = function () {
+    if (window.Cookiebot && Cookiebot.consent && Cookiebot.consent.statistics) {
+      if (!posthog.has_opted_in_capturing()) {
+        posthog.opt_in_capturing();
+      }
+    } else if (!posthog.has_opted_out_capturing()) {
+      posthog.opt_out_capturing();
+    }
+  };
+
+  // OnAccept/OnDecline fire both on the consent click and on every page
+  // load for returning visitors with stored consent, so these two cover
+  // new choices and returning sessions alike.
+  window.addEventListener('CookiebotOnAccept', syncConsent);
+  window.addEventListener('CookiebotOnDecline', syncConsent);
+
+  // Fallback: if Cookiebot never loads (adblocker kills GTM), treat as
+  // declined — counts the user via the anonymous cookieless hash, stores
+  // nothing client-side. Cookiebot-present-but-unclicked stays pending,
+  // so the banner flow remains authoritative.
+  setTimeout(function () {
+    if (!window.Cookiebot && posthog.get_explicit_consent_status && posthog.get_explicit_consent_status() === 'pending') {
+      posthog.opt_out_capturing();
+    }
+  }, 3000);
+}`;

--- a/nx-dev/nx-dev/app/layout.tsx
+++ b/nx-dev/nx-dev/app/layout.tsx
@@ -1,3 +1,4 @@
+import { POSTHOG_SNIPPET } from '@nx/nx-dev-feature-analytics';
 import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
 import '../styles/main.css';
@@ -72,6 +73,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           name="msapplication-TileColor"
           content="#DA532C"
           key="windows-tile-color"
+        />
+        <script
+          data-cookieconsent="ignore"
+          dangerouslySetInnerHTML={{ __html: POSTHOG_SNIPPET }}
         />
         <script
           type="text/javascript"

--- a/nx-dev/nx-dev/package.json
+++ b/nx-dev/nx-dev/package.json
@@ -8,6 +8,7 @@
     "@nx/nx-dev-data-access-courses": "workspace:*",
     "@nx/nx-dev-data-access-documents": "workspace:*",
     "@nx/nx-dev-feature-ai": "workspace:*",
+    "@nx/nx-dev-feature-analytics": "workspace:*",
     "@nx/nx-dev-ui-common": "workspace:*",
     "@nx/nx-dev-ui-courses": "workspace:*",
     "@nx/nx-dev-ui-primitives": "workspace:*",

--- a/nx-dev/nx-dev/pages/_document.tsx
+++ b/nx-dev/nx-dev/pages/_document.tsx
@@ -1,3 +1,4 @@
+import { POSTHOG_SNIPPET } from '@nx/nx-dev-feature-analytics';
 import { Head, Html, Main, NextScript } from 'next/document';
 import type { ReactElement } from 'react';
 
@@ -28,6 +29,10 @@ export default function Document(): ReactElement {
           rel="mask-icon"
           href="/favicon/safari-pinned-tab.svg"
           color="#5bbad5"
+        />
+        <script
+          data-cookieconsent="ignore"
+          dangerouslySetInnerHTML={{ __html: POSTHOG_SNIPPET }}
         />
         <script
           dangerouslySetInnerHTML={{

--- a/nx-dev/nx-dev/tsconfig.json
+++ b/nx-dev/nx-dev/tsconfig.json
@@ -39,6 +39,9 @@
   ],
   "references": [
     {
+      "path": "../feature-analytics"
+    },
+    {
       "path": "../ui-primitives"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1895,6 +1895,9 @@ importers:
       '@nx/nx-dev-feature-ai':
         specifier: workspace:*
         version: link:../feature-ai
+      '@nx/nx-dev-feature-analytics':
+        specifier: workspace:*
+        version: link:../feature-analytics
       '@nx/nx-dev-ui-common':
         specifier: workspace:*
         version: link:../ui-common


### PR DESCRIPTION
## Current Behavior

The docs and blog sites do not share the analytics setup used on our other web properties.

## Expected Behavior

The docs and blog sites use the same consent-gated analytics setup as our other web properties. Dev and preview builds are unaffected.

## Related Issue(s)

Internal maintenance; no linked issue.
