### PR TITLE
docs(misc): stop recommending deprecated module federation generators

### DIFF
--- a/astro-docs/src/content/docs/kb/webpack-config-setup.mdoc
+++ b/astro-docs/src/content/docs/kb/webpack-config-setup.mdoc
@@ -228,7 +228,9 @@ module.exports = composePlugins(
 ```
 
 {% aside type="note" title="Install @nx/module-federation" %}
-The `withModuleFederation` plugins live in the `@nx/module-federation` package. Install it with your package manager, or use the Nx Module Federation generators (such as `@nx/angular:host`, `@nx/angular:remote`, `@nx/react:host`, or `@nx/react:remote`), which add the dependency for you.
+The `withModuleFederation` plugins live in the `@nx/module-federation` package. Install it with your package manager.
+
+The `host` and `remote` generators that previously added it are deprecated as of Nx v23. Start new React micro frontends with the [`@nx/react:consumer` and `@nx/react:provider`](/docs/kb/consumer-and-provider) generators, which configure the official Module Federation bundler plugins instead of these webpack plugins. For Angular micro frontends, use [`@angular-architects/native-federation`](https://www.npmjs.com/package/@angular-architects/native-federation), covered in [Micro Frontends with Angular](/docs/kb/angular-micro-frontends).
 {% /aside %}
 
 Reference the [Webpack documentation](https://webpack.js.org/configuration/) for details on the structure of the Webpack

--- a/astro-docs/src/content/docs/kb/webpack-plugins.mdoc
+++ b/astro-docs/src/content/docs/kb/webpack-plugins.mdoc
@@ -567,7 +567,9 @@ For more information, refer to
 the [Module Federation recipe](/docs/kb/faster-builds-with-module-federation).
 
 {% aside type="note" title="Install @nx/module-federation" %}
-These plugins live in the `@nx/module-federation` package. Install it with your package manager, or use the Nx Module Federation generators (such as `@nx/angular:host`, `@nx/angular:remote`, `@nx/react:host`, or `@nx/react:remote`), which add the dependency for you.
+These plugins live in the `@nx/module-federation` package. Install it with your package manager.
+
+As of Nx v23, the `host` and `remote` generators that previously added it are deprecated. New React micro frontends use the [`@nx/react:consumer` and `@nx/react:provider`](/docs/kb/consumer-and-provider) generators, which wire up the official Module Federation bundler plugins rather than these webpack plugins. For Angular micro frontends, use [`@angular-architects/native-federation`](https://www.npmjs.com/package/@angular-architects/native-federation). See [Micro Frontends with Angular](/docs/kb/angular-micro-frontends) for the setup path.
 {% /aside %}
 
 #### Options


### PR DESCRIPTION
## Current Behavior

`kb/webpack-plugins.mdoc` and `kb/webpack-config-setup.mdoc` both tell readers to install `@nx/module-federation` by running `@nx/angular:host`, `@nx/angular:remote`, `@nx/react:host`, or `@nx/react:remote`. All four carry `x-deprecated` and are removed in Nx v24. Two other pages already say so, so the doc set contradicts itself.

## Expected Behavior

Install instruction stands on its own. Deprecated generators are no longer presented as the live path. React points at `@nx/react:consumer` / `@nx/react:provider`, Angular at `@angular-architects/native-federation`, matching `technologies/angular/introduction.mdoc` and `kb/react-micro-frontends.mdoc`.

Note the replacement generators do not install `@nx/module-federation` at all - they wire the official MF bundler plugins (`packages/react/src/generators/_utils/mf-dependencies.ts`). So the sentence was split rather than word-swapped.

Scope is one file wider than the ticket: `kb/webpack-config-setup.mdoc:231` carried the identical sentence.

Follow-up, not in this PR: `kb/faster-builds-with-module-federation.mdoc:114,121` still teaches `nx g @nx/react:host` / `@nx/angular:host` as the primary instruction, and both asides fixed here link to it. That is a page rewrite, not a one-sentence fix.

## Related Issue(s)

DOC-650


## Preview

- [Webpack plugins](https://deploy-preview-36796--nx-docs.netlify.app/docs/kb/webpack-plugins) (the `Install @nx/module-federation` aside)
- [Webpack config setup](https://deploy-preview-36796--nx-docs.netlify.app/docs/kb/webpack-config-setup) (same aside, second occurrence found during the fix)
