### PR TITLE
fix(maven): stop writing a failing task's output three times

### DIFF
--- a/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/NxMavenBatchRunner.kt
+++ b/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/NxMavenBatchRunner.kt
@@ -100,14 +100,11 @@ private fun printFailedTasks(results: Map<String, TaskResult>) {
     log.info("═".repeat(80))
     log.info("❌ FAILED TASKS")
     log.info("═".repeat(80))
-    failedResults.forEach { (taskId, result) ->
-        log.info("")
-        log.info("Task: $taskId")
-        log.info("-".repeat(40))
-        if (result.terminalOutput.isNotBlank()) {
-            log.info(result.terminalOutput)
-        }
-    }
+    // Ids only. Nx renders each failed task's output in its own block, so
+    // repeating the bodies here is a third copy of what the tee already
+    // streamed; the recap earns its place by naming what failed, which is
+    // otherwise hard to pick out of interleaved parallel output.
+    failedResults.keys.forEach { taskId -> log.info(taskId) }
     log.info("═".repeat(80))
     log.info("")
 }

--- a/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/runner/MavenInvokerRunner.kt
+++ b/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/runner/MavenInvokerRunner.kt
@@ -247,11 +247,10 @@ class MavenInvokerRunner(private val workspaceRoot: File, private val options: M
           log.debug("Maven output for task $taskId:\n$outputText")
         }
       } else {
-        // Log at ERROR level when task fails so user can see what went wrong
+        // Only the outcome: the output itself already reached stdout through the
+        // tee as Maven produced it, and Nx renders it again from terminalOutput.
         log.error("Task $taskId FAILED with exit code: $exitCode (${duration}ms)")
-        if (outputText.isNotEmpty()) {
-          log.error("Maven output for failed task $taskId:\n$outputText")
-        } else {
+        if (outputText.isEmpty()) {
           log.error("Task $taskId had no output from Maven")
         }
       }


### PR DESCRIPTION
## Current Behavior

A failing `@nx/maven` task's output lands in the captured batch log **three times**:

1. **Live tee** — `ResidentMavenExecutor.execute` wraps Maven's streams in `TeeOutputStream`, whose second parameter defaults to `System.out`, so every byte goes to the worker's stdout as produced *and* into the capture buffer.
2. **`MavenInvokerRunner`, on failure** — `log.error("Maven output for failed task $taskId:\n$outputText")` dumps that same buffer again.
3. **`printFailedTasks`** — the `❌ FAILED TASKS` recap prints `result.terminalOutput` per failed task, which is that same `outputText`.

`BatchProcess` captures the worker's stdout and stderr into one file, so all three land in the same fold regardless of stream.

This was always true, but #36453 renders that log as a `::group::` fold in CI, so the duplication is now visible rather than buried in a stream.

## Expected Behavior

**Copy 2 is gone.** It added a header and nothing else. The `Task $taskId FAILED with exit code: N` line stays — that's the outcome, not a duplicate — as does the `had no output from Maven` branch, which is real information.

**Copy 3 is reduced to ids.** Nx now renders each failed task's output in its own block, so printing the bodies here is the plugin re-implementing the caller. The recap still earns its place by naming *which* tasks failed, which is genuinely hard to pick out of interleaved parallel output — it just no longer repeats the bodies.

**The live tee is untouched**, so the build log still streams as Maven produces it.

The result: the fold shrinks to roughly the live build log, and the only duplication left is the intended one from #36453's print-both behavior (a failing task's body in the fold and in its own block).

## Testing

`./mvnw clean compile -am -pl dev.nx.maven:maven-batch-runner` — compiles clean. There is no `src/test` in this module, so there are no unit tests to extend.

**Worth flagging for whoever validates this:** the batch runner is a JAR, a different artifact from anything in the TypeScript packages. It needs a rebuild and republish to be exercised, and silently tests stale if that step is missed.

## Related Issue(s)

Fixes NXC-4852.