### PR TITLE
fix(gradle): compile Kotlin in-process in the e2e fixture

### DIFF
--- a/e2e/gradle/src/utils/create-gradle-project.ts
+++ b/e2e/gradle/src/utils/create-gradle-project.ts
@@ -65,6 +65,14 @@ export function createGradleProject(
     // gradle init's template doesn't include it, so events for those
     // files leak through the daemon's watcher and cause recompute storms.
     appendToGitignore(cwd, '.kotlin/');
+    // Compile Kotlin inside each Gradle daemon instead of the per-user Kotlin
+    // compile daemon, which is shared by every e2e workspace on the agent
+    // and stalls all of them when its heap fills. The Gradle daemon then
+    // hosts the compiler, so raise it above Gradle's 512m default.
+    appendFileSync(
+      join(cwd, 'gradle.properties'),
+      '\nkotlin.compiler.execution.strategy=in-process\norg.gradle.jvmargs=-Xmx2g\n'
+    );
   }
 
   try {


### PR DESCRIPTION
## Current Behavior

The gradle e2e fixture (`createGradleProject`) leaves Kotlin compilation on the default strategy: every Gradle daemon hands `compileKotlin` to a single per-user Kotlin compile daemon. On CI the five kotlin e2e workspaces on one agent all share that daemon. Once its heap fills, it enters a GC spiral (memory flat at the ceiling, 500–800% CPU for over an hour) and every workspace's `compileKotlin` blocks on it, so all the gradle e2e tasks hang until the job is killed. It reads as a task deadlock, but the other Gradle daemons are simply idle, waiting on the one wedged compiler.

Resource-usage CSV from the affected job: PID 52162 (`kotlin-daemon-embeddable`) at ~966 MB and ~665% mean CPU from 17:28 to 18:49, while the other four Gradle daemons sat at 0–1% CPU.

## Expected Behavior

The generated `gradle.properties` sets `kotlin.compiler.execution.strategy=in-process`, so each Gradle daemon compiles Kotlin in its own JVM and no e2e workspace can stall another. Since the Gradle daemon now hosts the compiler, `org.gradle.jvmargs=-Xmx2g` raises its heap above Gradle's 512m default.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Compile-Kotlin-in-process-in-the-gradle-e2e-fixture-d9338aa9">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->