### PR TITLE
docs(nx-dev): attribute nx cloud docs ctas and offer browser onboarding

### DIFF
--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -49,7 +49,7 @@ const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUnti
                     Contact
                   </a>
                   <a
-                    href="https://cloud.nx.app?utm_source=nx-dev&utm_medium=header"
+                    href="https://cloud.nx.app?utm_source=nx-dev&utm_medium=header&utm_campaign=try-nx-cloud"
                     target="_blank"
                     rel="noopener noreferrer"
                     class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition no-underline bg-blue-500 dark:bg-sky-500 text-white hover:bg-blue-600 dark:hover:bg-sky-600 shadow-sm"

--- a/astro-docs/src/content/docs/enterprise/Single Tenant/overview.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Single Tenant/overview.mdoc
@@ -16,12 +16,12 @@ Get the package that [best fits your needs](https://nx.dev/enterprise)
 
 The quickest and easiest way to start using Nx Cloud is by utilizing our pre-existing secure, multi-tenant managed clusters:
 
-- [https://nx.app/](https://nx.app/)
+- [https://nx.app/](https://nx.app/?utm_source=nx-dev&utm_medium=website&utm_campaign=single-tenant)
 - Enterprise customers can contact their developer productivity engineer (DPE) to configure the EU hosted version of Nx Cloud.
 
 We also offer an uptime SLA guarantee of 99.98% for our Enterprise customers, SOC certificates on request, and we're happy to meet with your security teams if they have questions, or fill in security questionnaires. We also maintain a [Status Page here](https://status.nx.app/).
 
-To start with this option, it's as easy as creating an account on [nx.app](https://cloud.nx.app) and connecting your repository.
+To start with this option, it's as easy as creating an account on [nx.app](https://cloud.nx.app?utm_source=nx-dev&utm_medium=website&utm_campaign=single-tenant) and connecting your repository.
 
 ## Single tenant instance
 

--- a/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
@@ -33,6 +33,10 @@ To enable task distribution with Nx Agents, make sure your Nx workspace is conne
 npx nx@latest connect
 ```
 
+{% call_to_action title="Connect from your browser" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=distribute-task-execution" icon="nxcloud" description="Sign in to Nx Cloud and connect your repository without the CLI" /%}
+
+For the full pipeline walkthrough, see [Setting Up CI](/docs/getting-started/setup-ci).
+
 Choose one of the following setup paths.
 
 {% tabs %}

--- a/astro-docs/src/content/docs/features/CI Features/flaky-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/flaky-tasks.mdoc
@@ -39,7 +39,9 @@ To connect your workspace to Nx Cloud run:
 npx nx@latest connect
 ```
 
-See the [connect to Nx Cloud recipe](/docs/kb/setup-ci) for all the details.
+{% call_to_action title="Connect from your browser" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=flaky-tasks" icon="nxcloud" description="Sign in to Nx Cloud and connect your repository without the CLI" /%}
+
+For the full pipeline walkthrough, see [Setting Up CI](/docs/getting-started/setup-ci).
 
 ## Automatically re-run flaky tasks
 

--- a/astro-docs/src/content/docs/features/CI Features/github-integration.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/github-integration.mdoc
@@ -140,6 +140,6 @@ With the Nx Cloud GitHub App installed, every pull request gets:
 
 ## Connect your repository
 
-{% call_to_action title="Get started with Nx Cloud" url="https://cloud.nx.app/get-started/" icon="nxcloud" description="Connect your repository to Nx Cloud" %}
+{% call_to_action title="Get started with Nx Cloud" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=github-integration" icon="nxcloud" description="Connect your repository to Nx Cloud" %}
 Get started with Nx Cloud
 {% /call_to_action %}

--- a/astro-docs/src/content/docs/features/CI Features/remote-cache.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/remote-cache.mdoc
@@ -29,7 +29,9 @@ Connect your workspace to Nx Cloud:
 npx nx@latest connect
 ```
 
-For authentication and CI setup details, see [set up CI](/docs/kb/setup-ci).
+{% call_to_action title="Connect from your browser" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=remote-cache" icon="nxcloud" description="Sign in to Nx Cloud and connect your repository without the CLI" /%}
+
+For authentication and CI setup details, see [Setting Up CI](/docs/getting-started/setup-ci).
 
 ## Why use remote caching
 

--- a/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
@@ -33,6 +33,10 @@ If you haven't already connected to Nx Cloud, run the following command:
 npx nx@latest connect
 ```
 
+{% call_to_action title="Connect from your browser" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=self-healing-ci" icon="nxcloud" description="Sign in to Nx Cloud and connect your repository without the CLI" /%}
+
+For the full pipeline walkthrough, see [Setting Up CI](/docs/getting-started/setup-ci).
+
 Next, check the [Nx Cloud workspace settings](https://cloud.nx.app/go/workspace/settings/self-healing-ci) in the Nx Cloud web application to ensure that "Self-Healing CI" is enabled.
 
 ### Configure your CI pipeline

--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -30,7 +30,9 @@ To use **automated task splitting**, you need to connect your workspace to Nx Cl
 npx nx@latest connect
 ```
 
-See the [connect to Nx Cloud recipe](/docs/kb/setup-ci) for all the details.
+{% call_to_action title="Connect from your browser" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=split-e2e-tasks" icon="nxcloud" description="Sign in to Nx Cloud and connect your repository without the CLI" /%}
+
+For the full pipeline walkthrough, see [Setting Up CI](/docs/getting-started/setup-ci).
 
 ### Step 2: add the appropriate plugin
 

--- a/astro-docs/src/content/docs/getting-started/nx-cloud.mdoc
+++ b/astro-docs/src/content/docs/getting-started/nx-cloud.mdoc
@@ -19,7 +19,7 @@ Nx Cloud improves many aspects of the CI/CD process:
 
 To connect your Nx workspace with Nx Cloud, use the web application:
 
-{% call_to_action variant="default" title="Create a new or connect an existing repo" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=nx-cloud_intro&utm_campaign=try-nx-cloud" description="Setup takes less than 2 minutes" /%}
+{% call_to_action variant="default" title="Create a new or connect an existing repo" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=nx-cloud-intro" description="Setup takes less than 2 minutes" /%}
 
 Alternatively, you can also run the following command in your Nx workspace (make sure you have it pushed to a remote repository first):
 

--- a/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
@@ -38,7 +38,7 @@ Page: {pageUrl}
 Connect your workspace to Nx Cloud and run your CI tasks through `nx`. That turns on remote caching, affected, distribution, and self-healing CI.
 Each section below covers one of those in isolation. If you would rather start from a working pipeline, jump to the [complete example](#complete-example).
 
-{% call_to_action variant="default" title="Tour an Nx Cloud workspace" url="https://cloud.nx.app/demo/intro?utm_source=nx-dev&utm_medium=ci-tutorial&utm_campaign=workspace-tour" description="See distributed task execution, caching, and run analytics on a live workspace before you wire up your own CI." /%}
+{% call_to_action variant="default" title="Tour an Nx Cloud workspace" url="https://cloud.nx.app/demo/intro?utm_source=nx-dev&utm_medium=website&utm_campaign=ci-setup" description="See distributed task execution, caching, and run analytics on a live workspace before you wire up your own CI." /%}
 
 ## Make sure you have Nx
 
@@ -84,7 +84,7 @@ Supported `--ci` values: `github`, `circleci`, `gitlab`, `azure`, `bitbucket-pip
 
 Remote cache allows your CI runs to benefit from previous runs. It takes less than 5 minutes to set up and is free to start.
 
-{% call_to_action variant="default" title="Connect your workspace" url="https://cloud.nx.app/setup/connect-workspace/guide?utm_source=nx-dev&utm_medium=ci-tutorial&utm_campaign=try-nx-cloud" description="Setup takes less than 5 minutes" /%}
+{% call_to_action variant="default" title="Connect your workspace" url="https://cloud.nx.app/setup/connect-workspace/guide?utm_source=nx-dev&utm_medium=website&utm_campaign=ci-setup" description="Setup takes less than 5 minutes" /%}
 
 See [Remote Caching](/docs/features/ci-features/remote-cache) for details on the security model and eviction. For more granular control in CI, with separate read-only and read-write tokens and branch-scoped permissions, see [CI access tokens](/docs/kb/access-tokens).
 

--- a/astro-docs/src/content/docs/guides/Nx Cloud/optimize-your-ttg.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/optimize-your-ttg.mdoc
@@ -41,6 +41,10 @@ If you haven't already, run the following command to connect your workspace to N
 npx nx@latest connect
 ```
 
+{% call_to_action title="Connect from your browser" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=optimize-your-ttg" icon="nxcloud" description="Sign in to Nx Cloud and connect your repository without the CLI" /%}
+
+For the full pipeline walkthrough, see [Setting Up CI](/docs/getting-started/setup-ci).
+
 ### 1) Get failure feedback immediately (avoid late discovery)
 
 When you don't notice CI failed, you lose time before you can act. Tighten the loop so failures surface where you're working.

--- a/astro-docs/src/content/docs/kb/access-tokens.mdoc
+++ b/astro-docs/src/content/docs/kb/access-tokens.mdoc
@@ -10,7 +10,7 @@ topics:
 
 {% youtube src="https://youtu.be/vBokLJ_F8qs" title="Configure CI access tokens" /%}
 
-The permissions and membership define what developers can access on [nx.app](https://cloud.nx.app?utm_source=nx.dev&utm_medium=docs&utm_campaign=nx-cloud-security), but they don't affect what happens when you run Nx commands in CI. To manage that, you need to provision CI access tokens in your workspace settings, under the `Access Control` tab.
+The permissions and membership define what developers can access on [nx.app](https://cloud.nx.app?utm_source=nx-dev&utm_medium=website&utm_campaign=access-tokens), but they don't affect what happens when you run Nx commands in CI. To manage that, you need to provision CI access tokens in your workspace settings, under the `Access Control` tab.
 Learn more about [cache security best practices](/docs/kb/cache-security).
 
 {% aside type="tip" title="Quickest path: use recommended settings" %}

--- a/astro-docs/src/content/docs/kb/adding-to-existing-project.mdoc
+++ b/astro-docs/src/content/docs/kb/adding-to-existing-project.mdoc
@@ -345,7 +345,7 @@ Now connect your repository to Nx Cloud with the following command:
 npx nx@latest connect
 ```
 
-A browser window will open to register your repository in your [Nx Cloud](https://cloud.nx.app) account. The link is also printed to the terminal if the windows does not open, or you closed it before finishing the steps. The app will guide you to create a PR to enable Nx Cloud on your repository.
+A browser window will open to register your repository in your [Nx Cloud](https://cloud.nx.app?utm_source=nx-dev&utm_medium=website&utm_campaign=adding-to-existing-project) account. The link is also printed to the terminal if the windows does not open, or you closed it before finishing the steps. The app will guide you to create a PR to enable Nx Cloud on your repository.
 
 ![](../../../assets/guides/adopting-nx/nx-cloud-github-connect.avif)
 

--- a/astro-docs/src/content/docs/kb/adding-to-monorepo.mdoc
+++ b/astro-docs/src/content/docs/kb/adding-to-monorepo.mdoc
@@ -360,7 +360,7 @@ Now connect your repository to Nx Cloud with the following command:
 npx nx@latest connect
 ```
 
-A browser window will open to register your repository in your [Nx Cloud](https://cloud.nx.app) account. The link is also printed to the terminal if the windows does not open, or you closed it before finishing the steps. The app will guide you to create a PR to enable Nx Cloud on your repository.
+A browser window will open to register your repository in your [Nx Cloud](https://cloud.nx.app?utm_source=nx-dev&utm_medium=website&utm_campaign=adding-to-monorepo) account. The link is also printed to the terminal if the windows does not open, or you closed it before finishing the steps. The app will guide you to create a PR to enable Nx Cloud on your repository.
 
 ![](../../../assets/guides/adopting-nx/nx-cloud-github-connect.avif)
 

--- a/astro-docs/src/content/docs/kb/console-nx-cloud.mdoc
+++ b/astro-docs/src/content/docs/kb/console-nx-cloud.mdoc
@@ -15,7 +15,7 @@ If your workspace is connected to Nx Cloud, you will have access to a new view i
 ![Nx Console Nx Cloud View](../../../assets/guides/nx-console/cloud-view.png)
 
 {% aside type="note" %}
-Nx Console will only show information about CI Pipelines from the last hour and triggered from branches that you have modified locally. If you want to see information about other pipelines, use the Nx Cloud application at [cloud.nx.app](https://cloud.nx.app).
+Nx Console will only show information about CI Pipelines from the last hour and triggered from branches that you have modified locally. If you want to see information about other pipelines, use the Nx Cloud application at [cloud.nx.app](https://cloud.nx.app?utm_source=nx-dev&utm_medium=website&utm_campaign=console-nx-cloud).
 {% /aside %}
 
 ## Notifications

--- a/astro-docs/src/content/docs/kb/faster-builds-with-module-federation.mdoc
+++ b/astro-docs/src/content/docs/kb/faster-builds-with-module-federation.mdoc
@@ -77,7 +77,7 @@ Before you begin, check out the example repos (React and Angular) if you want to
 These examples have fully
 functioning [CI](https://github.com/nrwl/react-module-federation/blob/main/.github/workflows/ci.yml) [workflows](https://github.com/nrwl/ng-module-federation/blob/main/.github/workflows/ci.yml)
 that are simple to set up. You can see what the CI does by viewing the sample pull requests in each repo. Also notice
-the [Nx Cloud](https://nx.app) integration, which gives you insight into each pipeline. We'll touch on
+the [Nx Cloud](https://cloud.nx.app?utm_source=nx-dev&utm_medium=website&utm_campaign=module-federation) integration, which gives you insight into each pipeline. We'll touch on
 This [later ](#remote-computation-caching-with-nx-cloud).
 
 ![Nx Cloud integration for GitHub](../../../assets/concepts/module-federation/pull-request.png)
@@ -361,8 +361,8 @@ If you have any feedback regarding this feature, let us know on [our community p
 
 ## Remote computation caching with Nx Cloud
 
-To use Module Federation well, we recommend that you enable [Nx Cloud](https://nx.app). If you haven't enabled it yet
-when using `create-nx-workspace`, create an account at [https://cloud.nx.app](https://cloud.nx.app) and connect to your repository.
+To use Module Federation well, we recommend that you enable [Nx Cloud](https://cloud.nx.app?utm_source=nx-dev&utm_medium=website&utm_campaign=module-federation). If you haven't enabled it yet
+when using `create-nx-workspace`, create an account and connect to your repository.
 
 With Nx Cloud enabled, a large set of builds can be skipped entirely when running the application locally (and in
 CI/CD). When you run builds through Nx + Nx Cloud, the artifacts are stored in the remote cache, so as long as the

--- a/astro-docs/src/content/docs/kb/gradle-tutorial.mdoc
+++ b/astro-docs/src/content/docs/kb/gradle-tutorial.mdoc
@@ -118,7 +118,7 @@ Finally, commit and push all the changes to GitHub and proceed with finishing yo
 
 Nx Cloud provides remote caching and many other features. [Learn more about Nx Cloud features](/docs/features/ci-features).
 
-Click the link printing in your terminal, or you can [finish setup in Nx Cloud](https://cloud.nx.app/setup/connect-workspace/github/select)
+Click the link printing in your terminal, or you can [finish setup in Nx Cloud](https://cloud.nx.app/setup/connect-workspace/github/select?utm_source=nx-dev&utm_medium=website&utm_campaign=gradle-tutorial)
 
 ### Verify your setup
 

--- a/astro-docs/src/content/docs/kb/incremental-builds.mdoc
+++ b/astro-docs/src/content/docs/kb/incremental-builds.mdoc
@@ -205,7 +205,7 @@ Ensure all build targets include `"dependsOn": ["^build"]` so Nx knows to build 
 
 ### Leverage Nx cache
 
-Enable [Nx Cloud](https://nx.app) to share build cache across your team and CI/CD pipelines, maximizing the performance benefits of incremental builds.
+Enable [Nx Cloud](https://cloud.nx.app?utm_source=nx-dev&utm_medium=website&utm_campaign=incremental-builds) to share build cache across your team and CI/CD pipelines, maximizing the performance benefits of incremental builds.
 
 ### Monitor build performance
 

--- a/astro-docs/src/content/docs/kb/monorepo-ci-best-practices.mdoc
+++ b/astro-docs/src/content/docs/kb/monorepo-ci-best-practices.mdoc
@@ -455,4 +455,4 @@ Connect an existing workspace:
 npx nx connect
 ```
 
-Or start from [cloud.nx.app/get-started](https://cloud.nx.app/get-started/).
+Or start from [cloud.nx.app/get-started](https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=monorepo-ci-best-practices).

--- a/astro-docs/src/content/docs/kb/self-hosted-caching.mdoc
+++ b/astro-docs/src/content/docs/kb/self-hosted-caching.mdoc
@@ -25,7 +25,7 @@ You'll also get access to advanced CI features:
 
 {% /aside %}
 
-{% call_to_action title="Get started with Nx Cloud" url="https://cloud.nx.app/get-started/" icon="nxcloud" description="Fully managed remote caching with Nx Cloud" %}
+{% call_to_action title="Get started with Nx Cloud" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=self-hosted-caching" icon="nxcloud" description="Fully managed remote caching with Nx Cloud" %}
 Get started with Nx Cloud
 {% /call_to_action %}
 

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -1059,7 +1059,7 @@ Some presets use the `extends` property to hide some default options in a separa
 
 ## Nx Cloud
 
-There are also options for [Nx Cloud](https://nx.app) that are set in the `nx.json` file. For instance, you connect to the Nx Cloud service using an `nxCloudId` like this:
+There are also options for [Nx Cloud](https://cloud.nx.app?utm_source=nx-dev&utm_medium=website&utm_campaign=nx-json) that are set in the `nx.json` file. For instance, you connect to the Nx Cloud service using an `nxCloudId` like this:
 
 ```json
 // nx.json

--- a/astro-docs/src/pages/templates/[slug].astro
+++ b/astro-docs/src/pages/templates/[slug].astro
@@ -111,7 +111,7 @@ const accentVars = `--tpl-accent:${template.accent};--tpl-accent-to:${template.a
           <div class="tpl-actions">
             <a
               class="tpl-btn tpl-btn-primary"
-              href="https://cloud.nx.app/setup/connect-workspace/guide?utm_source=nx.dev&utm_medium=templates&utm_campaign=templates_gallery"
+              href="https://cloud.nx.app/setup/connect-workspace/guide?utm_source=nx-dev&utm_medium=website&utm_campaign=templates"
               target="_blank"
               rel="noreferrer"
             >


### PR DESCRIPTION
## Current Behavior

Most Nx Cloud links in docs carry no UTM params, so sign-ups cannot be traced back to the page that sent them. The tagged ones disagreed with each other: `utm_source` was split between `nx.dev` and `nx-dev`, and `utm_medium` held a page name.

High-intent CI pages give `npx nx@latest connect` as the only path to Nx Cloud.

## Expected Behavior

Every sign-up and connect link to nx.app carries `utm_source=nx-dev&utm_medium=website&utm_campaign=<page>`, so campaign alone identifies the source page.

Connect sections on remote caching, self-healing CI, flaky tasks, task distribution, split e2e tasks and optimize your TTG offer three paths: the CLI command, a `call_to_action` to `cloud.nx.app/get-started`, then the CI setup guide.

In-app deep links (`/go/*`, `/orgs`), legal, status and security URLs stay untagged.

## Related Issue(s)

DOC-596
