### PR TITLE
fix(nextjs): expose compiler and inSourceTests options in the library generator

### DIFF
--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -1,12 +1,14 @@
 import { getInstalledCypressMajorVersion } from '@nx/cypress/internal';
 import {
   readJson,
+  readJsonFile,
   readProjectConfiguration,
   Tree,
   updateJson,
   writeJson,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { dirname, join } from 'path';
 import libraryGenerator from './library';
 import { Schema } from './schema';
 
@@ -153,6 +155,63 @@ describe('next library', () => {
     expect(
       readJson(appTree, 'package.json').devDependencies['cypress']
     ).toBeUndefined();
+  });
+
+  it('should install swc dependencies when compiler is swc', async () => {
+    const appTree = createTreeWithEmptyWorkspace();
+
+    await libraryGenerator(appTree, {
+      directory: 'my-lib',
+      linter: 'eslint',
+      skipFormat: false,
+      skipTsConfig: false,
+      unitTestRunner: 'jest',
+      style: 'css',
+      component: false,
+      buildable: true,
+      compiler: 'swc',
+    });
+
+    expect(
+      readJson(appTree, 'package.json').devDependencies['@swc/core']
+    ).toEqual(expect.any(String));
+  });
+
+  it('should generate in-source tests when inSourceTests is true', async () => {
+    const appTree = createTreeWithEmptyWorkspace();
+
+    await libraryGenerator(appTree, {
+      directory: 'my-lib',
+      linter: 'eslint',
+      skipFormat: false,
+      skipTsConfig: false,
+      unitTestRunner: 'vitest',
+      style: 'css',
+      component: true,
+      inSourceTests: true,
+    });
+
+    expect(appTree.exists('my-lib/src/lib/my-lib.spec.tsx')).toBeFalsy();
+    expect(appTree.read('my-lib/src/lib/my-lib.tsx', 'utf-8')).toContain(
+      'import.meta.vitest'
+    );
+  });
+
+  it('should keep its options aligned with @nx/react:library', () => {
+    const nextSchema = require('./schema.json');
+    const reactSchema = readJsonFile(
+      join(
+        dirname(require.resolve('@nx/react/package.json')),
+        'src/generators/library/schema.json'
+      )
+    );
+    // `minimal` is only declared in the React schema; nothing reads it.
+    const { minimal, ...reactProperties } = reactSchema.properties;
+    const { name, ...nextProperties } = nextSchema.properties;
+    const { name: reactName, ...expectedProperties } = reactProperties;
+
+    expect(nextProperties).toEqual(expectedProperties);
+    expect(name).toEqual({ ...reactName, pattern: expect.any(String) });
   });
 
   describe('TS solution setup', () => {

--- a/packages/next/src/generators/library/schema.d.ts
+++ b/packages/next/src/generators/library/schema.d.ts
@@ -11,12 +11,14 @@ export interface Schema {
   routing?: boolean;
   appProject?: string;
   unitTestRunner: 'jest' | 'vitest' | 'none';
+  inSourceTests?: boolean;
   linter?: LinterType;
   component?: boolean;
   publishable?: boolean;
   /** @deprecated Use bundler instead. */
   buildable?: boolean;
   bundler?: 'none' | 'vite' | 'rollup';
+  compiler?: 'babel' | 'swc';
   importPath?: string;
   js?: boolean;
   globalCss?: boolean;

--- a/packages/next/src/generators/library/schema.json
+++ b/packages/next/src/generators/library/schema.json
@@ -69,6 +69,11 @@
       "x-prompt": "What unit test runner should be used?",
       "x-priority": "important"
     },
+    "inSourceTests": {
+      "type": "boolean",
+      "default": false,
+      "description": "When using Vitest, separate spec files will not be generated and instead will be included within the source files."
+    },
     "tags": {
       "type": "string",
       "description": "Add tags to the library (used for linting).",
@@ -77,12 +82,14 @@
     "skipFormat": {
       "description": "Skip formatting files.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-priority": "internal"
     },
     "skipTsConfig": {
       "type": "boolean",
       "default": false,
-      "description": "Do not update tsconfig.json for development experience."
+      "description": "Do not update `tsconfig.json` for development experience.",
+      "x-priority": "internal"
     },
     "routing": {
       "type": "boolean",
@@ -119,7 +126,7 @@
     },
     "globalCss": {
       "type": "boolean",
-      "description": "When true, the stylesheet is generated using global CSS instead of CSS modules (e.g. file is `*.css` rather than `*.module.css`).",
+      "description": "When `true`, the stylesheet is generated using global CSS instead of CSS modules (e.g. file is `*.css` rather than `*.module.css`).",
       "default": false
     },
     "strict": {
@@ -137,6 +144,12 @@
       "description": "Deprecated alias for `enableTypedLinting`.",
       "default": false,
       "x-deprecated": "Use `enableTypedLinting` instead. This option will be removed in Nx v24."
+    },
+    "compiler": {
+      "type": "string",
+      "enum": ["babel", "swc"],
+      "default": "babel",
+      "description": "Which compiler to use."
     },
     "skipPackageJson": {
       "type": "boolean",


### PR DESCRIPTION
## Current Behavior

`@nx/next:library` forwards its options to `@nx/react:library`, but its schema is a stale copy of the React one. Two options React honors are missing from it, so the CLI, Nx Console and the docs do not offer them. Two internal-only options show as regular options, and two descriptions differ from the React ones.

## Expected Behavior

The Next.js library schema declares the same options as the React one, with the same visibility and descriptions. A spec compares the two schemas so they stop drifting.

## Related Issue(s)

NXC-4864

## Implementation Notes

- Added `compiler` and `inSourceTests`. Marked `skipFormat` and `skipTsConfig` as `x-priority: internal`. Matched the `globalCss` and `skipTsConfig` descriptions.
- `minimal` is left out. The React library schema declares it, but no code in the React library generator reads it (only the application generator does).
- The `name` pattern stays on the Next.js side. It matches `@nx/next:application`, `@nx/vue:library` and `@nx/node:library`.
- The schema `$id`, title and description are changed in #36776 and are left untouched here.
- The drift guard spec fails against the schema on master.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4781-4abd80b2">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->