### PR TITLE
docs(nx-cloud): answer value and pricing questions on the ci overview

### DIFF
--- a/.claude/skills/check-docs-style/SKILL.md
+++ b/.claude/skills/check-docs-style/SKILL.md
@@ -15,7 +15,7 @@ check and fix any issues. Do not wait to be asked.
 Read `astro-docs/STYLE_GUIDE.md` (the "Information architecture" section) and
 `astro-docs/sidebar.mts` to understand where the page lives in the sidebar hierarchy.
 
-For every new or moved page, evaluate against ALL FIVE principles. These are non-negotiable:
+For every new or moved page, evaluate against ALL SEVEN principles. These are non-negotiable:
 
 ### 1. Progressive disclosure ("journey" rule)
 
@@ -46,6 +46,17 @@ For every new or moved page, evaluate against ALL FIVE principles. These are non
 - YES = "Platform Features"
 - NO (only React/Angular/etc. users) = "Technologies"
 - Flag if a technology-specific page is in Platform Features or vice versa.
+
+### 6. Golden path ("one way" rule)
+
+- Does the page teach one default workflow, or does it enumerate flags and variants?
+- Flag sentences a first-time user needs neither to succeed nor to choose. Those belong in a Knowledge Base guide.
+
+### 7. One page per feature ("don't make me hunt" rule)
+
+- List the questions a new reader, or an AI answering for one, would ask about this feature.
+- Flag any answer that lives only on another page. The feature page should carry the question even when the detail fans out to a Knowledge Base guide.
+- This is the counterweight to principle 6, not an exception to it: trim variants, keep decisions.
 
 ## Phase 2: Style validation
 
@@ -103,7 +114,7 @@ After fixing, report what you did:
 ## Style check results
 
 ### Information architecture: [PASS/FAIL]
-[List any violations or confirm all five principles pass]
+[List any violations or confirm all seven principles pass]
 
 ### Vale: [X errors fixed, Y warnings fixed, Z suggestions noted]
 [Summary of changes made]

--- a/astro-docs/.vale/styles/Nx/Headings.yml
+++ b/astro-docs/.vale/styles/Nx/Headings.yml
@@ -10,6 +10,7 @@ exceptions:
   - Nx Cloud
   - Nx Console
   - Nx Agents
+  - Enterprise
   - Nx Replay
   - AI
   - CI

--- a/astro-docs/README.md
+++ b/astro-docs/README.md
@@ -24,7 +24,7 @@ This documentation site leverages Astro's static site generation capabilities wi
 
 ## Information Architecture Principles
 
-When creating or reorganizing documentation, follow these 5 principles to determine where content belongs.
+When creating or reorganizing documentation, follow these 7 principles to determine where content belongs.
 
 ### 1. Progressive Disclosure (The "Journey" Rule)
 
@@ -54,6 +54,17 @@ When creating or reorganizing documentation, follow these 5 principles to determ
 - **The Test:** _Does this feature apply to EVERY user (e.g., Caching, Agents)?_
 - **Yes:** **Platform Features**.
 - **No (Only React users):** **Technologies**.
+
+### 6. The Golden Path (The "One Way" Rule)
+
+- **Concept:** Feature pages teach the default workflow. Limit flags and variants to the ones a reader needs to make a decision.
+- **The Test:** _Would a first-time user need this sentence to succeed or to choose? If not, it belongs in the corresponding Knowledge Base guide._
+
+### 7. One Page Per Feature (The "Don't Make Me Hunt" Rule)
+
+- **Concept:** A feature page answers most of what a new reader arrives with. Specifics fan out to Knowledge Base guides, the questions stay on the page.
+- **The Test:** _List the questions a new reader, or an AI answering for one, would ask about this feature. Does any answer live only on another page?_
+- **Counterweight to rule 6:** Trim variants and edge cases, keep every question a reader has to answer before they can choose or start.
 
 ### Sidebar Structure
 

--- a/astro-docs/STYLE_GUIDE.md
+++ b/astro-docs/STYLE_GUIDE.md
@@ -59,6 +59,23 @@ belongs in the corresponding Knowledge Base guide.
   applies to workflows a new flag has superseded.
 - When two sections converge on the same flag or topic after a rewrite, merge them into one.
 
+### 7. One page per feature (the "don't make me hunt" rule)
+
+A feature page answers most of what a new reader arrives with, on the page. Specifics fan out
+to Knowledge Base guides. The questions themselves stay.
+
+**The test:** List the questions a new reader, or an AI answering on their behalf, would ask
+about this feature. If an answer lives only on another page, the feature page is incomplete.
+
+For Nx Cloud that set is what it is, whether it's free, what it adds over Nx Core, how to
+connect, and when Enterprise or self-hosted applies. Spread across three or five pages, a reader
+has to find and visit each one before they can form a view, and a model answering the question
+cites none of them.
+
+Rule 6 trims variants and edge cases off the page. This one keeps every question a reader has to
+answer before they can choose or start. Both push detail to the Knowledge Base. Neither pushes
+the decision there.
+
 ### Sidebar structure
 
 The sidebar has four top-level sections that follow the user journey:

--- a/astro-docs/src/content/docs/features/CI Features/index.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/index.mdoc
@@ -16,6 +16,17 @@ Nx Cloud improves many aspects of the CI/CD process:
 - **Cost** - 40% - 75% reduction in CI costs (observed on the Nx OSS monorepo)
 - **Reliability** - by automatically identifying flaky tasks (e2e tests in particular) and re-running them
 
+## What you get with Nx Cloud on top of Nx Core
+
+|                  | Nx Core                                                                                                    | Nx Cloud                                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Caching          | Local cache, per machine                                                                                   | Adds a [remote cache](/docs/features/ci-features/remote-cache) shared across your team and CI   |
+| Task scheduling  | Task graph on one machine, [`nx affected`](/docs/features/ci-features/affected) to skip untouched projects | Adds [distribution across agent machines](/docs/features/ci-features/distribute-task-execution) |
+| End-to-end tests | Run as one task per project                                                                                | [Split per file](/docs/features/ci-features/split-e2e-tasks) and distributed                    |
+| Flaky tasks      | You rerun the pipeline                                                                                     | [Detected and rerun](/docs/features/ci-features/flaky-tasks) within the same run                |
+| Failing CI       | You read the logs and fix it                                                                               | [Self-healing CI](/docs/features/ci-features/self-healing-ci) proposes a fix on the PR          |
+| Visibility       | Terminal output for the run in front of you                                                                | Run history, task analytics, and CI observability                                               |
+
 ## Connect your workspace to Nx Cloud
 
 Run the following command in your Nx workspace (make sure you have it pushed to a remote repository first):
@@ -43,6 +54,38 @@ For example:
 ## Nx Cloud features
 
 {% index_page_cards path="features/ci-features" /%}
+
+## Frequently asked questions
+
+### Is Nx Cloud free?
+
+Yes. Nx Cloud starts on the free Hobby plan, which includes 50,000 credits per month, 5 contributors, and 10 concurrent CI connections, with no credit card.
+
+Nx itself is free and open source too. Task running, the project graph, local caching, `nx affected`, generators, and migrations all work without an Nx Cloud account.
+
+### What happens when I use up my credits?
+
+On the Hobby plan, Nx Cloud features turn off once the monthly credits are gone and turn back on at the next reset.
+
+The Team plan has no such cap, and usage beyond the $29 of included credit is billed at $5.50 per 10,000 credits. See [credit pricing](/docs/reference/nx-cloud/credits-pricing) for what each operation costs.
+
+### Do unused credits carry over?
+
+No. Your allowance resets at the start of each billing cycle.
+
+### Is there a plan for open source projects?
+
+Yes. Nx Cloud is free for qualifying open source organizations. [Talk to our engineering team](https://nx.dev/contact/engineering) to get set up.
+
+### Can I get a shared cache without Nx Cloud?
+
+Yes. Build your own server against the [remote cache OpenAPI specification](/docs/kb/self-hosted-caching), in any language. You maintain the storage, authentication, and uptime.
+
+### When should I consider Enterprise or self-hosted options?
+
+The [Enterprise plan](https://nx.dev/enterprise) adds SSO and SAML, dedicated support with SLAs, [conformance rules](/docs/enterprise/conformance), [code owners](/docs/enterprise/owners), and cross-repo visibility.
+
+On a [single-tenant instance](/docs/enterprise/single-tenant/overview) or an on-prem install, you choose the region and the infrastructure your cache and run data live on. For what a standard Nx Cloud workspace sends and stores, see the [privacy policy](https://nx.app/privacy).
 
 ## Learn more
 

--- a/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
@@ -82,7 +82,7 @@ Supported `--ci` values: `github`, `circleci`, `gitlab`, `azure`, `bitbucket-pip
 
 ## Remote caching
 
-Remote cache allows your CI runs to benefit from previous runs. It takes less than 5 minutes to set up and is free to start.
+Remote cache allows your CI runs to benefit from previous runs. It takes less than 5 minutes to set up and is free to start. For what the free plan covers and what Nx Cloud adds on top of Nx Core, see [Orchestration & CI with Nx Cloud](/docs/features/ci-features).
 
 {% call_to_action variant="default" title="Connect your workspace" url="https://cloud.nx.app/setup/connect-workspace/guide?utm_source=nx-dev&utm_medium=ci-tutorial&utm_campaign=try-nx-cloud" description="Setup takes less than 5 minutes" /%}
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/credits-pricing.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/credits-pricing.mdoc
@@ -19,6 +19,8 @@ Credits represent the computational resources consumed during CI/CD operations. 
 
 ## Credit pricing
 
+Each plan includes a monthly credit allowance. Beyond it, the Team plan bills $5.50 per 10,000 credits, and Enterprise plans get volume discounts. See [plans and pricing](https://nx.dev/pricing) for allowances, and [Orchestration & CI with Nx Cloud](/docs/features/ci-features) for what happens when they run out.
+
 ### Non-compute pricing
 
 - **CI Pipeline Execution: 500 credits per execution**. A CI Pipeline Execution is a CI run or a Workflow run (depending on your CI provider). For instance, running a PR or running CI on the main branch are CI Pipeline Executions.


### PR DESCRIPTION
## Current Behavior

The Nx Cloud CI overview lists features and a connect CTA. The credit reference lists rates. Neither answers whether Nx Cloud is free or what it adds over Nx Core, and the nx.dev/pricing FAQ answers sit in JS accordions that search and LLMs cannot read.

## Expected Behavior

The overview leads with a table of what Nx Cloud adds on top of Nx Core above the connect CTA, and closes with an FAQ covering the free plan, out-of-credits behavior per plan, credit carryover, open source eligibility, self-hosted caching, and when Enterprise or single-tenant applies. The CI setup page links to it and the credit reference maps credits to dollars.

Also adds IA principle 7 (one page per feature) to `STYLE_GUIDE.md`, backfills the missing principle 6 in `README.md`, and updates the `check-docs-style` skill from five principles to seven.

## Preview

- [Orchestration & CI with Nx Cloud](https://deploy-preview-36798--nx-docs.netlify.app/docs/features/ci-features)
- [CI setup](https://deploy-preview-36798--nx-docs.netlify.app/docs/getting-started/setup-ci) (one cross-reference)
- [Nx Cloud credit pricing](https://deploy-preview-36798--nx-docs.netlify.app/docs/reference/nx-cloud/credits-pricing)

## Related Issue(s)

Fixes DOC-595
