### PR TITLE
cleanup(core): give the terminal output path its own module

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -74,16 +74,6 @@ export function getCache(options: DefaultTasksRunnerOptions): DbCache | Cache {
     : new Cache(options);
 }
 
-/**
- * Where a task's terminal output lives on disk, for callers that have a hash but
- * no cache instance. Mirrors the native layout (`get_task_outputs_path_internal`
- * in cache.rs) and the legacy cache's `terminalOutputsDir`; both resolve
- * `<cacheDir>/terminalOutputs/<hash>`.
- */
-export function terminalOutputPathForHash(hash: string): string {
-  return join(cacheDir, 'terminalOutputs', hash);
-}
-
 export class DbCache {
   private nxJson = readNxJson();
   private cache = new NxCache(

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
@@ -4,7 +4,7 @@ import type { TaskResult } from '../life-cycle';
 import { TaskStatus } from '../tasks-runner';
 import { SummaryTerminalOutputLifeCycle } from './summary-terminal-output-life-cycle';
 
-jest.mock('../cache', () => ({
+jest.mock('../terminal-output-path', () => ({
   terminalOutputPathForHash: (hash: string) => `/cache/terminalOutputs/${hash}`,
 }));
 

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
@@ -1,6 +1,6 @@
 import { Task } from '../../config/task-graph';
 import { output } from '../../utils/output';
-import { terminalOutputPathForHash } from '../cache';
+import { terminalOutputPathForHash } from '../terminal-output-path';
 import type { LifeCycle, TaskResult } from '../life-cycle';
 
 /**

--- a/packages/nx/src/tasks-runner/terminal-output-path.ts
+++ b/packages/nx/src/tasks-runner/terminal-output-path.ts
@@ -1,0 +1,16 @@
+import { join } from 'path';
+import { cacheDir } from '../utils/cache-directory';
+
+/**
+ * Where a task's terminal output lives on disk, for callers that have a hash but
+ * no cache instance. Mirrors the native layout (`get_task_outputs_path_internal`
+ * in cache.rs) and the legacy cache's `terminalOutputsDir`; both resolve
+ * `<cacheDir>/terminalOutputs/<hash>`.
+ *
+ * Its own module rather than part of `cache.ts` so the graph and plugin paths
+ * can resolve a path without pulling the cache — and the database, cloud and
+ * task-IO modules behind it — into their import graph.
+ */
+export function terminalOutputPathForHash(hash: string): string {
+  return join(cacheDir, 'terminalOutputs', hash);
+}


### PR DESCRIPTION
## Current Behavior

`terminalOutputPathForHash` lives in `tasks-runner/cache.ts`. It needs nothing but `cacheDir`, but importing it drags the whole cache module in behind it — and with it the database, Nx Cloud and task-IO modules.

`summary-terminal-output-life-cycle.ts` wants only the path, and loads **184 modules** to get it. Its spec has to `jest.mock('../cache', ...)`, replacing the entire cache module with a single function.

## Expected Behavior

The helper lives in `tasks-runner/terminal-output-path.ts`, which imports only `path` and `cacheDir`. The summary life cycle now loads **11 modules**, and its spec mocks the one function it actually fakes.

Moved rather than re-exported. A re-export would have left every existing caller on the heavy edge, which is the thing the split exists to remove.

No behavior change — same function, same path, same output.

## Related Issue(s)

Stacked on #36703, which introduced both the helper and the summary life cycle. Prerequisite for the NXC-4802 fix, where a plugin-path caller needs to resolve a terminal output path without pulling the cache into graph construction.