### PR TITLE
fix(core): give pnpm a fresh cache dir per e2e run

### DIFF
--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -96,6 +96,9 @@ export default async function (globalConfig: Config.ConfigGlobals) {
     // same version is republished to the local registry.
     const e2eCacheDir = mkdtempSync(join(tmpdir(), 'nx-e2e-cache-'));
     process.env.npm_config_cache = join(e2eCacheDir, 'npm');
+    // pnpm resolves an exact version from its own metadata cache without asking
+    // the registry; `pnpm_config_` is the prefix it honours for cache-dir.
+    process.env.pnpm_config_cache_dir = join(e2eCacheDir, 'pnpm');
     // yarnv1
     process.env.YARN_CACHE_FOLDER = join(e2eCacheDir, 'yarn');
     // yarnv2


### PR DESCRIPTION
## Current Behavior

The e2e harness republishes the same `nx@24.0.0` to the local registry on every run. `global-setup.ts` gives npm and yarn a fresh cache directory per run, but not pnpm. pnpm resolves an exact version from its global metadata cache (`~/.cache/pnpm/v11/metadata/localhost+4873`) without asking the registry, so a later run installs the tarball from a previous run — verdaccio holds the fresh package, the workspace gets the old one. On a developer machine this shows up as e2e assertions failing against code that HEAD cannot produce.

## Expected Behavior

pnpm gets a per-run cache directory like the other package managers, so each run resolves the package that was just published. pnpm 11 ignores `npm_config_cache_dir`, `PNPM_CACHE_DIR`, and a project-level `.npmrc` for `cache-dir`; it honours `pnpm_config_cache_dir`, which is what `global-setup.ts` now sets. Verified by deleting the global cache, running `e2e-nx:e2e-ci--src/io-snapshots.test.ts`, and confirming the global entry is not recreated while the per-run directory holds the registry metadata.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/NXC-4846-snapshot-resolution-in-Nx-core-ac467078">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->