### PR TITLE
fix(core): stop the daemon before nx add installs a package

### DIFF
--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -23,10 +23,16 @@ import {
 import { globalSpinner } from '../../utils/spinner';
 import { NxPackageJson } from '../../utils/package-json';
 import { reportNxAddCommand } from '../../analytics';
+import { daemonClient } from '../../daemon/client/client';
 
 export function addHandler(options: AddOptions): Promise<number> {
   return handleErrors(options.verbose, async () => {
     output.addNewline();
+
+    // Package managers write the lock file before node_modules is fully linked,
+    // so a live daemon restarts mid-install and caches a graph whose plugins,
+    // still being relinked, no longer resolve.
+    await daemonClient.stop();
 
     const [pkgName, version] = parsePackageSpecifier(options.packageSpecifier);
     reportNxAddCommand(pkgName, version);


### PR DESCRIPTION
## Current Behavior

`nx add <plugin>` can leave the Nx daemon holding a project graph it cannot build, when the install relocates an already-installed plugin inside the package manager store.

Package managers write the lock file **before** `node_modules` is linked. The daemon polls the lock files every 20ms (`daemonIsOutdated` in `packages/nx/src/daemon/server/server.ts`) and restarts on `LOCK_FILES_CHANGED`, so the replacement daemon can start while a plugin is mid-relink, compute a graph, and cache the resolution failure:

```
[Server] lock file hash changed! old=1278222706875891392, new=2971850183851616126
[Server] Restarting daemon...
New daemon starting from: <ws>/node_modules/nx/dist/src/daemon/server/server.js
Plugin listed in `nx.json` not found: @nx/vitest
```

That daemon then serves the error to the `nx g <plugin>:init` child that `nx add` spawns:

```
 NX   Failed to load 1 Nx plugin(s):
  - @nx/vitest: Cannot find module '@nx/vitest'
 NX   Failed to initialize @nx/react
```

This is timing dependent: the package has to stay unresolvable long enough for the daemon to restart and recompute. Measured windows on one machine were 791ms on 23.1.1 and 194ms on 23.2.0-beta.9, and later runs on the same machine stopped reproducing once the window closed. Repro workspace: https://github.com/jaysoo/nxc4773-repro

## Expected Behavior

`nx add` stops the daemon before installing, which is what `nx migrate` already does at the top of its handler. Nothing is alive to restart mid-install, and the init generator's child process starts a clean daemon afterwards.

Before/after while the window was open, on 23.1.1: 5/5 runs poisoned the daemon and failed unpatched, 0/5 patched.

## Related Issue(s)

NXC-4773
