### PR TITLE
fix(nextjs): describe the library generator and export its server entry

### DIFF
--- a/packages/next/docs/library-examples.md
+++ b/packages/next/docs/library-examples.md
@@ -13,3 +13,13 @@ The following will create a library at `libs/shared/my-lib`.
 ```shell
 nx g lib libs/shared/my-lib
 ```
+
+##### Export React Server Components
+
+Unlike a React library, a Next.js library has a second entry point, `src/server.ts`, for React Server Components. Exporting a server component from `src/index.ts` marks that whole file as server-only and breaks imports from client components, so keep client components in `src/index.ts` and server components in `src/server.ts`.
+
+```typescript
+// apps/my-app/app/page.tsx
+import { MyComponent } from '@myorg/my-lib';
+import { HelloServer } from '@myorg/my-lib/server';
+```

--- a/packages/next/generators.json
+++ b/packages/next/generators.json
@@ -31,7 +31,7 @@
       "schema": "./dist/src/generators/library/schema.json",
       "aliases": ["lib"],
       "x-type": "library",
-      "description": "Create a library."
+      "description": "Create a Next.js library."
     },
     "custom-server": {
       "factory": "./dist/src/generators/custom-server/custom-server#customServerGenerator",

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -300,6 +300,36 @@ describe('next library', () => {
       expect(appTree.exists('my-buildable-lib/vite.config.mts')).toBeTruthy();
     });
 
+    it('should export the server entry from source for non-buildable libraries', async () => {
+      await libraryGenerator(tree, {
+        directory: 'mylib',
+        linter: 'none',
+        skipFormat: true,
+        skipTsConfig: false,
+        unitTestRunner: 'none',
+        style: 'css',
+        component: false,
+        useProjectJson: false,
+      });
+
+      expect(readJson(tree, 'mylib/package.json').exports)
+        .toMatchInlineSnapshot(`
+        {
+          ".": {
+            "default": "./src/index.ts",
+            "import": "./src/index.ts",
+            "types": "./src/index.ts",
+          },
+          "./package.json": "./package.json",
+          "./server": {
+            "default": "./src/server.ts",
+            "import": "./src/server.ts",
+            "types": "./src/server.ts",
+          },
+        }
+      `);
+    });
+
     it('should create a correct package.json for buildable libraries', async () => {
       await libraryGenerator(tree, {
         directory: 'mylib',

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -134,6 +134,32 @@ export async function HelloServer() {
     addTsConfigPath(host, `${options.importPath}/server`, [serverEntryPath]);
   }
 
+  const isBuildable =
+    (options.bundler && options.bundler !== 'none') ||
+    options.buildable ||
+    options.publishable;
+  if (isTsSolutionSetup && !isBuildable) {
+    // Non-buildable libs resolve `.` straight to source, so `./server` does the same.
+    const packageJsonPath = joinPathFragments(
+      options.projectRoot,
+      'package.json'
+    );
+    if (host.exists(packageJsonPath)) {
+      updateJson(host, packageJsonPath, (json) => {
+        json.exports ??= {};
+        const serverSource = `./src/server.${options.js ? 'js' : 'ts'}`;
+        json.exports['./server'] = options.js
+          ? serverSource
+          : {
+              types: serverSource,
+              import: serverSource,
+              default: serverSource,
+            };
+        return json;
+      });
+    }
+  }
+
   // Configure Vite and package.json for server entry point when using Vite bundler
   if (options.bundler === 'vite') {
     // Update vite.config.mts to support multiple entry points

--- a/packages/next/src/generators/library/schema.json
+++ b/packages/next/src/generators/library/schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/schema",
   "cli": "nx",
-  "$id": "NxReactLibrary",
-  "title": "Create a React Library for Nx",
-  "description": "Create a React Library for an Nx workspace.",
+  "$id": "NxNextLibrary",
+  "title": "Create a Next.js Library for Nx",
+  "description": "Create a Next.js library for an Nx workspace. Same output as `@nx/react:library`, plus a `server` entry point for React Server Components and the Next.js type declarations.",
   "type": "object",
   "properties": {
     "directory": {


### PR DESCRIPTION
## Current Behavior

`nx g @nx/next:lib` presents itself as a React library. Its schema title and description are copied from `@nx/react:library`. `generators.json` describes it as "Create a library.". The generators reference page and Nx Console give no hint of what the Next.js generator adds. The `src/server.ts` it creates is the only visible difference and nothing documents its purpose.

In a TS solution workspace, a Next.js library created without a bundler has no `./server` entry in its `package.json` exports, so `import { HelloServer } from '@org/my-lib/server'` fails to resolve. Only libraries built with Vite got that export.

## Expected Behavior

The library generator is named as a Next.js library. Its description says what it adds over `@nx/react:library`: a `server` entry point for React Server Components and the Next.js type declarations. The generators reference page shows how to import from `@org/my-lib/server`.

Non-buildable Next.js libraries in TS solution workspaces export `./server` from source, the same way they export `.`.

## Related Issue(s)

NXC-4781

## Implementation Notes

- Libraries built with Rollup still bundle only `src/index.ts` and get no `./server` export. Tracked in NXC-4862.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4781-4abd80b2">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->
