### PR TITLE
chore(repo): bump the tar override to ^7.5.22

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,7 +364,7 @@ overrides:
   hasown: 2.0.4
   '@xhmikosr/decompress': 10.2.1
   websocket-driver: ^0.7.5
-  tar: ^7.5.19
+  tar: ^7.5.22
   seroval: ^1.5.6
   sharp@<0.35.0: ^0.35.3
   path-to-regexp@<0.1.13: ^0.1.13
@@ -25071,8 +25071,8 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.20:
-    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   tcp-port-used@1.0.2:
@@ -33069,7 +33069,7 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 8.1.0
       semver: 7.8.5
-      tar: 7.5.20
+      tar: 7.5.22
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -39247,7 +39247,7 @@ snapshots:
   '@tailwindcss/oxide@4.1.11':
     dependencies:
       detect-libc: 2.1.2
-      tar: 7.5.20
+      tar: 7.5.22
     optionalDependencies:
       '@tailwindcss/oxide-android-arm64': 4.1.11
       '@tailwindcss/oxide-darwin-arm64': 4.1.11
@@ -42458,7 +42458,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 4.0.0
       ssri: 10.0.6
-      tar: 7.5.20
+      tar: 7.5.22
       unique-filename: 3.0.0
 
   cacheable-lookup@6.1.0: {}
@@ -55323,7 +55323,7 @@ snapshots:
       fast-fifo: 1.3.2
       streamx: 2.22.1
 
-  tar@7.5.20:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ overrides:
   hasown: '2.0.4'
   '@xhmikosr/decompress': '10.2.1'
   websocket-driver: '^0.7.5'
-  tar: '^7.5.19'
+  tar: '^7.5.22'
   seroval: '^1.5.6'
   # astro/ipx/next pull their own sharp; the libvips CVEs (GHSA-f88m-g3jw-g9cj)
   # are only patched from 0.35.0 on.


### PR DESCRIPTION
## Current Behavior

The `tar` override in `pnpm-workspace.yaml` is pinned `^7.5.19` and resolves `7.5.20`, which is vulnerable to GHSA-r292-9mhp-454m (HIGH, CVSS 7.5) - uncontrolled recursion in `mapHas`/`filesFilter` allows an uncatchable stack-overflow DoS from a crafted tar. Reached via `@tailwindcss/oxide@4.1.11`, `@mapbox/node-pre-gyp@2.0.0` and `cacache@17.1.4`.

## Expected Behavior

Override bumped to `^7.5.22`; all four consumer edges resolve `7.5.22`. The advisory patches at `7.5.21`. The bare override form is kept deliberately - every `tar` edge in the tree is on the 7.x line, so there is no version range that needs to stay put and no scoped selector is warranted.

No shipped version constants change: nothing under `packages/` declares `tar` in a manifest, a `versions.ts`, or a `packageJsonUpdates` gate. Lockfile only.

**Note on the lockfile edit.** The change to `pnpm-lock.yaml` was made surgically (two snapshot keys, one integrity hash, four dependency edges, zero residual `7.5.20` references) rather than by regenerating. A full `pnpm install --lockfile-only` currently churns ~7400 lines in this repo and carries unrelated version movement - `@remix-run/react` and `@remix-run/server-runtime` 2.16.8 -> 2.17.5, `react-router`/`react-router-dom` 6.30.0 -> 6.30.4, plus newly added optional and platform packages. That churn is not caused by this bump: pinning the override to `7.5.20`, the version already resolved, produces the same ~7400-line diff. The committed lockfile has gone stale since the last dependency PR touched this block, and that is worth its own change rather than riding along on a security fix.

Verified with `CI=true pnpm install --frozen-lockfile` (passes, lockfile not rewritten) and `pnpm audit` filtered to the target advisory (absent).

## Related Issue(s)

NXC-4881

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/triage-cves-4bcb700b">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->