### PR TITLE
fix(dotnet): derive output paths from MSBuild instead of hardcoded assumptions

### DIFF
--- a/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
+++ b/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
@@ -78,6 +78,7 @@ public class AnalyzerSmokeTests : IDisposable
         };
 
         using var process = Process.Start(startInfo)!;
+        process.StandardInput.WriteLine(string.Empty);
         process.StandardInput.WriteLine(projectFile);
         process.StandardInput.Close();
 

--- a/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
+++ b/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// End-to-end checks that run the analyzer the way the plugin does: as a
+/// process, against a real project, with MSBuild doing the evaluation.
+///
+/// The rest of the suite hands <see cref="Utilities.TargetBuilder.BuildTargets"/>
+/// a hand-built property dictionary, which cannot catch a wrong assumption about
+/// what MSBuild actually evaluates - the fixture simply asserts whatever the
+/// author believed. Two real defects reached review that way: a package whose
+/// props default OpenApiDocumentsDirectory to $(BaseIntermediateOutputPath), and
+/// PackageOutputPath always being set to a Debug path the pack target never
+/// writes to. These tests cover that seam; they are deliberately few, since each
+/// one pays for a process launch and a full MSBuild evaluation.
+/// </summary>
+public class AnalyzerSmokeTests : IDisposable
+{
+    private readonly string _workspaceRoot =
+        Path.Combine(Path.GetTempPath(), "nx-dotnet-smoke-" + Guid.NewGuid().ToString("n"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workspaceRoot))
+        {
+            Directory.Delete(_workspaceRoot, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private string WriteProject(string projectName, string propertyGroup, string? directoryBuildProps = null)
+    {
+        var projectDirectory = Path.Combine(_workspaceRoot, "apps", projectName);
+        Directory.CreateDirectory(projectDirectory);
+
+        if (directoryBuildProps is not null)
+        {
+            File.WriteAllText(
+                Path.Combine(_workspaceRoot, "Directory.Build.props"),
+                $"<Project><PropertyGroup>{directoryBuildProps}</PropertyGroup></Project>");
+        }
+
+        var projectFile = Path.Combine(projectDirectory, $"{projectName}.csproj");
+        File.WriteAllText(projectFile, $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                {propertyGroup}
+              </PropertyGroup>
+            </Project>
+            """);
+
+        return projectFile;
+    }
+
+    /// <summary>
+    /// Runs the analyzer over one project and returns that project's targets.
+    /// The analyzer registers MSBuildLocator itself, so it has to run out of
+    /// process - registering in the test host would fight the runner over which
+    /// MSBuild assemblies get loaded.
+    /// </summary>
+    private Dictionary<string, JsonElement> Analyze(string projectFile)
+    {
+        // Both MsbuildAnalyzer.dll and its runtimeconfig.json land next to the
+        // test assembly via the project reference.
+        var analyzer = Path.Combine(AppContext.BaseDirectory, "MsbuildAnalyzer.dll");
+        Assert.True(File.Exists(analyzer), $"Analyzer not found at {analyzer}");
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            ArgumentList = { analyzer, _workspaceRoot },
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        using var process = Process.Start(startInfo)!;
+        process.StandardInput.WriteLine(projectFile);
+        process.StandardInput.Close();
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(milliseconds: 180_000), "Analyzer timed out");
+        Assert.True(process.ExitCode == 0, $"Analyzer exited {process.ExitCode}. stderr:\n{stderr}");
+
+        var relativeProjectFile = Path.GetRelativePath(_workspaceRoot, projectFile).Replace('\\', '/');
+        var result = JsonDocument.Parse(stdout).RootElement;
+
+        return result
+            .GetProperty("nodesByFile")
+            .GetProperty(relativeProjectFile)
+            .GetProperty("targets")
+            .EnumerateObject()
+            .ToDictionary(p => p.Name, p => p.Value);
+    }
+
+    private static string[] Outputs(Dictionary<string, JsonElement> targets, string targetName) =>
+        [.. targets[targetName].GetProperty("outputs").EnumerateArray().Select(o => o.GetString()!)];
+
+    [Fact]
+    public void DefaultProject_DeclaresBinAndObj()
+    {
+        var targets = Analyze(WriteProject("MyLib", ""));
+
+        Assert.Equal(new[] { "{projectRoot}/bin", "{projectRoot}/obj" }, Outputs(targets, "build"));
+    }
+
+    [Fact]
+    public void OpenApiDocumentsDirectory_DeclaresTheDocumentGlobs()
+    {
+        var projectFile = WriteProject(
+            "MyApi",
+            "<OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/openapi</OpenApiDocumentsDirectory>");
+
+        var targets = Analyze(projectFile);
+
+        Assert.Equal(
+            new[]
+            {
+                "{projectRoot}/bin",
+                "{projectRoot}/obj",
+                "{projectRoot}/openapi/MyApi.json",
+                "{projectRoot}/openapi/MyApi_*.json",
+            },
+            Outputs(targets, "build"));
+    }
+
+    [Fact]
+    public void Pack_DeclaresTheReleasePackageDirectory()
+    {
+        // MSBuild always evaluates PackageOutputPath, and does so at the default
+        // Debug configuration, while pack runs --configuration Release. No
+        // hand-built fixture caught this because none of them set the property.
+        var targets = Analyze(WriteProject("MyLib", ""));
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin/Release/*.nupkg", "{projectRoot}/obj" },
+            Outputs(targets, "pack"));
+    }
+
+    [Fact]
+    public void ArtifactsLayout_DeclaresTheMSBuildProjectNameNotTheNxName()
+    {
+        // ArtifactsProjectName defaults to MSBuildProjectName. Naming the project
+        // something else for Nx must not move the declared output.
+        var projectFile = WriteProject(
+            "Renamed",
+            "<Nx><Name>my-renamed-api</Name></Nx>",
+            directoryBuildProps: "<UseArtifactsOutput>true</UseArtifactsOutput>");
+
+        var targets = Analyze(projectFile);
+
+        Assert.Equal(
+            new[]
+            {
+                "{workspaceRoot}/artifacts/bin/Renamed",
+                "{workspaceRoot}/artifacts/obj/Renamed",
+            },
+            Outputs(targets, "build"));
+    }
+}

--- a/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
+++ b/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
@@ -78,6 +78,7 @@ public class AnalyzerSmokeTests : IDisposable
         };
 
         using var process = Process.Start(startInfo)!;
+        // First stdin line is the plugin-options slot; empty means defaults.
         process.StandardInput.WriteLine(string.Empty);
         process.StandardInput.WriteLine(projectFile);
         process.StandardInput.Close();

--- a/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
@@ -599,6 +599,7 @@ public class TargetBuilderOutputPathsTests
         var projectDirectory = ProjectDir("apps", "foo");
         var properties = new Dictionary<string, string>
         {
+            ["Configuration"] = "Debug",
             ["PublishDir"] = "dist-publish",
         };
 

--- a/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
@@ -637,6 +637,28 @@ public class TargetBuilderOutputPathsTests
     }
 
     [Fact]
+    public void Pack_RewritesEvaluatedDebugPackageOutputPathToRelease()
+    {
+        // MSBuild always sets PackageOutputPath, evaluated at the default
+        // (Debug) configuration, but the pack target runs --configuration
+        // Release. Declaring the evaluated value pointed the output at
+        // bin/Debug while the .nupkg was written to bin/Release.
+        var projectDirectory = ProjectDir("libs", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["PackageOutputPath"] = "bin\\Debug/",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin/Release/*.nupkg", "{projectRoot}/obj" },
+            targets["pack"].Outputs);
+    }
+
+    [Fact]
     public void Pack_ArtifactsLayout_EmitsWorkspaceRootPackageAndObjPaths()
     {
         var projectDirectory = ProjectDir("libs", "foo");

--- a/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
@@ -49,6 +49,30 @@ public class TargetBuilderOutputPathsTests
             nxJson: null,
             directoryBuildInputs: directoryBuildInputs ?? new List<string>());
 
+    /// <summary>
+    /// The properties MSBuild actually evaluates for a project under the
+    /// artifacts layout, measured from `dotnet msbuild -getProperty:` on a real
+    /// project. BaseOutputPath and BaseIntermediateOutputPath are always set,
+    /// and both carry ArtifactsProjectName, which defaults to the MSBuild
+    /// project name and is unrelated to the Nx project name.
+    /// </summary>
+    private static Dictionary<string, string> ArtifactsProperties(
+        string msbuildProjectName,
+        string artifactsDir = "artifacts",
+        string binOutputName = "bin")
+    {
+        var artifactsRoot = Path.Combine(WorkspaceRoot, artifactsDir);
+        return new Dictionary<string, string>
+        {
+            ["UseArtifactsOutput"] = "true",
+            ["ArtifactsPath"] = artifactsRoot,
+            ["ArtifactsProjectName"] = msbuildProjectName,
+            ["MSBuildProjectName"] = msbuildProjectName,
+            ["BaseOutputPath"] = Path.Combine(artifactsRoot, binOutputName, msbuildProjectName) + Path.DirectorySeparatorChar,
+            ["BaseIntermediateOutputPath"] = Path.Combine(artifactsRoot, "obj", msbuildProjectName) + Path.DirectorySeparatorChar,
+        };
+    }
+
     // --- Original #33971: Microsoft.NET.Sdk.Web ---------------------------
 
     [Fact]
@@ -167,13 +191,8 @@ public class TargetBuilderOutputPathsTests
     public void Build_ArtifactsOutput_EmitsWorkspaceRootOutputs()
     {
         var projectDirectory = ProjectDir("apps", "foo");
-        var properties = new Dictionary<string, string>
-        {
-            ["UseArtifactsOutput"] = "true",
-            // ArtifactsPath defaults to "artifacts" relative to workspace root.
-        };
 
-        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+        var targets = BuildTargets(ArtifactsProperties("foo"), projectDirectory, projectName: "foo");
 
         Assert.Equal(
             new[]
@@ -188,13 +207,11 @@ public class TargetBuilderOutputPathsTests
     public void Build_ArtifactsOutput_WithCustomArtifactsPath_EmitsWorkspaceRootOutputs()
     {
         var projectDirectory = ProjectDir("apps", "foo");
-        var properties = new Dictionary<string, string>
-        {
-            ["UseArtifactsOutput"] = "true",
-            ["ArtifactsPath"] = Path.Combine(WorkspaceRoot, "build-output"),
-        };
 
-        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+        var targets = BuildTargets(
+            ArtifactsProperties("foo", artifactsDir: "build-output"),
+            projectDirectory,
+            projectName: "foo");
 
         Assert.Equal(
             new[]
@@ -203,6 +220,65 @@ public class TargetBuilderOutputPathsTests
                 "{workspaceRoot}/build-output/obj/foo",
             },
             targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_ArtifactsOutput_WithRenamedNxProject_UsesTheMSBuildProjectName()
+    {
+        // ArtifactsProjectName defaults to MSBuildProjectName, so a project
+        // renamed for Nx via <Nx><Name> still writes to artifacts/bin/<csproj
+        // name>. Deriving the output from the Nx name pointed it at a directory
+        // the build never writes.
+        var projectDirectory = ProjectDir("apps", "foo");
+
+        var targets = BuildTargets(
+            ArtifactsProperties("Renamed"),
+            projectDirectory,
+            projectName: "my-renamed-api");
+
+        Assert.Equal(
+            new[]
+            {
+                "{workspaceRoot}/artifacts/bin/Renamed",
+                "{workspaceRoot}/artifacts/obj/Renamed",
+            },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Build_ArtifactsOutput_HonoursArtifactsProjectNameAndBinOutputName()
+    {
+        // Both segments are overridable; MSBuild folds them into BaseOutputPath.
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = ArtifactsProperties("Override", binOutputName: "binaries");
+        properties["ArtifactsProjectName"] = "custom-name";
+        properties["ArtifactsBinOutputName"] = "binaries";
+        properties["BaseOutputPath"] =
+            Path.Combine(WorkspaceRoot, "artifacts", "binaries", "custom-name") + Path.DirectorySeparatorChar;
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[]
+            {
+                "{workspaceRoot}/artifacts/binaries/custom-name",
+                "{workspaceRoot}/artifacts/obj/Override",
+            },
+            targets["build"].Outputs);
+    }
+
+    [Fact]
+    public void Publish_ArtifactsOutput_HonoursArtifactsPublishOutputName()
+    {
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = ArtifactsProperties("Foo");
+        properties["ArtifactsPublishOutputName"] = "published";
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo", isExe: true);
+
+        Assert.Equal(
+            new[] { "{workspaceRoot}/artifacts/published/Foo", "{workspaceRoot}/artifacts/obj/Foo" },
+            targets["publish"].Outputs);
     }
 
     // --- OpenApiDocumentsDirectory: the generated document is a build output --
@@ -536,12 +612,8 @@ public class TargetBuilderOutputPathsTests
     public void Publish_ArtifactsLayout_EmitsWorkspaceRootPublishPath()
     {
         var projectDirectory = ProjectDir("apps", "foo");
-        var properties = new Dictionary<string, string>
-        {
-            ["UseArtifactsOutput"] = "true",
-        };
 
-        var targets = BuildTargets(properties, projectDirectory, projectName: "foo", isExe: true);
+        var targets = BuildTargets(ArtifactsProperties("foo"), projectDirectory, projectName: "foo", isExe: true);
 
         Assert.Equal(
             new[] { "{workspaceRoot}/artifacts/publish/foo", "{workspaceRoot}/artifacts/obj/foo" },
@@ -568,12 +640,8 @@ public class TargetBuilderOutputPathsTests
     public void Pack_ArtifactsLayout_EmitsWorkspaceRootPackageAndObjPaths()
     {
         var projectDirectory = ProjectDir("libs", "foo");
-        var properties = new Dictionary<string, string>
-        {
-            ["UseArtifactsOutput"] = "true",
-        };
 
-        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+        var targets = BuildTargets(ArtifactsProperties("foo"), projectDirectory, projectName: "foo");
 
         Assert.Equal(
             new[] { "{workspaceRoot}/artifacts/package/*.nupkg", "{workspaceRoot}/artifacts/obj/foo" },

--- a/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
@@ -580,6 +580,7 @@ public class TargetBuilderOutputPathsTests
         var projectDirectory = ProjectDir("apps", "foo");
         var properties = new Dictionary<string, string>
         {
+            ["Configuration"] = "Debug",
             ["PublishDir"] = "bin\\Debug\\publish\\",
         };
 
@@ -646,6 +647,7 @@ public class TargetBuilderOutputPathsTests
         var projectDirectory = ProjectDir("libs", "foo");
         var properties = new Dictionary<string, string>
         {
+            ["Configuration"] = "Debug",
             ["BaseOutputPath"] = "bin\\",
             ["BaseIntermediateOutputPath"] = "obj\\",
             ["PackageOutputPath"] = "bin\\Debug/",
@@ -668,5 +670,83 @@ public class TargetBuilderOutputPathsTests
         Assert.Equal(
             new[] { "{workspaceRoot}/artifacts/package/*.nupkg", "{workspaceRoot}/artifacts/obj/foo" },
             targets["pack"].Outputs);
+    }
+
+    // --- Regressions: comparer preservation and configuration matching -------
+
+    [Fact]
+    public void Pack_NonCanonicallyCasedPackageOutputPath_IsStillHonoured()
+    {
+        // CollectProperties hands the builders a case-insensitive dictionary,
+        // because MSBuild reports whatever spelling the project (or an
+        // environment variable, which is a global property) declared. The
+        // Release copy must keep that comparer or pack silently declares bin/.
+        var projectDirectory = ProjectDir("libs", "foo");
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["configuration"] = "Debug",
+            ["packageoutputpath"] = "custompkg/",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/custompkg/*.nupkg", "{projectRoot}/obj" },
+            targets["pack"].Outputs);
+    }
+
+    [Fact]
+    public void Publish_NonCanonicallyCasedPublishDir_IsStillHonoured()
+    {
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["configuration"] = "Debug",
+            ["publishdir"] = "custompub/",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo", isExe: true);
+
+        Assert.Equal(
+            new[] { "{projectRoot}/custompub", "{projectRoot}/obj" },
+            targets["publish"].Outputs);
+    }
+
+    [Fact]
+    public void Pack_LeavesLiteralReleaseDirectoryAlone()
+    {
+        // The directory is named "release" in its own right, not produced from
+        // $(Configuration) - rewriting it to "Release" pointed the glob at a
+        // directory pack never writes (and never matches on a case-sensitive
+        // filesystem).
+        var projectDirectory = ProjectDir("libs", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["Configuration"] = "Debug",
+            ["PackageOutputPath"] = "nupkgs/release/",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/nupkgs/release/*.nupkg", "{projectRoot}/obj" },
+            targets["pack"].Outputs);
+    }
+
+    [Fact]
+    public void Publish_LeavesLiteralReleaseDirectoryAlone()
+    {
+        var projectDirectory = ProjectDir("apps", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["Configuration"] = "Debug",
+            ["PublishDir"] = "out/release/",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo", isExe: true);
+
+        Assert.Equal(
+            new[] { "{projectRoot}/out/release", "{projectRoot}/obj" },
+            targets["publish"].Outputs);
     }
 }

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -256,55 +256,24 @@ public static class Analyzer
         return projectRefs;
     }
 
+    /// <summary>
+    /// Snapshots the project's evaluated MSBuild properties. Every property is
+    /// captured rather than a curated list: the helpers that read them look up
+    /// by name, so a list is one more thing to keep in sync and a typo in it
+    /// fails silently. Empty values are skipped so callers can treat a missing
+    /// key and an unset property alike.
+    /// </summary>
     private static Dictionary<string, string> CollectProperties(ProjectInstance project)
     {
-        var properties = new Dictionary<string, string>();
-        var propertiesToCollect = new[]
+        // MSBuild property names are case-insensitive; matching that here keeps
+        // a project that spells one <outputpath> readable to the helpers.
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var property in project.Properties)
         {
-            // Project identification
-            "TargetFramework",
-            "TargetFrameworks",
-            "OutputType",
-            "AssemblyName",
-            "IsTestProject",
-
-            // Build configuration
-            "Configuration",
-            "Platform",
-            "RuntimeIdentifier",
-
-            // Artifacts output (new SDK layout)
-            "UseArtifactsOutput",
-            "ArtifactsPath",
-            "ArtifactsPivots",
-
-            // Output paths
-            "OutputPath",
-            "OutDir",
-            "BaseIntermediateOutputPath",
-            "IntermediateOutputPath",
-            "BaseOutputPath",
-
-            // Publish paths
-            "PublishDir",
-
-            // Package paths
-            "PackageOutputPath",
-
-            // Test paths
-            "TestResultsDirectory",
-
-            // OpenAPI document paths
-            "OpenApiDocumentsDirectory",
-            "OpenApiGenerateDocumentsOptions"
-        };
-
-        foreach (var prop in propertiesToCollect)
-        {
-            var val = project.GetPropertyValue(prop);
-            if (!string.IsNullOrEmpty(val))
+            if (!string.IsNullOrEmpty(property.EvaluatedValue))
             {
-                properties[prop] = val;
+                properties[property.Name] = property.EvaluatedValue;
             }
         }
 

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
@@ -23,8 +23,8 @@ public static partial class TargetBuilder
         string description,
         List<string> directoryBuildInputs)
     {
-        var outputPath = GetOutputPath(properties, projectName, projectDirectory, workspaceRoot);
-        var intermediatePath = GetIntermediateOutputPath(properties, projectName, projectDirectory, workspaceRoot);
+        var outputPath = GetOutputPath(properties, projectDirectory, workspaceRoot);
+        var intermediatePath = GetIntermediateOutputPath(properties, projectDirectory, workspaceRoot);
         // The package defaults OpenApiDocumentsDirectory to $(BaseIntermediateOutputPath),
         // so merely referencing it lands on obj, which is already an output.
         var openApiDocumentsOutputs = GetOpenApiDocumentsOutputs(properties, fileName, projectDirectory, workspaceRoot, outputPath, intermediatePath);

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
@@ -18,13 +18,11 @@ public static partial class TargetBuilder
         string productionInput,
         List<string> directoryBuildInputs)
     {
-        // Create a copy of properties with Configuration=Release
-        var releaseProperties = new Dictionary<string, string>(properties)
-        {
-            ["Configuration"] = "Release"
-        };
+        // The configuration MSBuild evaluated the paths at; the target runs at Release.
+        var defaultConfiguration = properties.GetValueOrDefault("Configuration");
+        var releaseProperties = WithConfiguration(properties, "Release");
 
-        var packageOutputPath = GetPackageOutputPath(releaseProperties, projectDirectory, workspaceRoot);
+        var packageOutputPath = GetPackageOutputPath(releaseProperties, defaultConfiguration, projectDirectory, workspaceRoot);
         // `dotnet pack` writes intermediate state into the intermediate (obj)
         // directory, so it must be declared as an output alongside the package
         // output, mirroring the build target.

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
@@ -24,11 +24,11 @@ public static partial class TargetBuilder
             ["Configuration"] = "Release"
         };
 
-        var packageOutputPath = GetPackageOutputPath(releaseProperties, projectName, projectDirectory, workspaceRoot);
+        var packageOutputPath = GetPackageOutputPath(releaseProperties, projectDirectory, workspaceRoot);
         // `dotnet pack` writes intermediate state into the intermediate (obj)
         // directory, so it must be declared as an output alongside the package
         // output, mirroring the build target.
-        var intermediatePath = GetIntermediateOutputPath(releaseProperties, projectName, projectDirectory, workspaceRoot);
+        var intermediatePath = GetIntermediateOutputPath(releaseProperties, projectDirectory, workspaceRoot);
 
         var buildReleaseTarget = $"{options.BuildTargetName}:release";
         targets[options.PackTargetName] = new Target

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
@@ -153,18 +153,48 @@ public static partial class TargetBuilder
     }
 
     /// <summary>
+    /// Builds an artifacts-layout subdirectory from the names MSBuild evaluated,
+    /// rather than hard-coding them: every segment
+    /// (<c>ArtifactsPath</c>, the output name, <c>ArtifactsProjectName</c>) is
+    /// overridable, and <c>ArtifactsProjectName</c> defaults to
+    /// <c>MSBuildProjectName</c>, which is not the Nx project name.
+    /// The pivot segment is deliberately omitted so one output covers every
+    /// configuration. Returns <c>null</c> when the path escapes the workspace.
+    /// </summary>
+    private static string? GetArtifactsSubdirectory(
+        Dictionary<string, string> properties,
+        string workspaceRoot,
+        string outputNameProperty,
+        string defaultOutputName,
+        bool includeProjectName)
+    {
+        var artifactsPath = GetArtifactsRelativePath(properties, workspaceRoot);
+        if (artifactsPath is null)
+        {
+            return null;
+        }
+
+        var outputName = properties.GetValueOrDefault(outputNameProperty) ?? defaultOutputName;
+        var path = $"{{workspaceRoot}}/{artifactsPath}/{outputName}";
+
+        if (!includeProjectName)
+        {
+            return path;
+        }
+
+        var artifactsProjectName = properties.GetValueOrDefault("ArtifactsProjectName")
+            ?? properties.GetValueOrDefault("MSBuildProjectName");
+
+        return string.IsNullOrEmpty(artifactsProjectName) ? path : $"{path}/{artifactsProjectName}";
+    }
+
+    /// <summary>
     /// Gets the output directory path for build outputs, as a fully-qualified
     /// Nx-prefixed string. Handles both traditional and artifacts layouts.
     /// Returns <c>null</c> when the path lives outside the workspace.
     /// </summary>
-    private static string? GetOutputPath(Dictionary<string, string> properties, string projectName, string projectDirectory, string workspaceRoot)
+    private static string? GetOutputPath(Dictionary<string, string> properties, string projectDirectory, string workspaceRoot)
     {
-        if (UsesArtifactsOutput(properties))
-        {
-            var artifactsPath = GetArtifactsRelativePath(properties, workspaceRoot);
-            return artifactsPath is null ? null : $"{{workspaceRoot}}/{artifactsPath}/bin/{projectName}";
-        }
-
         var baseOutputPath = properties.GetValueOrDefault("BaseOutputPath");
         if (!string.IsNullOrEmpty(baseOutputPath))
         {
@@ -184,14 +214,8 @@ public static partial class TargetBuilder
     /// Nx-prefixed string. Returns <c>null</c> when the path lives outside the
     /// workspace.
     /// </summary>
-    private static string? GetIntermediateOutputPath(Dictionary<string, string> properties, string projectName, string projectDirectory, string workspaceRoot)
+    private static string? GetIntermediateOutputPath(Dictionary<string, string> properties, string projectDirectory, string workspaceRoot)
     {
-        if (UsesArtifactsOutput(properties))
-        {
-            var artifactsPath = GetArtifactsRelativePath(properties, workspaceRoot);
-            return artifactsPath is null ? null : $"{{workspaceRoot}}/{artifactsPath}/obj/{projectName}";
-        }
-
         var baseIntermediatePath = properties.GetValueOrDefault("BaseIntermediateOutputPath");
         if (!string.IsNullOrEmpty(baseIntermediatePath))
         {
@@ -208,12 +232,14 @@ public static partial class TargetBuilder
     /// Gets the publish output directory path, as a fully-qualified Nx-prefixed
     /// string. Returns <c>null</c> when the path lives outside the workspace.
     /// </summary>
-    private static string? GetPublishDir(Dictionary<string, string> properties, string projectName, string projectDirectory, string workspaceRoot)
+    private static string? GetPublishDir(Dictionary<string, string> properties, string projectDirectory, string workspaceRoot)
     {
         if (UsesArtifactsOutput(properties))
         {
-            var artifactsPath = GetArtifactsRelativePath(properties, workspaceRoot);
-            return artifactsPath is null ? null : $"{{workspaceRoot}}/{artifactsPath}/publish/{projectName}";
+            // PublishDir carries the pivot (…/publish/<project>/debug), which is
+            // per-configuration. Declare its parent so one output covers every
+            // configuration, as the bin and obj outputs do.
+            return GetArtifactsSubdirectory(properties, workspaceRoot, "ArtifactsPublishOutputName", "publish", includeProjectName: true);
         }
 
         // PublishDir (e.g. "bin/Debug/publish") is evaluated by MSBuild at the
@@ -227,7 +253,7 @@ public static partial class TargetBuilder
             return ApplyConfiguration(resolved, properties.GetValueOrDefault("Configuration"));
         }
 
-        var outputPath = GetOutputPath(properties, projectName, projectDirectory, workspaceRoot);
+        var outputPath = GetOutputPath(properties, projectDirectory, workspaceRoot);
         return outputPath is null ? null : $"{outputPath.TrimEnd('/')}/publish";
     }
 
@@ -261,12 +287,12 @@ public static partial class TargetBuilder
     /// Gets the package output directory path, as a fully-qualified Nx-prefixed
     /// string. Returns <c>null</c> when the path lives outside the workspace.
     /// </summary>
-    private static string? GetPackageOutputPath(Dictionary<string, string> properties, string projectName, string projectDirectory, string workspaceRoot)
+    private static string? GetPackageOutputPath(Dictionary<string, string> properties, string projectDirectory, string workspaceRoot)
     {
         if (UsesArtifactsOutput(properties))
         {
-            var artifactsPath = GetArtifactsRelativePath(properties, workspaceRoot);
-            return artifactsPath is null ? null : $"{{workspaceRoot}}/{artifactsPath}/package";
+            // The package layout has no per-project segment.
+            return GetArtifactsSubdirectory(properties, workspaceRoot, "ArtifactsPackageOutputName", "package", includeProjectName: false);
         }
 
         var packageOutputPath = properties.GetValueOrDefault("PackageOutputPath");
@@ -275,7 +301,7 @@ public static partial class TargetBuilder
             return ResolvePath(packageOutputPath, projectDirectory, workspaceRoot);
         }
 
-        return GetOutputPath(properties, projectName, projectDirectory, workspaceRoot);
+        return GetOutputPath(properties, projectDirectory, workspaceRoot);
     }
 
     /// <summary>

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
@@ -274,8 +274,10 @@ public static partial class TargetBuilder
             return path;
         }
 
+        // Segment 0 is the {projectRoot}/{workspaceRoot} token every ResolvePath
+        // result carries, and a Configuration value could otherwise match it.
         var segments = path.Split('/');
-        for (var i = 0; i < segments.Length; i++)
+        for (var i = 1; i < segments.Length; i++)
         {
             if (segments[i].Equals(defaultConfiguration, StringComparison.Ordinal))
             {

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
@@ -232,7 +232,7 @@ public static partial class TargetBuilder
     /// Gets the publish output directory path, as a fully-qualified Nx-prefixed
     /// string. Returns <c>null</c> when the path lives outside the workspace.
     /// </summary>
-    private static string? GetPublishDir(Dictionary<string, string> properties, string projectDirectory, string workspaceRoot)
+    private static string? GetPublishDir(Dictionary<string, string> properties, string? defaultConfiguration, string projectDirectory, string workspaceRoot)
     {
         if (UsesArtifactsOutput(properties))
         {
@@ -250,7 +250,7 @@ public static partial class TargetBuilder
         if (!string.IsNullOrEmpty(publishDir))
         {
             var resolved = ResolvePath(publishDir, projectDirectory, workspaceRoot);
-            return ApplyConfiguration(resolved, properties.GetValueOrDefault("Configuration"));
+            return ApplyConfiguration(resolved, defaultConfiguration, properties.GetValueOrDefault("Configuration"));
         }
 
         var outputPath = GetOutputPath(properties, projectDirectory, workspaceRoot);
@@ -258,14 +258,18 @@ public static partial class TargetBuilder
     }
 
     /// <summary>
-    /// Rewrites any <c>Debug</c>/<c>Release</c> path segment to the given
-    /// configuration. Used for paths (like PublishDir) that MSBuild evaluates at
-    /// the default configuration but a target consumes at another. A no-op when
-    /// the configuration is empty or the path contains no configuration segment.
+    /// Rewrites the segments MSBuild produced from <paramref name="defaultConfiguration"/>
+    /// to <paramref name="targetConfiguration"/>. Used for paths (like PublishDir) that
+    /// MSBuild evaluates at the project's default configuration but a target consumes at
+    /// another. Matching the evaluated default exactly, rather than any Debug/Release
+    /// segment, leaves a directory that merely happens to be named `release` alone.
+    /// A no-op when either configuration is unknown.
     /// </summary>
-    private static string? ApplyConfiguration(string? path, string? configuration)
+    private static string? ApplyConfiguration(string? path, string? defaultConfiguration, string? targetConfiguration)
     {
-        if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(configuration))
+        if (string.IsNullOrEmpty(path)
+            || string.IsNullOrEmpty(defaultConfiguration)
+            || string.IsNullOrEmpty(targetConfiguration))
         {
             return path;
         }
@@ -273,10 +277,9 @@ public static partial class TargetBuilder
         var segments = path.Split('/');
         for (var i = 0; i < segments.Length; i++)
         {
-            if (segments[i].Equals("Debug", StringComparison.OrdinalIgnoreCase) ||
-                segments[i].Equals("Release", StringComparison.OrdinalIgnoreCase))
+            if (segments[i].Equals(defaultConfiguration, StringComparison.Ordinal))
             {
-                segments[i] = configuration;
+                segments[i] = targetConfiguration;
             }
         }
 
@@ -287,7 +290,7 @@ public static partial class TargetBuilder
     /// Gets the package output directory path, as a fully-qualified Nx-prefixed
     /// string. Returns <c>null</c> when the path lives outside the workspace.
     /// </summary>
-    private static string? GetPackageOutputPath(Dictionary<string, string> properties, string projectDirectory, string workspaceRoot)
+    private static string? GetPackageOutputPath(Dictionary<string, string> properties, string? defaultConfiguration, string projectDirectory, string workspaceRoot)
     {
         if (UsesArtifactsOutput(properties))
         {
@@ -303,7 +306,7 @@ public static partial class TargetBuilder
         if (!string.IsNullOrEmpty(packageOutputPath))
         {
             var resolved = ResolvePath(packageOutputPath, projectDirectory, workspaceRoot);
-            return ApplyConfiguration(resolved, properties.GetValueOrDefault("Configuration"));
+            return ApplyConfiguration(resolved, defaultConfiguration, properties.GetValueOrDefault("Configuration"));
         }
 
         return GetOutputPath(properties, projectDirectory, workspaceRoot);

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
@@ -295,10 +295,15 @@ public static partial class TargetBuilder
             return GetArtifactsSubdirectory(properties, workspaceRoot, "ArtifactsPackageOutputName", "package", includeProjectName: false);
         }
 
+        // PackageOutputPath is evaluated at the project's default Configuration,
+        // but pack runs at the Configuration in `properties` (Release). Rewrite
+        // the configuration segment so the declared output matches where the
+        // .nupkg lands, as GetPublishDir does for PublishDir.
         var packageOutputPath = properties.GetValueOrDefault("PackageOutputPath");
         if (!string.IsNullOrEmpty(packageOutputPath))
         {
-            return ResolvePath(packageOutputPath, projectDirectory, workspaceRoot);
+            var resolved = ResolvePath(packageOutputPath, projectDirectory, workspaceRoot);
+            return ApplyConfiguration(resolved, properties.GetValueOrDefault("Configuration"));
         }
 
         return GetOutputPath(properties, projectDirectory, workspaceRoot);

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
@@ -25,12 +25,12 @@ public static partial class TargetBuilder
             ["Configuration"] = "Release"
         };
 
-        var publishDir = GetPublishDir(releaseProperties, projectName, projectDirectory, workspaceRoot);
+        var publishDir = GetPublishDir(releaseProperties, projectDirectory, workspaceRoot);
         // `dotnet publish` writes incremental-publish state (e.g.
         // obj/<Configuration>/PublishOutputs.<hash>.txt) into the intermediate
         // (obj) directory, so it must be declared as an output alongside the
         // publish directory, mirroring the build target.
-        var intermediatePath = GetIntermediateOutputPath(releaseProperties, projectName, projectDirectory, workspaceRoot);
+        var intermediatePath = GetIntermediateOutputPath(releaseProperties, projectDirectory, workspaceRoot);
 
         string[] defaultFlags = ["--no-build", "--no-dependencies", "--no-restore"];
 

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
@@ -19,13 +19,11 @@ public static partial class TargetBuilder
         string productionInput,
         List<string> directoryBuildInputs)
     {
-        // Create a copy of properties with Configuration=Release
-        var releaseProperties = new Dictionary<string, string>(properties)
-        {
-            ["Configuration"] = "Release"
-        };
+        // The configuration MSBuild evaluated the paths at; the target runs at Release.
+        var defaultConfiguration = properties.GetValueOrDefault("Configuration");
+        var releaseProperties = WithConfiguration(properties, "Release");
 
-        var publishDir = GetPublishDir(releaseProperties, projectDirectory, workspaceRoot);
+        var publishDir = GetPublishDir(releaseProperties, defaultConfiguration, projectDirectory, workspaceRoot);
         // `dotnet publish` writes incremental-publish state (e.g.
         // obj/<Configuration>/PublishOutputs.<hash>.txt) into the intermediate
         // (obj) directory, so it must be declared as an output alongside the

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
@@ -70,4 +70,21 @@ public static partial class TargetBuilder
 
         return "default";
     }
+
+    /// <summary>
+    /// Copies <paramref name="properties"/> with <c>Configuration</c> set to
+    /// <paramref name="configuration"/>, preserving the source comparer. The
+    /// <c>Dictionary</c> copy constructor silently falls back to an ordinal
+    /// comparer, which would hide any property MSBuild reports under a
+    /// non-canonical spelling from every helper reading the copy.
+    /// </summary>
+    private static Dictionary<string, string> WithConfiguration(
+        Dictionary<string, string> properties,
+        string configuration)
+    {
+        return new Dictionary<string, string>(properties, properties.Comparer)
+        {
+            ["Configuration"] = configuration
+        };
+    }
 }


### PR DESCRIPTION
> **Stacked on #36788.** Base is `feat/dotnet-openapi-documents-output`, so the diff here is only the four commits on top. Merge #36788 first and this retargets to `master` cleanly.

## Current Behavior

One root cause with three symptoms: the analyzer reconstructs values MSBuild has already evaluated, and the tests can't catch it when the reconstruction is wrong.

**1. The property whitelist is unverifiable.** `CollectProperties` copies a curated list of property names out of each project. Nothing exercises the list, so a typo in it leaves whatever feature reads that property silently inert with the suite green. It has already drifted, just harmlessly: six of the twenty-one entries — `TargetFramework`, `TargetFrameworks`, `AssemblyName`, `Platform`, `RuntimeIdentifier`, `ArtifactsPivots` — are never read from the collected dictionary, and have not been since #32869.

**2. Artifacts-layout paths are wrong under supported configuration.** Under `UseArtifactsOutput` the analyzer rebuilds each path from string literals — `artifacts/bin/<name>`, `artifacts/publish/<name>`, `artifacts/package` — using the **Nx** project name:

- `ArtifactsProjectName` defaults to `MSBuildProjectName`, never the Nx name. A project renamed via `<Nx><Name>` declares `artifacts/bin/<nx-name>` while the build writes `artifacts/bin/<csproj-name>` — so its output is neither cached nor restored. That needs no unusual setup, just an Nx rename.
- `ArtifactsBinOutputName`, `ArtifactsPublishOutputName` and `ArtifactsPackageOutputName` are all overridable and ignored.

**3. `pack` declares the wrong configuration.** MSBuild always sets `PackageOutputPath`, evaluated at the project's default configuration — `bin\Debug/` for a stock project. The pack target runs `dotnet pack --configuration Release`, writing the `.nupkg` to `bin/Release/`. The declared output pointed at a directory pack never writes, so the package was never cached or restored.

## Expected Behavior

**Collect every evaluated property.** The dictionary never leaves the process — built, handed to the target builders, dropped — so the list bounded nothing but which names a helper was allowed to ask for. Removing it removes the bug class rather than testing around it. It is now case-insensitive to match MSBuild; the list previously laundered casing, since `GetPropertyValue` matches a project that declared `<outputpath>` and the value was then stored under the list's spelling, so the ordinal lookup downstream succeeded by accident.

**Read the paths MSBuild computed.** `BaseOutputPath` and `BaseIntermediateOutputPath` are always set under the artifacts layout and are pivot-free — exactly the parent-of-all-configurations the hardcoded paths were approximating. Both special cases are deleted and the existing branches handle artifacts for free, honouring every override. Publish and pack keep a constructed path because `PublishDir` and `PackageOutputPath` carry the per-configuration pivot segment; they now build from the evaluated names rather than literals.

**Apply the target's configuration to the package path**, exactly as `GetPublishDir` already does for `PublishDir`. The pack target has been passing `Configuration=Release` in its properties copy all along; `GetPackageOutputPath` just never used it.

### Why the artifacts pivot is still omitted

`OutputPath = $(BaseOutputPath)$(ArtifactsPivots)`, so the pivot is the leaf, and declaring the parent covers every configuration at once — the same thing `StripConfiguration` does for `bin/Debug` → `bin`. The evaluated `ArtifactsPivots` could not be used for precision anyway: MSBuild evaluates it once at the analyzer's `Configuration`, but the analyzer emits both `build` and `build:release` from that single evaluation.

## Smoke tests

Every existing test hands `BuildTargets` a hand-built property dictionary, so it can only assert what its author *believed* MSBuild evaluates — and when the belief is wrong, the test agrees with it. All three defects above are that failure mode, and so was a fourth found while reviewing #36788 (the ApiDescription package defaulting `OpenApiDocumentsDirectory` to `$(BaseIntermediateOutputPath)`).

So this adds tests that run the analyzer the way the plugin does: as a process, over a real `.csproj` in a temp workspace, with MSBuild doing the evaluation. **The pack bug above was found by these on their first run** — the existing `Pack_EmitsNupkgGlobAndIntermediateObj` missed it because it passes an empty dictionary and therefore exercises a fallback branch real MSBuild never reaches.

Out of process is deliberate: the analyzer calls `MSBuildLocator.RegisterInstance` itself, and registering inside the test host would fight the runner over which MSBuild assemblies load. Both `MsbuildAnalyzer.dll` and its `runtimeconfig.json` already land beside the test assembly via the project reference, so `AppContext.BaseDirectory` locates it with no path arithmetic and no new build wiring.

Four cases, deliberately few since each pays for a process launch and a full evaluation: default `bin`/`obj`, the OpenAPI document globs, the pack release directory, and an artifacts project renamed for Nx.

They sit here rather than in the e2e suite because the question they answer — "what does MSBuild evaluate for this property" — is answered slowly and indirectly through a real workspace, where a failure gives you a task exit code instead of a property name. These run in the existing `test-native` target and need no verdaccio.

## Verification

Measured with `dotnet msbuild -getProperty:` against real projects rather than inferred:

| Setup | Evaluated |
| --- | --- |
| plain | `BaseOutputPath = artifacts/bin/MyApi/` |
| `<Nx><Name>my-renamed-api</Name></Nx>` | `artifacts/bin/Renamed/` — unaffected by the Nx name |
| `ArtifactsProjectName` + `ArtifactsBinOutputName` | `artifacts/binaries/custom-name/` |
| stock project, default | `PackageOutputPath = bin\Debug/` |
| stock project, `-p:Configuration=Release` | `PackageOutputPath = bin\Release/` |

- `dotnet test` on `analyzer.Tests` — 56 passing, including four smoke tests (~270ms each, ~1s for the whole suite) and four new unit regressions. The artifacts and pack fixes were each confirmed to fail against the previous implementation.
- `nx test dotnet` — 34 passing. `nx run-many -t build,test` across the three projects — green. `format-native` — clean.

The existing artifacts fixtures asserted a state MSBuild never produces (`UseArtifactsOutput` set with no `BaseOutputPath`), which is why they went red here; they are rebuilt from the measured values above.

## Related Issue(s)

No filed issue; found while reviewing #36788. Previously split as #36805, folded in here.
