### PR TITLE
fix(misc): declare the nx peer dependency that plugins forward from @nx/devkit

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -101,6 +101,7 @@
     "@nx/rspack": "workspace:*",
     "@nx/webpack": "workspace:*",
     "ng-packagr": "catalog:angular-supported-versions",
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "rxjs": "catalog:angular-supported-versions",
     "webpack-merge": "^5.8.0"
   },
@@ -127,6 +128,9 @@
       "optional": true
     },
     "ng-packagr": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     },
     "webpack-merge": {

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -97,10 +97,14 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "cypress": ">= 13 < 16"
+    "cypress": ">= 13 < 16",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "cypress": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/detox/package.json
+++ b/packages/detox/package.json
@@ -47,10 +47,14 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "detox": "^20.0.0"
+    "detox": "^20.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "detox": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -90,5 +90,13 @@
   },
   "devDependencies": {
     "nx": "workspace:*"
+  },
+  "peerDependencies": {
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "nx": {
+      "optional": true
+    }
   }
 }

--- a/packages/dotnet/package.json
+++ b/packages/dotnet/package.json
@@ -61,6 +61,14 @@
     "ts-jest": "catalog:jest",
     "typescript": "catalog:typescript"
   },
+  "peerDependencies": {
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "nx": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -51,10 +51,14 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "esbuild": ">=0.19.2 <1.0.0"
+    "esbuild": ">=0.19.2 <1.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "esbuild": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -89,13 +89,17 @@
   },
   "peerDependencies": {
     "@typescript-eslint/parser": "^8.0.0",
-    "eslint-config-prettier": "catalog:eslint"
+    "eslint-config-prettier": "catalog:eslint",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "@typescript-eslint/parser": {
       "optional": true
     },
     "eslint-config-prettier": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -73,7 +73,8 @@
   "peerDependencies": {
     "@nx/jest": "workspace:*",
     "@zkochan/js-yaml": "0.0.7",
-    "eslint": "^9.0.0 || ^10.0.0"
+    "eslint": "^9.0.0 || ^10.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",
@@ -90,6 +91,9 @@
       "optional": true
     },
     "@zkochan/js-yaml": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -72,7 +72,8 @@
     "expo": ">=53.0.0",
     "@expo/metro": ">= 55.0.0",
     "metro-config": ">= 0.82.0",
-    "metro-resolver": ">= 0.82.0"
+    "metro-resolver": ">= 0.82.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "@nx/cypress": {
@@ -91,6 +92,9 @@
       "optional": true
     },
     "metro-resolver": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/gradle/package.json
+++ b/packages/gradle/package.json
@@ -82,6 +82,14 @@
   "devDependencies": {
     "nx": "workspace:*"
   },
+  "peerDependencies": {
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "nx": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -92,10 +92,14 @@
   },
   "peerDependencies": {
     "jest": "^29.0.0 || ^30.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "ts-jest": "^29.0.0"
   },
   "peerDependenciesMeta": {
     "jest": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     },
     "ts-jest": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -162,10 +162,14 @@
   },
   "peerDependencies": {
     "@swc/cli": ">=0.6.0 <0.9.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "verdaccio": "^6.0.5"
   },
   "peerDependenciesMeta": {
     "@swc/cli": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     },
     "verdaccio": {

--- a/packages/maven/package.json
+++ b/packages/maven/package.json
@@ -63,6 +63,14 @@
     "ts-jest": "catalog:jest",
     "typescript": "catalog:typescript"
   },
+  "peerDependencies": {
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "nx": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/module-federation/package.json
+++ b/packages/module-federation/package.json
@@ -136,6 +136,7 @@
   "peerDependencies": {
     "@module-federation/enhanced": "^2.0.0",
     "@module-federation/node": "^2.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "webpack": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -143,6 +144,9 @@
       "optional": true
     },
     "@module-federation/node": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     },
     "webpack": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -68,10 +68,14 @@
   },
   "peerDependencies": {
     "next": ">=14.0.0 <17.0.0",
-    "@nx/webpack": "workspace:*"
+    "@nx/webpack": "workspace:*",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "@nx/webpack": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -87,7 +87,8 @@
   "peerDependencies": {
     "express": ">=4.0.0 <6.0.0",
     "koa": ">=2.0.0 <4.0.0",
-    "fastify": ">=4.0.0 <6.0.0"
+    "fastify": ">=4.0.0 <6.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "express": {
@@ -97,6 +98,9 @@
       "optional": true
     },
     "fastify": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -76,7 +76,8 @@
     "@nuxt/schema": "^3.0.0 || ^4.0.0",
     "@nuxt/kit": "^3.0.0 || ^4.0.0",
     "@nx/cypress": "workspace:*",
-    "@nx/playwright": "workspace:*"
+    "@nx/playwright": "workspace:*",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "nuxt": {
@@ -92,6 +93,9 @@
       "optional": true
     },
     "@nx/playwright": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -74,9 +74,13 @@
     "tslib": "catalog:typescript"
   },
   "peerDependencies": {
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "oxlint": "^1.43.0"
   },
   "peerDependenciesMeta": {
+    "nx": {
+      "optional": true
+    },
     "oxlint": {
       "optional": true
     }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -86,10 +86,14 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "@playwright/test": "catalog:"
+    "@playwright/test": "catalog:",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "@playwright/test": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -45,10 +45,14 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "@nx/vitest": "workspace:*"
+    "@nx/vitest": "workspace:*",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "@nx/vitest": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -68,11 +68,15 @@
     "tslib": "catalog:typescript"
   },
   "peerDependencies": {
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "react-native": ">=0.83.0 <0.85.0",
     "metro-config": ">= 0.82.0",
     "metro-resolver": ">= 0.82.0"
   },
   "peerDependenciesMeta": {
+    "nx": {
+      "optional": true
+    },
     "react-native": {
       "optional": true
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -92,6 +92,7 @@
   },
   "peerDependencies": {
     "babel-plugin-react-compiler": "^1.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "react": ">=18.0.0 <20.0.0",
     "react-dom": ">=18.0.0 <20.0.0",
     "@nx/module-federation": "workspace:*",
@@ -109,6 +110,9 @@
       "optional": true
     },
     "http-proxy-middleware": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -69,7 +69,8 @@
   "peerDependencies": {
     "@nx/cypress": "workspace:*",
     "@nx/playwright": "workspace:*",
-    "@remix-run/dev": "^2.0.0"
+    "@remix-run/dev": "^2.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "@nx/cypress": {
@@ -79,6 +80,9 @@
       "optional": true
     },
     "@remix-run/dev": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -95,9 +95,13 @@
     "tslib": "catalog:typescript"
   },
   "peerDependencies": {
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "rollup": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
+    "nx": {
+      "optional": true
+    },
     "rollup": {
       "optional": true
     }

--- a/packages/rsbuild/package.json
+++ b/packages/rsbuild/package.json
@@ -64,10 +64,14 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0"
+    "@rsbuild/core": "^1.0.0 || ^2.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -164,7 +164,8 @@
     "@rspack/cli": "^1.0.0 || ^2.0.0",
     "@rspack/core": "^1.0.0 || ^2.0.0",
     "@rspack/dev-server": "^1.0.0 || ^2.0.0",
-    "@rspack/plugin-react-refresh": "^1.0.0 || ^2.0.0"
+    "@rspack/plugin-react-refresh": "^1.0.0 || ^2.0.0",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "@rspack/cli": {
@@ -177,6 +178,9 @@
       "optional": true
     },
     "@rspack/plugin-react-refresh": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -103,10 +103,14 @@
   },
   "peerDependencies": {
     "@nx/web": "workspace:*",
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "storybook": ">=8.0.0 <11.0.0"
   },
   "peerDependenciesMeta": {
     "@nx/web": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -109,7 +109,13 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "nx": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -86,11 +86,15 @@
   },
   "peerDependencies": {
     "@nx/eslint": "workspace:*",
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "vitest": "^3.0.0 || ^4.0.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "@nx/eslint": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     },
     "vitest": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -81,6 +81,7 @@
     "@nx/playwright": "workspace:*",
     "@nx/rsbuild": "workspace:*",
     "@nx/storybook": "workspace:*",
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "vue": "^3.0.0",
     "vue-router": "^4.0.0",
     "vue-tsc": "^2.0.0",
@@ -97,6 +98,9 @@
       "optional": true
     },
     "@nx/storybook": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     },
     "vue": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -92,7 +92,8 @@
     "@nx/jest": "workspace:*",
     "@nx/playwright": "workspace:*",
     "@nx/vite": "workspace:*",
-    "@nx/webpack": "workspace:*"
+    "@nx/webpack": "workspace:*",
+    "nx": ">= 22 <= 24 || ^23.0.0-0"
   },
   "peerDependenciesMeta": {
     "@nx/cypress": {
@@ -111,6 +112,9 @@
       "optional": true
     },
     "@nx/webpack": {
+      "optional": true
+    },
+    "nx": {
       "optional": true
     }
   },

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -122,11 +122,15 @@
     "@nx/js": "workspace:*"
   },
   "peerDependencies": {
+    "nx": ">= 22 <= 24 || ^23.0.0-0",
     "webpack": "^5.0.0",
     "webpack-cli": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "webpack-dev-server": "^5.0.0"
   },
   "peerDependenciesMeta": {
+    "nx": {
+      "optional": true
+    },
     "webpack": {
       "optional": true
     },

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -2,7 +2,7 @@
 import { createProjectGraphAsync, workspaceRoot } from '@nx/devkit';
 import { styleText } from 'node:util';
 import { execSync } from 'node:child_process';
-import { rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { rmSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { URL } from 'node:url';
 import { isRelativeVersionKeyword } from 'nx/src/command-line/release/utils/semver';
@@ -539,7 +539,6 @@ function determineDistTag(
 
 //TODO(@Coly010): Remove this after fixing up the release peer dep handling
 function hackFixForDevkitPeerDependencies() {
-  const { readFileSync, writeFileSync } = require('fs');
   const devkitPackageJson = JSON.parse(
     readFileSync('./packages/devkit/package.json', 'utf-8')
   );
@@ -557,5 +556,26 @@ function hackFixForDevkitPeerDependencies() {
       './packages/devkit/package.json',
       JSON.stringify(devkitPackageJson, null, 2)
     );
+  }
+
+  // The plugins depending on @nx/devkit re-declare its `nx` peer to forward it,
+  // so every copy of the range has to match whatever devkit ends up publishing.
+  for (const dir of readdirSync('./packages', { withFileTypes: true })) {
+    if (!dir.isDirectory()) {
+      continue;
+    }
+    const packageJsonPath = `./packages/${dir.name}/package.json`;
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    if (
+      !packageJson.peerDependencies?.['nx'] ||
+      packageJson.peerDependencies['nx'] ===
+        devkitPackageJson.peerDependencies['nx']
+    ) {
+      continue;
+    }
+    console.log(`Syncing ${packageJson.name} nx peer dependency range.`);
+    packageJson.peerDependencies['nx'] =
+      devkitPackageJson.peerDependencies['nx'];
+    writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
   }
 }


### PR DESCRIPTION
> **Please read #36784 first — this PR is one possible answer to it, not a request to merge as-is.**
>
> @FrozenPandaz asked for an issue before a PR, which is fair. That issue is #36784, with a 12-case reproduction at https://github.com/unrevised6419/nx-peer-repro. It confirms the point in that review comment: on the default configuration the inheritance does work, and the failure is confined to strict Yarn PnP. **Closing this in favour of the issue is a perfectly good outcome.**

## Current Behavior

`@nx/devkit` declares `nx` as a required peer dependency and requires it at module load — `@nx/devkit@23.1.1/dist/index.js` line 16 is `require("nx/src/devkit-exports")`. It cannot load unless `nx` is resolvable from its own position.

The plugins that take `@nx/devkit` as a regular dependency declare `nx` in neither `dependencies` nor `peerDependencies` — only in `devDependencies`, which is not published. A package can only satisfy a transitive peer by declaring it too, so none of them can forward `nx` down to devkit.

Yarn reports it at install time as `YN0086`, and under strict Yarn PnP it is a hard runtime crash:

```
Error: @nx/devkit tried to access nx (a peer dependency) but it isn't provided by its
ancestors; this makes the require call ambiguous and unsound.
Ancestor breaking the chain: @nx/js@virtual:...#npm:23.1.1
```

**Scope is narrow.** Of 12 cases tested in the reproduction, only two fail, both strict Yarn PnP. npm, pnpm, pnpm with `autoInstallPeers: false` + `strictPeerDependencies: true`, Yarn `node-modules`, and Yarn's `pnpm` linker all resolve it fine. A normal Nx workspace on the default configuration is unaffected.

## Expected Behavior

Each affected plugin declares the same `nx` range as `@nx/devkit`, marked optional so no workspace gains a new install warning:

```json
"peerDependencies": { "nx": ">= 22 <= 24 || ^23.0.0-0" },
"peerDependenciesMeta": { "nx": { "optional": true } }
```

Because the range is now duplicated across manifests, `hackFixForDevkitPeerDependencies` in `scripts/nx-release.ts` propagates devkit's final range to every copy before publishing, so a release that rewrites devkit's range can't ship plugins pinned to a stale one. All affected packages are already in `packagesToReset`, so the release-time writes are reverted exactly as devkit's are.

## Lockfile impact: none

`pnpm-lock.yaml` is unchanged by this PR, and `pnpm install --frozen-lockfile` (what `ci.yml:86` runs) passes against the committed lockfile.

The reason is that the lockfile records *resolutions*, not *declarations* — there are zero `peerDependencies:` blocks anywhere in its `importers:` section. The 32 packages changed here already depend on the workspace `nx` (`nx: workspace:*` → `version: link:../nx`), which satisfies the new peer with nothing new to resolve, so nothing is written.

> An earlier revision of this description claimed this change required a 2366-hunk lockfile update and would fail CI. That was wrong. It was caused by a defect in the first version of this patch — see the excluded packages below — not by the approach, and this section replaces it.

## Deliberately not covered

**`@nx/workspace`** — `packages/workspace/project.json` already injects `nx` as a real dependency at release time via `add-extra-dependencies`, and declaring `nx` as both a dependency and a peer of one package is the state package managers complain about.

**`@nx/angular-rspack`, `@nx/angular-rspack-compiler`, `@nx/express`, `@nx/nest`** — these are the only affected packages with no `nx` in `devDependencies`. With no local `nx` to satisfy the new peer, pnpm resolves it from the registry instead and writes a published `nx` plus its transitive tree into this repo's own lockfile (+8000/−3227). Adding `nx: workspace:*` to them avoids the registry fetch but still costs ~7456 lockfile lines for reasons I could not explain, so I have left them alone rather than ship a change I don't understand.

They are affected — all four depend on `@nx/devkit` and import it in shipped source (`@nx/nest` in 35 files) — so this PR does not fully fix them. Worth noting though: installing `@nx/nest` alone produces seven broken peer chains, and six of them (`@nx/docker`, `@nx/eslint` ×2, `@nx/jest`, `@nx/js`, `@nx/node`) are fixed here. Only `@nx/nest`'s own chain remains.

Guidance welcome on whether those four should get `nx` in `devDependencies` — the asymmetry with the other 32 looks like drift rather than intent, and someone who knows why the repo root depends on a published `nx@23.2.0-beta.9` rather than `workspace:*` can probably explain the lockfile cost in one line.

## Related Issue(s)

Discussion and reproduction: #36784
