### PR TITLE
chore(dotnet): add analyzer smoke tests over real MSBuild evaluation

### DIFF
--- a/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
+++ b/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// End-to-end checks that run the analyzer the way the plugin does: as a
+/// process, against a real project, with MSBuild doing the evaluation.
+///
+/// The rest of the suite hands <see cref="Utilities.TargetBuilder.BuildTargets"/>
+/// a hand-built property dictionary, which cannot catch a wrong assumption about
+/// what MSBuild actually evaluates - the fixture simply asserts whatever the
+/// author believed. Two real defects reached review that way: a package whose
+/// props default OpenApiDocumentsDirectory to $(BaseIntermediateOutputPath), and
+/// PackageOutputPath always being set to a Debug path the pack target never
+/// writes to. These tests cover that seam; they are deliberately few, since each
+/// one pays for a process launch and a full MSBuild evaluation.
+/// </summary>
+public class AnalyzerSmokeTests : IDisposable
+{
+    private readonly string _workspaceRoot =
+        Path.Combine(Path.GetTempPath(), "nx-dotnet-smoke-" + Guid.NewGuid().ToString("n"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workspaceRoot))
+        {
+            Directory.Delete(_workspaceRoot, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private string WriteProject(string projectName, string propertyGroup, string? directoryBuildProps = null)
+    {
+        var projectDirectory = Path.Combine(_workspaceRoot, "apps", projectName);
+        Directory.CreateDirectory(projectDirectory);
+
+        if (directoryBuildProps is not null)
+        {
+            File.WriteAllText(
+                Path.Combine(_workspaceRoot, "Directory.Build.props"),
+                $"<Project><PropertyGroup>{directoryBuildProps}</PropertyGroup></Project>");
+        }
+
+        var projectFile = Path.Combine(projectDirectory, $"{projectName}.csproj");
+        File.WriteAllText(projectFile, $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                {propertyGroup}
+              </PropertyGroup>
+            </Project>
+            """);
+
+        return projectFile;
+    }
+
+    /// <summary>
+    /// Runs the analyzer over one project and returns that project's targets.
+    /// The analyzer registers MSBuildLocator itself, so it has to run out of
+    /// process - registering in the test host would fight the runner over which
+    /// MSBuild assemblies get loaded.
+    /// </summary>
+    private Dictionary<string, JsonElement> Analyze(string projectFile)
+    {
+        // Both MsbuildAnalyzer.dll and its runtimeconfig.json land next to the
+        // test assembly via the project reference.
+        var analyzer = Path.Combine(AppContext.BaseDirectory, "MsbuildAnalyzer.dll");
+        Assert.True(File.Exists(analyzer), $"Analyzer not found at {analyzer}");
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            ArgumentList = { analyzer, _workspaceRoot },
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        using var process = Process.Start(startInfo)!;
+        process.StandardInput.WriteLine(projectFile);
+        process.StandardInput.Close();
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(milliseconds: 180_000), "Analyzer timed out");
+        Assert.True(process.ExitCode == 0, $"Analyzer exited {process.ExitCode}. stderr:\n{stderr}");
+
+        var relativeProjectFile = Path.GetRelativePath(_workspaceRoot, projectFile).Replace('\\', '/');
+        var result = JsonDocument.Parse(stdout).RootElement;
+
+        return result
+            .GetProperty("nodesByFile")
+            .GetProperty(relativeProjectFile)
+            .GetProperty("targets")
+            .EnumerateObject()
+            .ToDictionary(p => p.Name, p => p.Value);
+    }
+
+    private static string[] Outputs(Dictionary<string, JsonElement> targets, string targetName) =>
+        [.. targets[targetName].GetProperty("outputs").EnumerateArray().Select(o => o.GetString()!)];
+
+    [Fact]
+    public void DefaultProject_DeclaresBinAndObj()
+    {
+        var targets = Analyze(WriteProject("MyLib", ""));
+
+        Assert.Equal(new[] { "{projectRoot}/bin", "{projectRoot}/obj" }, Outputs(targets, "build"));
+    }
+
+    [Fact]
+    public void OpenApiDocumentsDirectory_DeclaresTheDocumentGlobs()
+    {
+        var projectFile = WriteProject(
+            "MyApi",
+            "<OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/openapi</OpenApiDocumentsDirectory>");
+
+        var targets = Analyze(projectFile);
+
+        Assert.Equal(
+            new[]
+            {
+                "{projectRoot}/bin",
+                "{projectRoot}/obj",
+                "{projectRoot}/openapi/MyApi.json",
+                "{projectRoot}/openapi/MyApi_*.json",
+            },
+            Outputs(targets, "build"));
+    }
+
+    [Fact]
+    public void Pack_DeclaresTheReleasePackageDirectory()
+    {
+        // MSBuild always evaluates PackageOutputPath, and does so at the default
+        // Debug configuration, while pack runs --configuration Release. No
+        // hand-built fixture caught this because none of them set the property.
+        var targets = Analyze(WriteProject("MyLib", ""));
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin/Release/*.nupkg", "{projectRoot}/obj" },
+            Outputs(targets, "pack"));
+    }
+
+    [Fact]
+    public void ArtifactsLayout_DeclaresTheMSBuildProjectNameNotTheNxName()
+    {
+        // ArtifactsProjectName defaults to MSBuildProjectName. Naming the project
+        // something else for Nx must not move the declared output.
+        var projectFile = WriteProject(
+            "Renamed",
+            "<Nx><Name>my-renamed-api</Name></Nx>",
+            directoryBuildProps: "<UseArtifactsOutput>true</UseArtifactsOutput>");
+
+        var targets = Analyze(projectFile);
+
+        Assert.Equal(
+            new[]
+            {
+                "{workspaceRoot}/artifacts/bin/Renamed",
+                "{workspaceRoot}/artifacts/obj/Renamed",
+            },
+            Outputs(targets, "build"));
+    }
+}

--- a/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
@@ -637,6 +637,28 @@ public class TargetBuilderOutputPathsTests
     }
 
     [Fact]
+    public void Pack_RewritesEvaluatedDebugPackageOutputPathToRelease()
+    {
+        // MSBuild always sets PackageOutputPath, evaluated at the default
+        // (Debug) configuration, but the pack target runs --configuration
+        // Release. Declaring the evaluated value pointed the output at
+        // bin/Debug while the .nupkg was written to bin/Release.
+        var projectDirectory = ProjectDir("libs", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["BaseOutputPath"] = "bin\\",
+            ["BaseIntermediateOutputPath"] = "obj\\",
+            ["PackageOutputPath"] = "bin\\Debug/",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin/Release/*.nupkg", "{projectRoot}/obj" },
+            targets["pack"].Outputs);
+    }
+
+    [Fact]
     public void Pack_ArtifactsLayout_EmitsWorkspaceRootPackageAndObjPaths()
     {
         var projectDirectory = ProjectDir("libs", "foo");

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.PathHelpers.cs
@@ -295,10 +295,15 @@ public static partial class TargetBuilder
             return GetArtifactsSubdirectory(properties, workspaceRoot, "ArtifactsPackageOutputName", "package", includeProjectName: false);
         }
 
+        // PackageOutputPath is evaluated at the project's default Configuration,
+        // but pack runs at the Configuration in `properties` (Release). Rewrite
+        // the configuration segment so the declared output matches where the
+        // .nupkg lands, as GetPublishDir does for PublishDir.
         var packageOutputPath = properties.GetValueOrDefault("PackageOutputPath");
         if (!string.IsNullOrEmpty(packageOutputPath))
         {
-            return ResolvePath(packageOutputPath, projectDirectory, workspaceRoot);
+            var resolved = ResolvePath(packageOutputPath, projectDirectory, workspaceRoot);
+            return ApplyConfiguration(resolved, properties.GetValueOrDefault("Configuration"));
         }
 
         return GetOutputPath(properties, projectDirectory, workspaceRoot);


### PR DESCRIPTION
> **Stacked on #36804**, which is stacked on #36788. Base is `fix/dotnet-artifacts-output-paths`, so the diff here is only the two commits on top. Merge order: #36788 → #36804 → this.

## Current Behavior

Every analyzer test hands `TargetBuilder.BuildTargets` a hand-built property dictionary. That makes them fast and focused, but it means a test can only assert what its author *believed* MSBuild evaluates — and when that belief is wrong, the test agrees with it.

That seam has now produced three defects in as many reviews:

- `Microsoft.Extensions.ApiDescription.Server.props` defaults `OpenApiDocumentsDirectory` to `$(BaseIntermediateOutputPath)`, so merely referencing the package reports the property as set (#36788).
- The artifacts fixtures set `UseArtifactsOutput` with no `BaseOutputPath` — a state MSBuild never produces (#36804).
- `PackageOutputPath` is *always* set, to a Debug path the pack target never writes to. That one is fixed here.

## Expected Behavior

### The pack bug

MSBuild evaluates `PackageOutputPath` at the project's default configuration — `bin\Debug/` for a stock project. The pack target runs `dotnet pack --configuration Release`, which writes the `.nupkg` to `bin/Release/`. So the declared output pointed at a directory pack never writes, and the package was neither cached nor restored.

`GetPublishDir` already solves exactly this for `PublishDir` via `ApplyConfiguration`, and the pack target has been passing `Configuration=Release` in its properties copy all along — `GetPackageOutputPath` just never applied it. Measured on a stock project:

```
PackageOutputPath (default)             bin\Debug/
PackageOutputPath (-p:Configuration=Release)  bin\Release/
```

The existing `Pack_EmitsNupkgGlobAndIntermediateObj` missed it because it passes an empty dictionary, so it exercised the `GetOutputPath` fallback — a branch real MSBuild never reaches.

### The smoke tests

Run the analyzer the way the plugin does: as a process, over a real `.csproj` in a temp workspace, with MSBuild doing the evaluation, asserting the targets it emits.

Out of process is deliberate — the analyzer calls `MSBuildLocator.RegisterInstance` itself, and registering inside the test host would fight the runner over which MSBuild assemblies load. Both `MsbuildAnalyzer.dll` and its `runtimeconfig.json` land beside the test assembly via the existing project reference, so `AppContext.BaseDirectory` finds it with no path arithmetic and no new build wiring.

Four cases, deliberately few, since each pays for a process launch and a full evaluation:

| Case | Covers |
| --- | --- |
| default project | `bin` / `obj` |
| `<OpenApiDocumentsDirectory>` | the document globs from #36788 |
| pack | the Release package directory fixed here |
| artifacts + `<Nx><Name>` rename | `ArtifactsProjectName` from #36804 |

## Verification

- `dotnet test` — 56 passing, of which 4 are the new smoke tests at ~270ms each (~1s for the whole suite).
- The pack fix was confirmed to fail both its unit test and its smoke test against the previous implementation.
- `nx test dotnet` — 34 passing. `nx run-many -t build,test` across the three projects — green. `format-native` — clean.

These need a .NET SDK at runtime, which CI already has since it runs `dotnet test`.

## Why here rather than the e2e suite

The e2e suite exercises the plugin through a real workspace, which is the right place for plugin-level behaviour but a slow and indirect way to ask "what does MSBuild evaluate for this property". These sit next to the code they cover, run in the existing `test-native` target, need no verdaccio or workspace setup, and a failure names the property rather than a task exit code.

## Related Issue(s)

No filed issue; the pack bug was found by the smoke tests on their first run.
