### PR TITLE
chore(repo): dump surviving task processes when an e2e command times out

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -539,6 +539,7 @@ export function runLernaCLI(
       cwd: opts.cwd || tmpProjPath(),
       env: {
         CI: 'true',
+        ...timeoutDiagnosticsEnv(),
         ...(opts.env || getStrippedEnvironmentVariables()),
       },
       encoding: 'utf-8',
@@ -563,7 +564,9 @@ export function runLernaCLI(
       const processOutput = stripVTControlCharacters(
         `${e.stdout ?? ''}\n\n${e.stderr ?? ''}`
       ).trim();
-      const msg = `Command timed out after ${timeoutSec}s: ${command}\n\nProcess output:\n${processOutput}`;
+      const msg = `Command timed out after ${timeoutSec}s: ${command}\n\nProcess output:\n${processOutput}${collectTimeoutDiagnostics(
+        opts.cwd || tmpProjPath()
+      )}`;
       logError(`Command timed out`, msg);
       throw new Error(msg);
     }

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -26,6 +26,10 @@ import {
   isVerboseE2ERun,
 } from './get-env-info';
 import { logError, logInfo } from './log-utils';
+import {
+  collectTimeoutDiagnostics,
+  timeoutDiagnosticsEnv,
+} from './timeout-diagnostics';
 
 export interface RunCmdOpts {
   silenceError?: boolean;
@@ -472,6 +476,7 @@ export function runCLI(
         // Use new versioning by default in e2e tests
         NX_INTERNAL_USE_LEGACY_VERSIONING: 'false',
         ...getStrippedEnvironmentVariables(),
+        ...timeoutDiagnosticsEnv(),
         ...opts.env,
       },
       encoding: 'utf-8',
@@ -500,7 +505,9 @@ export function runCLI(
       const processOutput = stripVTControlCharacters(
         `${e.stdout ?? ''}\n\n${e.stderr ?? ''}`
       ).trim();
-      const msg = `Command timed out after ${timeoutSec}s: ${command}\n\nProcess output:\n${processOutput}`;
+      const msg = `Command timed out after ${timeoutSec}s: ${command}\n\nProcess output:\n${processOutput}${collectTimeoutDiagnostics(
+        opts.cwd || tmpProjPath()
+      )}`;
       logError(`Command timed out`, msg);
       throw new Error(msg);
     }

--- a/e2e/utils/dump-handles.js
+++ b/e2e/utils/dump-handles.js
@@ -1,0 +1,37 @@
+// Preloaded into every node process an e2e command spawns (NODE_OPTIONS
+// --require, see timeout-diagnostics.ts). On SIGUSR2 it writes whatever keeps
+// this process's event loop alive to $NX_E2E_HANDLE_DUMP_DIR/<pid>.txt, so a
+// task child that finished its work but never exited can name its culprit.
+// Writes to a file, not stdio: by the time it is signalled the parent's pipe
+// is usually gone.
+const { writeFileSync } = require('fs');
+const { join } = require('path');
+const { inspect } = require('util');
+
+const dir = process.env.NX_E2E_HANDLE_DUMP_DIR;
+if (dir) {
+  process.on('SIGUSR2', () => {
+    const counts = {};
+    for (const type of process.getActiveResourcesInfo()) {
+      counts[type] = (counts[type] ?? 0) + 1;
+    }
+    const lines = [
+      `pid=${process.pid} argv=${process.argv.join(' ')}`,
+      `cwd=${process.cwd()}`,
+      `active resources: ${inspect(counts)}`,
+      'active handles:',
+      ...process
+        ._getActiveHandles()
+        .map((h) => '  ' + inspect(h, { depth: 1, breakLength: 200 })),
+      'active requests:',
+      ...process
+        ._getActiveRequests()
+        .map((r) => '  ' + inspect(r, { depth: 1, breakLength: 200 })),
+    ];
+    try {
+      writeFileSync(join(dir, `${process.pid}.txt`), lines.join('\n') + '\n');
+    } catch {
+      // nothing left to report to; the parent reads the file or nothing.
+    }
+  });
+}

--- a/e2e/utils/timeout-diagnostics.ts
+++ b/e2e/utils/timeout-diagnostics.ts
@@ -1,0 +1,141 @@
+import { execSync } from 'child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * Diagnostics for the `Command timed out after 300s` flake: an nx command whose
+ * tasks all printed their final output, yet a task child (observed: `rollup -c`)
+ * never exits, so the client waits until the harness kills it.
+ *
+ * Every node process the command spawns preloads dump-handles.js. On timeout,
+ * {@link collectTimeoutDiagnostics} finds the survivors by cwd, asks each to
+ * dump its live handles, and reports them next to `/proc` state — then kills
+ * them so they cannot outlive the test.
+ */
+
+const dumpDir = join(tmpdir(), 'nx-e2e-handle-dumps');
+
+/** Env that makes {@link collectTimeoutDiagnostics} able to read a survivor. */
+export function timeoutDiagnosticsEnv(): Record<string, string> {
+  mkdirSync(dumpDir, { recursive: true });
+  const preload = `--require ${join(__dirname, 'dump-handles.js')}`;
+  return {
+    NODE_OPTIONS: [process.env.NODE_OPTIONS, preload].filter(Boolean).join(' '),
+    NX_E2E_HANDLE_DUMP_DIR: dumpDir,
+  };
+}
+
+/**
+ * Returns a report on every process still running with a cwd under
+ * `projectPath`, or '' when there is nothing to report (or not on Linux, where
+ * `/proc` is what makes cwd-based discovery possible).
+ */
+export function collectTimeoutDiagnostics(projectPath: string): string {
+  if (process.platform !== 'linux') return '';
+
+  const survivors = findProcessesUnder(projectPath);
+  if (survivors.length === 0) {
+    return '\n\nNo surviving processes with a cwd under the e2e project.';
+  }
+
+  for (const pid of survivors) {
+    try {
+      process.kill(pid, 'SIGUSR2');
+    } catch {
+      // already gone
+    }
+  }
+  // Give the preload a moment to write; the handler is synchronous once scheduled.
+  execSync('sleep 2');
+
+  const sections = survivors.map((pid) => {
+    const parts = [`--- pid ${pid}: ${ps(pid)}`];
+    parts.push(`state: ${procField(pid, 'status', 'State')}`);
+    parts.push(`wchan: ${readProc(pid, 'wchan')}`);
+    parts.push(`fds:\n${listFds(pid)}`);
+    const dump = join(dumpDir, `${pid}.txt`);
+    parts.push(
+      existsSync(dump)
+        ? readFileSync(dump, 'utf-8')
+        : 'no handle dump (not a node process, or exited before SIGUSR2)'
+    );
+    return parts.join('\n');
+  });
+
+  for (const pid of survivors) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // already gone
+    }
+  }
+
+  return `\n\nSurviving processes under ${projectPath}:\n${sections.join(
+    '\n'
+  )}`;
+}
+
+function findProcessesUnder(projectPath: string): number[] {
+  const pids: number[] = [];
+  for (const entry of readdirSync('/proc')) {
+    if (!/^\d+$/.test(entry)) continue;
+    const pid = Number(entry);
+    if (pid === process.pid) continue;
+    try {
+      if (readlinkSync(`/proc/${pid}/cwd`).startsWith(projectPath)) {
+        pids.push(pid);
+      }
+    } catch {
+      // exited, or not ours to read
+    }
+  }
+  return pids;
+}
+
+function ps(pid: number): string {
+  try {
+    return execSync(`ps -o pid=,ppid=,etime=,args= -p ${pid}`, {
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    return '(exited)';
+  }
+}
+
+function readProc(pid: number, file: string): string {
+  try {
+    return readFileSync(`/proc/${pid}/${file}`, 'utf-8').trim();
+  } catch {
+    return '?';
+  }
+}
+
+function procField(pid: number, file: string, field: string): string {
+  const line = readProc(pid, file)
+    .split('\n')
+    .find((l) => l.startsWith(`${field}:`));
+  return line ? line.slice(field.length + 1).trim() : '?';
+}
+
+function listFds(pid: number): string {
+  try {
+    return readdirSync(`/proc/${pid}/fd`)
+      .map((fd) => {
+        try {
+          return `  ${fd} -> ${readlinkSync(`/proc/${pid}/fd/${fd}`)}`;
+        } catch {
+          return `  ${fd} -> ?`;
+        }
+      })
+      .join('\n');
+  } catch {
+    return '  ?';
+  }
+}

--- a/e2e/utils/timeout-diagnostics.ts
+++ b/e2e/utils/timeout-diagnostics.ts
@@ -20,7 +20,9 @@ import { join } from 'path';
  * them so they cannot outlive the test.
  */
 
-const dumpDir = join(tmpdir(), 'nx-e2e-handle-dumps');
+// Per test-runner process: pids get reused across runs, so a shared dir could
+// surface a stale dump from an earlier run as this run's survivor.
+const dumpDir = join(tmpdir(), 'nx-e2e-handle-dumps', String(process.pid));
 
 /** Env that makes {@link collectTimeoutDiagnostics} able to read a survivor. */
 export function timeoutDiagnosticsEnv(): Record<string, string> {


### PR DESCRIPTION
## Current Behavior

An intermittent CI flake (~4% of master runs, always a rollup build in `e2e-react` / `e2e-next` / `e2e-remix`) fails as:

```
Command timed out after 300s: build childlib0253369
```

with every task having already printed its final output (`created …/dist in 4.7s`). An earlier CI dump established that the `rollup -c rollup.config.cjs` child process is still alive minutes after finishing its work, while nx's own post-task daemon round-trip completed in milliseconds. Rollup's CLI does not call `process.exit`, so a single ref'd Node handle left open hangs it — but the timeout error today carries nothing that says *which* handle, so every occurrence is a re-run and the cause stays unknown.

## Expected Behavior

When `runCLI` times out, the error message also reports every process still running with a cwd under the e2e project, and — for node processes — the handles keeping their event loop alive:

- `e2e/utils/dump-handles.js` is preloaded into every node process an e2e command spawns (`NODE_OPTIONS=--require`). On `SIGUSR2` it writes `process.getActiveResourcesInfo()` plus the inspected `_getActiveHandles()` / `_getActiveRequests()` to `$NX_E2E_HANDLE_DUMP_DIR/<pid>.txt`. It does nothing unless signalled.
- `e2e/utils/timeout-diagnostics.ts` finds survivors by `/proc/<pid>/cwd` (Linux only, where CI runs), signals them, waits 2s, and appends `ps` line, `/proc` state, `wchan`, open fds, and the handle dump to the timeout message — then `SIGKILL`s them so they cannot outlive the test.

Verified locally against a fake hung child (`fs.watch` + `setInterval`): the report shows `active resources: { FSEventWrap: 1, Timeout: 1 }` and the `FSWatcher`, and the child is gone afterwards. `tsc` on `e2e/utils` is clean.

The next real occurrence on CI should name the culprit directly; the fix then goes at the source (`@nx/rollup` `with-nx`, `@rollup/plugin-typescript`, or the native addon).

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/e2e-timeout-flake-dump-surviving-task-processes-a8ed6fa1">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->