### PR TITLE
fix(core): carry task terminal outputs to plugins by path

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -21,10 +21,8 @@ import {
   DaemonProjectGraphError,
   ProjectGraphError,
 } from '../../project-graph/error-types';
-import {
-  PostTasksExecutionContext,
-  PreTasksExecutionContext,
-} from '../../project-graph/plugins/public-api';
+import { PreTasksExecutionContext } from '../../project-graph/plugins/public-api';
+import type { MaybeStubbedPostTasksExecutionContext } from '../../project-graph/plugins/task-results-stub';
 import { getPluginResolveConditionNodeArgs } from '../../plugins/js/utils/typescript';
 import { preventRecursionInGraphConstruction } from '../../project-graph/project-graph';
 import { ConfigurationSourceMaps } from '../../project-graph/utils/project-configuration/source-maps';
@@ -1047,7 +1045,7 @@ export class DaemonClient {
   }
 
   async runPostTasksExecution(
-    context: PostTasksExecutionContext
+    context: MaybeStubbedPostTasksExecutionContext
   ): Promise<void> {
     const message: HandlePostTasksExecutionMessage = {
       type: POST_TASKS_EXECUTION,

--- a/packages/nx/src/daemon/message-types/run-tasks-execution-hooks.ts
+++ b/packages/nx/src/daemon/message-types/run-tasks-execution-hooks.ts
@@ -1,5 +1,5 @@
 import type { PreTasksExecutionContext } from '../../project-graph/plugins';
-import type { StubbedPostTasksExecutionContext } from '../../project-graph/plugins/task-results-stub';
+import type { MaybeStubbedPostTasksExecutionContext } from '../../project-graph/plugins/task-results-stub';
 
 export const PRE_TASKS_EXECUTION = 'PRE_TASKS_EXECUTION' as const;
 export const POST_TASKS_EXECUTION = 'POST_TASKS_EXECUTION' as const;
@@ -10,7 +10,7 @@ export type HandlePreTasksExecutionMessage = {
 };
 export type HandlePostTasksExecutionMessage = {
   type: typeof POST_TASKS_EXECUTION;
-  context: StubbedPostTasksExecutionContext;
+  context: MaybeStubbedPostTasksExecutionContext;
 };
 
 export function isHandlePreTasksExecutionMessage(

--- a/packages/nx/src/daemon/message-types/run-tasks-execution-hooks.ts
+++ b/packages/nx/src/daemon/message-types/run-tasks-execution-hooks.ts
@@ -1,7 +1,5 @@
-import type {
-  PostTasksExecutionContext,
-  PreTasksExecutionContext,
-} from '../../project-graph/plugins';
+import type { PreTasksExecutionContext } from '../../project-graph/plugins';
+import type { StubbedPostTasksExecutionContext } from '../../project-graph/plugins/task-results-stub';
 
 export const PRE_TASKS_EXECUTION = 'PRE_TASKS_EXECUTION' as const;
 export const POST_TASKS_EXECUTION = 'POST_TASKS_EXECUTION' as const;
@@ -12,7 +10,7 @@ export type HandlePreTasksExecutionMessage = {
 };
 export type HandlePostTasksExecutionMessage = {
   type: typeof POST_TASKS_EXECUTION;
-  context: PostTasksExecutionContext;
+  context: StubbedPostTasksExecutionContext;
 };
 
 export function isHandlePreTasksExecutionMessage(

--- a/packages/nx/src/daemon/server/handle-tasks-execution-hooks.ts
+++ b/packages/nx/src/daemon/server/handle-tasks-execution-hooks.ts
@@ -1,7 +1,5 @@
-import type {
-  PostTasksExecutionContext,
-  PreTasksExecutionContext,
-} from '../../project-graph/plugins/public-api';
+import type { PreTasksExecutionContext } from '../../project-graph/plugins/public-api';
+import type { MaybeStubbedPostTasksExecutionContext } from '../../project-graph/plugins/task-results-stub';
 import {
   runPostTasksExecution,
   runPreTasksExecution,
@@ -24,7 +22,7 @@ export async function handleRunPreTasksExecution(
   }
 }
 export async function handleRunPostTasksExecution(
-  context: PostTasksExecutionContext
+  context: MaybeStubbedPostTasksExecutionContext
 ) {
   try {
     await runPostTasksExecution(context);

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
@@ -20,6 +20,7 @@ import { getNxRequirePaths } from '../../../utils/installation-directory';
 import { isSandbox } from '../../../utils/is-sandbox';
 import { logger } from '../../../utils/logger';
 import { ProgressTopics } from '../../../utils/progress-topics';
+import { stubTerminalOutputs } from '../task-results-stub';
 import { waitForSocketConnection } from '../../../utils/wait-for-socket-connection';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import type { RawProjectGraphDependency } from '../../project-graph-builder';
@@ -439,7 +440,7 @@ export class IsolatedPlugin implements LoadedNxPlugin {
         this as { postTasksExecution: IsolatedPlugin['postTasksExecution'] }
       ).postTasksExecution = wrap('postTasksExecution', async (context) => {
         const result = await this.sendRequest('postTasksExecution', {
-          context,
+          context: stubTerminalOutputs(context),
         });
         if (result.success === false) {
           throw result.error;

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -5,11 +5,11 @@ import type { ProjectGraph } from '../../../config/project-graph';
 import { sendMessage } from '../../../daemon/socket-utils';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import type { LoadedNxPlugin } from '../loaded-nx-plugin';
+import type { StubbedPostTasksExecutionContext } from '../task-results-stub';
 import type {
   CreateDependenciesContext,
   CreateMetadataContext,
   CreateNodesContext,
-  PostTasksExecutionContext,
   PreTasksExecutionContext,
 } from '../public-api';
 import type {
@@ -126,7 +126,7 @@ type PluginMessageDefs = DefineMessages<{
 
   postTasksExecution: {
     payload: {
-      context: PostTasksExecutionContext;
+      context: StubbedPostTasksExecutionContext;
     };
     result:
       | {

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -5,7 +5,7 @@ import type { ProjectGraph } from '../../../config/project-graph';
 import { sendMessage } from '../../../daemon/socket-utils';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import type { LoadedNxPlugin } from '../loaded-nx-plugin';
-import type { StubbedPostTasksExecutionContext } from '../task-results-stub';
+import type { MaybeStubbedPostTasksExecutionContext } from '../task-results-stub';
 import type {
   CreateDependenciesContext,
   CreateMetadataContext,
@@ -126,7 +126,7 @@ type PluginMessageDefs = DefineMessages<{
 
   postTasksExecution: {
     payload: {
-      context: StubbedPostTasksExecutionContext;
+      context: MaybeStubbedPostTasksExecutionContext;
     };
     result:
       | {

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -12,7 +12,6 @@ import { logger } from '../../../utils/logger';
 import { createSerializableError } from '../../../utils/serializable-error';
 import { assertNotForeignWorkspaceMessage } from '../../../daemon/message-types/daemon-message';
 import type { LoadedNxPlugin } from '../loaded-nx-plugin';
-import { rehydrateTerminalOutputs } from '../task-results-stub';
 import { consumeMessage, isPluginWorkerMessage } from './messaging';
 import { setPluginWorkerHostSocket } from './worker-streaming';
 
@@ -194,9 +193,7 @@ const server = createServer((socket) => {
               return { success: true as const, mutations };
             }),
           postTasksExecution: async ({ context }) =>
-            withErrorHandling(() =>
-              plugin.postTasksExecution?.(rehydrateTerminalOutputs(context))
-            ),
+            withErrorHandling(() => plugin.postTasksExecution?.(context)),
           setWorkerEnv: (env) =>
             withErrorHandling(() => {
               applyDaemonEnvFromClient(env);

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -12,6 +12,7 @@ import { logger } from '../../../utils/logger';
 import { createSerializableError } from '../../../utils/serializable-error';
 import { assertNotForeignWorkspaceMessage } from '../../../daemon/message-types/daemon-message';
 import type { LoadedNxPlugin } from '../loaded-nx-plugin';
+import { rehydrateTerminalOutputs } from '../task-results-stub';
 import { consumeMessage, isPluginWorkerMessage } from './messaging';
 import { setPluginWorkerHostSocket } from './worker-streaming';
 
@@ -193,7 +194,9 @@ const server = createServer((socket) => {
               return { success: true as const, mutations };
             }),
           postTasksExecution: async ({ context }) =>
-            withErrorHandling(() => plugin.postTasksExecution?.(context)),
+            withErrorHandling(() =>
+              plugin.postTasksExecution?.(rehydrateTerminalOutputs(context))
+            ),
           setWorkerEnv: (env) =>
             withErrorHandling(() => {
               applyDaemonEnvFromClient(env);

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -12,13 +12,15 @@ import type {
   CreateNodesContext,
   CreateNodesResult,
   NxPlugin,
-  PostTasksExecutionContext,
   PreTasksExecutionContext,
   ProjectsMetadata,
 } from './public-api';
 import { isIsolationEnabled } from './isolation/enabled';
 import { isDaemonEnabled } from '../../daemon/client/client';
-import { rehydrateTerminalOutputs } from './task-results-stub';
+import {
+  rehydrateTerminalOutputs,
+  type MaybeStubbedPostTasksExecutionContext,
+} from './task-results-stub';
 
 /**
  * NOTE: Avoid using `import type` with this class. It causes issues with
@@ -49,7 +51,7 @@ export class LoadedNxPlugin {
     context: PreTasksExecutionContext
   ) => Promise<NodeJS.ProcessEnv>;
   readonly postTasksExecution?: (
-    context: PostTasksExecutionContext
+    context: MaybeStubbedPostTasksExecutionContext
   ) => Promise<void>;
 
   readonly options?: unknown;
@@ -175,9 +177,12 @@ export class LoadedNxPlugin {
     }
 
     if (plugin.postTasksExecution) {
-      // Rehydrated here rather than on receipt from the daemon, so a context
-      // bound for an isolated plugin stays stubbed across that second hop.
-      this.postTasksExecution = async (context: PostTasksExecutionContext) =>
+      // The single rehydration point: every transport hands its context
+      // straight here, so a context bound for an isolated plugin stays stubbed
+      // across that second hop rather than being read and re-stubbed.
+      this.postTasksExecution = async (
+        context: MaybeStubbedPostTasksExecutionContext
+      ) =>
         plugin.postTasksExecution(
           this.options,
           rehydrateTerminalOutputs(context)

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -18,6 +18,7 @@ import type {
 } from './public-api';
 import { isIsolationEnabled } from './isolation/enabled';
 import { isDaemonEnabled } from '../../daemon/client/client';
+import { rehydrateTerminalOutputs } from './task-results-stub';
 
 /**
  * NOTE: Avoid using `import type` with this class. It causes issues with
@@ -174,8 +175,13 @@ export class LoadedNxPlugin {
     }
 
     if (plugin.postTasksExecution) {
+      // Rehydrated here rather than on receipt from the daemon, so a context
+      // bound for an isolated plugin stays stubbed across that second hop.
       this.postTasksExecution = async (context: PostTasksExecutionContext) =>
-        plugin.postTasksExecution(this.options, context);
+        plugin.postTasksExecution(
+          this.options,
+          rehydrateTerminalOutputs(context)
+        );
     }
   }
 }

--- a/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
+++ b/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
@@ -1,0 +1,190 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let mockCacheRoot = '';
+
+jest.mock('../../tasks-runner/terminal-output-path', () => ({
+  terminalOutputPathForHash: (hash: string) =>
+    require('node:path').join(mockCacheRoot, hash),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn() },
+}));
+
+import { serialize } from '../../daemon/socket-utils';
+import { logger } from '../../utils/logger';
+import type { PostTasksExecutionContext } from './public-api';
+import {
+  rehydrateTerminalOutputs,
+  stubTerminalOutputs,
+} from './task-results-stub';
+
+function result(hash: string | undefined, terminalOutput: string | undefined) {
+  return {
+    task: { id: `proj:${hash}`, hash, target: { project: 'proj' } },
+    status: 'success',
+    code: 0,
+    terminalOutput,
+  } as any;
+}
+
+function contextWith(
+  taskResults: Record<string, any>
+): PostTasksExecutionContext {
+  return {
+    id: 'run-1',
+    workspaceRoot: '/ws',
+    nxJsonConfiguration: {},
+    taskResults,
+    argv: [],
+    startTime: 0,
+    endTime: 1,
+  } as any;
+}
+
+describe('task results terminal output stubbing', () => {
+  beforeEach(() => {
+    mockCacheRoot = mkdtempSync(join(tmpdir(), 'nx-stub-'));
+    (logger.warn as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    rmSync(mockCacheRoot, { recursive: true, force: true });
+  });
+
+  function writeOutput(hash: string, contents: string) {
+    writeFileSync(join(mockCacheRoot, hash), contents);
+  }
+
+  it('replaces the output with its path when the file exists', () => {
+    writeOutput('abc', 'the real output');
+    const stubbed = stubTerminalOutputs(
+      contextWith({ 'proj:build': result('abc', 'the real output') })
+    );
+
+    expect(stubbed.taskResults['proj:build'].terminalOutput).toBe(
+      join(mockCacheRoot, 'abc')
+    );
+    expect(stubbed.stubbedTerminalOutputs).toEqual(['proj:build']);
+  });
+
+  it('round trips the exact bytes back', () => {
+    const output = 'line one\nline two[31m red [0m';
+    writeOutput('abc', output);
+
+    const rehydrated = rehydrateTerminalOutputs(
+      stubTerminalOutputs(contextWith({ 'proj:build': result('abc', output) }))
+    );
+
+    expect(rehydrated.taskResults['proj:build'].terminalOutput).toBe(output);
+    expect(rehydrated).not.toHaveProperty('stubbedTerminalOutputs');
+  });
+
+  // The bug this exists to fix: both JSON.stringify and the v8 fallback have to
+  // materialize the payload as one string, so the bytes must not be in it.
+  it('keeps the output out of the serialized payload', () => {
+    const output = 'a-very-distinctive-output-marker';
+    writeOutput('abc', output);
+
+    const wire = serialize(
+      stubTerminalOutputs(contextWith({ 'proj:build': result('abc', output) }))
+    );
+
+    expect(wire).not.toContain(output);
+    expect(wire).toContain('abc');
+  });
+
+  // Returned as-is rather than rebuilt, so a run with nothing on disk puts
+  // exactly the payload on the wire that it did before any of this existed.
+  describe('hands back the context untouched when there is no file to point at', () => {
+    it('when the task was never hashed', () => {
+      const context = contextWith({
+        'proj:build': result(undefined, 'crashed early'),
+      });
+
+      expect(stubTerminalOutputs(context)).toBe(context);
+    });
+
+    it('when the file was never written', () => {
+      const context = contextWith({
+        'proj:build': result('nofile', 'still here'),
+      });
+
+      expect(stubTerminalOutputs(context)).toBe(context);
+    });
+
+    it('when the task produced no output', () => {
+      writeOutput('abc', 'orphan file');
+      const context = contextWith({ 'proj:build': result('abc', undefined) });
+
+      expect(stubTerminalOutputs(context)).toBe(context);
+    });
+  });
+
+  // The daemon stubs, then hands the same context to an isolated plugin, which
+  // stubs again before its own send.
+  it('is idempotent, so a second transport can re-stub', () => {
+    writeOutput('abc', 'the real output');
+    const once = stubTerminalOutputs(
+      contextWith({ 'proj:build': result('abc', 'the real output') })
+    );
+    const twice = stubTerminalOutputs(once);
+
+    expect(twice).toBe(once);
+    expect(twice.taskResults['proj:build'].terminalOutput).toBe(
+      join(mockCacheRoot, 'abc')
+    );
+    expect(twice.stubbedTerminalOutputs).toEqual(['proj:build']);
+    expect(
+      rehydrateTerminalOutputs(twice).taskResults['proj:build'].terminalOutput
+    ).toBe('the real output');
+  });
+
+  it('returns an unstubbed context untouched', () => {
+    const context = contextWith({
+      'proj:build': result('abc', 'never left the process'),
+    });
+
+    expect(rehydrateTerminalOutputs(context)).toBe(context);
+  });
+
+  it('reports a missing file as no output rather than handing back the path', () => {
+    writeOutput('abc', 'about to vanish');
+    const stubbed = stubTerminalOutputs(
+      contextWith({ 'proj:build': result('abc', 'about to vanish') })
+    );
+    rmSync(join(mockCacheRoot, 'abc'));
+
+    const rehydrated = rehydrateTerminalOutputs(stubbed);
+
+    expect(rehydrated.taskResults['proj:build'].terminalOutput).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(join(mockCacheRoot, 'abc'))
+    );
+  });
+
+  it('stubs only the results that have a file, leaving the rest inline', () => {
+    writeOutput('has-file', 'read me from disk');
+    const stubbed = stubTerminalOutputs(
+      contextWith({
+        'proj:build': result('has-file', 'read me from disk'),
+        'proj:test': result('no-file', 'inline please'),
+      })
+    );
+
+    expect(stubbed.stubbedTerminalOutputs).toEqual(['proj:build']);
+    expect(stubbed.taskResults['proj:test'].terminalOutput).toBe(
+      'inline please'
+    );
+
+    const rehydrated = rehydrateTerminalOutputs(stubbed);
+    expect(rehydrated.taskResults['proj:build'].terminalOutput).toBe(
+      'read me from disk'
+    );
+    expect(rehydrated.taskResults['proj:test'].terminalOutput).toBe(
+      'inline please'
+    );
+  });
+});

--- a/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
+++ b/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
@@ -1,16 +1,17 @@
+import type { Mock } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 let mockCacheRoot = '';
 
-jest.mock('../../tasks-runner/terminal-output-path', () => ({
+vi.mock('../../tasks-runner/terminal-output-path', async () => ({
   terminalOutputPathForHash: (hash: string) =>
     require('node:path').join(mockCacheRoot, hash),
 }));
 
-jest.mock('../../utils/logger', () => ({
-  logger: { warn: jest.fn() },
+vi.mock('../../utils/logger', async () => ({
+  logger: { warn: vi.fn() },
 }));
 
 import { serialize } from '../../daemon/socket-utils';
@@ -47,7 +48,7 @@ function contextWith(
 describe('task results terminal output stubbing', () => {
   beforeEach(() => {
     mockCacheRoot = mkdtempSync(join(tmpdir(), 'nx-stub-'));
-    (logger.warn as jest.Mock).mockClear();
+    (logger.warn as Mock).mockClear();
   });
 
   afterEach(() => {
@@ -88,9 +89,13 @@ describe('task results terminal output stubbing', () => {
     const output = 'a-very-distinctive-output-marker';
     writeOutput('abc', output);
 
+    // `serialize` returns bytes, not a string. Decoded as latin1 so a byte
+    // buffer is searchable for ASCII either way: an `expect(buffer)
+    // .not.toContain(string)` looks for a matching ELEMENT and so passes on
+    // any buffer, which would make the first assertion here unfalsifiable.
     const wire = serialize(
       stubTerminalOutputs(contextWith({ 'proj:build': result('abc', output) }))
-    );
+    ).toString('latin1');
 
     expect(wire).not.toContain(output);
     expect(wire).toContain('abc');

--- a/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
+++ b/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
@@ -20,7 +20,14 @@ import type { PostTasksExecutionContext } from './public-api';
 import {
   rehydrateTerminalOutputs,
   stubTerminalOutputs,
+  type StubbedPostTasksExecutionContext,
 } from './task-results-stub';
+
+// `stubTerminalOutputs` returns the union, so the tests that read the map say
+// once that they expect the stubbed arm rather than casting at each assertion.
+function stub(context: PostTasksExecutionContext) {
+  return stubTerminalOutputs(context) as StubbedPostTasksExecutionContext;
+}
 
 function result(hash: string | undefined, terminalOutput: string | undefined) {
   return {
@@ -61,14 +68,16 @@ describe('task results terminal output stubbing', () => {
 
   it('replaces the output with its path when the file exists', () => {
     writeOutput('abc', 'the real output');
-    const stubbed = stubTerminalOutputs(
+    const stubbed = stub(
       contextWith({ 'proj:build': result('abc', 'the real output') })
     );
 
-    expect(stubbed.taskResults['proj:build'].terminalOutput).toBe(
-      join(mockCacheRoot, 'abc')
+    expect(stubbed.taskResults['proj:build']).not.toHaveProperty(
+      'terminalOutput'
     );
-    expect(stubbed.stubbedTerminalOutputs).toEqual(['proj:build']);
+    expect(stubbed.stubbedTerminalOutputs).toEqual({
+      'proj:build': join(mockCacheRoot, 'abc'),
+    });
   });
 
   it('round trips the exact bytes back', () => {
@@ -98,7 +107,7 @@ describe('task results terminal output stubbing', () => {
     ).toString('latin1');
 
     expect(wire).not.toContain(output);
-    expect(wire).toContain('abc');
+    expect(wire).toContain(join(mockCacheRoot, 'abc'));
   });
 
   // Returned as-is rather than rebuilt, so a run with nothing on disk puts
@@ -132,16 +141,15 @@ describe('task results terminal output stubbing', () => {
   // stubs again before its own send.
   it('is idempotent, so a second transport can re-stub', () => {
     writeOutput('abc', 'the real output');
-    const once = stubTerminalOutputs(
+    const once = stub(
       contextWith({ 'proj:build': result('abc', 'the real output') })
     );
-    const twice = stubTerminalOutputs(once);
+    const twice = stubTerminalOutputs(once) as StubbedPostTasksExecutionContext;
 
     expect(twice).toBe(once);
-    expect(twice.taskResults['proj:build'].terminalOutput).toBe(
-      join(mockCacheRoot, 'abc')
-    );
-    expect(twice.stubbedTerminalOutputs).toEqual(['proj:build']);
+    expect(twice.stubbedTerminalOutputs).toEqual({
+      'proj:build': join(mockCacheRoot, 'abc'),
+    });
     expect(
       rehydrateTerminalOutputs(twice).taskResults['proj:build'].terminalOutput
     ).toBe('the real output');
@@ -157,7 +165,7 @@ describe('task results terminal output stubbing', () => {
 
   it('reports a missing file as no output rather than handing back the path', () => {
     writeOutput('abc', 'about to vanish');
-    const stubbed = stubTerminalOutputs(
+    const stubbed = stub(
       contextWith({ 'proj:build': result('abc', 'about to vanish') })
     );
     rmSync(join(mockCacheRoot, 'abc'));
@@ -172,14 +180,16 @@ describe('task results terminal output stubbing', () => {
 
   it('stubs only the results that have a file, leaving the rest inline', () => {
     writeOutput('has-file', 'read me from disk');
-    const stubbed = stubTerminalOutputs(
+    const stubbed = stub(
       contextWith({
         'proj:build': result('has-file', 'read me from disk'),
         'proj:test': result('no-file', 'inline please'),
       })
     );
 
-    expect(stubbed.stubbedTerminalOutputs).toEqual(['proj:build']);
+    expect(stubbed.stubbedTerminalOutputs).toEqual({
+      'proj:build': join(mockCacheRoot, 'has-file'),
+    });
     expect(stubbed.taskResults['proj:test'].terminalOutput).toBe(
       'inline please'
     );
@@ -191,5 +201,98 @@ describe('task results terminal output stubbing', () => {
     expect(rehydrated.taskResults['proj:test'].terminalOutput).toBe(
       'inline please'
     );
+  });
+
+  // The point of holding paths out of band: a transport that stubs and forgets
+  // to rehydrate hands over a missing value, never a filename that a plugin
+  // would read as the output itself.
+  it('leaves no path behind in terminalOutput for an unrehydrated reader', () => {
+    writeOutput('abc', 'the real output');
+    const stubbed = stub(
+      contextWith({ 'proj:build': result('abc', 'the real output') })
+    );
+
+    expect(stubbed.taskResults['proj:build'].terminalOutput).toBeUndefined();
+    expect(JSON.stringify(stubbed.taskResults)).not.toContain(mockCacheRoot);
+  });
+
+  // The daemon stubs for its own send, and the same context is then handed to
+  // an isolated plugin. A result that became stubbable in between joins the map
+  // rather than staying inline.
+  it('stubs a newly stubbable result on a context that is already stubbed', () => {
+    writeOutput('has-file', 'read me from disk');
+    const once = stub(
+      contextWith({
+        'proj:build': result('has-file', 'read me from disk'),
+        'proj:test': result('late-file', 'inline for now'),
+      })
+    );
+
+    writeOutput('late-file', 'now on disk');
+    const twice = stubTerminalOutputs(once) as StubbedPostTasksExecutionContext;
+
+    expect(twice.stubbedTerminalOutputs).toEqual({
+      'proj:build': join(mockCacheRoot, 'has-file'),
+      'proj:test': join(mockCacheRoot, 'late-file'),
+    });
+    const rehydrated = rehydrateTerminalOutputs(twice);
+    expect(rehydrated.taskResults['proj:build'].terminalOutput).toBe(
+      'read me from disk'
+    );
+    expect(rehydrated.taskResults['proj:test'].terminalOutput).toBe(
+      'now on disk'
+    );
+  });
+
+  // The caller keeps using its own context after handing one to a transport,
+  // so the swap has to build a new object rather than edit theirs.
+  it('does not mutate the context it was given', () => {
+    writeOutput('abc', 'the real output');
+    const context = contextWith({
+      'proj:build': result('abc', 'the real output'),
+    });
+
+    stubTerminalOutputs(context);
+
+    expect(context.taskResults['proj:build'].terminalOutput).toBe(
+      'the real output'
+    );
+    expect(context).not.toHaveProperty('stubbedTerminalOutputs');
+  });
+
+  // An empty log is a real result, and `''` is falsy, so it is the value most
+  // likely to be dropped by a truthiness check on the way through.
+  it('round trips an empty output rather than losing it', () => {
+    writeOutput('abc', '');
+    const rehydrated = rehydrateTerminalOutputs(
+      stub(contextWith({ 'proj:build': result('abc', '') }))
+    );
+
+    expect(rehydrated.taskResults['proj:build'].terminalOutput).toBe('');
+  });
+
+  // A hash is whatever the hasher returned, and this one reaches a read. The
+  // file has to exist for the assertion to mean anything: a traversal that
+  // lands on nothing is refused by the existence check either way.
+  it('does not read outside the cache dir when the hash is a path', () => {
+    const outside = join(mockCacheRoot, '..', 'nx-stub-outside-the-cache');
+    writeFileSync(outside, 'should never be read');
+    try {
+      const context = contextWith({
+        'proj:build': result(
+          join('..', 'nx-stub-outside-the-cache'),
+          'inline please'
+        ),
+      });
+
+      const stubbed = stubTerminalOutputs(context);
+
+      expect(stubbed).toBe(context);
+      expect(stubbed.taskResults['proj:build'].terminalOutput).toBe(
+        'inline please'
+      );
+    } finally {
+      rmSync(outside, { force: true });
+    }
   });
 });

--- a/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
+++ b/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
@@ -92,8 +92,8 @@ describe('task results terminal output stubbing', () => {
     expect(rehydrated).not.toHaveProperty('stubbedTerminalOutputs');
   });
 
-  // The cost this exists to remove: the sender builds every output string and
-  // copies it into the serialized payload, so the bytes must not be in it.
+  // The cost this exists to remove: the sender copies every output string into
+  // the serialized payload, so the bytes must not be in it.
   it('keeps the output out of the serialized payload', () => {
     const output = 'a-very-distinctive-output-marker';
     writeOutput('abc', output);
@@ -213,7 +213,12 @@ describe('task results terminal output stubbing', () => {
     );
 
     expect(stubbed.taskResults['proj:build'].terminalOutput).toBeUndefined();
-    expect(JSON.stringify(stubbed.taskResults)).not.toContain(mockCacheRoot);
+    // Compared as JSON escapes it: a Windows cache root's backslashes become
+    // `\\` inside the serialized string, so the raw path never appears
+    // literally and the sweep would pass for the wrong reason there.
+    expect(JSON.stringify(stubbed.taskResults)).not.toContain(
+      JSON.stringify(mockCacheRoot).slice(1, -1)
+    );
   });
 
   // The daemon stubs for its own send, and the same context is then handed to

--- a/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
+++ b/packages/nx/src/project-graph/plugins/task-results-stub.spec.ts
@@ -92,8 +92,8 @@ describe('task results terminal output stubbing', () => {
     expect(rehydrated).not.toHaveProperty('stubbedTerminalOutputs');
   });
 
-  // The bug this exists to fix: both JSON.stringify and the v8 fallback have to
-  // materialize the payload as one string, so the bytes must not be in it.
+  // The cost this exists to remove: the sender builds every output string and
+  // copies it into the serialized payload, so the bytes must not be in it.
   it('keeps the output out of the serialized payload', () => {
     const output = 'a-very-distinctive-output-marker';
     writeOutput('abc', output);

--- a/packages/nx/src/project-graph/plugins/task-results-stub.ts
+++ b/packages/nx/src/project-graph/plugins/task-results-stub.ts
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync } from 'node:fs';
+import type { TaskResult, TaskResults } from '../../tasks-runner/life-cycle';
+import { terminalOutputPathForHash } from '../../tasks-runner/terminal-output-path';
+import { logger } from '../../utils/logger';
+import type { PostTasksExecutionContext } from './public-api';
+
+/**
+ * A {@link PostTasksExecutionContext} whose terminal outputs have been replaced
+ * by the paths holding them, so it can cross a process boundary.
+ *
+ * `taskResults` carries every task's full output inline, which on a large
+ * workspace exceeds V8's maximum string length: `serialize` tries
+ * `JSON.stringify` and falls back to `v8.serialize(...).toString('binary')`,
+ * and both have to materialize the payload as a single string, so both throw.
+ * The bytes are already on disk at `<cacheDir>/terminalOutputs/<hash>`, so
+ * transports carry paths and each receiver reads them back before any plugin
+ * sees the context.
+ */
+export type StubbedPostTasksExecutionContext = PostTasksExecutionContext & {
+  /**
+   * Ids in `taskResults` whose `terminalOutput` holds a path rather than the
+   * output. Out of band because a task can print anything, so no in-band
+   * marker is safe from a task that prints it.
+   */
+  stubbedTerminalOutputs?: string[];
+};
+
+/**
+ * Swaps in paths ahead of a transport. Idempotent, so a context that was
+ * already stubbed for the daemon can be passed on to a plugin worker as-is.
+ */
+export function stubTerminalOutputs(
+  context: PostTasksExecutionContext | StubbedPostTasksExecutionContext
+): StubbedPostTasksExecutionContext {
+  if (!context.taskResults) {
+    return context;
+  }
+
+  const stubbed = new Set(
+    (context as StubbedPostTasksExecutionContext).stubbedTerminalOutputs ?? []
+  );
+  const taskResults: TaskResults = {};
+  let swapped = false;
+
+  for (const [id, result] of Object.entries(context.taskResults)) {
+    const path = stubbablePath(result, stubbed.has(id));
+    if (path) {
+      stubbed.add(id);
+      taskResults[id] = { ...result, terminalOutput: path };
+      swapped = true;
+    } else {
+      taskResults[id] = result;
+    }
+  }
+
+  // Nothing to swap: hand back the context as it came, so a run with no
+  // outputs on disk sends exactly what it sent before. Covers the
+  // already-stubbed case too, which keeps its own list by staying untouched.
+  if (!swapped) {
+    return context;
+  }
+
+  return { ...context, taskResults, stubbedTerminalOutputs: [...stubbed] };
+}
+
+/**
+ * Reads the outputs back. A no-op on a context that was never stubbed, which
+ * is every in-process plugin run without the daemon.
+ */
+export function rehydrateTerminalOutputs(
+  context: StubbedPostTasksExecutionContext
+): PostTasksExecutionContext {
+  if (!context.stubbedTerminalOutputs?.length) {
+    return context;
+  }
+
+  const taskResults: TaskResults = { ...context.taskResults };
+  for (const id of context.stubbedTerminalOutputs) {
+    const result = taskResults[id];
+    if (!result) {
+      continue;
+    }
+    taskResults[id] = {
+      ...result,
+      terminalOutput: readTerminalOutput(result.terminalOutput),
+    };
+  }
+
+  const { stubbedTerminalOutputs, ...rehydrated } = {
+    ...context,
+    taskResults,
+  };
+  return rehydrated;
+}
+
+/**
+ * The path to swap in, or null to leave the output inline. A task that failed
+ * before it was hashed has no path, and a task that never ran has no file —
+ * both keep whatever they already carry rather than losing it.
+ */
+function stubbablePath(
+  result: TaskResult,
+  alreadyStubbed: boolean
+): string | null {
+  if (alreadyStubbed || result.terminalOutput === undefined) {
+    return null;
+  }
+  const hash = result.task?.hash;
+  if (!hash) {
+    return null;
+  }
+  const path = terminalOutputPathForHash(hash);
+  return existsSync(path) ? path : null;
+}
+
+/**
+ * A path that no longer resolves means the bytes are gone. Saying so with
+ * `undefined` — already a legal value, skipped tasks have it — beats leaving
+ * the path, which would have plugins treat a filename as the output.
+ */
+function readTerminalOutput(path: string | undefined): string | undefined {
+  if (!path) {
+    return undefined;
+  }
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch (e) {
+    logger.warn(
+      `Nx could not read a task's terminal output from ${path}: ${e.message}`
+    );
+    return undefined;
+  }
+}

--- a/packages/nx/src/project-graph/plugins/task-results-stub.ts
+++ b/packages/nx/src/project-graph/plugins/task-results-stub.ts
@@ -1,12 +1,14 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { basename } from 'node:path';
 import type { TaskResult, TaskResults } from '../../tasks-runner/life-cycle';
 import { terminalOutputPathForHash } from '../../tasks-runner/terminal-output-path';
 import { logger } from '../../utils/logger';
 import type { PostTasksExecutionContext } from './public-api';
 
 /**
- * A {@link PostTasksExecutionContext} whose terminal outputs have been replaced
- * by the paths holding them, so it can cross a process boundary.
+ * A {@link PostTasksExecutionContext} whose terminal outputs have been lifted
+ * out of `taskResults` and into a map of the paths holding them, so it can
+ * cross a process boundary.
  *
  * `taskResults` carries every task's full output inline, which on a large
  * workspace exceeds V8's maximum string length: `serialize` tries
@@ -15,38 +17,55 @@ import type { PostTasksExecutionContext } from './public-api';
  * The bytes are already on disk at `<cacheDir>/terminalOutputs/<hash>`, so
  * transports carry paths and each receiver reads them back before any plugin
  * sees the context.
+ *
+ * The paths live here rather than in `terminalOutput` so that field never
+ * holds two meanings: a stubbed result carries no `terminalOutput` at all, so
+ * a transport that forgets to rehydrate hands a plugin a missing value rather
+ * than a filename shaped exactly like real output. The map is required, so a
+ * stubbed context cannot typecheck without one.
  */
 export type StubbedPostTasksExecutionContext = PostTasksExecutionContext & {
   /**
-   * Ids in `taskResults` whose `terminalOutput` holds a path rather than the
-   * output. Out of band because a task can print anything, so no in-band
-   * marker is safe from a task that prints it.
+   * Path to the terminal output of each stubbed task, keyed by task id. Out of
+   * band because a task can print anything, so no in-band marker is safe from
+   * a task that prints it.
    */
-  stubbedTerminalOutputs?: string[];
+  stubbedTerminalOutputs: Record<string, string>;
 };
 
+export type MaybeStubbedPostTasksExecutionContext =
+  | PostTasksExecutionContext
+  | StubbedPostTasksExecutionContext;
+
+function isStubbed(
+  context: MaybeStubbedPostTasksExecutionContext
+): context is StubbedPostTasksExecutionContext {
+  return !!(context as StubbedPostTasksExecutionContext).stubbedTerminalOutputs;
+}
+
 /**
- * Swaps in paths ahead of a transport. Idempotent, so a context that was
+ * Swaps outputs out for paths ahead of a transport. Idempotent, so a context
  * already stubbed for the daemon can be passed on to a plugin worker as-is.
  */
 export function stubTerminalOutputs(
-  context: PostTasksExecutionContext | StubbedPostTasksExecutionContext
-): StubbedPostTasksExecutionContext {
+  context: MaybeStubbedPostTasksExecutionContext
+): MaybeStubbedPostTasksExecutionContext {
   if (!context.taskResults) {
     return context;
   }
 
-  const stubbed = new Set(
-    (context as StubbedPostTasksExecutionContext).stubbedTerminalOutputs ?? []
-  );
+  const stubbedTerminalOutputs: Record<string, string> = {
+    ...(isStubbed(context) ? context.stubbedTerminalOutputs : {}),
+  };
   const taskResults: TaskResults = {};
   let swapped = false;
 
   for (const [id, result] of Object.entries(context.taskResults)) {
-    const path = stubbablePath(result, stubbed.has(id));
+    const path = id in stubbedTerminalOutputs ? null : stubbablePath(result);
     if (path) {
-      stubbed.add(id);
-      taskResults[id] = { ...result, terminalOutput: path };
+      const { terminalOutput, ...withoutOutput } = result;
+      stubbedTerminalOutputs[id] = path;
+      taskResults[id] = withoutOutput as TaskResult;
       swapped = true;
     } else {
       taskResults[id] = result;
@@ -55,12 +74,12 @@ export function stubTerminalOutputs(
 
   // Nothing to swap: hand back the context as it came, so a run with no
   // outputs on disk sends exactly what it sent before. Covers the
-  // already-stubbed case too, which keeps its own list by staying untouched.
+  // already-stubbed case too, which keeps its own map by staying untouched.
   if (!swapped) {
     return context;
   }
 
-  return { ...context, taskResults, stubbedTerminalOutputs: [...stubbed] };
+  return { ...context, taskResults, stubbedTerminalOutputs };
 }
 
 /**
@@ -68,22 +87,19 @@ export function stubTerminalOutputs(
  * is every in-process plugin run without the daemon.
  */
 export function rehydrateTerminalOutputs(
-  context: StubbedPostTasksExecutionContext
+  context: MaybeStubbedPostTasksExecutionContext
 ): PostTasksExecutionContext {
-  if (!context.stubbedTerminalOutputs?.length) {
+  if (!isStubbed(context)) {
     return context;
   }
 
   const taskResults: TaskResults = { ...context.taskResults };
-  for (const id of context.stubbedTerminalOutputs) {
+  for (const [id, path] of Object.entries(context.stubbedTerminalOutputs)) {
     const result = taskResults[id];
     if (!result) {
       continue;
     }
-    taskResults[id] = {
-      ...result,
-      terminalOutput: readTerminalOutput(result.terminalOutput),
-    };
+    taskResults[id] = { ...result, terminalOutput: readTerminalOutput(path) };
   }
 
   const { stubbedTerminalOutputs, ...rehydrated } = {
@@ -98,18 +114,19 @@ export function rehydrateTerminalOutputs(
  * before it was hashed has no path, and a task that never ran has no file —
  * both keep whatever they already carry rather than losing it.
  */
-function stubbablePath(
-  result: TaskResult,
-  alreadyStubbed: boolean
-): string | null {
-  if (alreadyStubbed || result.terminalOutput === undefined) {
+function stubbablePath(result: TaskResult): string | null {
+  if (result.terminalOutput === undefined) {
     return null;
   }
   const hash = result.task?.hash;
   if (!hash) {
     return null;
   }
-  const path = terminalOutputPathForHash(hash);
+  // `getCustomHasher` lets a plugin return any string, and this one reaches a
+  // read, so the sink is kept inside the cache dir here rather than trusted to
+  // the hasher. A hash that needed stripping resolves to a file that does not
+  // exist, which falls back to sending the output inline.
+  const path = terminalOutputPathForHash(basename(hash));
   return existsSync(path) ? path : null;
 }
 

--- a/packages/nx/src/project-graph/plugins/task-results-stub.ts
+++ b/packages/nx/src/project-graph/plugins/task-results-stub.ts
@@ -10,9 +10,11 @@ import type { PostTasksExecutionContext } from './public-api';
  * out of `taskResults` and into a map of the paths holding them, so it can
  * cross a process boundary.
  *
- * `taskResults` carries every task's full output inline, so the sender builds
- * every one of those strings, copies them into the serialized payload and
- * pushes the whole thing across the socket, once per boundary. The bytes are
+ * `taskResults` carries every task's full output inline, so the sender copies
+ * every one of those strings into the serialized payload and pushes the whole
+ * thing across the socket, once per boundary. The strings themselves exist
+ * either way: the runner puts them on each result as its task completes, and
+ * the receiver reads them back eagerly. The bytes are
  * already on disk at `<cacheDir>/terminalOutputs/<hash>`, so transports carry
  * paths and each receiver reads them back before any plugin sees the context.
  *

--- a/packages/nx/src/project-graph/plugins/task-results-stub.ts
+++ b/packages/nx/src/project-graph/plugins/task-results-stub.ts
@@ -10,13 +10,17 @@ import type { PostTasksExecutionContext } from './public-api';
  * out of `taskResults` and into a map of the paths holding them, so it can
  * cross a process boundary.
  *
- * `taskResults` carries every task's full output inline, which on a large
- * workspace exceeds V8's maximum string length: `serialize` tries
- * `JSON.stringify` and falls back to `v8.serialize(...).toString('binary')`,
- * and both have to materialize the payload as a single string, so both throw.
- * The bytes are already on disk at `<cacheDir>/terminalOutputs/<hash>`, so
- * transports carry paths and each receiver reads them back before any plugin
- * sees the context.
+ * `taskResults` carries every task's full output inline, so the sender builds
+ * every one of those strings, copies them into the serialized payload and
+ * pushes the whole thing across the socket, once per boundary. The bytes are
+ * already on disk at `<cacheDir>/terminalOutputs/<hash>`, so transports carry
+ * paths and each receiver reads them back before any plugin sees the context.
+ *
+ * This is no longer a crash fix. The fallback used to be
+ * `v8.serialize(...).toString('binary')`, which put an oversized payload back
+ * through V8's maximum string length after `JSON.stringify` had already hit it,
+ * so both arms threw. `serialize` returns bytes now and the ceiling is gone;
+ * what is left is the cost of moving the payload at all.
  *
  * The paths live here rather than in `terminalOutput` so that field never
  * holds two meanings: a stubbed result carries no `terminalOutput` at all, so

--- a/packages/nx/src/project-graph/plugins/tasks-execution-hooks.ts
+++ b/packages/nx/src/project-graph/plugins/tasks-execution-hooks.ts
@@ -1,13 +1,13 @@
-import type {
-  PostTasksExecutionContext,
-  PreTasksExecutionContext,
-} from './public-api';
+import type { PreTasksExecutionContext } from './public-api';
 import { readNxJson } from '../../config/nx-json';
 import { getPlugins } from './get-plugins';
 import { isOnDaemon } from '../../daemon/is-on-daemon';
 import { daemonClient, isDaemonEnabled } from '../../daemon/client/client';
 import { workspaceRoot } from '../../utils/workspace-root';
-import { stubTerminalOutputs } from './task-results-stub';
+import {
+  stubTerminalOutputs,
+  type MaybeStubbedPostTasksExecutionContext,
+} from './task-results-stub';
 
 export async function runPreTasksExecution(
   pluginContext: PreTasksExecutionContext
@@ -61,7 +61,7 @@ function applyProcessEnvs(envs: NodeJS.ProcessEnv[]) {
 }
 
 export async function runPostTasksExecution(
-  context: PostTasksExecutionContext
+  context: MaybeStubbedPostTasksExecutionContext
 ) {
   if (isOnDaemon() || !isDaemonEnabled()) {
     performance.mark(`postTasksExecution:start`);

--- a/packages/nx/src/project-graph/plugins/tasks-execution-hooks.ts
+++ b/packages/nx/src/project-graph/plugins/tasks-execution-hooks.ts
@@ -7,6 +7,7 @@ import { getPlugins } from './get-plugins';
 import { isOnDaemon } from '../../daemon/is-on-daemon';
 import { daemonClient, isDaemonEnabled } from '../../daemon/client/client';
 import { workspaceRoot } from '../../utils/workspace-root';
+import { stubTerminalOutputs } from './task-results-stub';
 
 export async function runPreTasksExecution(
   pluginContext: PreTasksExecutionContext
@@ -89,6 +90,6 @@ export async function runPostTasksExecution(
       `postTasksExecution:end`
     );
   } else {
-    await daemonClient.runPostTasksExecution(context);
+    await daemonClient.runPostTasksExecution(stubTerminalOutputs(context));
   }
 }

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -76,16 +76,6 @@ export function getCache(options: DefaultTasksRunnerOptions): DbCache | Cache {
 }
 
 /**
- * Where a task's terminal output lives on disk, for callers that have a hash but
- * no cache instance. Mirrors the native layout (`get_task_outputs_path_internal`
- * in cache.rs) and the legacy cache's `terminalOutputsDir`; both resolve
- * `<cacheDir>/terminalOutputs/<hash>`.
- */
-export function terminalOutputPathForHash(hash: string): string {
-  return join(cacheDir, 'terminalOutputs', hash);
-}
-
-/**
  * Collects the batch worker logs written by `batchOutputPathForKey`.
  *
  * Guarded rather than called straight through: `cache.rs` is

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.spec.ts
@@ -4,7 +4,7 @@ import type { TaskResult } from '../life-cycle';
 import { TaskStatus } from '../tasks-runner';
 import { SummaryTerminalOutputLifeCycle } from './summary-terminal-output-life-cycle';
 
-vi.mock('../cache', async () => ({
+vi.mock('../terminal-output-path', async () => ({
   terminalOutputPathForHash: (hash: string) => `/cache/terminalOutputs/${hash}`,
 }));
 

--- a/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/summary-terminal-output-life-cycle.ts
@@ -1,6 +1,6 @@
 import { Task } from '../../config/task-graph';
 import { output } from '../../utils/output';
-import { terminalOutputPathForHash } from '../cache';
+import { terminalOutputPathForHash } from '../terminal-output-path';
 import type { LifeCycle, TaskResult } from '../life-cycle';
 
 /**

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -49,6 +49,7 @@ import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { ForkedProcessTaskRunner } from './forked-process-task-runner';
 import { isTuiEnabled } from './is-tui-enabled';
 import { TaskMetadata, TaskResult } from './life-cycle';
+import { terminalOutputPathForHash } from './terminal-output-path';
 import { PseudoTtyProcess } from './pseudo-terminal';
 import { BatchProcess } from './running-tasks/batch-process';
 import { NoopChildProcess } from './running-tasks/noop-child-process';

--- a/packages/nx/src/tasks-runner/terminal-output-path.ts
+++ b/packages/nx/src/tasks-runner/terminal-output-path.ts
@@ -1,0 +1,16 @@
+import { join } from 'path';
+import { cacheDir } from '../utils/cache-directory';
+
+/**
+ * Where a task's terminal output lives on disk, for callers that have a hash but
+ * no cache instance. Mirrors the native layout (`get_task_outputs_path_internal`
+ * in cache.rs) and the legacy cache's `terminalOutputsDir`; both resolve
+ * `<cacheDir>/terminalOutputs/<hash>`.
+ *
+ * Its own module rather than part of `cache.ts` so the graph and plugin paths
+ * can resolve a path without pulling the cache — and the database, cloud and
+ * task-IO modules behind it — into their import graph.
+ */
+export function terminalOutputPathForHash(hash: string): string {
+  return join(cacheDir, 'terminalOutputs', hash);
+}


### PR DESCRIPTION
## Current Behavior

`PostTasksExecutionContext.taskResults` carries every task's full terminal output inline (`TaskResult.terminal_output`, `native/tasks/types.rs`), across two process boundaries rather than one: the daemon send (`daemonClient.runPostTasksExecution`) and the plugin worker send. The daemon is off in CI, which is why only the isolated-plugin boundary was reported.

As reported, a typecheck across 1,376 projects could not serialize that payload at all. `JSON.stringify` threw on V8's maximum string length, and the fallback of the time, `v8.serialize(...).toString('binary')`, threw for the same reason, which is why the symptom was "JSON fails and the V8 fallback also fails" rather than one or the other. The only workaround was `NX_ISOLATE_PLUGINS=false`, which skips serialization by running the plugin in-process.

**That crash is already fixed on master.** #36838 made `serialize` return a `Buffer`, so the fallback is now `v8_serialize(data)` with no `.toString()` and no JS string to overflow. This PR is not what keeps that workspace running any more.

What is left is the cost. The host still builds all 1,376 output strings, v8 still walks and copies every one of them into the buffer, and the whole payload still crosses the socket. Carrying paths removes that work rather than surviving it.

## Expected Behavior

The bytes are already on disk at `<cacheDir>/terminalOutputs/<hash>`, so each transport carries paths and each terminal consumer reads them back before the plugin is invoked:

| Path | Behavior |
| --- | --- |
| No daemon + in-process | Never stubbed, never touches disk |
| No daemon + isolated | Stubbed at the worker send → worker rehydrates |
| Daemon + in-process | Stubbed at the daemon send → `LoadedNxPlugin` rehydrates |
| Daemon + isolated | Stubbed once, re-stub is a no-op → worker rehydrates |

`terminalOutput` is still bytes by the time any plugin sees it, so **the public plugin API is unchanged**. Rehydration lives in `LoadedNxPlugin` and the worker rather than on daemon receipt, so a context bound for an isolated plugin stays stubbed across the second hop instead of being re-inflated in front of another serialize.

Notes on the edges:

- Stubbing is **idempotent**, so the daemon's already-stubbed context can be passed straight to a worker.
- A result is stubbed **only when its file is actually present**. A task that was never hashed, never ran, or produced no output keeps whatever it already carried — nothing is dropped.
- Which ids were stubbed travels **beside** the results, not as a marker inside the string: a task can print anything, including a marker.
- A path that no longer resolves rehydrates to `undefined` with a warning, rather than leaving the path in place for a plugin to mistake for output. `undefined` is already legal — skipped tasks have it.

## The first commit: extracting the path helper

Reviewable on its own, and not cosmetic. `terminalOutputPathForHash` needs only `cacheDir`, but living in `cache.ts` meant importing it dragged in the cache and, behind it, the database, Nx Cloud and task-IO modules.

Pointing the plugin path at `cache.ts` **broke `project-graph-incremental-recomputation.spec.ts`** — a graph-watcher test with no topical relationship to this change. `loaded-nx-plugin.ts` sits deep in graph construction, and the new edge changed module initialization order for everything downstream of it; in CJS a resulting cycle resolves to a partially-initialized export rather than an error, so the symptom was an unrelated value coming back `undefined`.

Moved rather than re-exported, so the edge is severed instead of preserved for existing callers. As a side effect `summary-terminal-output-life-cycle.ts` drops from loading 184 modules to 11, and its spec stops replacing all of `cache.ts` with a single stub.

Net import cost of this PR at every consumer (`loaded-nx-plugin`, `tasks-execution-hooks`, `plugin-worker`, `isolated-plugin`): **+2 modules**, both new files.

## Testing

10 new tests: round-trip fidelity, idempotency, all three no-file fallbacks, missing-file-on-read, mixed stubbed/inline, and that the serialized payload does not contain the output bytes.

**What is not covered:** the crash itself. V8's limit is ~512MB of string, so reproducing it in a unit test is not viable. The tests pin the mechanism — the bytes are absent from the wire — not the ceiling being cleared.

## Related Issue(s)

Fixes NXC-4802.

Stacked on #36703, which guarantees a terminal output file exists to point at.
