### PR TITLE
docs(nx-dev): point NEXT_PUBLIC_FRAMER_URL examples at nx.framer.website

### DIFF
--- a/netlify/edge-functions/README.md
+++ b/netlify/edge-functions/README.md
@@ -27,7 +27,7 @@ This ensures:
 
 **Environment variables** (configured in Netlify):
 
-- `NEXT_PUBLIC_FRAMER_URL`: The Framer site URL (e.g., `https://ready-knowledge-238309.framer.app`)
+- `NEXT_PUBLIC_FRAMER_URL`: The Framer site URL (e.g., `https://nx.framer.website`)
 
 ### `additional-sitemaps.ts`
 

--- a/nx-dev/nx-dev/DEPLOYMENT.md
+++ b/nx-dev/nx-dev/DEPLOYMENT.md
@@ -202,7 +202,7 @@ included_files = [
 
 | Variable                 | Description                                   | Example                                         |
 | ------------------------ | --------------------------------------------- | ----------------------------------------------- |
-| `NEXT_PUBLIC_FRAMER_URL` | Framer site URL for marketing pages           | `https://ready-knowledge-238309.framer.app`     |
+| `NEXT_PUBLIC_FRAMER_URL` | Framer site URL for marketing pages           | `https://nx.framer.website`                     |
 | `NEXT_PUBLIC_ASTRO_URL`  | Astro docs site URL                           | `https://master--nx-docs.netlify.app`           |
 | `NEXT_PUBLIC_BANNER_URL` | Framer CMS URL for banner data                | `https://your-site.framer.app/api/banners/main` |
 | `BLOG_URL`               | nx-blog site URL for blog/changelog pages     | `https://blog.nx.app`                           |


### PR DESCRIPTION
The Framer project's published domain moved to `nx.framer.website`. This updates the two documentation examples that still named the retired host.

## Current Behavior

`DEPLOYMENT.md` and `netlify/edge-functions/README.md` give `https://ready-knowledge-238309.framer.app` as the example value for `NEXT_PUBLIC_FRAMER_URL`. That host now returns a 303 to Framer's OAuth login and no longer serves the site.

## Expected Behavior

Both examples name `https://nx.framer.website`.

No code change is needed: the edge functions read the origin from `NEXT_PUBLIC_FRAMER_URL` rather than a literal, and the Netlify variable has already been updated. Framer now emits `nx.framer.website` in `canonical`, `og:url` and all 35 sitemap entries, so the existing rewrite matches and continues to scrub the Framer domain out of nx.dev responses.

## Related Issue(s)

None.
