### PR TITLE
fix(repo): restore missing linux native binding entries to pnpm-lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10274,6 +10274,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@nx/nx-linux-arm64-gnu@23.2.0-beta.9':
+    resolution: {integrity: sha512-VCLgWgp0H2ljtYZWq4snJuyQj9azQszw2Jo7Wn9Bm4bP4yOACmhVInTXAt5LFuft3m2RNpU56Ff5RctQYsuNdQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@nx/nx-linux-arm64-musl@21.6.2':
     resolution: {integrity: sha512-pB67mhywxV+WrVCiYV/+DgK2lfen3dv8PPgmBN/7qHQUgHqTJSLw7f9upiLlApuVN20qyCaktNT6Nq41Q88NCg==}
     cpu: [arm64]
@@ -10300,6 +10306,12 @@ packages:
 
   '@nx/nx-linux-x64-musl@21.6.2':
     resolution: {integrity: sha512-nEEkb3fBuqL18q6q7oqC1PpRiP8LMCmLf7UkGl6owDzCPy48K36Nept2YjHzABdUN2Wv5kojCWjNpGqhnTZSiw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@nx/nx-linux-x64-musl@23.2.0-beta.9':
+    resolution: {integrity: sha512-CTcvbwmXAep6dis5W3URZ0gkKZ85N8ZY5PbIiW4i24008e5FMsrCnMQeJ8IJi7fm9OPEx1YZsiz6iUS102X04Q==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -35907,6 +35919,9 @@ snapshots:
   '@nx/nx-linux-arm64-gnu@21.6.2':
     optional: true
 
+  '@nx/nx-linux-arm64-gnu@23.2.0-beta.9':
+    optional: true
+
   '@nx/nx-linux-arm64-musl@21.6.2':
     optional: true
 
@@ -35920,6 +35935,9 @@ snapshots:
     optional: true
 
   '@nx/nx-linux-x64-musl@21.6.2':
+    optional: true
+
+  '@nx/nx-linux-x64-musl@23.2.0-beta.9':
     optional: true
 
   '@nx/nx-win32-arm64-msvc@21.6.2':
@@ -51303,8 +51321,10 @@ snapshots:
       '@nx/nx-darwin-x64': 23.2.0-beta.9
       '@nx/nx-freebsd-x64': 23.2.0-beta.9
       '@nx/nx-linux-arm-gnueabihf': 23.2.0-beta.9
+      '@nx/nx-linux-arm64-gnu': 23.2.0-beta.9
       '@nx/nx-linux-arm64-musl': 23.2.0-beta.9
       '@nx/nx-linux-x64-gnu': 23.2.0-beta.9
+      '@nx/nx-linux-x64-musl': 23.2.0-beta.9
       '@nx/nx-win32-arm64-msvc': 23.2.0-beta.9
       '@nx/nx-win32-x64-msvc': 23.2.0-beta.9
       '@swc-node/register': 1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3)
@@ -51441,8 +51461,10 @@ snapshots:
       '@nx/nx-darwin-x64': 23.2.0-beta.9
       '@nx/nx-freebsd-x64': 23.2.0-beta.9
       '@nx/nx-linux-arm-gnueabihf': 23.2.0-beta.9
+      '@nx/nx-linux-arm64-gnu': 23.2.0-beta.9
       '@nx/nx-linux-arm64-musl': 23.2.0-beta.9
       '@nx/nx-linux-x64-gnu': 23.2.0-beta.9
+      '@nx/nx-linux-x64-musl': 23.2.0-beta.9
       '@nx/nx-win32-arm64-msvc': 23.2.0-beta.9
       '@nx/nx-win32-x64-msvc': 23.2.0-beta.9
       '@swc-node/register': 1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.23))(@swc/types@0.1.25)(typescript@6.0.3)


### PR DESCRIPTION
## Current Behavior

Every release has been red since `23.2.0-beta.9`, failing on both Alpine build jobs (`x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`) during project graph construction, which skips `Publish`:

```
NX  error parsing glob '**/{*.{csproj,fsproj,vbproj},Directory.Build.{props,targets,rsp},Directory.Solution.{props,targets},Directory.Packages.props}':
    nested alternate groups are not allowed
```

The glob is only the messenger. `pnpm-lock.yaml` is missing two native bindings at the current version:

| binding | versions in lockfile |
| --- | --- |
| `@nx/nx-linux-x64-musl` | `21.6.2` only |
| `@nx/nx-linux-arm64-gnu` | `21.6.2` only |
| every other platform | `21.6.2`, `23.2.0-beta.9` |

**How it happened.** #36751 generated its lockfile at 16:32 UTC on 2026-08-21. `@nx/nx-linux-x64-musl@23.2.0-beta.9` and `@nx/nx-linux-arm64-gnu@23.2.0-beta.9` were published at 17:06 and 17:36 UTC — late retries of the beta.9 release, so they did not exist yet. They are `optionalDependencies`, so pnpm skipped them silently rather than failing.

**How it breaks.** On Alpine, `nx@23.2.0-beta.9` finds no matching binding and falls back to the hoisted `@nx/nx-linux-x64-musl@21.6.2` that `packages/nx`'s `"@nx/nx-*": "*"` optionalDependencies pull from the registry. That two-major-versions-old binary ships **globset 0.4.14**, which predates nested brace alternate support, so the `@nx/dotnet` `createNodes` pattern kills graph construction. (globset 0.4.18, which current nx builds against, still defines `NestedAlternates` but never emits it.)

The same JS/native mismatch also produces **22×** `Failed to initialize telemetry: Failed to convert JavaScript value \`Undefined\` into rust type \`String\`` in the failing jobs, and **zero** in the passing `x86_64-unknown-linux-gnu` job or in the last green musl job (which still ran `nx@23.2.0-beta.7`).

The `arm64-gnu` gap is latent in CI only because napi-rs's `lts-debian-aarch64` image runs an x64 node, so no job resolves an arm64 glibc binding. It would still bite arm64 Linux contributors.

## Expected Behavior

The lockfile pins a `23.2.0-beta.9` binding for every platform, so Alpine resolves nx's own native module instead of silently loading a 21.6.2 binary. The musl build jobs get past graph construction and `Publish` runs again.

The diff is insert-only (22 lines) and was spliced by hand: `pnpm install --fix-lockfile` produces the same binding entries but also rewrites ~7.6k unrelated lines re-adding `(supports-color@7.2.0)` peer suffixes repo-wide. Integrity hashes were verified against npm, and `pnpm install --lockfile-only --frozen-lockfile` passes and leaves the file byte-identical.

## Related Issue(s)

No tracking issue. Regression introduced by #36751. Failing runs:

- 23.2.0-beta.10 — https://github.com/nrwl/nx/actions/runs/32867778067
- Canary 2026-08-24 — https://github.com/nrwl/nx/actions/runs/32767030263
- Canary 2026-08-25 — https://github.com/nrwl/nx/actions/runs/32888429557

Follow-up worth considering (not in this PR): a CI check that every platform in `packages/nx` `optionalDependencies` has a lockfile entry at the current nx version, so a lagging binding publish fails loudly instead of silently downgrading the native module.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/weird-release-glob-issues-e7572235">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->