### PR TITLE
docs(misc): improve nx.dev agent readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,6 @@ e2e/**/*.d.ts
 e2e/**/*.d.ts.map
 
 .nx/migrate-runs
+
+# Generated on Netlify builds by astro-docs/scripts/sync-agent-skills.mjs
+astro-docs/public/.well-known/agent-skills

--- a/.prettierignore
+++ b/.prettierignore
@@ -59,3 +59,7 @@ tools/documentation/create-embeddings/src/main.mts
 
 # Inlined from `@yarnpkg/parser` keep as is
 packages/nx/src/utils/yarn-syml/syml-grammar.js
+
+# Generated on Netlify builds; reformatting invalidates the sha256 digests in
+# index.json (see astro-docs/scripts/sync-agent-skills.mjs)
+astro-docs/public/.well-known/agent-skills

--- a/astro-docs/netlify/edge-functions/add-link-headers.ts
+++ b/astro-docs/netlify/edge-functions/add-link-headers.ts
@@ -4,20 +4,43 @@ import type { Context } from 'https://edge.netlify.com';
  * Content negotiation for LLM-friendly docs access.
  * See: https://llmstxt.org/
  */
+/**
+ * Both variants of a docs URL have to advertise the same cache variation, or a
+ * cache that stored one can hand it to a client asking for the other.
+ * Netlify-Vary drives Netlify's own CDN, which ignores Vary.
+ */
+function withCacheVariation(response: Response, link?: string): Response {
+  // Netlify responses are immutable
+  const headers = new Headers(response.headers);
+  headers.set('Vary', 'Accept, Accept-Encoding');
+  headers.set('Netlify-Vary', 'header=accept|accept-encoding');
+  if (link) {
+    headers.set('Link', link);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 export default async function handler(
   request: Request,
   context: Context
-): Promise<Response | URL> {
+): Promise<Response> {
   const url = new URL(request.url);
   const pathname = url.pathname;
+  const mdPath = pathname.replace(/\/?$/, '.md');
 
   const acceptHeader = request.headers.get('accept') || '';
 
   // Serve markdown for LLM tools that explicitly request it
   // Or if there are no accept headers passed (e.g. Cursor)
   if (!acceptHeader || acceptHeader.includes('text/markdown')) {
-    const mdPath = pathname.replace(/\/?$/, '.md');
-    return new URL(mdPath, request.url);
+    return withCacheVariation(
+      await context.rewrite(new URL(mdPath, request.url))
+    );
   }
 
   const response = await context.next();
@@ -27,23 +50,13 @@ export default async function handler(
     return response;
   }
 
-  const mdPath = pathname.replace(/\/?$/, '.md');
-
   const linkHeader = [
     `<${mdPath}>; rel="alternate"; type="text/markdown"`,
     `</docs/llms.txt>; rel="alternate"; type="text/markdown"; title="LLM Index"`,
     `</docs/llms-full.txt>; rel="alternate"; type="text/markdown"; title="Full Documentation"`,
   ].join(', ');
 
-  // Netlify responses are immutable
-  const newHeaders = new Headers(response.headers);
-  newHeaders.set('Link', linkHeader);
-
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: newHeaders,
-  });
+  return withCacheVariation(response, linkHeader);
 }
 
 export const config = {
@@ -52,7 +65,13 @@ export const config = {
     '/docs/*.md',
     '/docs/*.js',
     '/docs/*.txt',
+    // pagefind-entry.json; a request without an Accept header must not be
+    // rewritten to a nonexistent `.md` sibling.
+    '/docs/*.json',
     '/docs/images/*',
+    // Agent skills mirror, forwarded here from the apex. A request without an
+    // Accept header must not be rewritten to a nonexistent `.md` sibling.
+    '/docs/.well-known/*',
     // _astro and other asset paths
     '/docs/_*',
   ],

--- a/astro-docs/project.json
+++ b/astro-docs/project.json
@@ -45,6 +45,7 @@
     "build": {
       "dependsOn": [
         "prebuild-banner",
+        "prebuild-agent-skills",
         {
           "projects": [
             "nx",
@@ -172,6 +173,14 @@
         "{projectRoot}/.vale/styles/**/*",
         "{projectRoot}/scripts/vale-changed.mjs"
       ]
+    },
+    "prebuild-agent-skills": {
+      "cache": false,
+      "outputs": ["{projectRoot}/public/.well-known/agent-skills"],
+      "command": "node scripts/sync-agent-skills.mjs",
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "format": {
       "cache": true,

--- a/astro-docs/scripts/sync-agent-skills.mjs
+++ b/astro-docs/scripts/sync-agent-skills.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Generates the Agent Skills Discovery index (RFC v0.2.0) that nx.dev serves at
+ * /.well-known/agent-skills/, from the skills published in
+ * nrwl/nx-ai-agents-config.
+ *
+ * The output is build-time only and gitignored. Vendoring the skills into this
+ * repo meant every upstream edit landed here as a large diff, three of them
+ * binary archives, and the copy went stale between syncs.
+ *
+ * Runs only on Netlify, so CI, local builds, and the dev server neither reach
+ * for GitHub nor produce the directory. Set NETLIFY=1 to generate it locally.
+ */
+import { createHash } from 'node:crypto';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { gzipSync } from 'node:zlib';
+
+const REPO = 'nrwl/nx-ai-agents-config';
+const SOURCE_DIR = 'artifacts/skills';
+const SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
+const PUBLIC_PATH = '/.well-known/agent-skills';
+
+if (!process.env.NETLIFY) {
+  console.log(
+    'Not a Netlify build, skipping the agent skills index. Set NETLIFY=1 to generate it locally.'
+  );
+  process.exit(0);
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const outDir = join(scriptDir, '..', 'public', '.well-known', 'agent-skills');
+
+async function githubJson(url) {
+  const headers = { accept: 'application/vnd.github+json' };
+  if (process.env.GITHUB_TOKEN) {
+    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`GET ${url} failed: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+async function fetchText(url) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`GET ${url} failed: ${res.status} ${res.statusText}`);
+  }
+  return res.text();
+}
+
+function sha256(content) {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
+}
+
+/** Escape a description for a double-quoted YAML scalar. */
+function yamlString(value) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * The repo stores the body and its metadata separately; agents expect one
+ * SKILL.md whose frontmatter carries name and description.
+ */
+function withFrontmatter(meta, body) {
+  return [
+    '---',
+    `name: ${meta.name}`,
+    `description: ${yamlString(meta.description)}`,
+    '---',
+    '',
+    body.trimStart(),
+  ].join('\n');
+}
+
+const BLOCK = 512;
+
+/** Octal field, NUL-terminated, as ustar specifies. */
+function octal(value, width) {
+  return value.toString(8).padStart(width - 1, '0') + '\0';
+}
+
+/** Serializes one ustar header. Ownership and timestamps are zeroed. */
+function tarHeader(name, size) {
+  if (Buffer.byteLength(name) > 100) {
+    throw new Error(`Path too long for a ustar header: ${name}`);
+  }
+  const header = Buffer.alloc(BLOCK);
+  header.write(name, 0, 100);
+  header.write(octal(0o644, 8), 100, 8); // mode
+  header.write(octal(0, 8), 108, 8); // uid
+  header.write(octal(0, 8), 116, 8); // gid
+  header.write(octal(size, 12), 124, 12);
+  header.write(octal(0, 12), 136, 12); // mtime
+  header.write('        ', 148, 8); // checksum placeholder: spaces
+  header.write('0', 156, 1); // typeflag: regular file
+  header.write('ustar\0', 257, 6);
+  header.write('00', 263, 2);
+
+  let checksum = 0;
+  for (const byte of header) checksum += byte;
+  header.write(checksum.toString(8).padStart(6, '0') + '\0 ', 148, 8);
+  return header;
+}
+
+/** .tar.gz of `files`, contents at the archive root per the RFC. */
+function tarGz(files) {
+  const blocks = [];
+  for (const { name, content } of [...files].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  )) {
+    const body = Buffer.from(content);
+    blocks.push(tarHeader(name, body.length), body);
+    const padding = (BLOCK - (body.length % BLOCK)) % BLOCK;
+    if (padding) blocks.push(Buffer.alloc(padding));
+  }
+  // Two zero blocks end the archive; pad to the conventional 20-block record.
+  blocks.push(Buffer.alloc(BLOCK * 2));
+  const tar = Buffer.concat(blocks);
+  const record = BLOCK * 20;
+  const tail = (record - (tar.length % record)) % record;
+  return gzipSync(Buffer.concat([tar, Buffer.alloc(tail)]), { level: 9 });
+}
+
+const commit = await githubJson(
+  `https://api.github.com/repos/${REPO}/commits/main`
+);
+const tree = await githubJson(
+  `https://api.github.com/repos/${REPO}/git/trees/${commit.sha}?recursive=1`
+);
+
+const blobs = tree.tree.filter(
+  (node) => node.type === 'blob' && node.path.startsWith(`${SOURCE_DIR}/`)
+);
+if (blobs.length === 0) {
+  throw new Error(`No files found under ${SOURCE_DIR} in ${REPO}`);
+}
+
+const rawBase = `https://raw.githubusercontent.com/${REPO}/${commit.sha}`;
+const contents = new Map(
+  await Promise.all(
+    blobs.map(async (node) => [
+      node.path,
+      await fetchText(`${rawBase}/${node.path}`),
+    ])
+  )
+);
+
+/** Group the fetched blobs by skill, keyed by their path inside the skill. */
+const bySkill = new Map();
+for (const [path, content] of contents) {
+  const rest = path.slice(SOURCE_DIR.length + 1);
+  const slash = rest.indexOf('/');
+  const skillName = rest.slice(0, slash);
+  if (!bySkill.has(skillName)) bySkill.set(skillName, new Map());
+  bySkill.get(skillName).set(rest.slice(slash + 1), content);
+}
+
+const written = new Map();
+const skills = [];
+
+for (const [skillName, skillFiles] of bySkill) {
+  const metaRaw = skillFiles.get('SKILL.md.meta.json');
+  const body = skillFiles.get('SKILL.md');
+  if (!metaRaw || !body) {
+    throw new Error(`${skillName} is missing SKILL.md or SKILL.md.meta.json`);
+  }
+  const meta = JSON.parse(metaRaw);
+
+  const payload = [
+    { name: 'SKILL.md', content: withFrontmatter(meta, body) },
+    ...[...skillFiles]
+      .filter(([name]) => name !== 'SKILL.md' && name !== 'SKILL.md.meta.json')
+      .map(([name, content]) => ({ name, content })),
+  ];
+
+  for (const file of payload) {
+    written.set(`${skillName}/${file.name}`, file.content);
+  }
+
+  // A skill whose SKILL.md links to references/ or scripts/ has to ship as an
+  // archive; skill-md is defined as a single-file artifact, so a conforming
+  // client would never fetch the supporting files.
+  const isMultiFile = payload.length > 1;
+  const artifact = isMultiFile
+    ? { path: `${skillName}.tar.gz`, content: tarGz(payload) }
+    : { path: `${skillName}/SKILL.md`, content: payload[0].content };
+
+  if (isMultiFile) {
+    written.set(artifact.path, artifact.content);
+  }
+
+  skills.push({
+    name: meta.name,
+    type: isMultiFile ? 'archive' : 'skill-md',
+    description: meta.description,
+    url: `${PUBLIC_PATH}/${artifact.path}`,
+    digest: sha256(artifact.content),
+  });
+}
+
+skills.sort((a, b) => a.name.localeCompare(b.name));
+written.set(
+  'index.json',
+  JSON.stringify({ $schema: SCHEMA, skills }, null, 2) + '\n'
+);
+
+await rm(outDir, { recursive: true, force: true });
+for (const [file, content] of written) {
+  const target = join(outDir, file);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, content);
+}
+
+console.log(
+  `Generated ${skills.length} agent skills from ${REPO}@${commit.sha.slice(0, 7)}`
+);

--- a/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
+++ b/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
@@ -7,6 +7,22 @@ sidebar:
 filter: 'type:Features'
 ---
 
+{% llm_copy_prompt title="Prompt an agent to set this up" previewLines=8 %}
+
+Set up this Nx workspace to work with AI coding agents.
+
+1. Confirm the workspace has an `nx.json` and `nx` in `package.json`. If Nx is missing, stop and ask me before running `npx nx@latest init`.
+2. Ask me which agents to configure. The supported values are `claude`, `codex`, `copilot`, `cursor`, `gemini`, and `opencode`. Do not guess from what happens to be installed on my machine.
+3. Run `npx nx configure-ai-agents --agents <agents> --no-interactive` with the values I gave you.
+4. Verify with `npx nx configure-ai-agents --check=all` and show me the output.
+
+The command writes agent rules (`AGENTS.md`, `CLAUDE.md`, and equivalents), MCP server config, and the Nx agent skills. Show me the diff and let me review it. Do not commit on my behalf.
+
+If a step fails, surface the error rather than retrying. For what the integration provides and how to configure agents by hand, follow {pageUrl}.
+
+Page: {pageUrl}
+{% /llm_copy_prompt %}
+
 AI coding assistants often hallucinate outdated Nx commands and lack context about your workspace structure. Without workspace awareness, they suggest commands that don't exist or miss project relationships entirely.
 
 The Nx AI integration gives assistants accurate, real-time information about your workspace, projects, and available commands, making them smarter when working in an Nx monorepo and more autonomous when iterating on CI failures.
@@ -35,6 +51,8 @@ npx skills add nrwl/nx-ai-agents-config
 ```
 
 This copies the skills into your workspace but does not install the Claude Code plugin.
+
+Agents that discover skills over HTTP can read the same set from [https://nx.dev/.well-known/agent-skills/index.json](https://nx.dev/.well-known/agent-skills/index.json).
 
 Watch [our Youtube video](https://youtu.be/8gdvIz2r_QM) for a full walkthrough.
 

--- a/astro-docs/src/pages/kb/llms.txt.ts
+++ b/astro-docs/src/pages/kb/llms.txt.ts
@@ -1,0 +1,7 @@
+import type { APIRoute } from 'astro';
+import { renderSectionIndex, textResponse } from '../../utils/llms';
+
+export const GET: APIRoute = async ({ site }) =>
+  textResponse(
+    await renderSectionIndex('kb', site?.origin ?? 'https://nx.dev')
+  );

--- a/astro-docs/src/pages/llms-full.txt.ts
+++ b/astro-docs/src/pages/llms-full.txt.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
+import { DESCRIPTION, SECTION_NAMES, SECTION_ORDER } from '../utils/llms';
 import { readFileSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -32,34 +33,6 @@ function stripFrontmatter(content: string): string {
 export const GET: APIRoute = async ({ site }) => {
   const siteUrl = site?.origin ?? 'https://nx.dev';
   const entries: DocEntry[] = [];
-
-  // Preferred section order (same as llms.txt)
-  const sectionOrder = [
-    'quickstart',
-    'getting-started',
-    'concepts',
-    'features',
-    'guides',
-    'extending-nx',
-    'technologies',
-    'reference',
-    'enterprise',
-    'troubleshooting',
-  ];
-
-  // Section display names
-  const sectionNames: Record<string, string> = {
-    'getting-started': 'Getting Started',
-    concepts: 'Core Concepts',
-    features: 'Features',
-    guides: 'Guides',
-    'extending-nx': 'Extending Nx',
-    technologies: 'Technologies',
-    reference: 'Reference',
-    enterprise: 'Enterprise',
-    troubleshooting: 'Troubleshooting',
-    quickstart: 'Quickstart',
-  };
 
   // Get all docs from the content collection (static .mdoc/.mdx files)
   const docs = await getCollection('docs');
@@ -122,8 +95,8 @@ export const GET: APIRoute = async ({ site }) => {
 
   // Sort entries by section order, then by slug within section
   entries.sort((a, b) => {
-    const sectionIndexA = sectionOrder.indexOf(a.section);
-    const sectionIndexB = sectionOrder.indexOf(b.section);
+    const sectionIndexA = SECTION_ORDER.indexOf(a.section);
+    const sectionIndexB = SECTION_ORDER.indexOf(b.section);
     const orderA = sectionIndexA === -1 ? 999 : sectionIndexA;
     const orderB = sectionIndexB === -1 ? 999 : sectionIndexB;
 
@@ -139,7 +112,7 @@ export const GET: APIRoute = async ({ site }) => {
     '',
     '> Complete Nx documentation compiled into a single file for LLM consumption.',
     '',
-    'Nx is a powerful, open-source, technology-agnostic monorepo platform designed to efficiently manage codebases of any scale. From small workspaces to large enterprise monorepos, Nx provides intelligent task execution, caching, and CI optimization.',
+    DESCRIPTION,
     '',
     `This file was generated from ${entries.length} documentation pages.`,
     `Individual pages are available at: ${siteUrl}/docs/{slug}.md`,
@@ -153,7 +126,7 @@ export const GET: APIRoute = async ({ site }) => {
     // Add section header when section changes
     if (entry.section !== currentSection) {
       currentSection = entry.section;
-      const sectionName = sectionNames[currentSection] || currentSection;
+      const sectionName = SECTION_NAMES[currentSection] || currentSection;
       lines.push('');
       lines.push(`# ${sectionName}`);
       lines.push('');

--- a/astro-docs/src/pages/llms.txt.ts
+++ b/astro-docs/src/pages/llms.txt.ts
@@ -1,200 +1,85 @@
 import type { APIRoute } from 'astro';
-import { getCollection } from 'astro:content';
-
-interface DocEntry {
-  slug: string;
-  title: string;
-  description?: string;
-  packageType?: string;
-}
+import {
+  collectDocs,
+  DESCRIPTION,
+  INTRO,
+  NESTED_SECTIONS,
+  renderEntry,
+  SECTION_NAMES,
+  SECTION_ORDER,
+  textResponse,
+} from '../utils/llms';
 
 /**
  * Generates llms.txt dynamically from all documentation collections.
  * This file helps AI agents discover and navigate the Nx documentation.
  * See: https://llmstxt.org/
+ *
+ * Long-tail sections get their own nested index instead of being inlined, so
+ * this stays a navigation index an agent can read in one go rather than a
+ * six-figure dump of every page on the site.
  */
 export const GET: APIRoute = async ({ site }) => {
-  // Get the site URL, fallback to nx.dev
   const siteUrl = site?.origin ?? 'https://nx.dev';
-  const entries: DocEntry[] = [];
-  const devkitApiEntries: DocEntry[] = [];
+  const { sections, devkitApiEntries } = await collectDocs();
 
-  // Get all docs from the content collection
-  const docs = await getCollection('docs');
-  for (const doc of docs) {
-    const slug = doc.id;
-    const title = doc.data.title || slug.split('/').pop() || slug;
-    const description = doc.data.description;
-    entries.push({ slug, title, description });
-  }
-
-  // Get plugin docs (executors, generators for each plugin)
-  try {
-    const pluginDocs = await getCollection('plugin-docs');
-    for (const doc of pluginDocs) {
-      if (doc.data.slug) {
-        entries.push({
-          slug: doc.data.slug,
-          title: doc.data.title || doc.data.slug,
-          description: doc.data.description,
-        });
-      }
-    }
-  } catch {
-    // plugin-docs collection might not exist
-  }
-
-  // Get Devkit API docs separately for dedicated section
-  try {
-    const nxRefDocs = await getCollection('nx-reference-packages');
-    for (const doc of nxRefDocs) {
-      // Only include devkit package type for now
-      if (doc.data.slug !== undefined && doc.data.packageType === 'devkit') {
-        devkitApiEntries.push({
-          slug: doc.data.slug,
-          title: doc.data.title || doc.data.slug,
-          description: doc.data.description,
-          packageType: doc.data.packageType,
-        });
-      }
-    }
-  } catch {
-    // nx-reference-packages collection might not exist
-  }
-
-  // Sort entries by slug for consistent output
-  entries.sort((a, b) => a.slug.localeCompare(b.slug));
-
-  // Group entries by top-level section
-  const sections = new Map<string, DocEntry[]>();
-  for (const entry of entries) {
-    const section = entry.slug.split('/')[0] || 'other';
-    if (!sections.has(section)) {
-      sections.set(section, []);
-    }
-    sections.get(section)!.push(entry);
-  }
-
-  // Generate the llms.txt content
   const lines: string[] = [
     '# Nx',
     '',
-    '> Nx is an AI-first monorepo platform that connects your editor to CI. It helps you deliver fast without breaking things by optimizing builds, scaling CI, and fixing failed PRs.',
+    `> ${INTRO}`,
     '',
-    'Nx is a powerful, open-source, technology-agnostic monorepo platform designed to efficiently manage codebases of any scale. From small workspaces to large enterprise monorepos, Nx provides intelligent task execution, caching, and CI optimization.',
+    DESCRIPTION,
     '',
-    'Note: All documentation pages are available as raw Markdown by appending `.md` to the URL.',
-    `For example: ${siteUrl}/docs/getting-started/intro.md returns the raw Markdown content.`,
+    '## Reading these docs as an agent',
+    '',
+    `- Append \`.md\` to any docs URL for raw Markdown, for example ${siteUrl}/docs/getting-started/intro.md`,
+    `- Requesting a docs URL with \`Accept: text/markdown\` returns the same Markdown`,
+    `- [Full documentation](${siteUrl}/llms-full.txt): every page concatenated into one file`,
+    '',
+    '## When to use Nx',
+    '',
+    'Use Nx when a repository holds more than one buildable or testable project and you need to know what depends on what, run only the affected tasks, or reuse cached results. Reach for these entry points rather than scraping the docs:',
+    '',
+    `- Nx CLI: the \`nx\` package on npm. Run any command with \`npx nx <command>\`. Commands are documented at ${siteUrl}/docs/reference/nx-commands.md`,
+    `- [Nx MCP server](${siteUrl}/docs/reference/nx-mcp.md): run \`nx mcp\` to expose the workspace project graph, generators, and CI results as MCP tools`,
+    `- [Agent skills](${siteUrl}/.well-known/agent-skills/index.json): task-scoped instructions for navigating a workspace, running tasks, scaffolding code, and monitoring CI`,
+    `- [Set up AI agents](${siteUrl}/docs/getting-started/ai-setup.md): run \`nx configure-ai-agents\` to write agent rules, skills, and MCP config into a workspace`,
     '',
   ];
 
-  // Section display names
-  const sectionNames: Record<string, string> = {
-    'getting-started': 'Getting Started',
-    concepts: 'Core Concepts',
-    features: 'Features',
-    guides: 'Guides',
-    'extending-nx': 'Extending Nx',
-    technologies: 'Technologies',
-    reference: 'Reference',
-    enterprise: 'Enterprise',
-    troubleshooting: 'Troubleshooting',
-    quickstart: 'Quickstart',
+  const renderSection = (sectionKey: string) => {
+    const sectionEntries = sections.get(sectionKey);
+    if (!sectionEntries || sectionEntries.length === 0) return;
+
+    const sectionName = SECTION_NAMES[sectionKey] || sectionKey;
+    lines.push(`## ${sectionName}`);
+    lines.push('');
+
+    if ((NESTED_SECTIONS as readonly string[]).includes(sectionKey)) {
+      const count =
+        sectionKey === 'reference'
+          ? sectionEntries.length + devkitApiEntries.length
+          : sectionEntries.length;
+      lines.push(
+        `${count} pages, indexed separately: [${sectionName} index](${siteUrl}/docs/${sectionKey}/llms.txt)`
+      );
+      lines.push('');
+      return;
+    }
+
+    for (const entry of sectionEntries) {
+      lines.push(renderEntry(entry, siteUrl));
+    }
+    lines.push('');
   };
 
-  // Preferred section order
-  const sectionOrder = [
-    'quickstart',
-    'getting-started',
-    'concepts',
-    'features',
-    'guides',
-    'extending-nx',
-    'technologies',
-    'reference',
-    'enterprise',
-    'troubleshooting',
-  ];
-
-  // Helper to sanitize descriptions - collapse to single line and truncate
-  function sanitizeDescription(desc: string | undefined): string {
-    if (!desc) return '';
-    // Replace newlines and multiple spaces with single space, trim
-    const cleaned = desc
-      .replace(/[\r\n]+/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim();
-    // Truncate long descriptions
-    const maxLen = 150;
-    if (cleaned.length > maxLen) {
-      return cleaned.substring(0, maxLen).replace(/\s+\S*$/, '') + '...';
-    }
-    return cleaned;
+  for (const sectionKey of SECTION_ORDER) {
+    renderSection(sectionKey);
+  }
+  for (const sectionKey of sections.keys()) {
+    if (SECTION_ORDER.includes(sectionKey)) continue;
+    renderSection(sectionKey);
   }
 
-  // Output sections in preferred order
-  for (const sectionKey of sectionOrder) {
-    const sectionEntries = sections.get(sectionKey);
-    if (!sectionEntries || sectionEntries.length === 0) continue;
-
-    const sectionName = sectionNames[sectionKey] || sectionKey;
-    lines.push(`## ${sectionName}`);
-    lines.push('');
-
-    for (const entry of sectionEntries) {
-      // URL encode spaces in the slug
-      const encodedSlug = entry.slug.replace(/ /g, '%20');
-      const url = `${siteUrl}/docs/${encodedSlug}.md`;
-      const desc = sanitizeDescription(entry.description);
-      lines.push(`- [${entry.title}](${url})${desc ? `: ${desc}` : ''}`);
-    }
-    lines.push('');
-  }
-
-  // Output any remaining sections not in the preferred order
-  for (const [sectionKey, sectionEntries] of sections) {
-    if (sectionOrder.includes(sectionKey)) continue;
-    if (sectionEntries.length === 0) continue;
-
-    const sectionName = sectionNames[sectionKey] || sectionKey;
-    lines.push(`## ${sectionName}`);
-    lines.push('');
-
-    for (const entry of sectionEntries) {
-      const encodedSlug = entry.slug.replace(/ /g, '%20');
-      const url = `${siteUrl}/docs/${encodedSlug}.md`;
-      const desc = sanitizeDescription(entry.description);
-      lines.push(`- [${entry.title}](${url})${desc ? `: ${desc}` : ''}`);
-    }
-    lines.push('');
-  }
-
-  // Output Devkit API Reference section
-  if (devkitApiEntries.length > 0) {
-    devkitApiEntries.sort((a, b) => a.title.localeCompare(b.title));
-
-    lines.push('## Devkit API Reference (@nx/devkit)');
-    lines.push('');
-    lines.push(
-      'The following are API docs for `@nx/devkit`, the package used by plugin authors to extend Nx with custom generators, executors, and project graph plugins.'
-    );
-    lines.push('');
-
-    for (const entry of devkitApiEntries) {
-      const encodedSlug = entry.slug.replace(/ /g, '%20');
-      const url = `${siteUrl}/docs/reference/devkit/${encodedSlug}.md`;
-      lines.push(`- [${entry.title}](${url})`);
-    }
-    lines.push('');
-  }
-
-  const content = lines.join('\n');
-
-  return new Response(content, {
-    status: 200,
-    headers: {
-      'Content-Type': 'text/plain; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600',
-    },
-  });
+  return textResponse(lines.join('\n'));
 };

--- a/astro-docs/src/pages/reference/llms.txt.ts
+++ b/astro-docs/src/pages/reference/llms.txt.ts
@@ -1,0 +1,7 @@
+import type { APIRoute } from 'astro';
+import { renderSectionIndex, textResponse } from '../../utils/llms';
+
+export const GET: APIRoute = async ({ site }) =>
+  textResponse(
+    await renderSectionIndex('reference', site?.origin ?? 'https://nx.dev')
+  );

--- a/astro-docs/src/pages/technologies/llms.txt.ts
+++ b/astro-docs/src/pages/technologies/llms.txt.ts
@@ -1,0 +1,7 @@
+import type { APIRoute } from 'astro';
+import { renderSectionIndex, textResponse } from '../../utils/llms';
+
+export const GET: APIRoute = async ({ site }) =>
+  textResponse(
+    await renderSectionIndex('technologies', site?.origin ?? 'https://nx.dev')
+  );

--- a/astro-docs/src/utils/llms.ts
+++ b/astro-docs/src/utils/llms.ts
@@ -1,0 +1,185 @@
+import { getCollection } from 'astro:content';
+
+export interface DocEntry {
+  slug: string;
+  title: string;
+  description?: string;
+}
+
+/** Sections large enough that inlining them blows the llms.txt index budget. */
+export const NESTED_SECTIONS = ['technologies', 'reference', 'kb'] as const;
+export type NestedSection = (typeof NESTED_SECTIONS)[number];
+
+export const SECTION_NAMES: Record<string, string> = {
+  'getting-started': 'Getting Started',
+  concepts: 'Core Concepts',
+  features: 'Features',
+  guides: 'Guides',
+  'extending-nx': 'Extending Nx',
+  technologies: 'Technologies',
+  reference: 'Reference',
+  enterprise: 'Enterprise',
+  troubleshooting: 'Troubleshooting',
+  quickstart: 'Quickstart',
+  'how-nx-works': 'How Nx Works',
+  'platform-features': 'Platform Features',
+  'technologies-tools': 'Technologies and Tools',
+  kb: 'Knowledge Base',
+};
+
+export const SECTION_ORDER = [
+  'quickstart',
+  'getting-started',
+  'concepts',
+  'how-nx-works',
+  'features',
+  'platform-features',
+  'guides',
+  'extending-nx',
+  'technologies-tools',
+  'technologies',
+  'reference',
+  'kb',
+  'enterprise',
+  'troubleshooting',
+];
+
+export const INTRO =
+  'Nx is an AI-first monorepo platform that connects your editor to CI. It helps you deliver fast without breaking things by optimizing builds, scaling CI, and fixing failed PRs.';
+
+export const DESCRIPTION =
+  'Nx is a powerful, open-source, technology-agnostic monorepo platform designed to efficiently manage codebases of any scale. From small workspaces to large enterprise monorepos, Nx provides intelligent task execution, caching, and CI optimization.';
+
+/** Collapse to a single line and truncate so each index entry stays one row. */
+export function sanitizeDescription(desc: string | undefined): string {
+  if (!desc) return '';
+  const cleaned = desc
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const maxLen = 150;
+  if (cleaned.length > maxLen) {
+    return cleaned.substring(0, maxLen).replace(/\s+\S*$/, '') + '...';
+  }
+  return cleaned;
+}
+
+export function renderEntry(entry: DocEntry, siteUrl: string): string {
+  const encodedSlug = entry.slug.replace(/ /g, '%20');
+  const url = `${siteUrl}/docs/${encodedSlug}.md`;
+  const desc = sanitizeDescription(entry.description);
+  return `- [${entry.title}](${url})${desc ? `: ${desc}` : ''}`;
+}
+
+export interface CollectedDocs {
+  /** Doc entries keyed by their top-level slug segment. */
+  sections: Map<string, DocEntry[]>;
+  /** `@nx/devkit` API pages, kept apart so they can get their own heading. */
+  devkitApiEntries: DocEntry[];
+}
+
+export async function collectDocs(): Promise<CollectedDocs> {
+  const entries: DocEntry[] = [];
+  const devkitApiEntries: DocEntry[] = [];
+
+  const docs = await getCollection('docs');
+  for (const doc of docs) {
+    const slug = doc.id;
+    entries.push({
+      slug,
+      title: doc.data.title || slug.split('/').pop() || slug,
+      description: doc.data.description,
+    });
+  }
+
+  try {
+    const pluginDocs = await getCollection('plugin-docs');
+    for (const doc of pluginDocs) {
+      if (doc.data.slug) {
+        entries.push({
+          slug: doc.data.slug,
+          title: doc.data.title || doc.data.slug,
+          description: doc.data.description,
+        });
+      }
+    }
+  } catch {
+    // plugin-docs collection might not exist
+  }
+
+  try {
+    const nxRefDocs = await getCollection('nx-reference-packages');
+    for (const doc of nxRefDocs) {
+      if (doc.data.slug !== undefined && doc.data.packageType === 'devkit') {
+        devkitApiEntries.push({
+          slug: `reference/devkit/${doc.data.slug}`,
+          title: doc.data.title || doc.data.slug,
+          description: doc.data.description,
+        });
+      }
+    }
+  } catch {
+    // nx-reference-packages collection might not exist
+  }
+
+  entries.sort((a, b) => a.slug.localeCompare(b.slug));
+  devkitApiEntries.sort((a, b) => a.title.localeCompare(b.title));
+
+  const sections = new Map<string, DocEntry[]>();
+  for (const entry of entries) {
+    const section = entry.slug.split('/')[0] || 'other';
+    if (!sections.has(section)) {
+      sections.set(section, []);
+    }
+    sections.get(section)!.push(entry);
+  }
+
+  return { sections, devkitApiEntries };
+}
+
+export function textResponse(content: string): Response {
+  return new Response(content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}
+
+/**
+ * Renders the nested index for one long-tail section, linked from /llms.txt.
+ * Devkit API pages get their own heading inside the reference index.
+ */
+export async function renderSectionIndex(
+  sectionKey: NestedSection,
+  siteUrl: string
+): Promise<string> {
+  const { sections, devkitApiEntries } = await collectDocs();
+  const sectionName = SECTION_NAMES[sectionKey] || sectionKey;
+  const entries = sections.get(sectionKey) ?? [];
+
+  const lines: string[] = [
+    `# Nx ${sectionName}`,
+    '',
+    `> ${sectionName} pages from the Nx documentation. See ${siteUrl}/llms.txt for the full index.`,
+    '',
+    `## ${sectionName}`,
+    '',
+    ...entries.map((entry) => renderEntry(entry, siteUrl)),
+    '',
+  ];
+
+  if (sectionKey === 'reference' && devkitApiEntries.length > 0) {
+    lines.push('## Devkit API Reference (@nx/devkit)');
+    lines.push('');
+    lines.push(
+      'API docs for `@nx/devkit`, the package plugin authors use to extend Nx with custom generators, executors, and project graph plugins.'
+    );
+    lines.push('');
+    lines.push(...devkitApiEntries.map((entry) => renderEntry(entry, siteUrl)));
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -278,6 +278,8 @@ export const config = {
     '/courses/*',
     '/_next/*',
     '/.netlify/*',
+    // Agent discovery endpoints - Next rewrites these to astro-docs
+    '/.well-known/*',
     // Legacy docs paths — must bypass Framer so _redirects 301 rules fire
     '/ci',
     '/ci/*',

--- a/netlify/edge-functions/track-page-requests.ts
+++ b/netlify/edge-functions/track-page-requests.ts
@@ -91,6 +91,8 @@ export const config = {
   excludedPath: [
     // API routes
     '/api/*',
+    // Agent discovery endpoints
+    '/.well-known/*',
     // Next.js internals
     '/_next/*',
     '/.netlify/*',

--- a/nx-dev/nx-dev/DEPLOYMENT.md
+++ b/nx-dev/nx-dev/DEPLOYMENT.md
@@ -46,13 +46,22 @@ Rules are processed **top-to-bottom, first match wins**. Specific rules must com
 
 If no redirect matches, Next.js rewrites handle:
 
-| Pattern            | Destination                       | Description              |
-| ------------------ | --------------------------------- | ------------------------ |
-| `/docs`            | `${ASTRO_URL}/docs`               | Documentation root       |
-| `/docs/:path*`     | `${ASTRO_URL}/docs/:path*`        | All documentation pages  |
-| `/.netlify/:path*` | `${ASTRO_URL}/.netlify/:path*`    | Netlify functions/assets |
-| `/llms.txt`        | `${ASTRO_URL}/docs/llms.txt`      | LLM-friendly docs index  |
-| `/llms-full.txt`   | `${ASTRO_URL}/docs/llms-full.txt` | Full LLM documentation   |
+| Pattern                            | Destination                                         | Description                  |
+| ---------------------------------- | --------------------------------------------------- | ---------------------------- |
+| `/docs`                            | `${ASTRO_URL}/docs`                                 | Documentation root           |
+| `/docs/:path*`                     | `${ASTRO_URL}/docs/:path*`                          | All documentation pages      |
+| `/.netlify/:path*`                 | `${ASTRO_URL}/.netlify/:path*`                      | Netlify functions/assets     |
+| `/llms.txt`                        | `${ASTRO_URL}/docs/llms.txt`                        | LLM-friendly docs index      |
+| `/llms-full.txt`                   | `${ASTRO_URL}/docs/llms-full.txt`                   | Full LLM documentation       |
+| `/.well-known/agent-skills/:path*` | `${ASTRO_URL}/docs/.well-known/agent-skills/:path*` | Agent Skills Discovery index |
+
+Anything under `/.well-known/` has to be added to `rewrite-framer-urls.ts`'s
+`excludedPath` as well, or the Framer proxy answers it first and the rewrite
+never runs.
+
+The agent-skills payload is not committed. `astro-docs/scripts/sync-agent-skills.mjs`
+generates it into `astro-docs/public/` during Netlify builds only, so a local
+build or a CI run serves nothing at that path.
 
 ### 4. Next.js App Router
 

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -100,6 +100,12 @@ module.exports = withNx({
         source: '/llms-full.txt',
         destination: `${astroDocsUrl}/docs/llms-full.txt`,
       },
+      // Agent Skills Discovery requires the index at the apex; the mirror is
+      // served from astro-docs with the other agent-facing endpoints.
+      {
+        source: '/.well-known/agent-skills/:path*',
+        destination: `${astroDocsUrl}/docs/.well-known/agent-skills/:path*`,
+      },
     ];
 
     if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Current Behavior

`llms.txt` is a 125 KB flat dump of every page rather than a navigation index. Docs URLs serve HTML or Markdown off the same path but only vary on `Accept-Encoding`, so a cache can return the wrong variant. Nothing points an agent at the Nx CLI, `nx mcp`, or the Nx agent skills, and those skills are only reachable by cloning `nrwl/nx-ai-agents-config`.

## Expected Behavior

`llms.txt` is 26 KB, with `technologies`, `reference`, and `kb` moved to nested indexes at `/docs/<section>/llms.txt`, and it now names the CLI, MCP server, skills index, and `nx configure-ai-agents`. The negotiated HTML response carries `Vary: Accept`. An Agent Skills index is published at `/.well-known/agent-skills/index.json`, mirrored from `nx-ai-agents-config` and refreshed by `astro-docs/scripts/sync-agent-skills.mjs`. The AI integration page gets a "Prompt an agent to set this up" callout.

Baseline before this change: is-agentic 76/100, isitagentready Level 3 "Agent-Readable". Remaining failures are either not applicable to a docs site (OpenAPI, JSON error responses, OAuth, commerce) or need infrastructure this PR can't touch (MCP Server Card needs a hosted HTTP MCP; `nx mcp` is stdio-only, DNS-AID needs DNS records).

The two homepage findings, no JSON-LD/Organization schema and eight `<h1>` elements in the animated hero with no document outline, are Framer-side. Details are in a comment on DOC-637.

## Related Issue(s)

Fixes DOC-637

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/calm-stoat-c59c34c3">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->