### PR TITLE
docs(nx-cloud): remove scheduling constraints from the cli reference

### DIFF
--- a/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
@@ -414,7 +414,6 @@ If you accidentally run this command locally, remove all generated marker files 
 | ------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `--distribute-on`               | string  | Configure the number of agents, [launch templates](/docs/kb/launch-templates) and [assignment rules](/docs/kb/assignment-rules) for distributed execution              |         |
 | `--assignment-rules`            | string  | Path to the [assignment rules configuration](/docs/kb/assignment-rules#using-assignment-rules-when-you-bring-your-own-compute) for manual distribution.                |         |
-| `--scheduling-constraints`      | string  | Path to a YAML file with same-agent scheduling constraints                                                                                                             |         |
 | `--no-distribution`             | boolean | Disable distribution for this run                                                                                                                                      |         |
 | `--require-explicit-completion` | boolean | Disable automatic completion monitoring and require explicit `nx complete-ci-run`                                                                                      | `false` |
 | `--stop-agents-after`           | string  | Comma-separated list of targets after which agents should terminate                                                                                                    |         |
@@ -427,14 +426,9 @@ If you accidentally run this command locally, remove all generated marker files 
 
 #### Detailed option usage
 
-##### `--scheduling-constraints`
+##### `--assignment-rules`
 
-Point this at a YAML file describing which tasks have to run on the same agent.
-The file is read from disk before the run group is created, and both its contents and its path are sent to Nx Cloud.
-`start-ci-run` exits with an error when the file cannot be read or is empty.
-
-When `--distribute-on` points at a configuration file that already embeds scheduling constraints, the `--scheduling-constraints` file replaces them.
-The same applies to `--assignment-rules`, and the two flags override their embedded counterparts independently.
+When `--distribute-on` points at a configuration file that already embeds assignment rules, the `--assignment-rules` file replaces them.
 
 ##### `--no-distribution`
 


### PR DESCRIPTION
## Current Behavior

The `start-ci-run` options table and a detailed section document `--scheduling-constraints`. The feature is unreleased and intentionally undocumented, so the flag currently appears on this page and nowhere else on the site.

## Expected Behavior

Both removed. The feature appears nowhere until it ships.

One thing carried over rather than deleted: the removed section held the only statement that `--assignment-rules` overrides rules embedded in a `--distribute-on` config file. `--assignment-rules` is released, so that behavior keeps its own `##### --assignment-rules` entry.

No other page referenced the flag or its anchor, so nothing inbound breaks.

## Related Issue(s)

DOC-651


## Preview

- [Nx Cloud CLI reference](https://deploy-preview-36800--nx-docs.netlify.app/docs/reference/nx-cloud-cli) - `start-ci-run` options table and the `Detailed option usage` section below it
