### PR TITLE
fix(nextjs): stop installing unused Next.js ESLint packages from the library generator

### DIFF
--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -43,6 +43,24 @@ describe('next library', () => {
     expect(tsconfigTypes).toContain('@nx/next/typings/image.d.ts');
   });
 
+  it('should not install Next.js ESLint packages the library does not use', async () => {
+    const appTree = createTreeWithEmptyWorkspace();
+
+    await libraryGenerator(appTree, {
+      directory: 'my-lib',
+      linter: 'eslint',
+      skipFormat: false,
+      skipTsConfig: false,
+      unitTestRunner: 'jest',
+      style: 'css',
+      component: true,
+    });
+
+    const { devDependencies } = readJson(appTree, 'package.json');
+    expect(devDependencies['eslint-config-next']).toBeUndefined();
+    expect(devDependencies['@next/eslint-plugin-next']).toBeUndefined();
+  });
+
   it('should generate a buildable library', async () => {
     const appTree = createTreeWithEmptyWorkspace();
     await libraryGenerator(appTree, {

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -19,7 +19,7 @@ import { assertSupportedNextVersion } from '../../utils/assert-supported-next-ve
 import { Schema } from './schema';
 import { normalizeOptions } from './lib/normalize-options';
 import { updateViteConfigForServerEntry } from './lib/update-vite-config';
-import { eslintConfigNextVersion, tsLibVersion } from '../../utils/versions';
+import { tsLibVersion } from '../../utils/versions';
 import {
   isUsingTsSolutionSetup,
   addProjectToTsSolutionWorkspace,
@@ -68,11 +68,6 @@ export async function libraryGeneratorInternal(host: Tree, rawOptions: Schema) {
 
   if (!options.skipPackageJson) {
     const devDependencies: Record<string, string> = {};
-    if (options.linter === 'eslint') {
-      devDependencies['eslint-config-next'] = eslintConfigNextVersion;
-      devDependencies['@next/eslint-plugin-next'] = eslintConfigNextVersion;
-    }
-
     if (options.unitTestRunner && options.unitTestRunner !== 'none') {
       devDependencies['@testing-library/react'] = testingLibraryReactVersion;
       devDependencies['@testing-library/dom'] = testingLibraryDomVersion;


### PR DESCRIPTION
## Current Behavior

`nx g @nx/next:lib --linter=eslint` adds `eslint-config-next` and `@next/eslint-plugin-next` to the root `devDependencies`. The library's ESLint config comes from `@nx/react:library`. It never registers the `@next/next` plugin or enables any of its rules, so both packages are installed and unused. The install pins the Next.js 16 range (`^16.1.6`) regardless of the installed Next.js version.

## Expected Behavior

The library generator does not install the two packages. The application generator keeps installing both, with a version matched to the installed Next.js major, and keeps wiring the plugin into the application's ESLint config.

## Related Issue(s)

NXC-4863

## Implementation Notes

- The library install came from #21088, which moved the init generator's blanket `eslint-config-next` install into the library generator. Nothing wired the plugin for libraries before or after.
- The `eslint-config-next` migrations use `alwaysAddToPackageJson: false`, so existing workspaces are not affected.
- A regression test asserts neither package is installed for an ESLint library. It fails on `master`.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4781-4abd80b2">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->