### PR TITLE
fix(nextjs): bundle the server entry of Rollup-built libraries

### DIFF
--- a/e2e/next/src/next-generation.test.ts
+++ b/e2e/next/src/next-generation.test.ts
@@ -64,6 +64,11 @@ describe('Next.js Applications - Generation', () => {
     expect(runCLI(`build ${libName}`)).toContain(
       `Successfully ran target build for project ${libName}`
     );
+    // check the server entry is bundled next to the client entry
+    checkFilesExist(
+      `dist/${libName}/server.esm.js`,
+      `dist/${libName}/server.d.ts`
+    );
   }, 600_000);
 
   it('should build in dev mode without errors', async () => {

--- a/packages/next/src/generators/library/lib/add-rollup-server-entry.ts
+++ b/packages/next/src/generators/library/lib/add-rollup-server-entry.ts
@@ -1,0 +1,51 @@
+import {
+  joinPathFragments,
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import type { NormalizedSchema } from './normalize-options';
+
+/**
+ * Adds the server entry (`src/server.ts`, or `src/server.js` with `--js`) as a
+ * second Rollup entry so React Server Components are bundled separately from
+ * the client entry.
+ */
+export function addRollupServerEntry(
+  tree: Tree,
+  options: NormalizedSchema
+): void {
+  const serverEntry = `src/server.${options.js ? 'js' : 'ts'}`;
+
+  const rollupConfigPath = joinPathFragments(
+    options.projectRoot,
+    'rollup.config.cjs'
+  );
+  if (tree.exists(rollupConfigPath)) {
+    const content = tree.read(rollupConfigPath, 'utf-8');
+    const updated = content.replace(
+      /^(\s*)main: .*\n/m,
+      (line, indent) =>
+        line + `${indent}additionalEntryPoints: ['./${serverEntry}'],\n`
+    );
+    if (updated === content) {
+      throw new Error(
+        `Could not add the server entry to ${rollupConfigPath}: "main" option not found.`
+      );
+    }
+    tree.write(rollupConfigPath, updated);
+    return;
+  }
+
+  const project = readProjectConfiguration(tree, options.projectName);
+  const build = project.targets?.build;
+  if (build?.executor !== '@nx/rollup:rollup') {
+    throw new Error(
+      `Could not add the server entry to the "build" target of "${options.projectName}": expected the @nx/rollup:rollup executor.`
+    );
+  }
+  build.options.additionalEntryPoints = [
+    joinPathFragments(options.projectRoot, serverEntry),
+  ];
+  updateProjectConfiguration(tree, options.projectName, project);
+}

--- a/packages/next/src/generators/library/lib/normalize-options.ts
+++ b/packages/next/src/generators/library/lib/normalize-options.ts
@@ -11,6 +11,7 @@ export interface NormalizedSchema extends Schema {
   // `normalizeOptions` always resolves this, so it is no longer optional.
   linter: LinterType;
   importPath: string;
+  projectName: string;
   projectRoot: string;
   isUsingTsSolutionConfig: boolean;
 }
@@ -20,15 +21,13 @@ export async function normalizeOptions(
   options: Schema
 ): Promise<NormalizedSchema> {
   await ensureRootProjectName(options, 'library');
-  const { projectRoot, importPath } = await determineProjectNameAndRootOptions(
-    host,
-    {
+  const { projectName, projectRoot, importPath } =
+    await determineProjectNameAndRootOptions(host, {
       name: options.name,
       projectType: 'library',
       directory: options.directory,
       importPath: options.importPath,
-    }
-  );
+    });
 
   const nxJson = readNxJson(host);
   const addPlugin =
@@ -43,6 +42,9 @@ export async function normalizeOptions(
     // `=== 'eslint'`, and an unresolved `undefined` would skip all of it.
     linter: await normalizeLinterOption(host, options.linter),
     importPath,
+    // Same rule as the React library generator, which registers the project.
+    projectName:
+      isUsingTsSolutionConfig && !options.name ? importPath : projectName,
     projectRoot,
     isUsingTsSolutionConfig,
     useProjectJson: options.useProjectJson ?? !isUsingTsSolutionConfig,

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -109,6 +109,52 @@ describe('next library', () => {
     expect(packageJson.exports['./server'].default).toBe('./dist/server.js');
   });
 
+  it('should configure server entry point for buildable library with Rollup', async () => {
+    const appTree = createTreeWithEmptyWorkspace();
+    await libraryGenerator(appTree, {
+      directory: 'my-buildable-lib',
+      linter: 'eslint',
+      skipFormat: false,
+      skipTsConfig: false,
+      unitTestRunner: 'jest',
+      style: 'css',
+      component: true,
+      buildable: true,
+    });
+
+    const build = readProjectConfiguration(appTree, 'my-buildable-lib').targets
+      .build;
+    expect(build.executor).toBe('@nx/rollup:rollup');
+    expect(build.options.additionalEntryPoints).toEqual([
+      'my-buildable-lib/src/server.ts',
+    ]);
+    expect(build.options.generateExportsField).toBeUndefined();
+  });
+
+  it('should configure server entry point in the rollup config file when using the rollup plugin', async () => {
+    const appTree = createTreeWithEmptyWorkspace();
+    await libraryGenerator(appTree, {
+      directory: 'my-buildable-lib',
+      linter: 'eslint',
+      skipFormat: false,
+      skipTsConfig: false,
+      unitTestRunner: 'jest',
+      style: 'css',
+      component: true,
+      bundler: 'rollup',
+      addPlugin: true,
+    });
+
+    const rollupConfig = appTree.read(
+      'my-buildable-lib/rollup.config.cjs',
+      'utf-8'
+    );
+    expect(rollupConfig).toContain(`main: './src/index.ts',
+    additionalEntryPoints: ['./src/server.ts'],
+    outputPath:`);
+    expect(rollupConfig).not.toContain('generateExportsField');
+  });
+
   it('should generate a server-only entry point', async () => {
     const appTree = createTreeWithEmptyWorkspace();
 
@@ -435,6 +481,12 @@ describe('next library', () => {
               "types": "./dist/index.esm.d.ts",
               "import": "./dist/index.esm.js",
               "default": "./dist/index.esm.js"
+            },
+            "./server": {
+              "@proj/source": "./src/server.ts",
+              "types": "./dist/server.d.ts",
+              "import": "./dist/server.esm.js",
+              "default": "./dist/server.esm.js"
             }
           },
           "nx": {
@@ -465,6 +517,9 @@ describe('next library', () => {
                       "input": ".",
                       "output": "."
                     }
+                  ],
+                  "additionalEntryPoints": [
+                    "mylib/src/server.ts"
                   ]
                 }
               },
@@ -484,6 +539,36 @@ describe('next library', () => {
           }
         }
         "
+      `);
+    });
+
+    it('should configure server entry point in the rollup config file when using the rollup plugin', async () => {
+      await libraryGenerator(tree, {
+        directory: 'mylib',
+        linter: 'eslint',
+        skipFormat: true,
+        skipTsConfig: false,
+        unitTestRunner: 'jest',
+        style: 'css',
+        component: false,
+        useProjectJson: false,
+        bundler: 'rollup',
+        addPlugin: true,
+      });
+
+      const rollupConfig = tree.read('mylib/rollup.config.cjs', 'utf-8');
+      expect(rollupConfig).toContain(`main: './src/index.ts',
+    additionalEntryPoints: ['./src/server.ts'],
+    outputPath:`);
+      expect(rollupConfig).not.toContain('generateExportsField');
+      expect(readJson(tree, 'mylib/package.json').exports['./server'])
+        .toMatchInlineSnapshot(`
+        {
+          "@proj/source": "./src/server.ts",
+          "default": "./dist/server.esm.js",
+          "import": "./dist/server.esm.js",
+          "types": "./dist/server.d.ts",
+        }
       `);
     });
 

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -17,8 +17,9 @@ import {
 import { nextInitGenerator } from '../init/init';
 import { assertSupportedNextVersion } from '../../utils/assert-supported-next-version';
 import { Schema } from './schema';
-import { normalizeOptions } from './lib/normalize-options';
+import { normalizeOptions, NormalizedSchema } from './lib/normalize-options';
 import { updateViteConfigForServerEntry } from './lib/update-vite-config';
+import { addRollupServerEntry } from './lib/add-rollup-server-entry';
 import { tsLibVersion } from '../../utils/versions';
 import {
   isUsingTsSolutionSetup,
@@ -129,11 +130,27 @@ export async function HelloServer() {
     addTsConfigPath(host, `${options.importPath}/server`, [serverEntryPath]);
   }
 
-  const isBuildable =
-    (options.bundler && options.bundler !== 'none') ||
-    options.buildable ||
-    options.publishable;
-  if (isTsSolutionSetup && !isBuildable) {
+  // The React library generator defaults buildable and publishable libraries to Rollup.
+  const bundler =
+    options.bundler && options.bundler !== 'none'
+      ? options.bundler
+      : options.buildable || options.publishable
+        ? 'rollup'
+        : 'none';
+  if (bundler === 'vite') {
+    updateViteConfigForServerEntry(
+      host,
+      joinPathFragments(options.projectRoot, 'vite.config.mts')
+    );
+    addServerExport(host, options, './dist/server.js');
+  } else if (bundler === 'rollup') {
+    addRollupServerEntry(host, options);
+    if (isTsSolutionSetup) {
+      // Other setups publish no exports field, and introducing one would close
+      // every other subpath of the package.
+      addServerExport(host, options, './dist/server.esm.js');
+    }
+  } else if (bundler === 'none' && isTsSolutionSetup) {
     // Non-buildable libs resolve `.` straight to source, so `./server` does the same.
     const packageJsonPath = joinPathFragments(
       options.projectRoot,
@@ -150,46 +167,6 @@ export async function HelloServer() {
               import: serverSource,
               default: serverSource,
             };
-        return json;
-      });
-    }
-  }
-
-  // Configure Vite and package.json for server entry point when using Vite bundler
-  if (options.bundler === 'vite') {
-    // Update vite.config.mts to support multiple entry points
-    const viteConfigPath = joinPathFragments(
-      options.projectRoot,
-      'vite.config.mts'
-    );
-    updateViteConfigForServerEntry(host, viteConfigPath);
-
-    // Update package.json to include server export
-    const packageJsonPath = joinPathFragments(
-      options.projectRoot,
-      'package.json'
-    );
-    if (host.exists(packageJsonPath)) {
-      updateJson(host, packageJsonPath, (json) => {
-        if (!json.exports) {
-          json.exports = {};
-        }
-
-        // Add server export
-        const serverExport: any = {};
-
-        // For TS Solution setups, include development condition
-        if (isTsSolutionSetup) {
-          const customConditionName = getDefinedCustomConditionName(host);
-          serverExport[customConditionName] = './src/server.ts';
-        }
-
-        serverExport.types = './dist/server.d.ts';
-        serverExport.import = './dist/server.js';
-        serverExport.default = './dist/server.js';
-
-        json.exports['./server'] = serverExport;
-
         return json;
       });
     }
@@ -241,6 +218,39 @@ export async function HelloServer() {
   }
 
   return runTasksInSerial(...tasks);
+}
+
+function addServerExport(
+  host: Tree,
+  options: NormalizedSchema,
+  distFile: string
+): void {
+  const packageJsonPath = joinPathFragments(
+    options.projectRoot,
+    'package.json'
+  );
+  if (!host.exists(packageJsonPath)) {
+    return;
+  }
+  updateJson(host, packageJsonPath, (json) => {
+    json.exports ??= {};
+    const serverExport: Record<string, string> = {};
+    if (options.isUsingTsSolutionConfig) {
+      const customConditionName = getDefinedCustomConditionName(host);
+      if (customConditionName) {
+        serverExport[customConditionName] = `./src/server.${
+          options.js ? 'js' : 'ts'
+        }`;
+      }
+    }
+    // Both bundlers name the declaration after the entry, without the format
+    // suffix the JavaScript output carries.
+    serverExport.types = './dist/server.d.ts';
+    serverExport.import = distFile;
+    serverExport.default = distFile;
+    json.exports['./server'] = serverExport;
+    return json;
+  });
 }
 
 export default libraryGenerator;


### PR DESCRIPTION
## Current Behavior

`nx g @nx/next:lib` creates `src/server.ts` as a second entry point for React Server Components. With `--bundler=rollup`, or with `--buildable` / `--publishable` which default to Rollup, the build only bundles `src/index.ts` and `package.json` gets no `./server` export. Only Vite-built libraries wire the second entry.

```shell
nx g @nx/next:lib my-lib --bundler=rollup
nx build my-lib
ls dist/my-lib
# index.esm.js index.d.ts ... and no server.esm.js
```

## Expected Behavior

Rollup-built Next.js libraries bundle `src/server.ts` as a second entry, so the build emits `server.esm.js` and `server.d.ts` alongside the client entry. `import { HelloServer } from '@org/my-lib/server'` resolves in the workspace. In TS solution workspaces the published package exposes `./server`, so the same import works for its consumers.

## Related Issue(s)

NXC-4862

## Implementation Notes

- In TS solution workspaces the generator writes the `./server` export next to the existing `.` one. Its `types` points at `dist/server.d.ts`: Rollup drops the format suffix when naming declarations.
- Outside TS solution workspaces the built `package.json` keeps no `exports` field. The entry stays reachable in the workspace through the `<importPath>/server` tsconfig path.
- Rollup's `generateExportsField` would add that field. For ESM-only builds it omits the `default` condition and never lists emitted assets. Turning it on would break `require()` of the package root and hide the extracted stylesheet. NXC-4919 tracks both and unblocks `./server` there.
- The Vite branch uses the same export helper, which skips the source condition when `tsconfig.base.json` defines none. The old code wrote a `null` key there.
- A TS solution workspace with inference plugins off gets the deprecated `@nx/rollup:rollup` target. Its `outputPath` is `dist/<project>` while the exports point at `<project>/dist`, a mismatch `.` already has on `master`.
- Aligning them is left out on purpose. The edit is one line in `@nx/react`, but five library generators reach it, so it moves generated output and snapshots across all of them. The executor is removed in Nx v24 and the default path is already correct.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4781-4abd80b2">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->
