### PR TITLE
docs(misc): link conformance reference to the feature overview

### DIFF
--- a/astro-docs/src/content/docs/reference/Conformance/index.mdoc
+++ b/astro-docs/src/content/docs/reference/Conformance/index.mdoc
@@ -6,4 +6,6 @@ description: Code conformance and standards
 pagefind: false
 ---
 
+For setup and guides, see [Run Language-Agnostic Conformance Rules](/docs/enterprise/conformance). The pages below are the API reference.
+
 {% index_page_cards path="reference/conformance" /%}

--- a/astro-docs/src/content/docs/reference/Conformance/overview.mdoc
+++ b/astro-docs/src/content/docs/reference/Conformance/overview.mdoc
@@ -11,6 +11,8 @@ The `@nx/conformance` plugin allows [Nx Enterprise](https://nx.dev/enterprise) u
 
 The conformance plugin allows you to encode your own organization's standards so that they can be enforced automatically. Conformance rules can also complement linting tools by enforcing that those tools are configured in the recommended way. The rules are written in TypeScript but can be applied to any language in the codebase or focus entirely on configuration files.
 
+For setup and guides, see [Run Language-Agnostic Conformance Rules](/docs/enterprise/conformance).
+
 The plugin also provides the following pre-written rules:
 
 - [**Enforce Project Boundaries**](#enforce-project-boundaries): Similar to the Nx [ESLint Enforce Module Boundaries rule](/docs/features/enforce-module-boundaries), but enforces the boundaries on every project dependency, not just those created from TypeScript imports or `package.json` dependencies.


### PR DESCRIPTION
## Current Behavior

Searching "nx conformance" lands readers on the Conformance reference pages, which never link to the page explaining why and how to use Conformance. Reported by a customer whose new dev could not find it.

## Expected Behavior

Both reference entry points point at [Run Language-Agnostic Conformance Rules](/docs/enterprise/conformance), using the same pointer pattern as the other 20 reference index pages.

Two premise corrections from the ticket:

- "Orphaned from the sidebar" is half right. The five child pages are in `sidebar.mts:370-393` under `Conformance reference`, but the index page itself is `sidebar.hidden: true` and not linked there, so landing on `/docs/reference/conformance` does show a sidebar without the current page. `reference/playwright/index.mdoc` - the page cited as the model - is identical, so this is the site-wide pattern for reference index pages rather than a Conformance defect. Sidebar untouched.
- Applying the Playwright pattern to `index.mdoc` alone would not have fixed the report. That page is `pagefind: false`, so it never appears in search. `overview.mdoc` is the page that ranks and the one the reporter named, so it gets the pointer too.

## Related Issue(s)

DOC-648


## Preview

- [Conformance reference overview](https://deploy-preview-36797--nx-docs.netlify.app/docs/reference/conformance/overview) - the page that ranks in search, and the fix that addresses the report
- [Conformance reference index](https://deploy-preview-36797--nx-docs.netlify.app/docs/reference/conformance) (consistency with the other 20 reference index pages)

