### PR TITLE
cleanup(core): extract task input resolution

### DIFF
--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -1,18 +1,30 @@
-import {
-  FileData,
-  ProjectGraph,
-  ProjectGraphProjectNode,
-} from '../config/project-graph';
+import { ProjectGraph } from '../config/project-graph';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { Task, TaskGraph } from '../config/task-graph';
 import { DaemonClient } from '../daemon/client/client';
 import { hashArray } from './file-hasher';
-import { InputDefinition } from '../config/workspace-json-project-json';
-import { minimatch } from 'minimatch';
 import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { workspaceRoot } from '../utils/workspace-root';
 import { HashInputs, NxWorkspaceFilesExternals } from '../native';
 import { getTaskIOService } from '../tasks-runner/task-io-service';
+
+export type {
+  ExpandedDepsOutput,
+  ExpandedInput,
+  ExpandedSelfInput,
+} from './task-inputs';
+export {
+  expandNamedInput,
+  expandSingleProjectInputs,
+  extractPatternsFromFileSets,
+  filterUsingGlobPatterns,
+  getInputs,
+  getNamedInputs,
+  getTargetInputs,
+  isDepsOutput,
+  isSelfInput,
+  splitInputsIntoSelfAndDependencies,
+} from './task-inputs';
 
 // Re-export HashInputs from native module for public API
 export { HashInputs };
@@ -264,268 +276,4 @@ export class InProcessTaskHasher implements TaskHasher {
       JSON.stringify(sortedOverrides),
     ]);
   }
-}
-
-export type ExpandedSelfInput =
-  | { fileset: string }
-  | { runtime: string }
-  | { env: string }
-  | { externalDependencies: string[] };
-export type ExpandedDepsOutput = {
-  dependentTasksOutputFiles: string;
-  transitive?: boolean;
-};
-export type ExpandedInput = ExpandedSelfInput | ExpandedDepsOutput;
-const DEFAULT_INPUTS: ReadonlyArray<InputDefinition> = [
-  {
-    input: 'default',
-  },
-  {
-    dependencies: true,
-    input: 'default',
-  },
-];
-
-export function getNamedInputs(
-  nxJson: NxJsonConfiguration,
-  project: ProjectGraphProjectNode
-) {
-  return {
-    default: [{ fileset: '{projectRoot}/**/*' }],
-    ...nxJson.namedInputs,
-    ...project.data.namedInputs,
-  };
-}
-
-export function getTargetInputs(
-  nxJson: NxJsonConfiguration,
-  projectNode: ProjectGraphProjectNode,
-  target: string
-) {
-  const namedInputs = getNamedInputs(nxJson, projectNode);
-
-  const targetData = projectNode.data.targets[target];
-  const inputs = splitInputsIntoSelfAndDependencies(
-    targetData.inputs || DEFAULT_INPUTS,
-    namedInputs
-  );
-
-  const selfInputs = extractPatternsFromFileSets(inputs.selfInputs);
-
-  const dependencyInputs = [
-    ...extractPatternsFromFileSets(
-      inputs.depsInputs
-        .map((s) => expandNamedInput(s.input, namedInputs))
-        .flat()
-    ),
-    ...inputs.depsFilesets.map((d) => d.fileset),
-  ];
-
-  return { selfInputs, dependencyInputs };
-}
-
-export function extractPatternsFromFileSets(
-  inputs: readonly ExpandedInput[]
-): string[] {
-  return inputs
-    .filter((c): c is { fileset: string } => !!c['fileset'])
-    .map((c) => c['fileset']);
-}
-
-export function getInputs(
-  task: Task,
-  projectGraph: ProjectGraph,
-  nxJson: NxJsonConfiguration
-) {
-  const projectNode = projectGraph.nodes[task.target.project];
-  const namedInputs = getNamedInputs(nxJson, projectNode);
-  const targetData = projectNode.data.targets[task.target.target];
-  // See `getTargetInputs` — graph construction already merged any
-  // matching target-default's `inputs` onto `targetData.inputs`, so a
-  // separate `targetDefaults` lookup here would either repeat that
-  // work or drift from it.
-  const { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets } =
-    splitInputsIntoSelfAndDependencies(
-      targetData.inputs || (DEFAULT_INPUTS as any),
-      namedInputs
-    );
-  return { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets };
-}
-
-export function splitInputsIntoSelfAndDependencies(
-  inputs: ReadonlyArray<InputDefinition | string>,
-  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
-): {
-  depsInputs: { input: string; dependencies: true }[];
-  projectInputs: { input: string; projects: string[] }[];
-  selfInputs: ExpandedSelfInput[];
-  depsOutputs: ExpandedDepsOutput[];
-  depsFilesets: { fileset: string; dependencies: true }[];
-} {
-  const depsInputs: { input: string; dependencies: true }[] = [];
-  const projectInputs: { input: string; projects: string[] }[] = [];
-  const depsFilesets: { fileset: string; dependencies: true }[] = [];
-  const selfInputs = [];
-  for (const d of inputs) {
-    if (typeof d === 'string') {
-      if (d.startsWith('^')) {
-        const rest = d.substring(1);
-        if (
-          rest.startsWith('{projectRoot}') ||
-          rest.startsWith('{workspaceRoot}')
-        ) {
-          depsFilesets.push({ fileset: rest, dependencies: true });
-        } else {
-          depsInputs.push({ input: rest, dependencies: true });
-        }
-      } else {
-        selfInputs.push(d);
-      }
-    } else {
-      if ('fileset' in d && 'dependencies' in d && d.dependencies) {
-        depsFilesets.push({
-          fileset: (d as { fileset: string; dependencies: true }).fileset,
-          dependencies: true,
-        });
-      } else if (
-        'input' in d &&
-        !('fileset' in d) &&
-        (('dependencies' in d && d.dependencies) ||
-          // Todo(@AgentEnder): Remove check in v17
-          ('projects' in d &&
-            typeof d.projects === 'string' &&
-            d.projects === 'dependencies'))
-      ) {
-        depsInputs.push({
-          input: d.input,
-          dependencies: true,
-        });
-      } else if (
-        'input' in d &&
-        !('fileset' in d) &&
-        'projects' in d &&
-        d.projects &&
-        // Todo(@AgentEnder): Remove check in v17
-        !(d.projects === 'self')
-      ) {
-        projectInputs.push({
-          input: d.input,
-          projects: Array.isArray(d.projects) ? d.projects : [d.projects],
-        });
-      } else {
-        selfInputs.push(d);
-      }
-    }
-  }
-  const expandedInputs = expandSingleProjectInputs(selfInputs, namedInputs);
-  return {
-    depsInputs,
-    projectInputs,
-    selfInputs: expandedInputs.filter(isSelfInput),
-    depsOutputs: expandedInputs.filter(isDepsOutput),
-    depsFilesets,
-  };
-}
-
-export function isSelfInput(input: ExpandedInput): input is ExpandedSelfInput {
-  return !('dependentTasksOutputFiles' in input);
-}
-
-export function isDepsOutput(
-  input: ExpandedInput
-): input is ExpandedDepsOutput {
-  return 'dependentTasksOutputFiles' in input;
-}
-
-export function expandSingleProjectInputs(
-  inputs: ReadonlyArray<InputDefinition | string>,
-  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
-): ExpandedInput[] {
-  const expanded = [];
-  for (const d of inputs) {
-    if (typeof d === 'string') {
-      if (d.startsWith('^'))
-        throw new Error(`namedInputs definitions cannot start with ^`);
-
-      if (namedInputs[d]) {
-        expanded.push(...expandNamedInput(d, namedInputs));
-      } else {
-        expanded.push({ fileset: d });
-      }
-    } else {
-      if ((d as any).projects || (d as any).dependencies) {
-        throw new Error(
-          `namedInputs definitions can only refer to other namedInputs definitions within the same project.`
-        );
-      }
-      if (
-        (d as any).fileset ||
-        (d as any).env ||
-        (d as any).runtime ||
-        (d as any).externalDependencies ||
-        (d as any).dependentTasksOutputFiles ||
-        (d as any).workingDirectory ||
-        (d as any).json
-      ) {
-        expanded.push(d);
-      } else {
-        expanded.push(...expandNamedInput((d as any).input, namedInputs));
-      }
-    }
-  }
-  return expanded;
-}
-
-export function expandNamedInput(
-  input: string,
-  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
-): ExpandedInput[] {
-  namedInputs ||= {};
-  if (!namedInputs[input]) throw new Error(`Input '${input}' is not defined`);
-  return expandSingleProjectInputs(namedInputs[input], namedInputs);
-}
-
-export function filterUsingGlobPatterns(
-  root: string,
-  files: FileData[],
-  patterns: string[]
-): FileData[] {
-  const filesetWithExpandedProjectRoot = patterns
-    .map((f) => f.replace('{projectRoot}', root))
-    .map((r) => {
-      // handling root level projects that create './' pattern that doesn't work with minimatch
-      if (r.startsWith('./')) return r.substring(2);
-      if (r.startsWith('!./')) return '!' + r.substring(3);
-      return r;
-    });
-
-  const positive = [];
-  const negative = [];
-  for (const p of filesetWithExpandedProjectRoot) {
-    if (p.startsWith('!')) {
-      negative.push(p);
-    } else {
-      positive.push(p);
-    }
-  }
-
-  if (positive.length === 0 && negative.length === 0) {
-    return files;
-  }
-
-  return files.filter((f) => {
-    let matchedPositive = false;
-    if (
-      positive.length === 0 ||
-      (positive.length === 1 && positive[0] === `${root}/**/*`)
-    ) {
-      matchedPositive = true;
-    } else {
-      matchedPositive = positive.some((pattern) => minimatch(f.file, pattern));
-    }
-
-    if (!matchedPositive) return false;
-
-    return negative.every((pattern) => minimatch(f.file, pattern));
-  });
 }

--- a/packages/nx/src/hasher/task-inputs.spec.ts
+++ b/packages/nx/src/hasher/task-inputs.spec.ts
@@ -1,13 +1,11 @@
-// This must come before the Hasher import
-
 import {
   expandNamedInput,
   expandSingleProjectInputs,
   filterUsingGlobPatterns,
   splitInputsIntoSelfAndDependencies,
-} from './task-hasher';
+} from './task-inputs';
 
-describe('TaskHasher', () => {
+describe('task inputs', () => {
   describe('splitInputsIntoSelfAndDependencies', () => {
     it('should identify ^{projectRoot}/**/*.ts as a dependency fileset', () => {
       const result = splitInputsIntoSelfAndDependencies(

--- a/packages/nx/src/hasher/task-inputs.ts
+++ b/packages/nx/src/hasher/task-inputs.ts
@@ -1,0 +1,273 @@
+import {
+  FileData,
+  ProjectGraph,
+  ProjectGraphProjectNode,
+} from '../config/project-graph';
+import { NxJsonConfiguration } from '../config/nx-json';
+import { Task } from '../config/task-graph';
+import { InputDefinition } from '../config/workspace-json-project-json';
+import { minimatch } from 'minimatch';
+
+export type ExpandedSelfInput =
+  | { fileset: string }
+  | { runtime: string }
+  | { env: string }
+  | { externalDependencies: string[] };
+export type ExpandedDepsOutput = {
+  dependentTasksOutputFiles: string;
+  transitive?: boolean;
+};
+export type ExpandedInput = ExpandedSelfInput | ExpandedDepsOutput;
+const DEFAULT_INPUTS: ReadonlyArray<InputDefinition> = [
+  {
+    input: 'default',
+  },
+  {
+    dependencies: true,
+    input: 'default',
+  },
+];
+
+export function getNamedInputs(
+  nxJson: NxJsonConfiguration,
+  project: ProjectGraphProjectNode
+) {
+  return {
+    default: [{ fileset: '{projectRoot}/**/*' }],
+    ...nxJson.namedInputs,
+    ...project.data.namedInputs,
+  };
+}
+
+export function getTargetInputs(
+  nxJson: NxJsonConfiguration,
+  projectNode: ProjectGraphProjectNode,
+  target: string
+) {
+  const namedInputs = getNamedInputs(nxJson, projectNode);
+
+  const targetData = projectNode.data.targets[target];
+  const inputs = splitInputsIntoSelfAndDependencies(
+    targetData.inputs || DEFAULT_INPUTS,
+    namedInputs
+  );
+
+  const selfInputs = extractPatternsFromFileSets(inputs.selfInputs);
+
+  const dependencyInputs = [
+    ...extractPatternsFromFileSets(
+      inputs.depsInputs
+        .map((s) => expandNamedInput(s.input, namedInputs))
+        .flat()
+    ),
+    ...inputs.depsFilesets.map((d) => d.fileset),
+  ];
+
+  return { selfInputs, dependencyInputs };
+}
+
+export function extractPatternsFromFileSets(
+  inputs: readonly ExpandedInput[]
+): string[] {
+  return inputs
+    .filter((c): c is { fileset: string } => !!c['fileset'])
+    .map((c) => c['fileset']);
+}
+
+export function getInputs(
+  task: Task,
+  projectGraph: ProjectGraph,
+  nxJson: NxJsonConfiguration
+) {
+  const projectNode = projectGraph.nodes[task.target.project];
+  const namedInputs = getNamedInputs(nxJson, projectNode);
+  const targetData = projectNode.data.targets[task.target.target];
+  // See `getTargetInputs` — graph construction already merged any
+  // matching target-default's `inputs` onto `targetData.inputs`, so a
+  // separate `targetDefaults` lookup here would either repeat that
+  // work or drift from it.
+  const { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets } =
+    splitInputsIntoSelfAndDependencies(
+      targetData.inputs || (DEFAULT_INPUTS as any),
+      namedInputs
+    );
+  return { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets };
+}
+
+export function splitInputsIntoSelfAndDependencies(
+  inputs: ReadonlyArray<InputDefinition | string>,
+  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
+): {
+  depsInputs: { input: string; dependencies: true }[];
+  projectInputs: { input: string; projects: string[] }[];
+  selfInputs: ExpandedSelfInput[];
+  depsOutputs: ExpandedDepsOutput[];
+  depsFilesets: { fileset: string; dependencies: true }[];
+} {
+  const depsInputs: { input: string; dependencies: true }[] = [];
+  const projectInputs: { input: string; projects: string[] }[] = [];
+  const depsFilesets: { fileset: string; dependencies: true }[] = [];
+  const selfInputs = [];
+  for (const d of inputs) {
+    if (typeof d === 'string') {
+      if (d.startsWith('^')) {
+        const rest = d.substring(1);
+        if (
+          rest.startsWith('{projectRoot}') ||
+          rest.startsWith('{workspaceRoot}')
+        ) {
+          depsFilesets.push({ fileset: rest, dependencies: true });
+        } else {
+          depsInputs.push({ input: rest, dependencies: true });
+        }
+      } else {
+        selfInputs.push(d);
+      }
+    } else {
+      if ('fileset' in d && 'dependencies' in d && d.dependencies) {
+        depsFilesets.push({
+          fileset: (d as { fileset: string; dependencies: true }).fileset,
+          dependencies: true,
+        });
+      } else if (
+        'input' in d &&
+        !('fileset' in d) &&
+        (('dependencies' in d && d.dependencies) ||
+          // Todo(@AgentEnder): Remove check in v17
+          ('projects' in d &&
+            typeof d.projects === 'string' &&
+            d.projects === 'dependencies'))
+      ) {
+        depsInputs.push({
+          input: d.input,
+          dependencies: true,
+        });
+      } else if (
+        'input' in d &&
+        !('fileset' in d) &&
+        'projects' in d &&
+        d.projects &&
+        // Todo(@AgentEnder): Remove check in v17
+        !(d.projects === 'self')
+      ) {
+        projectInputs.push({
+          input: d.input,
+          projects: Array.isArray(d.projects) ? d.projects : [d.projects],
+        });
+      } else {
+        selfInputs.push(d);
+      }
+    }
+  }
+  const expandedInputs = expandSingleProjectInputs(selfInputs, namedInputs);
+  return {
+    depsInputs,
+    projectInputs,
+    selfInputs: expandedInputs.filter(isSelfInput),
+    depsOutputs: expandedInputs.filter(isDepsOutput),
+    depsFilesets,
+  };
+}
+
+export function isSelfInput(input: ExpandedInput): input is ExpandedSelfInput {
+  return !('dependentTasksOutputFiles' in input);
+}
+
+export function isDepsOutput(
+  input: ExpandedInput
+): input is ExpandedDepsOutput {
+  return 'dependentTasksOutputFiles' in input;
+}
+
+export function expandSingleProjectInputs(
+  inputs: ReadonlyArray<InputDefinition | string>,
+  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
+): ExpandedInput[] {
+  const expanded = [];
+  for (const d of inputs) {
+    if (typeof d === 'string') {
+      if (d.startsWith('^'))
+        throw new Error(`namedInputs definitions cannot start with ^`);
+
+      if (namedInputs[d]) {
+        expanded.push(...expandNamedInput(d, namedInputs));
+      } else {
+        expanded.push({ fileset: d });
+      }
+    } else {
+      if ((d as any).projects || (d as any).dependencies) {
+        throw new Error(
+          `namedInputs definitions can only refer to other namedInputs definitions within the same project.`
+        );
+      }
+      if (
+        (d as any).fileset ||
+        (d as any).env ||
+        (d as any).runtime ||
+        (d as any).externalDependencies ||
+        (d as any).dependentTasksOutputFiles ||
+        (d as any).workingDirectory ||
+        (d as any).json
+      ) {
+        expanded.push(d);
+      } else {
+        expanded.push(...expandNamedInput((d as any).input, namedInputs));
+      }
+    }
+  }
+  return expanded;
+}
+
+export function expandNamedInput(
+  input: string,
+  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
+): ExpandedInput[] {
+  namedInputs ||= {};
+  if (!namedInputs[input]) throw new Error(`Input '${input}' is not defined`);
+  return expandSingleProjectInputs(namedInputs[input], namedInputs);
+}
+
+export function filterUsingGlobPatterns(
+  root: string,
+  files: FileData[],
+  patterns: string[]
+): FileData[] {
+  const filesetWithExpandedProjectRoot = patterns
+    .map((f) => f.replace('{projectRoot}', root))
+    .map((r) => {
+      // handling root level projects that create './' pattern that doesn't work with minimatch
+      if (r.startsWith('./')) return r.substring(2);
+      if (r.startsWith('!./')) return '!' + r.substring(3);
+      return r;
+    });
+
+  const positive = [];
+  const negative = [];
+  for (const p of filesetWithExpandedProjectRoot) {
+    if (p.startsWith('!')) {
+      negative.push(p);
+    } else {
+      positive.push(p);
+    }
+  }
+
+  if (positive.length === 0 && negative.length === 0) {
+    return files;
+  }
+
+  return files.filter((f) => {
+    let matchedPositive = false;
+    if (
+      positive.length === 0 ||
+      (positive.length === 1 && positive[0] === `${root}/**/*`)
+    ) {
+      matchedPositive = true;
+    } else {
+      matchedPositive = positive.some((pattern) => minimatch(f.file, pattern));
+    }
+
+    if (!matchedPositive) return false;
+
+    return negative.every((pattern) => minimatch(f.file, pattern));
+  });
+}


### PR DESCRIPTION
_This PR description was generated by AMP._

> [!NOTE]
> Follow-up #36772 depends on this extraction.

## Current Behavior

The pure TypeScript helpers for resolving configured task inputs live in `task-hasher.ts`, even though the production task hasher delegates hashing to the native implementation. Non-hasher consumers therefore have to import input-model helpers through the hasher module.

## Expected Behavior

The input-resolution functions and types live in `task-inputs.ts`. `task-hasher.ts` permanently re-exports them, preserving existing imports and behavior while giving query and inspection code a boundary that does not imply it is invoking the production hasher.

This PR only moves existing code and its tests; it does not change hashing or input-resolution behavior.

## Validation

- `npx --no-install jest --config packages/nx/jest.config.cts --runInBand packages/nx/src/hasher/task-inputs.spec.ts packages/nx/src/plugins/js/package-json/create-package-json.spec.ts` (42 tests passed)
- `npx tsc -p packages/nx/tsconfig.lib.json --noEmit --pretty false` (passed when run for this commit)
- `git diff --check` (passed)
- Full `nx prepush` could not construct the repository project graph on this machine because the .NET and Gradle toolchains are unavailable. The same failure reproduces on the untouched base commit.

## Related Issue(s)

Related to #15414 and #16478.
