### PR TITLE
fix(repo): stop CI cache churn from evicting the cargo caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
@@ -291,7 +291,7 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ steps.pnpm-cache-macos.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 

--- a/.github/workflows/generate-embeddings.yml
+++ b/.github/workflows/generate-embeddings.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -343,8 +343,12 @@ jobs:
           corepack enable
           corepack prepare --activate
 
-      - name: Cache cargo
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      # Restore always, but only save from master. A cache written on a tag or PR ref
+      # is scoped to that ref, so nothing can ever read it back — it just consumes the
+      # repo-wide 10GB budget and evicts the master entries these builds depend on.
+      - name: Restore cargo cache
+        id: cargo-cache
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -405,6 +409,18 @@ jobs:
         run: ${{ matrix.settings.build }}
         if: ${{ !matrix.settings.docker }}
         shell: bash
+
+      - name: Save cargo cache
+        if: github.ref == 'refs/heads/master' && steps.cargo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            .cargo-cache
+            target/
+          key: ${{ matrix.settings.target }}-cargo-registry
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Current Behavior

The repository is over GitHub's 10 GB Actions cache limit, so entries are continuously LRU-evicted:

```
active_caches_size_in_bytes: 11,918,326,063   (11.10 GB)
active_caches_count: 44
```

There is one cache pool per repository, shared by every workflow. The cargo caches lose the eviction race structurally: `ci.yml` touches the pnpm caches on every run, all day, while `publish.yml` touches the cargo caches once a day. By the next publish, they are gone.

Two consecutive publish runs, `x86_64-unknown-linux-gnu`:

| run | date | native build step |
|---|---|---|
| [32681005735](https://github.com/nrwl/nx/actions/runs/32681005735) | 2026-08-24 | `Cache not found` → 401 `Compiling` → `Cache saved` |
| [32888429557](https://github.com/nrwl/nx/actions/runs/32888429557) | 2026-08-25 | `Cache not found` → 394 `Compiling` → `Cache saved` |

It misses every run *and* saves every run. The cache is rebuilt and discarded before anyone reads it, so each publish pays a full cold dependency build on all 9 targets.

Two things are consuming the budget:

**1. The pnpm store key matches 33 lockfiles.**

```yaml
key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
```

`**/` matches the root lockfile plus ~30 under `examples/`. A 1.14 GB store gets a fresh key whenever any example app's lockfile changes, stranding ~1.9 GB (Linux + macOS) for 7 days each time. Currently 3 Linux entries (3.41 GB) and 2 macOS entries (1.50 GB) — **4.91 GB, 44% of the budget**. `e2e-matrix.yml` already scopes this to the root lockfile; `ci.yml` and `generate-embeddings.yml` do not.

**2. `publish.yml` writes caches nothing can read.**

Caches are scoped to the ref that created them. Grouping the current entries by ref:

```
8.14 GB  x43  refs/heads/master
1.89 GB  x2   refs/pull/36756/merge
1.07 GB  x2   refs/heads/refs/tags/23.2.0-beta.10
```

A tag ref has no descendants, so those 550 MB × 2 entries are unreadable by any future run. They exist only to evict the master entries the builds depend on. **2.96 GB — 27% of the budget — is currently dead weight.**

## Expected Behavior

**Scope the pnpm key to the root lockfile** (`ci.yml` ×2, `generate-embeddings.yml`). `restore-keys` fallback is already present in all three, so a miss degrades to the key prefix rather than a cold install.

**Split `publish.yml`'s cargo cache into restore + save**, saving only from `master`, and skipping the save entirely when the restore already hit.

Net effect on the budget:

| | before | after |
|---|---|---|
| pnpm entries | 4.91 GB (3 Linux + 2 macOS) | ~1.9 GB (1 + 1) |
| tag / PR-scoped waste | 2.96 GB | ~0 |
| **total** | **11.10 GB** (evicting) | **~6 GB** |

Under the limit, eviction stops, and the cargo caches survive between publishes.

### Why this is a build-time fix

Step timings from the latest publish run:

| step | macOS x86_64 | Windows x86_64 |
|---|---|---|
| Cache cargo | 0s (miss) | 0s (miss) |
| Install dependencies | 166s | 150s |
| **Build** | **448s** | **757s** |
| job total | ~10.6 min | ~21 min |

That Build time is cold dependency compilation. With the cache intact, a publish rebuilds only the `nx` crate plus LTO. Measured locally, that is 29.7s versus 3m25s cold (6.9×) at `-j4`, matching CI's 4 vCPU runners.

Projecting conservatively onto CI hardware, Build should land around 2–4 min, taking the native stage from ~21 min (gated by the Windows jobs) to roughly ~13 min. The 6.9× is measured; the projection onto CI is not.

### Deliberately not included

- **Sharing `ci.yml`'s pnpm cache with `publish.yml`.** Possible via restore-only, at zero budget cost, but it helps only the 2 macOS targets (the 5 Docker targets install inside the container, and no `Windows-pnpm-store-*` producer exists). macOS jobs are 10.6 min against Windows' 21 min, so it saves machine time and no wall-clock. Worth doing separately, for cost.
- **Windows `Setup toolchain`, 265s.** The second-largest cost on the longest job, unaddressed here. Deserves its own investigation.

## Related Issue(s)

N/A — CI infrastructure fix, no linked issue.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-CI-Actions-cache-quota-evicting-cargo-caches-8f1a8f2e">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->