### PR TITLE
fix(gradle): retry nxProjectGraph on lock timeout and kill orphaned gradle builds on exit

### DIFF
--- a/astro-docs/src/content/docs/reference/environment-variables.mdoc
+++ b/astro-docs/src/content/docs/reference/environment-variables.mdoc
@@ -246,12 +246,13 @@ The following environment variables are ones that you can set to change the beha
 
 The following environment variables can be used to configure specific Nx plugins. This is useful in CI environments where the required tooling (e.g., Java) is not available or where plugin behavior needs to be customized.
 
-| Property                          | Type    | Description                                                                                                                                               |
-| --------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NX_DOTNET_DISABLE`               | boolean | If set to `true`, disables the `@nx/dotnet` plugin. Useful in environments where .NET SDK is not available.                                               |
-| `NX_GRADLE_DISABLE`               | boolean | If set to `true`, disables the `@nx/gradle` plugin. Useful in environments where Java/Gradle is not available.                                            |
-| `NX_GRADLE_PROJECT_GRAPH_TIMEOUT` | number  | Timeout in seconds for Gradle project graph generation. Defaults to `60`. Increase this value for large Gradle workspaces that need more time to resolve. |
-| `NX_MAVEN_DISABLE`                | boolean | If set to `true`, disables the `@nx/maven` plugin. Useful in environments where Java/Maven is not available.                                              |
+| Property                          | Type    | Description                                                                                                                                                                        |
+| --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NX_DOTNET_DISABLE`               | boolean | If set to `true`, disables the `@nx/dotnet` plugin. Useful in environments where .NET SDK is not available.                                                                        |
+| `NX_GRADLE_DISABLE`               | boolean | If set to `true`, disables the `@nx/gradle` plugin. Useful in environments where Java/Gradle is not available.                                                                     |
+| `NX_GRADLE_PROJECT_GRAPH_TIMEOUT` | number  | Timeout in seconds for Gradle project graph generation. Defaults to `600` in CI and `120` locally. Increase this value for large Gradle workspaces that need more time to resolve. |
+| `NX_MAVEN_DISABLE`                | boolean | If set to `true`, disables the `@nx/maven` plugin. Useful in environments where Java/Maven is not available.                                                                       |
+| `NX_MAVEN_ANALYSIS_TIMEOUT`       | number  | Timeout in seconds for Maven analysis. Defaults to `600` in CI and `120` locally.                                                                                                  |
 
 Nx will set the following environment variables so they can be accessible within the process even outside of executors and generators.
 

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -241,6 +241,7 @@ export {
   isProjectGraphProjectNode,
   isRelativePath,
   isWholeFileChange,
+  killChildOnHostExit,
   killProcessTreeGraceful,
   loadTsFile,
   mergeTargetConfigurations,

--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.spec.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.spec.ts
@@ -1,0 +1,110 @@
+import { execGradleAsync } from '../../utils/exec-gradle';
+import { getNxProjectGraphLines } from './get-project-graph-lines';
+
+jest.mock('../../utils/exec-gradle', () => ({
+  ...jest.requireActual('../../utils/exec-gradle'),
+  execGradleAsync: jest.fn(),
+}));
+
+const lockTimeoutOutput = Buffer.from(
+  'FAILURE: Build failed with an exception.\n' +
+    '* What went wrong:\n' +
+    'Timeout waiting to lock build logic queue. It is currently in use by another Gradle instance.'
+);
+
+describe('getNxProjectGraphLines', () => {
+  const execGradleAsyncMock = execGradleAsync as jest.Mock;
+
+  beforeEach(() => {
+    execGradleAsyncMock.mockReset();
+    delete process.env.NX_GRADLE_PROJECT_GRAPH_TIMEOUT;
+  });
+
+  afterEach(() => {
+    delete process.env.NX_GRADLE_PROJECT_GRAPH_TIMEOUT;
+  });
+
+  it('should retry when gradle times out waiting for a lock', async () => {
+    execGradleAsyncMock
+      .mockRejectedValueOnce(lockTimeoutOutput)
+      .mockResolvedValueOnce(Buffer.from('line1\nline2\n'));
+
+    await expect(
+      getNxProjectGraphLines('/proj/gradlew', 'hash', {})
+    ).resolves.toEqual(['line1', 'line2']);
+    expect(execGradleAsyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should give up after the retry budget is exhausted', async () => {
+    execGradleAsyncMock.mockRejectedValue(lockTimeoutOutput);
+
+    await expect(
+      getNxProjectGraphLines('/proj/gradlew', 'hash', {})
+    ).rejects.toMatchObject({
+      errors: [
+        [
+          '/proj/gradlew',
+          expect.objectContaining({
+            message: expect.stringMatching(
+              /another Gradle build is holding a lock/
+            ),
+          }),
+        ],
+      ],
+    });
+    expect(execGradleAsyncMock).toHaveBeenCalledTimes(3);
+  });
+
+  // Regression: retries used to run under the graph timeout without checking it,
+  // so the timeout aborted mid-retry and its generic message replaced the lock
+  // guidance on the default local budget.
+  it('should not retry when another lock wait would outlast the graph timeout', async () => {
+    // Budget must satisfy rejectMs < budget <= 2 * rejectMs: below the budget so
+    // the attempt loses the lock before the abort fires, at or under twice it so
+    // the guard refuses a second attempt. Kept well clear of both bounds — a
+    // narrower margin flips to the timeout message on a loaded machine.
+    process.env.NX_GRADLE_PROJECT_GRAPH_TIMEOUT = '0.5';
+    execGradleAsyncMock.mockImplementation(
+      () =>
+        new Promise((_, reject) =>
+          setTimeout(() => reject(lockTimeoutOutput), 300)
+        )
+    );
+
+    await expect(
+      getNxProjectGraphLines('/proj/gradlew', 'hash', {})
+    ).rejects.toMatchObject({
+      errors: [
+        [
+          '/proj/gradlew',
+          expect.objectContaining({
+            message: expect.stringMatching(
+              /another Gradle build is holding a lock/
+            ),
+          }),
+        ],
+      ],
+    });
+    expect(execGradleAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not retry other gradle failures', async () => {
+    execGradleAsyncMock.mockRejectedValue(
+      Buffer.from("Task 'nxProjectGraph' not found in root project")
+    );
+
+    await expect(
+      getNxProjectGraphLines('/proj/gradlew', 'hash', {})
+    ).rejects.toMatchObject({
+      errors: [
+        [
+          expect.any(String),
+          expect.objectContaining({
+            message: expect.stringMatching(/nx generate @nx\/gradle:init/),
+          }),
+        ],
+      ],
+    });
+    expect(execGradleAsyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.spec.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.spec.ts
@@ -1,5 +1,8 @@
 import { execGradleAsync } from '../../utils/exec-gradle';
-import { getNxProjectGraphLines } from './get-project-graph-lines';
+import {
+  getGraphTimeoutMs,
+  getNxProjectGraphLines,
+} from './get-project-graph-lines';
 
 jest.mock('../../utils/exec-gradle', () => ({
   ...jest.requireActual('../../utils/exec-gradle'),
@@ -86,6 +89,20 @@ describe('getNxProjectGraphLines', () => {
       ],
     });
     expect(execGradleAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  // setTimeout clamps a delay past the 32-bit signed max to 1ms, so an
+  // unclamped huge value would abort the build instantly — the opposite of
+  // what the timeout error tells the user to do.
+  it('should clamp an overflowing NX_GRADLE_PROJECT_GRAPH_TIMEOUT', () => {
+    process.env.NX_GRADLE_PROJECT_GRAPH_TIMEOUT = '9999999';
+    expect(getGraphTimeoutMs()).toBe(2 ** 31 - 1);
+
+    process.env.NX_GRADLE_PROJECT_GRAPH_TIMEOUT = 'Infinity';
+    expect(getGraphTimeoutMs()).toBe(2 ** 31 - 1);
+
+    process.env.NX_GRADLE_PROJECT_GRAPH_TIMEOUT = '30';
+    expect(getGraphTimeoutMs()).toBe(30_000);
   });
 
   it('should not retry other gradle failures', async () => {

--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
@@ -4,6 +4,9 @@ import { GradlePluginOptions } from './gradle-plugin-options';
 import { isCI } from '@nx/devkit/internal';
 
 const DEFAULT_GRAPH_TIMEOUT_SECONDS = isCI() ? 600 : 120;
+// setTimeout silently clamps a delay past the 32-bit signed max to 1ms, which
+// would abort immediately — the opposite of what a large value asks for.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 const GRADLE_LOCK_TIMEOUT_MESSAGE = 'Timeout waiting to lock';
 // Gradle gives up on a contended lock (e.g. buildLogic.lock held by another
 // build in the same project) after ~60s, so at the 120s local default one wait
@@ -31,7 +34,7 @@ export function getGraphTimeoutMs(): number {
   if (envTimeout) {
     const parsed = Number(envTimeout);
     if (!Number.isNaN(parsed) && parsed > 0) {
-      return parsed * 1000;
+      return Math.min(parsed * 1000, MAX_TIMEOUT_MS);
     }
   }
   return DEFAULT_GRAPH_TIMEOUT_SECONDS * 1000;

--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
@@ -4,6 +4,14 @@ import { GradlePluginOptions } from './gradle-plugin-options';
 import { isCI } from '@nx/devkit/internal';
 
 const DEFAULT_GRAPH_TIMEOUT_SECONDS = isCI() ? 600 : 120;
+const GRADLE_LOCK_TIMEOUT_MESSAGE = 'Timeout waiting to lock';
+// Gradle gives up on a contended lock (e.g. buildLogic.lock held by another
+// build in the same project) after ~60s, so at the 120s local default one wait
+// consumes the budget and the deadline guard below refuses a retry; retries
+// engage on CI (600s) or a raised NX_GRADLE_PROJECT_GRAPH_TIMEOUT. Do not relax
+// that `>=` to `>` — it refuses the borderline attempt rather than letting the
+// abort fire mid-retry and replace the lock message with a generic timeout.
+const MAX_LOCK_TIMEOUT_RETRIES = 2;
 
 let currentAbortController: AbortController | undefined;
 
@@ -29,6 +37,42 @@ export function getGraphTimeoutMs(): number {
   return DEFAULT_GRAPH_TIMEOUT_SECONDS * 1000;
 }
 
+function isGradleLockTimeout(e: unknown): boolean {
+  return String(e).includes(GRADLE_LOCK_TIMEOUT_MESSAGE);
+}
+
+async function execGradleWithLockRetry(
+  gradlewFile: string,
+  args: string[],
+  signal: AbortSignal,
+  deadline: number
+): Promise<Buffer> {
+  for (let attempt = 0; ; attempt++) {
+    const attemptStart = Date.now();
+    try {
+      return await execGradleAsync(gradlewFile, args, { signal });
+    } catch (e) {
+      if (
+        signal.aborted ||
+        attempt >= MAX_LOCK_TIMEOUT_RETRIES ||
+        !isGradleLockTimeout(e)
+      ) {
+        throw e;
+      }
+      // Retry only if another full lock wait still fits in the graph timeout.
+      // Otherwise the timeout aborts mid-attempt and its generic message
+      // replaces the lock guidance the user actually needs.
+      const lockWaitMs = Date.now() - attemptStart;
+      if (Date.now() + lockWaitMs >= deadline) {
+        throw e;
+      }
+      output.warn({
+        title: `Gradle lock is held by another build; retrying 'nxProjectGraph' (${attempt + 1}/${MAX_LOCK_TIMEOUT_RETRIES})`,
+      });
+    }
+  }
+}
+
 export async function getNxProjectGraphLines(
   gradlewFile: string,
   gradleConfigHash: string,
@@ -43,6 +87,7 @@ export async function getNxProjectGraphLines(
 
   const timeoutMs = getGraphTimeoutMs();
   const timeoutSeconds = timeoutMs / 1000;
+  const deadline = Date.now() + timeoutMs;
 
   // Cancel any in-flight Gradle process from a previous call, then create a fresh controller.
   cancelPendingProjectGraphRequest();
@@ -51,22 +96,25 @@ export async function getNxProjectGraphLines(
   const signal = controller.signal;
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
+  const args = [
+    'nxProjectGraph',
+    `-Phash=${gradleConfigHash}`,
+    '--no-configuration-cache', // disable configuration cache
+    '--parallel', // add parallel to improve performance
+    '--build-cache', // enable build cache
+    '--warning-mode',
+    'none',
+    ...gradlePluginOptionsArgs,
+    `-PworkspaceRoot=${workspaceRoot}`,
+    process.env.NX_GRADLE_VERBOSE_LOGGING ? '--info' : '',
+  ];
+
   try {
-    nxProjectGraphBuffer = await execGradleAsync(
+    nxProjectGraphBuffer = await execGradleWithLockRetry(
       gradlewFile,
-      [
-        'nxProjectGraph',
-        `-Phash=${gradleConfigHash}`,
-        '--no-configuration-cache', // disable configuration cache
-        '--parallel', // add parallel to improve performance
-        '--build-cache', // enable build cache
-        '--warning-mode',
-        'none',
-        ...gradlePluginOptionsArgs,
-        `-PworkspaceRoot=${workspaceRoot}`,
-        process.env.NX_GRADLE_VERBOSE_LOGGING ? '--info' : '',
-      ],
-      { signal }
+      args,
+      signal,
+      deadline
     );
   } catch (e: any) {
     // Cancelled by a newer populateProjectGraph call — let the caller handle it
@@ -95,6 +143,19 @@ export async function getNxProjectGraphLines(
             gradlewFile,
             new Error(
               `Could not find Java. Please install Java and try again: https://www.java.com/en/download/help/index_installing.html.\n\r${e.toString()}`
+            ),
+          ],
+        ],
+        []
+      );
+    } else if (isGradleLockTimeout(e)) {
+      throw new AggregateCreateNodesError(
+        [
+          [
+            gradlewFile,
+            new Error(
+              `Could not run 'nxProjectGraph' Gradle task because another Gradle build is holding a lock on the project.\n` +
+                `  Wait for the other build to finish, or run "gradlew --stop" to stop stale Gradle daemons, then try again.\n\r${e.toString()}`
             ),
           ],
         ],

--- a/packages/gradle/src/utils/exec-gradle.spec.ts
+++ b/packages/gradle/src/utils/exec-gradle.spec.ts
@@ -156,6 +156,7 @@ describe('execGradleAsync', () => {
     let captured: any;
     jest.doMock('@nx/devkit/internal', () => ({
       ...jest.requireActual('@nx/devkit/internal'),
+      killChildOnHostExit: jest.fn(),
       safeSpawn: jest.fn((binary, args, options) => {
         captured = { binary, args, options };
         const EventEmitter = require('events');
@@ -189,6 +190,7 @@ describe('execGradleAsync', () => {
     let captured: any;
     jest.doMock('@nx/devkit/internal', () => ({
       ...jest.requireActual('@nx/devkit/internal'),
+      killChildOnHostExit: jest.fn(),
       safeSpawn: jest.fn(() => {
         const EventEmitter = require('events');
         const cp: any = new EventEmitter();
@@ -211,6 +213,7 @@ describe('execGradleAsync', () => {
     const killProcessTreeGraceful = jest.fn(() => Promise.resolve());
     jest.doMock('@nx/devkit/internal', () => ({
       ...jest.requireActual('@nx/devkit/internal'),
+      killChildOnHostExit: jest.fn(),
       safeSpawn: jest.fn(() => {
         const EventEmitter = require('events');
         const cp: any = new EventEmitter();
@@ -231,6 +234,29 @@ describe('execGradleAsync', () => {
 
     await expect(promise).rejects.toBeDefined();
     expect(killProcessTreeGraceful).toHaveBeenCalledWith(123);
+  });
+
+  it('should register the gradle process to be killed on host exit', async () => {
+    const killChildOnHostExit = jest.fn();
+    let spawned: any;
+    jest.doMock('@nx/devkit/internal', () => ({
+      ...jest.requireActual('@nx/devkit/internal'),
+      safeSpawn: jest.fn(() => {
+        const EventEmitter = require('events');
+        spawned = new EventEmitter();
+        spawned.pid = 456;
+        spawned.stdout = new EventEmitter();
+        spawned.stderr = new EventEmitter();
+        setImmediate(() => spawned.emit('exit', 0, null));
+        return spawned;
+      }),
+      killChildOnHostExit,
+    }));
+    const { execGradleAsync } = require('./exec-gradle');
+
+    await execGradleAsync('/ws/gradlew', ['nxProjectGraph']);
+
+    expect(killChildOnHostExit).toHaveBeenCalledWith(spawned);
   });
 
   it('should drop empty args the shell used to swallow', async () => {

--- a/packages/gradle/src/utils/exec-gradle.ts
+++ b/packages/gradle/src/utils/exec-gradle.ts
@@ -8,6 +8,7 @@ import { existsSync } from 'node:fs';
 import { dirname, join, isAbsolute } from 'node:path';
 import { GradlePluginOptions } from '../plugin/utils/gradle-plugin-options';
 import {
+  killChildOnHostExit,
   killProcessTreeGraceful,
   safeSpawn,
   signalToCode,
@@ -53,6 +54,8 @@ export function execGradleAsync(
       ...restOptions,
     });
 
+    // A plugin worker torn down by `nx reset` would otherwise orphan the build.
+    killChildOnHostExit(cp);
     let stdout = Buffer.from('');
 
     // On abort, kill the entire process tree (gradlew spawns java) and settle

--- a/packages/maven/src/plugins/maven-analyzer.spec.ts
+++ b/packages/maven/src/plugins/maven-analyzer.spec.ts
@@ -1,4 +1,4 @@
-import { runMavenAnalysis } from './maven-analyzer';
+import { getAnalysisTimeoutMs, runMavenAnalysis } from './maven-analyzer';
 import { existsSync } from 'fs';
 import { readJsonFile } from '@nx/devkit';
 import { EventEmitter } from 'events';
@@ -35,6 +35,26 @@ describe('Maven Analyzer', () => {
     // Mock mvnd detection to fail by default, so tests use mvnw/mvn
     (safeExecFileSync as jest.Mock).mockImplementation(() => {
       throw new Error('mvnd not found');
+    });
+  });
+
+  describe('getAnalysisTimeoutMs', () => {
+    afterEach(() => {
+      delete process.env.NX_MAVEN_ANALYSIS_TIMEOUT;
+    });
+
+    // setTimeout clamps a delay past the 32-bit signed max to 1ms, so an
+    // unclamped huge value would abort the analysis instantly — the opposite
+    // of what the timeout error tells the user to do.
+    it('should clamp an overflowing NX_MAVEN_ANALYSIS_TIMEOUT', () => {
+      process.env.NX_MAVEN_ANALYSIS_TIMEOUT = '9999999';
+      expect(getAnalysisTimeoutMs()).toBe(2 ** 31 - 1);
+
+      process.env.NX_MAVEN_ANALYSIS_TIMEOUT = 'Infinity';
+      expect(getAnalysisTimeoutMs()).toBe(2 ** 31 - 1);
+
+      process.env.NX_MAVEN_ANALYSIS_TIMEOUT = '30';
+      expect(getAnalysisTimeoutMs()).toBe(30_000);
     });
   });
 

--- a/packages/maven/src/plugins/maven-analyzer.spec.ts
+++ b/packages/maven/src/plugins/maven-analyzer.spec.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 import { readJsonFile } from '@nx/devkit';
 import { EventEmitter } from 'events';
 import {
+  killChildOnHostExit,
   killProcessTreeGraceful,
   safeExecFileSync,
   safeSpawn,
@@ -17,6 +18,7 @@ jest.mock('@nx/devkit/internal', () => ({
   safeSpawn: jest.fn(),
   safeExecFileSync: jest.fn(),
   killProcessTreeGraceful: jest.fn().mockResolvedValue(undefined),
+  killChildOnHostExit: jest.fn(),
 }));
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual('@nx/devkit'),
@@ -37,6 +39,27 @@ describe('Maven Analyzer', () => {
   });
 
   describe('runMavenAnalysis', () => {
+    it('should register the maven process to be killed on host exit', async () => {
+      const mockChild = new EventEmitter() as any;
+      mockChild.stdout = new EventEmitter();
+      mockChild.stderr = new EventEmitter();
+      mockChild.pid = 1234;
+
+      (safeSpawn as jest.Mock).mockReturnValue(mockChild);
+      (readJsonFile as jest.Mock).mockReturnValue({
+        projects: [],
+        generatedAt: 0,
+      });
+
+      const promise = runMavenAnalysis(workspaceRoot, {});
+      setImmediate(() => {
+        mockChild.emit('close', 0);
+      });
+      await promise;
+
+      expect(killChildOnHostExit).toHaveBeenCalledWith(mockChild);
+    });
+
     it('should run Maven analysis with default options', async () => {
       const mockChild = new EventEmitter() as any;
       mockChild.stdout = new EventEmitter();

--- a/packages/maven/src/plugins/maven-analyzer.ts
+++ b/packages/maven/src/plugins/maven-analyzer.ts
@@ -5,6 +5,7 @@ import { MavenAnalysisData, MavenPluginOptions } from './types';
 import { detectMavenExecutable } from '../utils/detect-maven-executable';
 import {
   isCI,
+  killChildOnHostExit,
   killProcessTreeGraceful,
   safeSpawn,
   workspaceDataDirectory,
@@ -108,6 +109,8 @@ export async function runMavenAnalysis(
         cwd: workspaceRoot,
         stdio: 'pipe', // Always use pipe so we can control output
       });
+      // A plugin worker torn down by `nx reset` would otherwise orphan the build.
+      killChildOnHostExit(child);
 
       // On abort, kill the entire process tree and settle immediately — a
       // wedged process that outlives the kill signal would otherwise keep

--- a/packages/maven/src/plugins/maven-analyzer.ts
+++ b/packages/maven/src/plugins/maven-analyzer.ts
@@ -12,6 +12,9 @@ import {
 } from '@nx/devkit/internal';
 
 const DEFAULT_ANALYSIS_TIMEOUT_SECONDS = isCI() ? 600 : 120;
+// setTimeout silently clamps a delay past the 32-bit signed max to 1ms, which
+// would abort immediately — the opposite of what a large value asks for.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
 let currentAbortController: AbortController | undefined;
 
@@ -26,12 +29,12 @@ export function cancelPendingMavenAnalysis(): void {
   }
 }
 
-function getAnalysisTimeoutMs(): number {
+export function getAnalysisTimeoutMs(): number {
   const envTimeout = process.env.NX_MAVEN_ANALYSIS_TIMEOUT;
   if (envTimeout) {
     const parsed = Number(envTimeout);
     if (!Number.isNaN(parsed) && parsed > 0) {
-      return parsed * 1000;
+      return Math.min(parsed * 1000, MAX_TIMEOUT_MS);
     }
   }
   return DEFAULT_ANALYSIS_TIMEOUT_SECONDS * 1000;

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -162,6 +162,7 @@ export { hashFile } from './hasher/file-hasher';
 export { filterUsingGlobPatterns, getTargetInputs } from './hasher/task-hasher';
 export type { JsonInput } from './native';
 export { killProcessTreeGraceful } from './native';
+export { killChildOnHostExit } from './utils/kill-child-on-host-exit';
 export { connectToNxCloud } from './nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud';
 export type { NxCloudOnBoardingStatus } from './nx-cloud/models/onboarding-status';
 export {

--- a/packages/nx/src/utils/kill-child-on-host-exit.spec.ts
+++ b/packages/nx/src/utils/kill-child-on-host-exit.spec.ts
@@ -1,0 +1,68 @@
+import type { Mock } from 'vitest';
+vi.mock('../native', () => ({ killProcessTree: vi.fn() }));
+
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { killProcessTree } from '../native';
+import {
+  killChildOnHostExit,
+  killTrackedChildren,
+} from './kill-child-on-host-exit';
+
+function fakeChild(pid: number | undefined): ChildProcess {
+  const cp = new EventEmitter() as ChildProcess;
+  (cp as any).pid = pid;
+  return cp;
+}
+
+describe('killChildOnHostExit', () => {
+  beforeEach(() => {
+    (killProcessTree as Mock).mockReset();
+    killTrackedChildren();
+  });
+
+  it('should kill tracked children that are still running', () => {
+    killChildOnHostExit(fakeChild(123));
+
+    killTrackedChildren();
+
+    expect(killProcessTree).toHaveBeenCalledWith(123, 'SIGTERM');
+  });
+
+  it('should stop tracking a child once it exits', () => {
+    const cp = fakeChild(123);
+    killChildOnHostExit(cp);
+    cp.emit('exit', 0, null);
+
+    killTrackedChildren();
+
+    expect(killProcessTree).not.toHaveBeenCalled();
+  });
+
+  it('should stop tracking a child that failed to spawn', () => {
+    const cp = fakeChild(123);
+    killChildOnHostExit(cp);
+    cp.emit('error', new Error('ENOENT'));
+
+    killTrackedChildren();
+
+    expect(killProcessTree).not.toHaveBeenCalled();
+  });
+
+  it('should ignore a child without a pid', () => {
+    killChildOnHostExit(fakeChild(undefined));
+
+    killTrackedChildren();
+
+    expect(killProcessTree).not.toHaveBeenCalled();
+  });
+
+  it('should clear the set after killing', () => {
+    killChildOnHostExit(fakeChild(123));
+
+    killTrackedChildren();
+    killTrackedChildren();
+
+    expect(killProcessTree).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nx/src/utils/kill-child-on-host-exit.ts
+++ b/packages/nx/src/utils/kill-child-on-host-exit.ts
@@ -1,0 +1,40 @@
+import type { ChildProcess } from 'node:child_process';
+import { killProcessTree } from '../native';
+
+// Children spawned by this process that must not outlive it. Plugin workers
+// are torn down with `process.exit`, which leaves spawned build tools (gradle,
+// maven, ...) orphaned and still holding their project locks.
+const trackedChildren = new Set<number>();
+let exitHookRegistered = false;
+
+/**
+ * Kill `cp` (and its descendants) when this process exits, unless it has
+ * already exited on its own.
+ */
+export function killChildOnHostExit(cp: ChildProcess): void {
+  if (!cp.pid) return;
+  trackedChildren.add(cp.pid);
+  const untrack = () => {
+    trackedChildren.delete(cp.pid);
+    // Whichever fires first, drop both — otherwise the other stays registered
+    // on a child that is already gone.
+    cp.off('exit', untrack);
+    cp.off('error', untrack);
+  };
+  cp.once('exit', untrack);
+  cp.once('error', untrack);
+  if (!exitHookRegistered) {
+    exitHookRegistered = true;
+    process.once('exit', killTrackedChildren);
+  }
+}
+
+export function killTrackedChildren(): void {
+  for (const pid of trackedChildren) {
+    try {
+      // 'exit' handlers must be synchronous, so no graceful variant here.
+      killProcessTree(pid, 'SIGTERM');
+    } catch {}
+  }
+  trackedChildren.clear();
+}


### PR DESCRIPTION
## Current Behavior

When `@nx/gradle` runs `nxProjectGraph` while another Gradle build holds a lock in the same project (for example `.gradle/noVersion/buildLogic.lock` while `buildSrc` compiles), Gradle gives up after ~60s with `Timeout waiting to lock build logic queue` and the plugin surfaces it as a misleading `Could not run 'nxProjectGraph' Gradle task. Please install Gradle`.

One way to get into that state is `nx reset`: it tears down the plugin worker via `process.exit`, which orphans the in-flight `gradlew` child. Nothing cancels that build, so it runs to completion holding the project's locks. The next graph computation then times out on the lock. `e2e-gradle` `gradle-import.test.ts` hits exactly this after `nx reset` -> `nx show projects`, and #36803 (in-process Kotlin compilation) makes the cold `buildSrc` compile slow enough that the window is routinely longer than Gradle's 60s lock wait.

## Expected Behavior

- `nxProjectGraph` retries up to 2 more times when Gradle reports `Timeout waiting to lock`, bounded by the existing graph timeout / abort signal. Gradle already blocks ~60s per attempt on the lock, so no extra backoff is needed.
- When retries are exhausted, the error says another Gradle build is holding a lock and suggests `gradlew --stop`, instead of "Please install Gradle".
- Gradle builds spawned by the plugin are tracked, and a `process.once('exit')` hook kills their process trees when the host (e.g. a plugin worker torn down by `nx reset`) exits, so orphaned builds are cancelled instead of running to completion. `killProcessTree` is now re-exported from `@nx/devkit/internal` for this.

Unit specs added for the retry / give-up / no-retry paths and for the exit-time kill.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Retry-nxProjectGraph-on-Gradle-lock-timeout-and-kill-orphaned-builds-on-f1b78fd6">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->