### PR TITLE
feat(dotnet): infer OpenApiDocumentsDirectory as a build output

### DIFF
--- a/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
@@ -205,6 +205,164 @@ public class TargetBuilderOutputPathsTests
             targets["build"].Outputs);
     }
 
+    // --- OpenApiDocumentsDirectory: the generated document is a build output --
+
+    [Fact]
+    public void Build_WithoutOpenApiDocumentsDirectory_LeavesOutputsUnchanged()
+    {
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiDocumentsDirectoryInsideProject_EmitsProjectRootRelativeOutput()
+    {
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = "openapi",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiDocumentsDirectoryFromMSBuildProjectDirectory_EmitsProjectRootRelativeOutput()
+    {
+        // The form the ASP.NET Core docs recommend:
+        //   <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/openapi</OpenApiDocumentsDirectory>
+        // MSBuild evaluates this to an absolute path anchored at the project
+        // directory, which must still tokenize as {projectRoot}.
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = Path.Combine(projectDirectory, "openapi"),
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiDocumentsDirectoryOutsideProject_EmitsWorkspaceRootRelativeOutput()
+    {
+        // OpenApiDocumentsDirectory is a plain MSBuild property and can point
+        // anywhere, for example at a shared contracts folder consumed by a
+        // TypeScript codegen target elsewhere in the workspace.
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = Path.Combine(WorkspaceRoot, "contracts", "foo"),
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{workspaceRoot}/contracts/foo" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiDocumentsDirectoryOutsideWorkspace_IsDropped()
+    {
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = Path.Combine(Path.GetTempPath(), "outside-ws", "openapi"),
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiDocumentsDirectoryAtPackageDefault_DoesNotDuplicateObj()
+    {
+        // Microsoft.Extensions.ApiDescription.Server.props defaults the property
+        // to $(BaseIntermediateOutputPath), so merely referencing the package
+        // makes it "set". That must not emit obj a second time.
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = "obj\\",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void BuildRelease_OpenApiDocumentsDirectory_EmitsSameOutputAsBuild()
+    {
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = "openapi",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi" },
+            targets["build:release"].Outputs);
+    }
+
+    [Fact]
+    public void Publish_OpenApiDocumentsDirectory_IsNotAddedToNonBuildTargets()
+    {
+        // Only `build` writes the document; publish/pack/test must be untouched.
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["OpenApiDocumentsDirectory"] = "openapi",
+        };
+
+        var exeTargets = BuildTargets(properties, projectDirectory, projectName: "foo", isExe: true);
+        var libTargets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin/publish", "{projectRoot}/obj" },
+            exeTargets["publish"].Outputs);
+        Assert.Equal(
+            new[] { "{projectRoot}/bin/*.nupkg", "{projectRoot}/obj" },
+            libTargets["pack"].Outputs);
+    }
+
     // --- Publish output: configuration is rewritten to match the target -----
 
     [Fact]

--- a/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
@@ -238,7 +238,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo*.json" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo.json", "{projectRoot}/openapi/foo_*.json" },
             targets["build"].Outputs);
     }
 
@@ -259,7 +259,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo*.json" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo.json", "{projectRoot}/openapi/foo_*.json" },
             targets["build"].Outputs);
     }
 
@@ -280,7 +280,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{workspaceRoot}/contracts/foo/foo*.json" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{workspaceRoot}/contracts/foo/foo.json", "{workspaceRoot}/contracts/foo/foo_*.json" },
             targets["build"].Outputs);
     }
 
@@ -300,7 +300,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/foo*.json" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/foo.json", "{projectRoot}/foo_*.json" },
             targets["build"].Outputs);
     }
 
@@ -318,7 +318,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/foo*.json" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/foo.json", "{projectRoot}/foo_*.json" },
             targets["build"].Outputs);
     }
 
@@ -336,7 +336,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{workspaceRoot}/apps/contracts/foo*.json" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{workspaceRoot}/apps/contracts/foo.json", "{workspaceRoot}/apps/contracts/foo_*.json" },
             targets["build"].Outputs);
     }
 
@@ -393,7 +393,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo*.json" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo.json", "{projectRoot}/openapi/foo_*.json" },
             targets["build:release"].Outputs);
     }
 
@@ -409,6 +409,7 @@ public class TargetBuilderOutputPathsTests
 
         var exeTargets = BuildTargets(properties, projectDirectory, projectName: "foo", isExe: true);
         var libTargets = BuildTargets(properties, projectDirectory, projectName: "foo");
+        var testTargets = BuildTargets(properties, projectDirectory, projectName: "foo", isTest: true);
 
         Assert.Equal(
             new[] { "{projectRoot}/bin/publish", "{projectRoot}/obj" },
@@ -416,6 +417,79 @@ public class TargetBuilderOutputPathsTests
         Assert.Equal(
             new[] { "{projectRoot}/bin/*.nupkg", "{projectRoot}/obj" },
             libTargets["pack"].Outputs);
+        Assert.Equal(
+            new[] { "{projectRoot}/TestResults" },
+            testTargets["test"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiGenerateDocumentsOptionsWithoutFileName_UsesProjectNameStem()
+    {
+        // --openapi-version and --document-name do not change the stem: the
+        // document name is a suffix the glob's `*` already covers.
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = "openapi",
+            ["OpenApiGenerateDocumentsOptions"] = "--openapi-version v3.1 --document-name internal",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo.json", "{projectRoot}/openapi/foo_*.json" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiGenerateDocumentsOptionsFileName_OverridesProjectNameStem()
+    {
+        // --file-name replaces the stem dotnet-getdocument writes under, so the
+        // project-name glob would match nothing.
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = "openapi",
+            ["OpenApiGenerateDocumentsOptions"] = "--file-name PublicApi",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/PublicApi.json", "{projectRoot}/openapi/PublicApi_*.json" },
+            targets["build"].Outputs);
+    }
+
+    [Theory]
+    [InlineData("--file-name PublicApi", "PublicApi")]
+    [InlineData("--file-name=PublicApi", "PublicApi")]
+    [InlineData("--file-name:PublicApi", "PublicApi")]
+    [InlineData("--openapi-version v3.1 --file-name PublicApi", "PublicApi")]
+    [InlineData("--file-name \"PublicApi\"", "PublicApi")]
+    [InlineData("--file-name Public-Api_v2", "Public-Api_v2")]
+    public void Build_OpenApiFileNameOption_IsReadInEverySpelling(string options, string expectedStem)
+    {
+        // The package appends $(OpenApiGenerateDocumentsOptions) to the command
+        // verbatim, and the tool's parser accepts all three separators. It
+        // rejects values outside [A-Za-z0-9_-], so - and _ are the only extras.
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = "openapi",
+            ["OpenApiGenerateDocumentsOptions"] = options,
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", $"{{projectRoot}}/openapi/{expectedStem}.json", $"{{projectRoot}}/openapi/{expectedStem}_*.json" },
+            targets["build"].Outputs);
     }
 
     // --- Publish output: configuration is rewritten to match the target -----

--- a/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
@@ -238,17 +238,16 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo*.json" },
             targets["build"].Outputs);
     }
 
     [Fact]
     public void Build_OpenApiDocumentsDirectoryFromMSBuildProjectDirectory_EmitsProjectRootRelativeOutput()
     {
-        // The form the ASP.NET Core docs recommend:
-        //   <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/openapi</OpenApiDocumentsDirectory>
-        // MSBuild evaluates this to an absolute path anchored at the project
-        // directory, which must still tokenize as {projectRoot}.
+        // <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/openapi</OpenApiDocumentsDirectory>
+        // evaluates to an absolute path anchored at the project directory,
+        // which must still tokenize as {projectRoot}.
         var projectDirectory = ProjectDir("apps", "foo");
         var properties = new Dictionary<string, string>
         {
@@ -260,7 +259,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo*.json" },
             targets["build"].Outputs);
     }
 
@@ -281,7 +280,63 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{workspaceRoot}/contracts/foo" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{workspaceRoot}/contracts/foo/foo*.json" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiDocumentsDirectoryAtProjectRoot_EmitsDocumentGlobNotDirectory()
+    {
+        // The ASP.NET Core docs recommend `.` to emit the document beside the
+        // project file. The whole project directory must not become an output.
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = ".",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/foo*.json" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiDocumentsDirectoryAtAbsoluteProjectRoot_EmitsDocumentGlobNotDirectory()
+    {
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = projectDirectory,
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/foo*.json" },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_OpenApiDocumentsDirectoryRelativeAboveProject_EmitsWorkspaceRootRelativeOutput()
+    {
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["OpenApiDocumentsDirectory"] = "../contracts",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{workspaceRoot}/apps/contracts/foo*.json" },
             targets["build"].Outputs);
     }
 
@@ -338,7 +393,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi" },
+            new[] { "{projectRoot}/bin", "{projectRoot}/obj", "{projectRoot}/openapi/foo*.json" },
             targets["build:release"].Outputs);
     }
 

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -292,7 +292,10 @@ public static class Analyzer
             "PackageOutputPath",
 
             // Test paths
-            "TestResultsDirectory"
+            "TestResultsDirectory",
+
+            // OpenAPI document paths
+            "OpenApiDocumentsDirectory"
         };
 
         foreach (var prop in propertiesToCollect)

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -295,7 +295,8 @@ public static class Analyzer
             "TestResultsDirectory",
 
             // OpenAPI document paths
-            "OpenApiDocumentsDirectory"
+            "OpenApiDocumentsDirectory",
+            "OpenApiGenerateDocumentsOptions"
         };
 
         foreach (var prop in propertiesToCollect)

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
@@ -25,7 +25,9 @@ public static partial class TargetBuilder
     {
         var outputPath = GetOutputPath(properties, projectName, projectDirectory, workspaceRoot);
         var intermediatePath = GetIntermediateOutputPath(properties, projectName, projectDirectory, workspaceRoot);
-        var openApiDocumentsPath = GetOpenApiDocumentsDirectory(properties, projectDirectory, workspaceRoot);
+        // The package defaults OpenApiDocumentsDirectory to $(BaseIntermediateOutputPath),
+        // so merely referencing it lands on obj, which is already an output.
+        var openApiDocumentsOutput = GetOpenApiDocumentsOutput(properties, fileName, projectDirectory, workspaceRoot, outputPath, intermediatePath);
         string[] defaultFlags = ["--no-restore", "--no-dependencies"];
 
         var defaultArgs = defaultConfiguration == "Release"
@@ -62,11 +64,8 @@ public static partial class TargetBuilder
                 new { dependentTasksOutputFiles = "**/*" },
                 .. directoryBuildInputs
             ],
-            // OpenApiDocumentsDirectory defaults to $(BaseIntermediateOutputPath),
-            // so without Distinct a project referencing the package repeats obj.
-            Outputs = new[] { outputPath, intermediatePath, openApiDocumentsPath }
+            Outputs = new[] { outputPath, intermediatePath, openApiDocumentsOutput }
                 .Where(p => p is not null)
-                .Distinct()
                 .ToArray()!,
             Metadata = new TargetMetadata
             {

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
@@ -25,6 +25,7 @@ public static partial class TargetBuilder
     {
         var outputPath = GetOutputPath(properties, projectName, projectDirectory, workspaceRoot);
         var intermediatePath = GetIntermediateOutputPath(properties, projectName, projectDirectory, workspaceRoot);
+        var openApiDocumentsPath = GetOpenApiDocumentsDirectory(properties, projectDirectory, workspaceRoot);
         string[] defaultFlags = ["--no-restore", "--no-dependencies"];
 
         var defaultArgs = defaultConfiguration == "Release"
@@ -61,8 +62,11 @@ public static partial class TargetBuilder
                 new { dependentTasksOutputFiles = "**/*" },
                 .. directoryBuildInputs
             ],
-            Outputs = new[] { outputPath, intermediatePath }
+            // OpenApiDocumentsDirectory defaults to $(BaseIntermediateOutputPath),
+            // so without Distinct a project referencing the package repeats obj.
+            Outputs = new[] { outputPath, intermediatePath, openApiDocumentsPath }
                 .Where(p => p is not null)
+                .Distinct()
                 .ToArray()!,
             Metadata = new TargetMetadata
             {

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
@@ -27,7 +27,7 @@ public static partial class TargetBuilder
         var intermediatePath = GetIntermediateOutputPath(properties, projectName, projectDirectory, workspaceRoot);
         // The package defaults OpenApiDocumentsDirectory to $(BaseIntermediateOutputPath),
         // so merely referencing it lands on obj, which is already an output.
-        var openApiDocumentsOutput = GetOpenApiDocumentsOutput(properties, fileName, projectDirectory, workspaceRoot, outputPath, intermediatePath);
+        var openApiDocumentsOutputs = GetOpenApiDocumentsOutputs(properties, fileName, projectDirectory, workspaceRoot, outputPath, intermediatePath);
         string[] defaultFlags = ["--no-restore", "--no-dependencies"];
 
         var defaultArgs = defaultConfiguration == "Release"
@@ -64,8 +64,9 @@ public static partial class TargetBuilder
                 new { dependentTasksOutputFiles = "**/*" },
                 .. directoryBuildInputs
             ],
-            Outputs = new[] { outputPath, intermediatePath, openApiDocumentsOutput }
+            Outputs = new[] { outputPath, intermediatePath }
                 .Where(p => p is not null)
+                .Concat(openApiDocumentsOutputs)
                 .ToArray()!,
             Metadata = new TargetMetadata
             {

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
@@ -42,10 +42,11 @@ public static partial class TargetBuilder
             return null;
         }
 
+        // Relative paths are project-relative (MSBuild convention). Anchor them
+        // and fall through so `.` and `..` normalize like absolute paths.
         if (!Path.IsPathRooted(path))
         {
-            var normalized = path.Replace('\\', '/').TrimEnd('/');
-            return string.IsNullOrEmpty(normalized) ? "{projectRoot}" : $"{{projectRoot}}/{normalized}";
+            path = Path.Combine(projectDirectory, path.Replace('\\', '/'));
         }
 
         var normalizedPath = Path.GetFullPath(path);
@@ -278,7 +279,7 @@ public static partial class TargetBuilder
 
     /// <summary>
     /// Gets the directory Microsoft.Extensions.ApiDescription.Server writes the
-    /// generated OpenAPI document to, as a fully-qualified Nx-prefixed string.
+    /// generated OpenAPI documents to, as a fully-qualified Nx-prefixed string.
     /// The property may point anywhere, so it resolves under the same rules as
     /// the other outputs. Returns <c>null</c> when the property is unset or the
     /// path lives outside the workspace.
@@ -289,6 +290,30 @@ public static partial class TargetBuilder
         return string.IsNullOrEmpty(openApiDocumentsDirectory)
             ? null
             : ResolvePath(openApiDocumentsDirectory, projectDirectory, workspaceRoot);
+    }
+
+    /// <summary>
+    /// Gets a glob matching the OpenAPI documents dotnet-getdocument writes for
+    /// this project: <c>&lt;MSBuildProjectName&gt;.json</c> plus
+    /// <c>&lt;MSBuildProjectName&gt;_&lt;document&gt;.json</c> per extra document.
+    /// A glob rather than the directory: the directory may be the project root
+    /// (the value the ASP.NET Core docs recommend) or shared with other projects.
+    /// Returns <c>null</c> when the directory is already covered by an output.
+    /// </summary>
+    private static string? GetOpenApiDocumentsOutput(
+        Dictionary<string, string> properties,
+        string fileName,
+        string projectDirectory,
+        string workspaceRoot,
+        params string?[] coveredDirectories)
+    {
+        var directory = GetOpenApiDocumentsDirectory(properties, projectDirectory, workspaceRoot);
+        if (directory is null || coveredDirectories.Contains(directory))
+        {
+            return null;
+        }
+
+        return $"{directory}/{Path.GetFileNameWithoutExtension(fileName)}*.json";
     }
 
     /// <summary>

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using MsbuildAnalyzer.Models;
 
 namespace MsbuildAnalyzer.Utilities;
@@ -293,14 +294,18 @@ public static partial class TargetBuilder
     }
 
     /// <summary>
-    /// Gets a glob matching the OpenAPI documents dotnet-getdocument writes for
-    /// this project: <c>&lt;MSBuildProjectName&gt;.json</c> plus
-    /// <c>&lt;MSBuildProjectName&gt;_&lt;document&gt;.json</c> per extra document.
-    /// A glob rather than the directory: the directory may be the project root
+    /// Gets globs matching the OpenAPI documents dotnet-getdocument writes for
+    /// this project: <c>&lt;stem&gt;.json</c> for the default document and
+    /// <c>&lt;stem&gt;_&lt;document&gt;.json</c> for every other registered one, where
+    /// the stem comes from <see cref="GetOpenApiDocumentFileName"/>.
+    /// Globs rather than the directory: the directory may be the project root
     /// (the value the ASP.NET Core docs recommend) or shared with other projects.
-    /// Returns <c>null</c> when the directory is already covered by an output.
+    /// Two globs rather than <c>&lt;stem&gt;*.json</c>: the latter would also claim
+    /// siblings that merely share the prefix, and a declared output is removed
+    /// and rewritten on cache restore.
+    /// Returns an empty array when the directory is already covered by an output.
     /// </summary>
-    private static string? GetOpenApiDocumentsOutput(
+    private static string[] GetOpenApiDocumentsOutputs(
         Dictionary<string, string> properties,
         string fileName,
         string projectDirectory,
@@ -310,10 +315,45 @@ public static partial class TargetBuilder
         var directory = GetOpenApiDocumentsDirectory(properties, projectDirectory, workspaceRoot);
         if (directory is null || coveredDirectories.Contains(directory))
         {
-            return null;
+            return [];
         }
 
-        return $"{directory}/{Path.GetFileNameWithoutExtension(fileName)}*.json";
+        var stem = GetOpenApiDocumentFileName(properties, fileName);
+        return [$"{directory}/{stem}.json", $"{directory}/{stem}_*.json"];
+    }
+
+    /// <summary>
+    /// Matches the <c>--file-name</c> option inside
+    /// <c>$(OpenApiGenerateDocumentsOptions)</c>, which the package appends to the
+    /// dotnet-getdocument command verbatim. The tool accepts
+    /// <c>--file-name v</c>, <c>--file-name=v</c> and <c>--file-name:v</c>, and
+    /// rejects any value outside <c>[A-Za-z0-9_-]</c>, so the value never has
+    /// spaces to quote around.
+    /// </summary>
+    private static readonly Regex OpenApiFileNameOption = new(
+        @"--file-name[=:\s]\s*""?(?<name>[^\s""]+)""?",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Gets the file name stem dotnet-getdocument writes documents under:
+    /// <c>&lt;stem&gt;.json</c> for the default document and
+    /// <c>&lt;stem&gt;_&lt;document&gt;.json</c> for the rest. The stem is the project
+    /// name unless <c>$(OpenApiGenerateDocumentsOptions)</c> overrides it with
+    /// <c>--file-name</c>.
+    /// </summary>
+    private static string GetOpenApiDocumentFileName(Dictionary<string, string> properties, string fileName)
+    {
+        var options = properties.GetValueOrDefault("OpenApiGenerateDocumentsOptions");
+        if (!string.IsNullOrWhiteSpace(options))
+        {
+            var match = OpenApiFileNameOption.Match(options);
+            if (match.Success)
+            {
+                return match.Groups["name"].Value;
+            }
+        }
+
+        return Path.GetFileNameWithoutExtension(fileName);
     }
 
     /// <summary>

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
@@ -277,6 +277,21 @@ public static partial class TargetBuilder
     }
 
     /// <summary>
+    /// Gets the directory Microsoft.Extensions.ApiDescription.Server writes the
+    /// generated OpenAPI document to, as a fully-qualified Nx-prefixed string.
+    /// The property may point anywhere, so it resolves under the same rules as
+    /// the other outputs. Returns <c>null</c> when the property is unset or the
+    /// path lives outside the workspace.
+    /// </summary>
+    private static string? GetOpenApiDocumentsDirectory(Dictionary<string, string> properties, string projectDirectory, string workspaceRoot)
+    {
+        var openApiDocumentsDirectory = properties.GetValueOrDefault("OpenApiDocumentsDirectory");
+        return string.IsNullOrEmpty(openApiDocumentsDirectory)
+            ? null
+            : ResolvePath(openApiDocumentsDirectory, projectDirectory, workspaceRoot);
+    }
+
+    /// <summary>
     /// Gets the test results directory path, as a fully-qualified Nx-prefixed
     /// string. Returns <c>null</c> when the path lives outside the workspace.
     /// </summary>


### PR DESCRIPTION
## Current Behavior

`Microsoft.Extensions.ApiDescription.Server` writes an OpenAPI document at build time to whatever `<OpenApiDocumentsDirectory>` points at:

```xml
<OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/openapi</OpenApiDocumentsDirectory>
```

`@nx/dotnet` does not know those documents are build outputs, so they are neither cached nor restored. Anything consuming them — an OpenAPI-to-TypeScript codegen target, for example — misses on a fresh clone or a CI agent, because the `build` task can replay from cache without the document ever landing on disk.

The workaround today is hand-wiring the path into the plugin options in `nx.json`, which every consumer has to discover and repeat:

```json
{ "plugin": "@nx/dotnet", "options": { "build": { "outputs": ["...", "{projectRoot}/openapi"] } } }
```

## Expected Behavior

The MSBuild analyzer infers the documents and declares them as `build` outputs, so they are cached and restored like `bin` and `obj`. The manual `outputs` override is no longer necessary.

For a project `MyApi.csproj` with the directory above, `build` gains:

```
{projectRoot}/openapi/MyApi.json
{projectRoot}/openapi/MyApi_*.json
```

Only `build` and `build:release` gain them — `build` is what writes the documents. `restore`, `test`, `publish`, `pack`, `clean`, `watch` and `run` are unchanged.

### Why globs rather than the directory

`OpenApiDocumentsDirectory` is a plain MSBuild property that can point anywhere, including at the project directory itself — `.` is what the ASP.NET Core docs suggest when you commit the document. Declaring a directory Nx does not own is not safe: a declared output is removed and rewritten on cache restore, so a bare `{projectRoot}` output would delete every file in the project that the cached artifact does not carry. Files that are not build inputs never affect the hash, so nothing prevents that cache hit — `.user` files, developer certificates and local `appsettings.*.local.json` would go with it. The same argument applies to a `contracts/` directory shared by two projects.

Globbing the documents avoids all of it while still caching the real artifacts.

### Why two globs rather than `<stem>*.json`

A prefix wildcard would also claim siblings that merely share the prefix, such as a `MyApi.config.json` sitting in a directory the project does not exclusively own — and, per the above, claiming a file means removing and rewriting it on restore. `<stem>.json` plus `<stem>_*.json` is exactly the set `dotnet-getdocument` writes: the default document (`v1`) under the bare stem, and every other registered document suffixed with its own name.

### Resolving the stem

The stem is `MSBuildProjectName`, unless `$(OpenApiGenerateDocumentsOptions)` overrides it with `--file-name`, which the package appends to the `dotnet-getdocument` command verbatim. Both are handled. Of the tool's other options, `--openapi-version` changes only content and `--document-name` only produces the `_<name>` suffix the second glob already covers.

The property is also rarely truly absent — `Microsoft.Extensions.ApiDescription.Server.props` defaults it to `$(BaseIntermediateOutputPath)`, so merely referencing the package reports it as set, to `obj/`. That case is skipped, since `obj` is already an output. A project that does not configure the property sees no change to its outputs.

Paths are resolved with the same `ResolvePath` rules as the other outputs — `{projectRoot}/…` inside the project, `{workspaceRoot}/…` elsewhere in the workspace, dropped when they escape it. That helper now also anchors relative paths at the project directory before normalizing, so `../shared` resolves and escapes are dropped rather than emitted verbatim.

## Verification

- `dotnet test` on `analyzer.Tests` — 48 passing, covering: property unset, set inside the project, the `$(MSBuildProjectDirectory)/openapi` form, set outside the project, outside the workspace, at the package default, `.`, the absolute project directory, a relative path above the project, `--file-name` in each accepted spelling, `build:release`, and absence from `publish`/`pack`/`test`.
- `nx test dotnet` — 34 passing.
- `nx run dotnet:format-native` and `nx lint dotnet` — clean.

The filename convention was confirmed against a real build rather than inferred. Building a `MyApi.csproj` carrying `<AssemblyName>Totally.Different.Name</AssemblyName>` produced `bin/Debug/net9.0/Totally.Different.Name.dll` alongside `openapi/MyApi.json`, establishing that the stem follows `MSBuildProjectName` and not `AssemblyName`. `obj/MyApi.OpenApiFiles.cache`, which the tool writes with the absolute path of every document it produced, agrees. A two-document project produced `MyApi.json` and `MyApi_internal.json`, matching the two globs.

No change was needed in `packages/dotnet/src/plugins/create-nodes.ts`. The TS side receives finished `ProjectConfiguration` objects from the analyzer and `mergeUserTargetConfigurations` only layers user-supplied overrides on top — it has no `outputs` logic of its own.

## Related Issue(s)

No filed issue; reported directly.
