### PR TITLE
fix(js): keep the deprecated-prepend warning in the task's terminal output

### DIFF
--- a/packages/js/src/executors/tsc/lib/typescript-compilation.ts
+++ b/packages/js/src/executors/tsc/lib/typescript-compilation.ts
@@ -323,7 +323,8 @@ function compileTSWithWatch(
         logger.warn(
           `The project ${projectName} ` +
             `is using the deprecated "prepend" Typescript compiler option. ` +
-            `This option is not supported by the batch executor and it's ignored.`
+            `This option is not supported by the batch executor and it's ignored.`,
+          (project as any).project
         );
         continue;
       }


### PR DESCRIPTION
## Current Behavior

`typescript-compilation.ts:323` calls `logger.warn(...)` without the `tsConfig` second argument. The batch logger in `tsc.batch-impl.ts` writes to stdio unconditionally, but appends to a task's `terminalOutput` only when given a tsConfig:

```ts
warn: (message, tsConfig) => {
  process.stdout.write(message);
  if (tsConfig) {
    tsConfigTaskInfoMap[tsConfig].terminalOutput += message;
  }
},
```

So the deprecated-`prepend` warning reaches the terminal but never reaches the task's `terminalOutput` — and therefore never reaches the cache, Nx Cloud, or a replayed cache hit. A user who sees the warning once loses it on every subsequent cached run.

## Expected Behavior

The warning is part of the task's terminal output, like every other message the batch executor emits.

This reads as an oversight rather than a decision: the **identical warning text** at `:167` does pass `(project as any).project`, and `:323` was the only one of the twelve `logger.*` calls in the file omitting it.

The cast matches `:167` and is required — the `project.kind` check directly above narrows `project` to `never`, so `project.project` does not compile without it.

## Related Issue(s)

Fixes NXC-4853.

Surfaced while reviewing #36453, whose `shouldGroupBatchOutput` JSDoc asserted that a batch worker "reports the same text back as each task's `terminalOutput`". This is one of the counter-examples — the smallest one; `@nx/maven` (NXC-4852) and `@nx/gradle` (NXC-4812) are the substantive cases.