### PR TITLE
fix(repo): serve nx executor schema reads from source in unit tests

### DIFF
--- a/packages/nx/src/internal-testing-utils/executor-schemas-from-source.ts
+++ b/packages/nx/src/internal-testing-utils/executor-schemas-from-source.ts
@@ -1,0 +1,62 @@
+// nx's own executors.json points schemas at ./dist for the published layout,
+// so resolving an nx executor (e.g. the `continuous` lookup during target
+// normalization) reads build output the test task does not declare as an
+// input — and which may not exist locally. Redirect those reads to the
+// committed source files, which dist copies verbatim. Import this in any spec
+// that resolves one of nx's own executors against the real workspace.
+// Factories are inlined because vitest hoists these calls above any shared
+// helper definition.
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const { join, sep } = require('path');
+  const nxPackageRoot = join(__dirname, '..', '..');
+  const distDir = join(nxPackageRoot, 'dist') + sep;
+  const fromSource = (p: unknown) =>
+    typeof p === 'string' && p.startsWith(distDir)
+      ? join(nxPackageRoot, p.slice(distDir.length))
+      : p;
+  return {
+    ...actual,
+    readFileSync: ((p: any, ...rest: any[]) =>
+      (actual.readFileSync as any)(
+        fromSource(p),
+        ...rest
+      )) as typeof actual.readFileSync,
+    existsSync: ((p: any) =>
+      actual.existsSync(fromSource(p) as any)) as typeof actual.existsSync,
+    statSync: ((p: any, ...rest: any[]) =>
+      (actual.statSync as any)(
+        fromSource(p),
+        ...rest
+      )) as typeof actual.statSync,
+  };
+});
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const { join, sep } = require('path');
+  const nxPackageRoot = join(__dirname, '..', '..');
+  const distDir = join(nxPackageRoot, 'dist') + sep;
+  const fromSource = (p: unknown) =>
+    typeof p === 'string' && p.startsWith(distDir)
+      ? join(nxPackageRoot, p.slice(distDir.length))
+      : p;
+  return {
+    ...actual,
+    readFileSync: ((p: any, ...rest: any[]) =>
+      (actual.readFileSync as any)(
+        fromSource(p),
+        ...rest
+      )) as typeof actual.readFileSync,
+    existsSync: ((p: any) =>
+      actual.existsSync(fromSource(p) as any)) as typeof actual.existsSync,
+    statSync: ((p: any, ...rest: any[]) =>
+      (actual.statSync as any)(
+        fromSource(p),
+        ...rest
+      )) as typeof actual.statSync,
+  };
+});
+
+export {};

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1,3 +1,5 @@
+import '../../internal-testing-utils/executor-schemas-from-source';
+
 import {
   ProjectConfiguration,
   TargetConfiguration,

--- a/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
@@ -1,3 +1,5 @@
+import '../../../internal-testing-utils/executor-schemas-from-source';
+
 import type { MockInstance } from 'vitest';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';


### PR DESCRIPTION
## Current Behavior

<!-- This is the behavior we have today -->

`nx:test` fails CI with `Sandbox violation detected for task nx:test: 3 unexpected read(s)`.

nx's own `executors.json` points executor schemas at `./dist` for the published layout. When a unit test resolves one of nx's executors — the `continuous` lookup in `normalizeTarget`, which `command:` syntactic sugar triggers implicitly by expanding to `nx:run-commands` — it reads build output the test task never declared as an input. On agents where `build-base` has already run, Nx Cloud flags those three reads (`noop`, `run-commands`, `run-script` schemas), and the task's cache key omits files it actually reads.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Unit tests read executor schemas from the committed source files instead of build output, so the task reads only what it declares.

A new spec-scoped fs mock, `internal-testing-utils/executor-schemas-from-source`, redirects reads under `packages/nx/dist/` to the identical source files. It follows the existing `internal-testing-utils/mock-fs` idiom. Only the two specs that actually resolve nx's own executors import it:

- `project-graph/utils/project-configuration/target-normalization.spec.ts`
- `project-graph/utils/project-configuration-utils.spec.ts`

Those two were identified by tracing `fs` across the whole suite rather than by inspection, and a full-suite re-run with the same tracer afterwards reports zero reads under `dist/`. The redirect was also confirmed to work with `dist/` renamed away entirely.

This replaces an earlier approach on this branch that declared `build-base` as a `dependsOn` of `nx:test` and pulled in its `.json` outputs. That worked, but coupled unit tests to a build and widened the task's cache key; both commits are in the history for reference.

### Note on alternatives

Two other routes were investigated and rejected:

- **Point the tests at a temp workspace.** `nx` cannot be shadowed this way. `packages/nx/package.json` declares `"name": "nx"` with an `exports` field, so Node's self-reference resolution wins for any caller inside that package and ignores the `paths` option — verified in both directions. It works for any other plugin name, just not nx's own.
- **Pass a populated `projects` map.** `resolveSchema` does prefer source over dist outside `node_modules`, but `tryResolveFromSource` needs `projects` to map the package to its local project, and these specs pass `{}`. Supplying it does resolve from source, and it is clean for `target-normalization.spec.ts` — but in `project-configuration-utils.spec.ts` the projects maps are themselves the assertion subjects, so injecting an `nx` project would pollute expected output across six sites. Worth revisiting for the first spec on its own.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A — fixes the failing `main-linux` CI job on master.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Declare-nx-dist-executor-schemas-as-inputs-for-nxtest-d2a8d9b4">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->