### PR TITLE
feat(core): filter affected projects by task inputs

### DIFF
--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -15,7 +15,7 @@ export interface NxShowArgs {
 
 export type ShowProjectsOptions = NxShowArgs & {
   exclude?: string[];
-  files?: string;
+  files?: string[];
   uncommitted?: any;
   untracked?: any;
   base?: string;
@@ -24,6 +24,7 @@ export type ShowProjectsOptions = NxShowArgs & {
   type?: ProjectGraphProjectNode['type'];
   projects?: string[];
   withTarget?: string[];
+  filterByTaskInputs?: boolean;
   verbose?: boolean;
   sep?: string;
 };
@@ -124,6 +125,10 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
         description: 'Show only projects that have a specific target.',
         coerce: parseCSV,
       })
+      .option('filterByTaskInputs', {
+        type: 'boolean',
+        description: 'Narrow affected projects using target inputs.',
+      })
       .option('type', {
         type: 'string',
         description: 'Select only projects of the given type.',
@@ -138,6 +143,8 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
       .implies('files', 'affected')
       .implies('base', 'affected')
       .implies('head', 'affected')
+      .implies('filterByTaskInputs', 'affected')
+      .implies('filterByTaskInputs', 'withTarget')
       .conflicts('sep', 'json')
       .conflicts('json', 'sep')
       .example(
@@ -159,6 +166,10 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
       .example(
         '$0 show projects --affected --exclude=*-e2e',
         'Show affected projects in the workspace, excluding end-to-end projects'
+      )
+      .example(
+        '$0 show projects --affected -t build --filter-by-task-inputs',
+        'Show affected projects whose build inputs changed'
       ) as any,
   handler: async (args) => {
     const exitCode = await handleErrors(args.verbose as boolean, async () => {

--- a/packages/nx/src/command-line/show/projects.spec.ts
+++ b/packages/nx/src/command-line/show/projects.spec.ts
@@ -3,6 +3,8 @@ import type {
   ProjectGraphProjectNode,
 } from '../../config/project-graph';
 import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import { filterAffected } from '../../project-graph/affected/affected-project-graph';
+import { hasCustomHasher } from './show-target/utils';
 import { showProjectsHandler } from './projects';
 
 let graph: ProjectGraph = {
@@ -10,7 +12,14 @@ let graph: ProjectGraph = {
   dependencies: {},
   externalNodes: {},
 };
+let affectedProjects: string[] | undefined;
 
+jest.mock('../../config/nx-json', () => ({
+  ...(jest.requireActual(
+    '../../config/nx-json'
+  ) as typeof import('../../config/nx-json')),
+  readNxJson: jest.fn(() => ({})),
+}));
 jest.mock('../../project-graph/project-graph', () => ({
   ...(jest.requireActual(
     '../../project-graph/project-graph'
@@ -18,6 +27,19 @@ jest.mock('../../project-graph/project-graph', () => ({
   createProjectGraphAsync: jest
     .fn()
     .mockImplementation(() => Promise.resolve(graph)),
+}));
+jest.mock('../../project-graph/affected/affected-project-graph', () => ({
+  filterAffected: jest.fn((projectGraph: ProjectGraph) => ({
+    ...projectGraph,
+    nodes: Object.fromEntries(
+      Object.entries(projectGraph.nodes).filter(
+        ([name]) => !affectedProjects || affectedProjects.includes(name)
+      )
+    ),
+  })),
+}));
+jest.mock('./show-target/utils', () => ({
+  hasCustomHasher: jest.fn(() => false),
 }));
 
 performance.mark = jest.fn();
@@ -27,6 +49,8 @@ describe('show projects', () => {
   beforeEach(() => {
     jest.spyOn(console, 'log').mockImplementation(() => {});
     performance.mark('init-local');
+    affectedProjects = undefined;
+    (hasCustomHasher as jest.Mock).mockReturnValue(false);
   });
   afterEach(() => {
     jest.clearAllMocks();
@@ -348,6 +372,155 @@ describe('show projects', () => {
     expect(console.log).toHaveBeenCalledWith('proj2');
     expect(console.log).toHaveBeenCalledTimes(2);
   });
+
+  it('preserves affected and target behavior without input filtering', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration({
+        root: 'proj1',
+        name: 'proj1',
+        targets: {
+          build: { inputs: ['{projectRoot}/src/**/*'] },
+        },
+      })
+      .addProjectConfiguration({
+        root: 'proj2',
+        name: 'proj2',
+        targets: {
+          build: { inputs: ['{projectRoot}/src/**/*'] },
+        },
+      })
+      .build();
+
+    await showProjectsHandler({
+      affected: true,
+      withTarget: ['build'],
+      files: ['unrelated.txt'],
+      json: true,
+    });
+
+    expect(filterAffected).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith('["proj1","proj2"]');
+  });
+
+  it('narrows affected projects using target inputs', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration({
+        root: 'proj1',
+        name: 'proj1',
+        targets: {
+          build: { inputs: ['{projectRoot}/src/**/*'] },
+        },
+      })
+      .addProjectConfiguration({
+        root: 'proj2',
+        name: 'proj2',
+        targets: {
+          build: { inputs: ['{projectRoot}/src/**/*'] },
+        },
+      })
+      .build();
+
+    await showProjectsHandler({
+      affected: true,
+      withTarget: ['build'],
+      filterByTaskInputs: true,
+      files: ['proj1/src/main.ts'],
+      json: true,
+    });
+
+    expect(console.log).toHaveBeenCalledWith('["proj1"]');
+  });
+
+  it('uses OR semantics when filtering multiple targets', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration({
+        root: 'proj1',
+        name: 'proj1',
+        targets: {
+          build: { inputs: ['{projectRoot}/src/**/*'] },
+          test: { inputs: ['{projectRoot}/test/**/*'] },
+        },
+      })
+      .addProjectConfiguration({
+        root: 'proj2',
+        name: 'proj2',
+        targets: {
+          build: { inputs: ['{projectRoot}/src/**/*'] },
+          test: { inputs: ['{projectRoot}/test/**/*'] },
+        },
+      })
+      .build();
+
+    await showProjectsHandler({
+      affected: true,
+      withTarget: ['build', 'test'],
+      filterByTaskInputs: true,
+      files: ['proj1/test/example.spec.ts'],
+      json: true,
+    });
+
+    expect(console.log).toHaveBeenCalledWith('["proj1"]');
+  });
+
+  it('uses the full project graph to resolve target inputs', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration({
+        root: 'app',
+        name: 'app',
+        targets: {
+          build: { inputs: [{ input: 'schema', projects: ['schema'] }] },
+        },
+      })
+      .addProjectConfiguration({
+        root: 'schema',
+        name: 'schema',
+        namedInputs: { schema: ['{projectRoot}/**/*.json'] },
+      })
+      .build();
+    affectedProjects = ['app'];
+
+    await showProjectsHandler({
+      affected: true,
+      withTarget: ['build'],
+      filterByTaskInputs: true,
+      files: ['schema/model.json'],
+      json: true,
+    });
+
+    expect(console.log).toHaveBeenCalledWith('["app"]');
+  });
+
+  it('rejects direct handler calls without required options', async () => {
+    await expect(
+      showProjectsHandler({ filterByTaskInputs: true, withTarget: ['build'] })
+    ).rejects.toThrow('--filter-by-task-inputs requires --affected.');
+    await expect(
+      showProjectsHandler({ filterByTaskInputs: true, affected: true })
+    ).rejects.toThrow('--filter-by-task-inputs requires --with-target.');
+  });
+
+  it('conservatively retains targets with custom hashers', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration({
+        root: 'proj1',
+        name: 'proj1',
+        targets: {
+          build: { inputs: ['{projectRoot}/src/**/*'] },
+        },
+      })
+      .build();
+    (hasCustomHasher as jest.Mock).mockReturnValue(true);
+
+    await showProjectsHandler({
+      affected: true,
+      withTarget: ['build'],
+      filterByTaskInputs: true,
+      files: ['unrelated.txt'],
+      json: true,
+    });
+
+    expect(console.log).toHaveBeenCalledWith('["proj1"]');
+  });
 });
 
 class GraphBuilder {
@@ -355,7 +528,7 @@ class GraphBuilder {
 
   addProjectConfiguration(
     project: ProjectConfiguration,
-    type: ProjectGraph['nodes'][string]['type']
+    type: ProjectGraph['nodes'][string]['type'] = 'lib'
   ) {
     this.nodes[project.name] = {
       name: project.name,

--- a/packages/nx/src/command-line/show/projects.ts
+++ b/packages/nx/src/command-line/show/projects.ts
@@ -6,6 +6,10 @@ import {
 } from '../../config/project-graph';
 import { filterAffected } from '../../project-graph/affected/affected-project-graph';
 import {
+  filterAffectedTasksByInputs,
+  type RequestedTask,
+} from '../../project-graph/affected/affected-tasks';
+import {
   FileChange,
   calculateFileChanges,
 } from '../../project-graph/file-utils';
@@ -19,13 +23,22 @@ import {
 } from '../../utils/command-line-utils';
 import { findMatchingProjects } from '../../utils/find-matching-projects';
 import { ShowProjectsOptions } from './command-object';
+import { hasCustomHasher } from './show-target/utils';
 
 export async function showProjectsHandler(
   args: ShowProjectsOptions
 ): Promise<void> {
+  if (args.filterByTaskInputs && !args.affected) {
+    throw new Error('--filter-by-task-inputs requires --affected.');
+  }
+  if (args.filterByTaskInputs && !args.withTarget?.length) {
+    throw new Error('--filter-by-task-inputs requires --with-target.');
+  }
+
   performance.mark('code-loading:end');
   performance.measure('code-loading', 'init-local', 'code-loading:end');
-  let graph = await createProjectGraphAsync();
+  const projectGraph = await createProjectGraphAsync();
+  let graph = projectGraph;
   const nxJson = readNxJson();
   const { nxArgs } = splitArgsIntoNxArgsAndOverrides(
     args,
@@ -36,10 +49,11 @@ export async function showProjectsHandler(
     nxJson
   );
 
+  let touchedFiles: FileChange[] = [];
   // Affected touches dependencies so it needs to be processed first.
   if (args.affected) {
-    const touchedFiles = await getTouchedFiles(nxArgs);
-    graph = await getAffectedGraph(touchedFiles, nxJson, graph);
+    touchedFiles = await getTouchedFiles(nxArgs);
+    graph = await getAffectedGraph(touchedFiles, nxJson, projectGraph);
   }
 
   const filter = filterNodes((node) => {
@@ -68,6 +82,24 @@ export async function showProjectsHandler(
     );
   }
 
+  if (args.filterByTaskInputs) {
+    const candidates = createRequestedTasks(graph, args.withTarget);
+    const projectsWithMatchingInputs = new Set(
+      filterAffectedTasksByInputs(
+        candidates,
+        projectGraph,
+        nxJson,
+        touchedFiles,
+        (task) => hasCustomHasher(task.project, task.target, projectGraph)
+      ).map((task) => task.project)
+    );
+    graph.nodes = Object.fromEntries(
+      Object.entries(graph.nodes).filter(([project]) =>
+        projectsWithMatchingInputs.has(project)
+      )
+    );
+  }
+
   const selectedProjects = new Set(Object.keys(graph.nodes));
 
   if (args.exclude) {
@@ -90,6 +122,17 @@ export async function showProjectsHandler(
   // TODO: Find a better fix for this
   await new Promise((res) => setImmediate(res));
   await output.drain();
+}
+
+function createRequestedTasks(
+  graph: ProjectGraph,
+  targets: string[]
+): RequestedTask[] {
+  return Object.values(graph.nodes).flatMap((node) =>
+    targets
+      .filter((target) => node.data.targets?.[target])
+      .map((target) => ({ project: node.name, target }))
+  );
 }
 
 function getGraphNodesMatchingPatterns(

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -1,18 +1,30 @@
-import {
-  FileData,
-  ProjectGraph,
-  ProjectGraphProjectNode,
-} from '../config/project-graph';
+import { ProjectGraph } from '../config/project-graph';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { Task, TaskGraph } from '../config/task-graph';
 import { DaemonClient } from '../daemon/client/client';
 import { hashArray } from './file-hasher';
-import { InputDefinition } from '../config/workspace-json-project-json';
-import { minimatch } from 'minimatch';
 import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { workspaceRoot } from '../utils/workspace-root';
 import { HashInputs, NxWorkspaceFilesExternals } from '../native';
 import { getTaskIOService } from '../tasks-runner/task-io-service';
+
+export type {
+  ExpandedDepsOutput,
+  ExpandedInput,
+  ExpandedSelfInput,
+} from './task-inputs';
+export {
+  expandNamedInput,
+  expandSingleProjectInputs,
+  extractPatternsFromFileSets,
+  filterUsingGlobPatterns,
+  getInputs,
+  getNamedInputs,
+  getTargetInputs,
+  isDepsOutput,
+  isSelfInput,
+  splitInputsIntoSelfAndDependencies,
+} from './task-inputs';
 
 // Re-export HashInputs from native module for public API
 export { HashInputs };
@@ -264,268 +276,4 @@ export class InProcessTaskHasher implements TaskHasher {
       JSON.stringify(sortedOverrides),
     ]);
   }
-}
-
-export type ExpandedSelfInput =
-  | { fileset: string }
-  | { runtime: string }
-  | { env: string }
-  | { externalDependencies: string[] };
-export type ExpandedDepsOutput = {
-  dependentTasksOutputFiles: string;
-  transitive?: boolean;
-};
-export type ExpandedInput = ExpandedSelfInput | ExpandedDepsOutput;
-const DEFAULT_INPUTS: ReadonlyArray<InputDefinition> = [
-  {
-    input: 'default',
-  },
-  {
-    dependencies: true,
-    input: 'default',
-  },
-];
-
-export function getNamedInputs(
-  nxJson: NxJsonConfiguration,
-  project: ProjectGraphProjectNode
-) {
-  return {
-    default: [{ fileset: '{projectRoot}/**/*' }],
-    ...nxJson.namedInputs,
-    ...project.data.namedInputs,
-  };
-}
-
-export function getTargetInputs(
-  nxJson: NxJsonConfiguration,
-  projectNode: ProjectGraphProjectNode,
-  target: string
-) {
-  const namedInputs = getNamedInputs(nxJson, projectNode);
-
-  const targetData = projectNode.data.targets[target];
-  const inputs = splitInputsIntoSelfAndDependencies(
-    targetData.inputs || DEFAULT_INPUTS,
-    namedInputs
-  );
-
-  const selfInputs = extractPatternsFromFileSets(inputs.selfInputs);
-
-  const dependencyInputs = [
-    ...extractPatternsFromFileSets(
-      inputs.depsInputs
-        .map((s) => expandNamedInput(s.input, namedInputs))
-        .flat()
-    ),
-    ...inputs.depsFilesets.map((d) => d.fileset),
-  ];
-
-  return { selfInputs, dependencyInputs };
-}
-
-export function extractPatternsFromFileSets(
-  inputs: readonly ExpandedInput[]
-): string[] {
-  return inputs
-    .filter((c): c is { fileset: string } => !!c['fileset'])
-    .map((c) => c['fileset']);
-}
-
-export function getInputs(
-  task: Task,
-  projectGraph: ProjectGraph,
-  nxJson: NxJsonConfiguration
-) {
-  const projectNode = projectGraph.nodes[task.target.project];
-  const namedInputs = getNamedInputs(nxJson, projectNode);
-  const targetData = projectNode.data.targets[task.target.target];
-  // See `getTargetInputs` — graph construction already merged any
-  // matching target-default's `inputs` onto `targetData.inputs`, so a
-  // separate `targetDefaults` lookup here would either repeat that
-  // work or drift from it.
-  const { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets } =
-    splitInputsIntoSelfAndDependencies(
-      targetData.inputs || (DEFAULT_INPUTS as any),
-      namedInputs
-    );
-  return { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets };
-}
-
-export function splitInputsIntoSelfAndDependencies(
-  inputs: ReadonlyArray<InputDefinition | string>,
-  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
-): {
-  depsInputs: { input: string; dependencies: true }[];
-  projectInputs: { input: string; projects: string[] }[];
-  selfInputs: ExpandedSelfInput[];
-  depsOutputs: ExpandedDepsOutput[];
-  depsFilesets: { fileset: string; dependencies: true }[];
-} {
-  const depsInputs: { input: string; dependencies: true }[] = [];
-  const projectInputs: { input: string; projects: string[] }[] = [];
-  const depsFilesets: { fileset: string; dependencies: true }[] = [];
-  const selfInputs = [];
-  for (const d of inputs) {
-    if (typeof d === 'string') {
-      if (d.startsWith('^')) {
-        const rest = d.substring(1);
-        if (
-          rest.startsWith('{projectRoot}') ||
-          rest.startsWith('{workspaceRoot}')
-        ) {
-          depsFilesets.push({ fileset: rest, dependencies: true });
-        } else {
-          depsInputs.push({ input: rest, dependencies: true });
-        }
-      } else {
-        selfInputs.push(d);
-      }
-    } else {
-      if ('fileset' in d && 'dependencies' in d && d.dependencies) {
-        depsFilesets.push({
-          fileset: (d as { fileset: string; dependencies: true }).fileset,
-          dependencies: true,
-        });
-      } else if (
-        'input' in d &&
-        !('fileset' in d) &&
-        (('dependencies' in d && d.dependencies) ||
-          // Todo(@AgentEnder): Remove check in v17
-          ('projects' in d &&
-            typeof d.projects === 'string' &&
-            d.projects === 'dependencies'))
-      ) {
-        depsInputs.push({
-          input: d.input,
-          dependencies: true,
-        });
-      } else if (
-        'input' in d &&
-        !('fileset' in d) &&
-        'projects' in d &&
-        d.projects &&
-        // Todo(@AgentEnder): Remove check in v17
-        !(d.projects === 'self')
-      ) {
-        projectInputs.push({
-          input: d.input,
-          projects: Array.isArray(d.projects) ? d.projects : [d.projects],
-        });
-      } else {
-        selfInputs.push(d);
-      }
-    }
-  }
-  const expandedInputs = expandSingleProjectInputs(selfInputs, namedInputs);
-  return {
-    depsInputs,
-    projectInputs,
-    selfInputs: expandedInputs.filter(isSelfInput),
-    depsOutputs: expandedInputs.filter(isDepsOutput),
-    depsFilesets,
-  };
-}
-
-export function isSelfInput(input: ExpandedInput): input is ExpandedSelfInput {
-  return !('dependentTasksOutputFiles' in input);
-}
-
-export function isDepsOutput(
-  input: ExpandedInput
-): input is ExpandedDepsOutput {
-  return 'dependentTasksOutputFiles' in input;
-}
-
-export function expandSingleProjectInputs(
-  inputs: ReadonlyArray<InputDefinition | string>,
-  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
-): ExpandedInput[] {
-  const expanded = [];
-  for (const d of inputs) {
-    if (typeof d === 'string') {
-      if (d.startsWith('^'))
-        throw new Error(`namedInputs definitions cannot start with ^`);
-
-      if (namedInputs[d]) {
-        expanded.push(...expandNamedInput(d, namedInputs));
-      } else {
-        expanded.push({ fileset: d });
-      }
-    } else {
-      if ((d as any).projects || (d as any).dependencies) {
-        throw new Error(
-          `namedInputs definitions can only refer to other namedInputs definitions within the same project.`
-        );
-      }
-      if (
-        (d as any).fileset ||
-        (d as any).env ||
-        (d as any).runtime ||
-        (d as any).externalDependencies ||
-        (d as any).dependentTasksOutputFiles ||
-        (d as any).workingDirectory ||
-        (d as any).json
-      ) {
-        expanded.push(d);
-      } else {
-        expanded.push(...expandNamedInput((d as any).input, namedInputs));
-      }
-    }
-  }
-  return expanded;
-}
-
-export function expandNamedInput(
-  input: string,
-  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
-): ExpandedInput[] {
-  namedInputs ||= {};
-  if (!namedInputs[input]) throw new Error(`Input '${input}' is not defined`);
-  return expandSingleProjectInputs(namedInputs[input], namedInputs);
-}
-
-export function filterUsingGlobPatterns(
-  root: string,
-  files: FileData[],
-  patterns: string[]
-): FileData[] {
-  const filesetWithExpandedProjectRoot = patterns
-    .map((f) => f.replace('{projectRoot}', root))
-    .map((r) => {
-      // handling root level projects that create './' pattern that doesn't work with minimatch
-      if (r.startsWith('./')) return r.substring(2);
-      if (r.startsWith('!./')) return '!' + r.substring(3);
-      return r;
-    });
-
-  const positive = [];
-  const negative = [];
-  for (const p of filesetWithExpandedProjectRoot) {
-    if (p.startsWith('!')) {
-      negative.push(p);
-    } else {
-      positive.push(p);
-    }
-  }
-
-  if (positive.length === 0 && negative.length === 0) {
-    return files;
-  }
-
-  return files.filter((f) => {
-    let matchedPositive = false;
-    if (
-      positive.length === 0 ||
-      (positive.length === 1 && positive[0] === `${root}/**/*`)
-    ) {
-      matchedPositive = true;
-    } else {
-      matchedPositive = positive.some((pattern) => minimatch(f.file, pattern));
-    }
-
-    if (!matchedPositive) return false;
-
-    return negative.every((pattern) => minimatch(f.file, pattern));
-  });
 }

--- a/packages/nx/src/hasher/task-inputs.spec.ts
+++ b/packages/nx/src/hasher/task-inputs.spec.ts
@@ -1,13 +1,11 @@
-// This must come before the Hasher import
-
 import {
   expandNamedInput,
   expandSingleProjectInputs,
   filterUsingGlobPatterns,
   splitInputsIntoSelfAndDependencies,
-} from './task-hasher';
+} from './task-inputs';
 
-describe('TaskHasher', () => {
+describe('task inputs', () => {
   describe('splitInputsIntoSelfAndDependencies', () => {
     it('should identify ^{projectRoot}/**/*.ts as a dependency fileset', () => {
       const result = splitInputsIntoSelfAndDependencies(

--- a/packages/nx/src/hasher/task-inputs.ts
+++ b/packages/nx/src/hasher/task-inputs.ts
@@ -1,0 +1,273 @@
+import {
+  FileData,
+  ProjectGraph,
+  ProjectGraphProjectNode,
+} from '../config/project-graph';
+import { NxJsonConfiguration } from '../config/nx-json';
+import { Task } from '../config/task-graph';
+import { InputDefinition } from '../config/workspace-json-project-json';
+import { minimatch } from 'minimatch';
+
+export type ExpandedSelfInput =
+  | { fileset: string }
+  | { runtime: string }
+  | { env: string }
+  | { externalDependencies: string[] };
+export type ExpandedDepsOutput = {
+  dependentTasksOutputFiles: string;
+  transitive?: boolean;
+};
+export type ExpandedInput = ExpandedSelfInput | ExpandedDepsOutput;
+const DEFAULT_INPUTS: ReadonlyArray<InputDefinition> = [
+  {
+    input: 'default',
+  },
+  {
+    dependencies: true,
+    input: 'default',
+  },
+];
+
+export function getNamedInputs(
+  nxJson: NxJsonConfiguration,
+  project: ProjectGraphProjectNode
+) {
+  return {
+    default: [{ fileset: '{projectRoot}/**/*' }],
+    ...nxJson.namedInputs,
+    ...project.data.namedInputs,
+  };
+}
+
+export function getTargetInputs(
+  nxJson: NxJsonConfiguration,
+  projectNode: ProjectGraphProjectNode,
+  target: string
+) {
+  const namedInputs = getNamedInputs(nxJson, projectNode);
+
+  const targetData = projectNode.data.targets[target];
+  const inputs = splitInputsIntoSelfAndDependencies(
+    targetData.inputs || DEFAULT_INPUTS,
+    namedInputs
+  );
+
+  const selfInputs = extractPatternsFromFileSets(inputs.selfInputs);
+
+  const dependencyInputs = [
+    ...extractPatternsFromFileSets(
+      inputs.depsInputs
+        .map((s) => expandNamedInput(s.input, namedInputs))
+        .flat()
+    ),
+    ...inputs.depsFilesets.map((d) => d.fileset),
+  ];
+
+  return { selfInputs, dependencyInputs };
+}
+
+export function extractPatternsFromFileSets(
+  inputs: readonly ExpandedInput[]
+): string[] {
+  return inputs
+    .filter((c): c is { fileset: string } => !!c['fileset'])
+    .map((c) => c['fileset']);
+}
+
+export function getInputs(
+  task: Task,
+  projectGraph: ProjectGraph,
+  nxJson: NxJsonConfiguration
+) {
+  const projectNode = projectGraph.nodes[task.target.project];
+  const namedInputs = getNamedInputs(nxJson, projectNode);
+  const targetData = projectNode.data.targets[task.target.target];
+  // See `getTargetInputs` — graph construction already merged any
+  // matching target-default's `inputs` onto `targetData.inputs`, so a
+  // separate `targetDefaults` lookup here would either repeat that
+  // work or drift from it.
+  const { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets } =
+    splitInputsIntoSelfAndDependencies(
+      targetData.inputs || (DEFAULT_INPUTS as any),
+      namedInputs
+    );
+  return { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets };
+}
+
+export function splitInputsIntoSelfAndDependencies(
+  inputs: ReadonlyArray<InputDefinition | string>,
+  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
+): {
+  depsInputs: { input: string; dependencies: true }[];
+  projectInputs: { input: string; projects: string[] }[];
+  selfInputs: ExpandedSelfInput[];
+  depsOutputs: ExpandedDepsOutput[];
+  depsFilesets: { fileset: string; dependencies: true }[];
+} {
+  const depsInputs: { input: string; dependencies: true }[] = [];
+  const projectInputs: { input: string; projects: string[] }[] = [];
+  const depsFilesets: { fileset: string; dependencies: true }[] = [];
+  const selfInputs = [];
+  for (const d of inputs) {
+    if (typeof d === 'string') {
+      if (d.startsWith('^')) {
+        const rest = d.substring(1);
+        if (
+          rest.startsWith('{projectRoot}') ||
+          rest.startsWith('{workspaceRoot}')
+        ) {
+          depsFilesets.push({ fileset: rest, dependencies: true });
+        } else {
+          depsInputs.push({ input: rest, dependencies: true });
+        }
+      } else {
+        selfInputs.push(d);
+      }
+    } else {
+      if ('fileset' in d && 'dependencies' in d && d.dependencies) {
+        depsFilesets.push({
+          fileset: (d as { fileset: string; dependencies: true }).fileset,
+          dependencies: true,
+        });
+      } else if (
+        'input' in d &&
+        !('fileset' in d) &&
+        (('dependencies' in d && d.dependencies) ||
+          // Todo(@AgentEnder): Remove check in v17
+          ('projects' in d &&
+            typeof d.projects === 'string' &&
+            d.projects === 'dependencies'))
+      ) {
+        depsInputs.push({
+          input: d.input,
+          dependencies: true,
+        });
+      } else if (
+        'input' in d &&
+        !('fileset' in d) &&
+        'projects' in d &&
+        d.projects &&
+        // Todo(@AgentEnder): Remove check in v17
+        !(d.projects === 'self')
+      ) {
+        projectInputs.push({
+          input: d.input,
+          projects: Array.isArray(d.projects) ? d.projects : [d.projects],
+        });
+      } else {
+        selfInputs.push(d);
+      }
+    }
+  }
+  const expandedInputs = expandSingleProjectInputs(selfInputs, namedInputs);
+  return {
+    depsInputs,
+    projectInputs,
+    selfInputs: expandedInputs.filter(isSelfInput),
+    depsOutputs: expandedInputs.filter(isDepsOutput),
+    depsFilesets,
+  };
+}
+
+export function isSelfInput(input: ExpandedInput): input is ExpandedSelfInput {
+  return !('dependentTasksOutputFiles' in input);
+}
+
+export function isDepsOutput(
+  input: ExpandedInput
+): input is ExpandedDepsOutput {
+  return 'dependentTasksOutputFiles' in input;
+}
+
+export function expandSingleProjectInputs(
+  inputs: ReadonlyArray<InputDefinition | string>,
+  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
+): ExpandedInput[] {
+  const expanded = [];
+  for (const d of inputs) {
+    if (typeof d === 'string') {
+      if (d.startsWith('^'))
+        throw new Error(`namedInputs definitions cannot start with ^`);
+
+      if (namedInputs[d]) {
+        expanded.push(...expandNamedInput(d, namedInputs));
+      } else {
+        expanded.push({ fileset: d });
+      }
+    } else {
+      if ((d as any).projects || (d as any).dependencies) {
+        throw new Error(
+          `namedInputs definitions can only refer to other namedInputs definitions within the same project.`
+        );
+      }
+      if (
+        (d as any).fileset ||
+        (d as any).env ||
+        (d as any).runtime ||
+        (d as any).externalDependencies ||
+        (d as any).dependentTasksOutputFiles ||
+        (d as any).workingDirectory ||
+        (d as any).json
+      ) {
+        expanded.push(d);
+      } else {
+        expanded.push(...expandNamedInput((d as any).input, namedInputs));
+      }
+    }
+  }
+  return expanded;
+}
+
+export function expandNamedInput(
+  input: string,
+  namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }
+): ExpandedInput[] {
+  namedInputs ||= {};
+  if (!namedInputs[input]) throw new Error(`Input '${input}' is not defined`);
+  return expandSingleProjectInputs(namedInputs[input], namedInputs);
+}
+
+export function filterUsingGlobPatterns(
+  root: string,
+  files: FileData[],
+  patterns: string[]
+): FileData[] {
+  const filesetWithExpandedProjectRoot = patterns
+    .map((f) => f.replace('{projectRoot}', root))
+    .map((r) => {
+      // handling root level projects that create './' pattern that doesn't work with minimatch
+      if (r.startsWith('./')) return r.substring(2);
+      if (r.startsWith('!./')) return '!' + r.substring(3);
+      return r;
+    });
+
+  const positive = [];
+  const negative = [];
+  for (const p of filesetWithExpandedProjectRoot) {
+    if (p.startsWith('!')) {
+      negative.push(p);
+    } else {
+      positive.push(p);
+    }
+  }
+
+  if (positive.length === 0 && negative.length === 0) {
+    return files;
+  }
+
+  return files.filter((f) => {
+    let matchedPositive = false;
+    if (
+      positive.length === 0 ||
+      (positive.length === 1 && positive[0] === `${root}/**/*`)
+    ) {
+      matchedPositive = true;
+    } else {
+      matchedPositive = positive.some((pattern) => minimatch(f.file, pattern));
+    }
+
+    if (!matchedPositive) return false;
+
+    return negative.every((pattern) => minimatch(f.file, pattern));
+  });
+}

--- a/packages/nx/src/project-graph/affected/affected-tasks.spec.ts
+++ b/packages/nx/src/project-graph/affected/affected-tasks.spec.ts
@@ -1,0 +1,218 @@
+import type { ProjectGraph } from '../../config/project-graph';
+import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import { DeletedFileChange, WholeFileChange } from '../file-utils';
+import {
+  filterAffectedTasksByInputs,
+  type RequestedTask,
+} from './affected-tasks';
+
+describe('filterAffectedTasksByInputs', () => {
+  const task: RequestedTask = { project: 'app', target: 'build' };
+
+  it('matches self inputs and honors exclusions', () => {
+    const graph = graphWith({
+      app: project('app', 'apps/app', [
+        '{projectRoot}/**/*',
+        '!{projectRoot}/**/*.spec.ts',
+      ]),
+    });
+
+    expect(filter(graph, task, 'apps/app/src/main.ts')).toEqual([task]);
+    expect(filter(graph, task, 'apps/app/src/main.spec.ts')).toEqual([]);
+  });
+
+  it('matches workspace inputs', () => {
+    const graph = graphWith({
+      app: project('app', 'apps/app', ['{workspaceRoot}/tools/schema.txt']),
+    });
+
+    expect(filter(graph, task, 'tools/schema.txt')).toHaveLength(1);
+  });
+
+  it('uses default self and dependency inputs', () => {
+    const graph = graphWith(
+      {
+        app: project('app', 'apps/app'),
+        lib: project('lib', 'libs/lib'),
+      },
+      { app: ['lib'] }
+    );
+
+    expect(filter(graph, task, 'apps/app/src/main.ts')).toHaveLength(1);
+    expect(filter(graph, task, 'libs/lib/src/index.ts')).toHaveLength(1);
+  });
+
+  it('evaluates transitive dependency named inputs using each dependency project', () => {
+    const graph = graphWith(
+      {
+        app: project('app', 'apps/app', ['^production']),
+        middle: project('middle', 'libs/middle', undefined, {
+          production: ['{projectRoot}/src/**/*'],
+        }),
+        leaf: project('leaf', 'libs/leaf', undefined, {
+          production: ['{projectRoot}/source/**/*'],
+        }),
+      },
+      { app: ['middle'], middle: ['leaf'] }
+    );
+
+    expect(filter(graph, task, 'libs/leaf/source/index.ts')).toEqual([task]);
+  });
+
+  it('honors dependency named input exclusions', () => {
+    const graph = graphWith(
+      {
+        app: project('app', 'apps/app', ['^production']),
+        lib: project('lib', 'libs/lib', undefined, {
+          production: ['{projectRoot}/**/*', '!{projectRoot}/**/*.spec.ts'],
+        }),
+      },
+      { app: ['lib'] }
+    );
+
+    expect(filter(graph, task, 'libs/lib/src/index.spec.ts')).toEqual([]);
+  });
+
+  it('matches explicit project inputs without expanding the candidates', () => {
+    const graph = graphWith({
+      app: project('app', 'apps/app', [
+        { input: 'schema', projects: ['schema'] },
+      ]),
+      schema: project('schema', 'tools/schema', undefined, {
+        schema: ['{projectRoot}/**/*.json'],
+      }),
+    });
+
+    expect(filter(graph, task, 'tools/schema/model.json')).toEqual([task]);
+  });
+
+  it('resolves project input selectors', () => {
+    const graph = graphWith({
+      app: project('app', 'apps/app', [
+        { input: 'schema', projects: ['tag:schema'] },
+      ]),
+      schema: {
+        ...project('schema', 'tools/schema', undefined, {
+          schema: ['{projectRoot}/**/*.json'],
+        }),
+        tags: ['schema'],
+      },
+    });
+
+    expect(filter(graph, task, 'tools/schema/model.json')).toHaveLength(1);
+  });
+
+  it('matches deleted paths without reading the current file', () => {
+    const graph = graphWith({ app: project('app', 'apps/app') });
+    const result = filterAffectedTasksByInputs(taskList(task), graph, {}, [
+      {
+        file: 'apps/app/src/deleted.ts',
+        getChanges: () => [new DeletedFileChange()],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('handles root projects', () => {
+    const graph = graphWith({
+      app: project('app', '.', ['{projectRoot}/src/**/*']),
+    });
+
+    expect(filter(graph, task, 'src/main.ts')).toHaveLength(1);
+  });
+
+  it('conservatively retains unsupported inputs', () => {
+    const graph = graphWith({
+      app: project('app', 'apps/app', [{ runtime: 'node --version' }]),
+    });
+
+    expect(filter(graph, task, 'unrelated.txt')).toEqual([task]);
+  });
+
+  it('conservatively retains task configuration changes', () => {
+    const graph = graphWith({
+      app: project('app', 'apps/app', ['{projectRoot}/src/**/*']),
+    });
+
+    expect(filter(graph, task, 'apps/app/vite.config.ts')).toEqual([task]);
+  });
+
+  it('does not retain a task for another project configuration change', () => {
+    const graph = graphWith({
+      app: project('app', 'apps/app', ['{projectRoot}/src/**/*']),
+      lib: project('lib', 'libs/lib'),
+    });
+
+    expect(filter(graph, task, 'libs/lib/vite.config.ts')).toEqual([]);
+  });
+
+  it('conservatively retains dependency project configuration changes', () => {
+    const graph = graphWith(
+      {
+        app: project('app', 'apps/app'),
+        lib: project('lib', 'libs/lib'),
+      },
+      { app: ['lib'] }
+    );
+
+    expect(filter(graph, task, 'libs/lib/project.json')).toEqual([task]);
+  });
+
+  it('conservatively retains tasks for an unowned project configuration change', () => {
+    const graph = graphWith({
+      app: project('app', 'apps/app', ['{projectRoot}/src/**/*']),
+    });
+
+    expect(filter(graph, task, 'apps/deleted/project.json')).toEqual([task]);
+  });
+});
+
+function filter(graph: ProjectGraph, task: RequestedTask, changedPath: string) {
+  return filterAffectedTasksByInputs(taskList(task), graph, {}, [
+    { file: changedPath, getChanges: () => [new WholeFileChange()] },
+  ]);
+}
+
+function taskList(task: RequestedTask): RequestedTask[] {
+  return [task];
+}
+
+function project(
+  name: string,
+  root: string,
+  inputs?: ProjectConfiguration['targets'][string]['inputs'],
+  namedInputs?: ProjectConfiguration['namedInputs']
+): ProjectConfiguration {
+  return {
+    name,
+    root,
+    namedInputs,
+    targets: { build: { inputs } },
+  };
+}
+
+function graphWith(
+  projects: Record<string, ProjectConfiguration>,
+  dependencies: Record<string, string[]> = {}
+): ProjectGraph {
+  return {
+    nodes: Object.fromEntries(
+      Object.entries(projects).map(([name, data]) => [
+        name,
+        { name, type: 'lib', data },
+      ])
+    ),
+    externalNodes: {},
+    dependencies: Object.fromEntries(
+      Object.keys(projects).map((name) => [
+        name,
+        (dependencies[name] ?? []).map((target) => ({
+          source: name,
+          target,
+          type: 'static',
+        })),
+      ])
+    ),
+  };
+}

--- a/packages/nx/src/project-graph/affected/affected-tasks.ts
+++ b/packages/nx/src/project-graph/affected/affected-tasks.ts
@@ -1,0 +1,281 @@
+import { minimatch } from 'minimatch';
+import type { NxJsonConfiguration } from '../../config/nx-json';
+import type { ProjectGraph } from '../../config/project-graph';
+import type { Task } from '../../config/task-graph';
+import {
+  expandNamedInput,
+  getInputs,
+  getNamedInputs,
+  type ExpandedInput,
+} from '../../hasher/task-inputs';
+import { findMatchingProjects } from '../../utils/find-matching-projects';
+import type { FileChange } from '../file-utils';
+import {
+  createProjectRootMappings,
+  findProjectForPath,
+} from '../utils/find-project-for-path';
+
+export interface RequestedTask {
+  project: string;
+  target: string;
+}
+
+const WORKSPACE_CONFIGURATION_FILES = new Set([
+  'angular.json',
+  'nx.json',
+  'package.json',
+  'workspace.json',
+]);
+const LOCK_FILES = new Set([
+  'bun.lock',
+  'bun.lockb',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'pnpm-lock.yml',
+  'yarn.lock',
+]);
+
+/**
+ * Narrows an existing affected-project result. It intentionally does not add
+ * projects that the baseline affected calculation did not select.
+ */
+export function filterAffectedTasksByInputs(
+  candidates: RequestedTask[],
+  projectGraph: ProjectGraph,
+  nxJson: NxJsonConfiguration,
+  changes: FileChange[],
+  isCustomHasherTask: (task: RequestedTask) => boolean = () => false
+): RequestedTask[] {
+  const changedPaths = changes.map(({ file }) => normalizePath(file));
+  const projectRootMappings = createProjectRootMappings(projectGraph.nodes);
+  const projectConfigurationChanges = new Map<string, string>();
+  let unownedProjectConfigurationChange: string | undefined;
+  for (const path of changedPaths) {
+    if (!isProjectConfigurationFile(path)) continue;
+    const project = findProjectForPath(path, projectRootMappings);
+    if (project && !projectConfigurationChanges.has(project)) {
+      projectConfigurationChanges.set(project, path);
+    } else if (!project) {
+      unownedProjectConfigurationChange ??= path;
+    }
+  }
+  const workspaceConfigurationChange =
+    changedPaths.find((path) => isWorkspaceConfigurationFile(path)) ??
+    unownedProjectConfigurationChange;
+
+  return candidates.filter((task) => {
+    if (isCustomHasherTask(task)) {
+      return true;
+    }
+    if (workspaceConfigurationChange) {
+      return true;
+    }
+
+    return matchTaskInputs(
+      task,
+      projectGraph,
+      nxJson,
+      changedPaths,
+      projectConfigurationChanges
+    );
+  });
+}
+
+function matchTaskInputs(
+  task: RequestedTask,
+  projectGraph: ProjectGraph,
+  nxJson: NxJsonConfiguration,
+  changedPaths: string[],
+  projectConfigurationChanges: ReadonlyMap<string, string>
+): boolean {
+  const inputs = getInputs({ target: task } as Task, projectGraph, nxJson);
+  if (projectConfigurationChanges.has(task.project)) {
+    return true;
+  }
+
+  if (inputs.selfInputs.some(isUnsupportedInput)) {
+    return true;
+  }
+  if (inputs.depsOutputs.length > 0) {
+    return true;
+  }
+
+  if (
+    matchProjectInputSet(
+      task.project,
+      inputs.selfInputs,
+      projectGraph,
+      changedPaths
+    )
+  ) {
+    return true;
+  }
+
+  const dependencies = collectProjectDependencies(task.project, projectGraph);
+  for (const dependency of dependencies) {
+    const dependencyNode = projectGraph.nodes[dependency];
+    if (!dependencyNode) continue;
+    if (
+      projectConfigurationChanges.has(dependency) &&
+      (inputs.depsInputs.length > 0 || inputs.depsFilesets.length > 0)
+    ) {
+      return true;
+    }
+
+    let expanded: ExpandedInput[];
+    try {
+      const namedInputs = getNamedInputs(nxJson, dependencyNode);
+      expanded = inputs.depsInputs.flatMap(({ input }) =>
+        expandNamedInput(input, namedInputs)
+      );
+    } catch {
+      return true;
+    }
+
+    if (expanded.some(isUnsupportedInput)) {
+      return true;
+    }
+
+    if (
+      matchProjectInputSet(
+        dependency,
+        [
+          ...expanded,
+          ...inputs.depsFilesets.map(({ fileset }) => ({ fileset })),
+        ],
+        projectGraph,
+        changedPaths
+      )
+    ) {
+      return true;
+    }
+  }
+
+  for (const projectInput of inputs.projectInputs) {
+    const inputProjects = findMatchingProjects(
+      projectInput.projects,
+      projectGraph.nodes
+    );
+    if (inputProjects.length === 0) {
+      return true;
+    }
+    for (const inputProject of inputProjects) {
+      const inputProjectNode = projectGraph.nodes[inputProject];
+      if (projectConfigurationChanges.has(inputProject)) {
+        return true;
+      }
+
+      let expanded: ExpandedInput[];
+      try {
+        expanded = expandNamedInput(
+          projectInput.input,
+          getNamedInputs(nxJson, inputProjectNode)
+        );
+      } catch {
+        return true;
+      }
+      if (expanded.some(isUnsupportedInput)) {
+        return true;
+      }
+
+      if (
+        matchProjectInputSet(inputProject, expanded, projectGraph, changedPaths)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function matchProjectInputSet(
+  projectName: string,
+  inputs: readonly ExpandedInput[],
+  projectGraph: ProjectGraph,
+  changedPaths: string[]
+): boolean {
+  const project = projectGraph.nodes[projectName];
+  const patterns = inputs
+    .filter((input): input is { fileset: string } => 'fileset' in input)
+    .map(({ fileset }) =>
+      expandTokens(fileset, project.data.root, projectName)
+    );
+
+  return changedPaths.some((path) => matchesFileset(path, patterns));
+}
+
+function matchesFileset(path: string, patterns: string[]): boolean {
+  if (patterns.length === 0) return false;
+
+  const positive = patterns.filter((pattern) => !pattern.startsWith('!'));
+  const negative = patterns
+    .filter((pattern) => pattern.startsWith('!'))
+    .map((pattern) => pattern.slice(1));
+
+  const included =
+    positive.length === 0 ||
+    positive.some((pattern) => minimatch(path, pattern, { dot: true }));
+  return (
+    included &&
+    negative.every((pattern) => !minimatch(path, pattern, { dot: true }))
+  );
+}
+
+function expandTokens(
+  pattern: string,
+  projectRoot: string,
+  projectName: string
+): string {
+  const negated = pattern.startsWith('!');
+  let expanded = negated ? pattern.slice(1) : pattern;
+  expanded = expanded
+    .replaceAll('{projectRoot}', projectRoot === '.' ? '' : projectRoot)
+    .replaceAll('{workspaceRoot}', '')
+    .replaceAll('{projectName}', projectName)
+    .replace(/^\.\//, '')
+    .replace(/^\//, '');
+  return negated ? `!${expanded}` : expanded;
+}
+
+function collectProjectDependencies(
+  projectName: string,
+  projectGraph: ProjectGraph
+): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>([projectName]);
+  const visit = (name: string) => {
+    for (const dependency of projectGraph.dependencies[name] ?? []) {
+      if (seen.has(dependency.target)) continue;
+      seen.add(dependency.target);
+      if (projectGraph.nodes[dependency.target]) {
+        result.push(dependency.target);
+        visit(dependency.target);
+      }
+    }
+  };
+  visit(projectName);
+  return result;
+}
+
+function isUnsupportedInput(input: ExpandedInput): boolean {
+  return !('fileset' in input);
+}
+
+function isWorkspaceConfigurationFile(path: string): boolean {
+  return WORKSPACE_CONFIGURATION_FILES.has(path) || LOCK_FILES.has(path);
+}
+
+function isProjectConfigurationFile(path: string): boolean {
+  const basename = path.split('/').pop() ?? path;
+  return (
+    basename === 'package.json' ||
+    basename === 'project.json' ||
+    /^tsconfig(?:\..+)?\.json$/.test(basename) ||
+    /(?:^|\.)config\.[cm]?[jt]s$/.test(basename)
+  );
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}


### PR DESCRIPTION
_This PR description was generated by AMP._

> [!NOTE]
> Depends on #36771. This is a cross-fork stack, so GitHub cannot use the fork's extraction branch as this upstream PR's base. Until #36771 merges, GitHub shows both commits; after its squash merge, this branch will be rebased onto `master` so the PR shows only the incremental feature commit.

## Current Behavior

`nx show projects --affected` reports projects selected by Nx's existing affected-project calculation. `-t` / `--with-target` independently filters that list to projects defining a target. There is no additional filter that checks whether the changed paths match that target's configured inputs.

## Expected Behavior

Add one opt-in filter to the existing query:

```text
nx show projects --affected -t build --filter-by-task-inputs
```

- Existing `--affected` and `-t` behavior and project-name output remain unchanged when the new flag is absent.
- The new flag requires both `--affected` and `--with-target`.
- Nx first calculates the existing affected-project candidate set, then retains projects where at least one requested target's effective inputs match a changed path.
- Multiple targets retain the existing OR semantics of `--with-target`.
- Matching covers self, workspace, dependency, transitive dependency, and explicit project-selector inputs, including deleted paths.
- Configuration changes, input forms that cannot be decided from changed paths, and custom hashers are retained conservatively rather than producing a false negative.
- This does not change `nx affected` execution and does not introduce a new command or output format.

### Draft limitations / follow-ups

1. This PR narrows the existing affected-project candidate set; it does not expand candidates. A graphless explicit project input can therefore change a task hash without the owning project becoming a candidate. Candidate expansion should remain a separate change.
2. Matching uses the extracted TypeScript input model rather than materializing the workspace through `HashPlanInspector`. Unsupported/native-only cases are retained conservatively, but this is not a byte-for-byte native hash-plan diff.
3. A future native API could expose structured, non-materializing `HashPlanner` instructions if maintainers prefer native planner parity. That requires a separate Rust/N-API design.

## Validation

- Focused Jest: 2 suites, 29 tests passed
- Prettier: changed files formatted
- ESLint: passed for the five incremental files
- `npx --no-install tsc -p packages/nx/tsconfig.json --noEmit --pretty false`: passed
- `git diff --check`: passed
- Full `nx prepush` could not construct the repository project graph on this machine because the .NET and Gradle toolchains are unavailable. The same failure reproduces on the untouched base commit.

## Related Issue(s)

Related to #15414 and #16478.
