### PR TITLE
fix(core): recover recursive Windows watches after event loss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
  "bitflags 2.13.0",
  "inotify-sys",
@@ -1653,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1965,11 +1965,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -2348,6 +2348,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "9.0.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7768eb7201a1964d8eb10224e850df046ab584ee3c3d26e340a993d81f748148"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "objc2-core-foundation",
+ "objc2-core-services",
+ "walkdir",
+ "windows-sys 0.61.2",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "notify-types"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,7 +2483,8 @@ dependencies = [
  "napi-derive",
  "nix 0.30.1",
  "nom 7.1.3",
- "notify",
+ "notify 8.2.0",
+ "notify 9.0.0-rc.5",
  "once_cell",
  "parking_lot",
  "portable-pty",
@@ -2549,6 +2570,16 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -75,6 +75,8 @@ static_assertions = "1.1"
 wrap-ansi = "0.1"
 
 [target.'cfg(windows)'.dependencies]
+# Windows overflow detection first shipped in notify-rs/notify#964.
+notify = "=9.0.0-rc.5"
 winapi = { version = "0.3", features = [
   "fileapi",
   "psapi",
@@ -99,6 +101,7 @@ tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }
 uuid = "1"
 
 [target.'cfg(all(not(windows), not(target_family = "wasm")))'.dependencies]
+notify = "8"
 mio = "1.0"
 nix = { version = "0.30.0", features = ["fs", "process", "signal"] }
 
@@ -124,7 +127,6 @@ reqwest = { version = "0.12.22", default-features = false, features = [
   "hickory-dns",
 ] }
 rusqlite = { version = "0.32.1", features = ["bundled", "array", "vtab"] }
-notify = "8"
 machine-uid = "0.5.2"
 interprocess = { version = "=2.2.3", features = ["tokio"] }
 jsonrpsee = { version = "0.25.1", features = [

--- a/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
@@ -5,6 +5,7 @@ vi.mock('../logger', () => ({
   serverLogger: { watcherLog: vi.fn() },
 }));
 vi.mock('./outputs-tracking', () => ({
+  clearRecordedOutputsHashes: vi.fn(),
   disableOutputsTracking: vi.fn(),
   processFileChangesInOutputs: vi.fn(),
 }));
@@ -26,6 +27,7 @@ describe('handleOutputsChanges', () => {
   let handleOutputsChanges: typeof import('./handle-outputs-changes').handleOutputsChanges;
   let getOutputsWatcherTerminalError: typeof import('./handle-outputs-changes').getOutputsWatcherTerminalError;
   let outputsTracking: {
+    clearRecordedOutputsHashes: Mock;
     disableOutputsTracking: Mock;
     processFileChangesInOutputs: Mock;
   };
@@ -58,6 +60,18 @@ describe('handleOutputsChanges', () => {
 
   afterEach(() => {
     consoleError.mockRestore();
+  });
+
+  it('starts the tracker over and invalidates the graph on a rescan, without processing per-path events', async () => {
+    await handleOutputsChanges(null, [{ path: '', type: EventType.rescan }]);
+
+    expect(outputsTracking.clearRecordedOutputsHashes).toHaveBeenCalled();
+    expect(recomputation.invalidateGraphCache).toHaveBeenCalled();
+    expect(outputsTracking.processFileChangesInOutputs).not.toHaveBeenCalled();
+    expect(dotenvChanges.classifyDotEnvChanges).not.toHaveBeenCalled();
+    // A rescan is recoverable: the watch stream is still alive.
+    expect(getOutputsWatcherTerminalError()).toBeUndefined();
+    expect(outputsTracking.disableOutputsTracking).not.toHaveBeenCalled();
   });
 
   it('records a native watcher error as terminal, preserving its message, and disables outputs tracking', async () => {

--- a/packages/nx/src/daemon/server/handle-outputs-changes.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.ts
@@ -4,6 +4,7 @@ import {
   queuePendingDotEnvEvents,
 } from './dotenv-graph-changes';
 import {
+  clearRecordedOutputsHashes,
   disableOutputsTracking,
   processFileChangesInOutputs,
 } from './outputs-tracking';
@@ -73,6 +74,18 @@ export const handleOutputsChanges: FileWatcherCallback = async (
     // here cannot trip the outputs-tracking kill switch below, which belongs
     // to an unrelated subsystem, and it fails safe by invalidating: a stale
     // graph on a dotenv edit is the bug this prevents.
+    if (changeEvents.some((event) => event.type === 'rescan')) {
+      // Dropped events cannot be classified: any recorded output hash and any
+      // gitignored dotenv file may have changed unseen. Start the tracker
+      // over and invalidate the graph rather than trust either.
+      serverLogger.watcherLog(
+        'The outputs watcher reported dropped events; clearing recorded output hashes and invalidating the graph cache.'
+      );
+      clearRecordedOutputsHashes();
+      invalidateGraphCache();
+      return;
+    }
+
     try {
       const { invalidating, unclassified } = classifyDotEnvChanges(
         changeEvents,

--- a/packages/nx/src/daemon/server/outputs-tracking.ts
+++ b/packages/nx/src/daemon/server/outputs-tracking.ts
@@ -130,6 +130,24 @@ export function recordOutputsHashBatch(
   }
 }
 
+/**
+ * One-shot reset for a watcher rescan: recorded hashes may describe outputs
+ * whose change events were dropped, so none can be trusted. Unlike
+ * `disableOutputsTracking` the tracker keeps running; it just starts over.
+ */
+export function clearRecordedOutputsHashes() {
+  for (const store of [
+    dirsContainingOutputs,
+    recordedHashes,
+    timestamps,
+    numberOfExpandedOutputs,
+  ]) {
+    for (const key of Object.keys(store)) {
+      delete store[key];
+    }
+  }
+}
+
 export function disableOutputsTracking() {
   disabled = true;
 }

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
 import { TempFs } from '../../internal-testing-utils/temp-fs';
@@ -1947,5 +1953,124 @@ describe('pending dotenv replay before serving a graph', () => {
     const fourth = await getCachedSerializedProjectGraphPromise();
     expect(fourth.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
     expect(retrieveCallCount).toBe(2);
+  });
+});
+
+describe('handleWatcherRescan', () => {
+  let fs: TempFs;
+
+  beforeEach(() => {
+    fs = new TempFs('pgir-rescan');
+  });
+
+  afterEach(() => {
+    fs.cleanup();
+    delete (global as any).NX_DAEMON;
+  });
+
+  it('recovers file changes the watcher never delivered', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/src/index.ts': 'original',
+      'libs/foo/src/stale.ts': '',
+    });
+
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    // handleWatcherRescan runs on the daemon, where the context wrappers
+    // take their direct path.
+    (global as any).NX_DAEMON = true;
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+
+    const {
+      getCachedSerializedProjectGraphPromise,
+      handleWatcherRescan,
+      isKnownWorkspaceFile,
+    } = await import('./project-graph-incremental-recomputation');
+
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.error).toBeNull();
+    expect(first.projectGraph.nodes.foo).toBeDefined();
+    expect(isKnownWorkspaceFile('libs/bar/project.json')).toBe(false);
+
+    // Dropped events: the workspace moves on with no watcher batch at all.
+    writeFileSync(join(fs.tempDir, 'libs/foo/src/index.ts'), 'changed');
+    mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
+    writeFileSync(
+      join(fs.tempDir, 'libs/bar/project.json'),
+      JSON.stringify({ name: 'bar', root: 'libs/bar' })
+    );
+    rmSync(join(fs.tempDir, 'libs/foo/src/stale.ts'));
+
+    await handleWatcherRescan();
+
+    const second = await getCachedSerializedProjectGraphPromise();
+    expect(second.error).toBeNull();
+    expect(second.projectGraph.nodes.bar).toBeDefined();
+    expect(isKnownWorkspaceFile('libs/bar/project.json')).toBe(true);
+    expect(isKnownWorkspaceFile('libs/foo/src/stale.ts')).toBe(false);
+  });
+
+  it('keeps the cached graph when the re-walk finds no differences', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+
+    vi.resetModules();
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    (global as any).NX_DAEMON = true;
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+
+    const { getCachedSerializedProjectGraphPromise, handleWatcherRescan } =
+      await import('./project-graph-incremental-recomputation');
+
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.error).toBeNull();
+
+    await handleWatcherRescan();
+
+    // Same result object: no invalidation happened, the cached compute
+    // survived the rescan.
+    const second = await getCachedSerializedProjectGraphPromise();
+    expect(second).toBe(first);
+  });
+});
+
+describe('diffFileData', () => {
+  it('classifies created, updated, unchanged and deleted files', async () => {
+    const { diffFileData } =
+      await import('./project-graph-incremental-recomputation');
+
+    const diff = diffFileData(
+      [
+        { file: 'a.ts', hash: '1' },
+        { file: 'b.ts', hash: '2' },
+        { file: 'c.ts', hash: '3' },
+      ],
+      [
+        { file: 'b.ts', hash: '2' },
+        { file: 'c.ts', hash: 'changed' },
+        { file: 'd.ts', hash: '4' },
+      ]
+    );
+
+    expect(diff.createdFiles).toEqual(['d.ts']);
+    // Created files carry their hash too: the collector needs one for every
+    // file it records, created or updated.
+    expect(diff.updatedFiles).toEqual([
+      { file: 'c.ts', hash: 'changed' },
+      { file: 'd.ts', hash: '4' },
+    ]);
+    expect(diff.deletedFiles).toEqual(['a.ts']);
   });
 });

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -3,6 +3,8 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  statSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
@@ -1964,8 +1966,36 @@ describe('handleWatcherRescan', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     fs.cleanup();
     delete (global as any).NX_DAEMON;
+  });
+
+  it('restarts the watcher when a dropped ignore-file edit is recovered', async () => {
+    fs.createFilesSync({
+      'nx.json': '{}',
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.nxignore': '',
+    });
+    vi.resetModules();
+    (global as any).NX_DAEMON = true;
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+    const { setupWorkspaceContext, getAllFileDataInContext } =
+      await import('../../utils/workspace-context');
+    setupWorkspaceContext(fs.tempDir);
+    await getAllFileDataInContext(fs.tempDir);
+    const shutdown = await import('./shutdown-utils');
+    const terminate = vi
+      .spyOn(shutdown, 'handleServerProcessTermination')
+      .mockResolvedValue(undefined);
+    const { handleWatcherRescan } =
+      await import('./project-graph-incremental-recomputation');
+    writeFileSync(join(fs.tempDir, '.nxignore'), 'ignored/\n');
+
+    await handleWatcherRescan();
+
+    expect(terminate).toHaveBeenCalledOnce();
   });
 
   it('recovers file changes the watcher never delivered', async () => {
@@ -2002,6 +2032,13 @@ describe('handleWatcherRescan', () => {
     expect(isKnownWorkspaceFile('libs/bar/project.json')).toBe(false);
 
     // Dropped events: the workspace moves on with no watcher batch at all.
+    const projectPath = join(fs.tempDir, 'libs/foo/project.json');
+    const projectStat = statSync(projectPath);
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ name: 'foo', root: 'libs/foo', tags: ['recovered'] })
+    );
+    utimesSync(projectPath, projectStat.atime, projectStat.mtime);
     writeFileSync(join(fs.tempDir, 'libs/foo/src/index.ts'), 'changed');
     mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
     writeFileSync(
@@ -2015,6 +2052,7 @@ describe('handleWatcherRescan', () => {
     const second = await getCachedSerializedProjectGraphPromise();
     expect(second.error).toBeNull();
     expect(second.projectGraph.nodes.bar).toBeDefined();
+    expect(second.projectGraph.nodes.foo.data.tags).toEqual(['recovered']);
     expect(isKnownWorkspaceFile('libs/bar/project.json')).toBe(true);
     expect(isKnownWorkspaceFile('libs/foo/src/stale.ts')).toBe(false);
   });

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -38,7 +38,9 @@ import {
 } from '../../project-graph/utils/retrieve-workspace-files';
 import { fileExists } from '../../utils/fileutils';
 import {
+  getAllFileDataInContext,
   resetWorkspaceContext,
+  setupWorkspaceContext,
   updateFilesInContext,
 } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -393,6 +395,99 @@ export function scheduleProjectGraphRecomputation(
       kickOffRecompute();
     }
   }
+}
+
+export interface FileDataDiff {
+  createdFiles: string[];
+  updatedFiles: Array<{ file: string; hash: string }>;
+  deletedFiles: string[];
+}
+
+export function diffFileData(
+  before: FileData[],
+  after: FileData[]
+): FileDataDiff {
+  const beforeHashes = new Map(before.map((f) => [f.file, f.hash]));
+  const createdFiles: string[] = [];
+  const updatedFiles: Array<{ file: string; hash: string }> = [];
+  for (const f of after) {
+    const previousHash = beforeHashes.get(f.file);
+    if (previousHash === undefined) {
+      createdFiles.push(f.file);
+      updatedFiles.push({ file: f.file, hash: f.hash });
+    } else {
+      if (previousHash !== f.hash) {
+        updatedFiles.push({ file: f.file, hash: f.hash });
+      }
+      beforeHashes.delete(f.file);
+    }
+  }
+  return {
+    createdFiles,
+    updatedFiles,
+    deletedFiles: [...beforeHashes.keys()],
+  };
+}
+
+/**
+ * The watcher reported dropped events (a kernel event-queue overflow), so the
+ * per-path stream cannot be trusted complete. Recover by re-walking the
+ * workspace and diffing it against the context's known files, then feed the
+ * synthesized changes through the same collection and notification path a
+ * normal watcher batch takes.
+ */
+export async function handleWatcherRescan(): Promise<void> {
+  performance.mark('watcher-rescan-start');
+  const before = await getAllFileDataInContext(workspaceRoot);
+  resetWorkspaceContext();
+  setupWorkspaceContext(workspaceRoot);
+  const after = await getAllFileDataInContext(workspaceRoot);
+  performance.mark('watcher-rescan-end');
+  performance.measure(
+    're-walk workspace after watcher rescan',
+    'watcher-rescan-start',
+    'watcher-rescan-end'
+  );
+
+  const { createdFiles, updatedFiles, deletedFiles } = diffFileData(
+    before,
+    after
+  );
+  if (updatedFiles.length === 0 && deletedFiles.length === 0) {
+    serverLogger.watcherLog(
+      'Rescan re-walk found no differences; keeping the cached graph.'
+    );
+    return;
+  }
+  serverLogger.watcherLog(
+    `Rescan re-walk recovered ${createdFiles.length} created, ${
+      updatedFiles.length - createdFiles.length
+    } updated and ${deletedFiles.length} deleted file(s).`
+  );
+
+  ++fileChangeCounter;
+  const createdFileSet = new Set(createdFiles);
+  const updatedFileNames: string[] = [];
+  for (const { file, hash } of updatedFiles) {
+    collectedDeletedFiles.delete(file);
+    collectedUpdatedFiles.set(file, { version: fileChangeCounter, hash });
+    if (!createdFileSet.has(file)) {
+      updatedFileNames.push(file);
+    }
+  }
+  for (const file of deletedFiles) {
+    collectedUpdatedFiles.delete(file);
+    collectedDeletedFiles.set(file, fileChangeCounter);
+  }
+
+  notifyFileChangeListeners({
+    createdFiles,
+    updatedFiles: updatedFileNames,
+    deletedFiles,
+  });
+  notifyFileWatcherSockets(createdFiles, updatedFileNames, deletedFiles);
+  ++recomputationGeneration;
+  kickOffRecompute();
 }
 
 export function registerProjectGraphRecomputationListener(

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -38,9 +38,8 @@ import {
 } from '../../project-graph/utils/retrieve-workspace-files';
 import { fileExists } from '../../utils/fileutils';
 import {
-  getAllFileDataInContext,
   resetWorkspaceContext,
-  setupWorkspaceContext,
+  rescanWorkspaceContext,
   updateFilesInContext,
 } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -58,7 +57,10 @@ import {
 import { notifyFileChangeListeners } from './file-watching/file-change-events';
 import { notifyFileWatcherSockets } from './file-watching/file-watcher-sockets';
 import { notifyProjectGraphListenerSockets } from './project-graph-listener-sockets';
-import { flushPendingWorkspaceChanges } from './watcher';
+import {
+  flushPendingWorkspaceChanges,
+  restartDaemonIfIgnoreFilesChanged,
+} from './watcher';
 import { serverLogger } from '../logger';
 
 interface SerializedProjectGraph {
@@ -438,10 +440,7 @@ export function diffFileData(
  */
 export async function handleWatcherRescan(): Promise<void> {
   performance.mark('watcher-rescan-start');
-  const before = await getAllFileDataInContext(workspaceRoot);
-  resetWorkspaceContext();
-  setupWorkspaceContext(workspaceRoot);
-  const after = await getAllFileDataInContext(workspaceRoot);
+  const { before, after } = rescanWorkspaceContext(workspaceRoot);
   performance.mark('watcher-rescan-end');
   performance.measure(
     're-walk workspace after watcher rescan',
@@ -453,6 +452,14 @@ export async function handleWatcherRescan(): Promise<void> {
     before,
     after
   );
+  if (
+    restartDaemonIfIgnoreFilesChanged([
+      ...updatedFiles.map(({ file }) => file),
+      ...deletedFiles,
+    ])
+  ) {
+    return;
+  }
   if (updatedFiles.length === 0 && deletedFiles.length === 0) {
     serverLogger.watcherLog(
       'Rescan re-walk found no differences; keeping the cached graph.'

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -146,6 +146,7 @@ import {
   handleOutputsChanges,
 } from './handle-outputs-changes';
 import {
+  handleWatcherRescan,
   scheduleProjectGraphRecomputation,
   registerProjectGraphRecomputationListener,
 } from './project-graph-incremental-recomputation';
@@ -658,6 +659,14 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
       console.error(error);
       workspaceWatcherError = error;
       notifyFileWatcherSocketsOfError(error);
+      return;
+    }
+
+    if (changeEvents.some((event) => event.type === 'rescan')) {
+      serverLogger.watcherLog(
+        'The watcher reported dropped events; re-walking the workspace to recover the missed changes.'
+      );
+      await handleWatcherRescan();
       return;
     }
 

--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -26,8 +26,15 @@ let workspaceChangesCallback!: FileWatcherCallback;
 function dispatchWorkspaceChanges(
   events: WatchEvent[]
 ): Promise<void> | undefined {
-  for (const event of events) {
-    if (event.path.endsWith('.gitignore') || event.path === '.nxignore') {
+  if (restartDaemonIfIgnoreFilesChanged(events.map((event) => event.path))) {
+    return;
+  }
+  return workspaceChangesCallback(null, events);
+}
+
+export function restartDaemonIfIgnoreFilesChanged(paths: string[]): boolean {
+  for (const path of paths) {
+    if (path.endsWith('.gitignore') || path === '.nxignore') {
       // If the ignore files themselves have changed we need to dynamically
       // update our cached ignoreGlobs
       handleServerProcessTermination({
@@ -35,9 +42,10 @@ function dispatchWorkspaceChanges(
         reason: 'Stopping the daemon the set of ignored files changed (native)',
         sockets: openSockets,
       });
+      return true;
     }
   }
-  return workspaceChangesCallback(null, events);
+  return false;
 }
 
 export async function watchWorkspace(server: Server, cb: FileWatcherCallback) {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -357,7 +357,12 @@ export interface EventDimensions {
 export declare const enum EventType {
   delete = 'delete',
   update = 'update',
-  create = 'create'
+  create = 'create',
+  /**
+   * The kernel dropped events (e.g. an inotify queue overflow); per-path
+   * events cannot be trusted complete and consumers must re-walk.
+   */
+  rescan = 'rescan'
 }
 
 export declare function expandOutputs(directory: string, entries: Array<string>): Array<string>

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -264,6 +264,8 @@ export declare class WorkspaceContext {
   incrementalUpdate(updatedFiles: Array<string>, deletedFiles: Array<string>): Record<string, string>
   updateProjectFiles(projectRootMappings: Record<string, string>, projectFiles: ExternalObject<Record<string, Array<FileData>>>, globalFiles: ExternalObject<Array<FileData>>, updatedFiles: Record<string, string>, deletedFiles: Array<string>): UpdatedWorkspaceFiles
   allFileData(): Array<FileData>
+  /** After event loss, timestamps cannot establish that cached hashes are fresh. */
+  rescan(): Array<FileData>
   getFilesInDirectory(directory: string): Array<string>
 }
 

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -58,6 +58,10 @@ pub enum EventType {
     update,
     #[allow(non_camel_case_types)]
     create,
+    /// The kernel dropped events (e.g. an inotify queue overflow); per-path
+    /// events cannot be trusted complete and consumers must re-walk.
+    #[allow(non_camel_case_types)]
+    rescan,
 }
 
 #[derive(Debug, Clone)]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -116,6 +116,10 @@ struct WatchPipeline {
     ignore_globs: Arc<NxGlobSet>,
 
     accumulator: HashMap<PathBuf, WatchEventInternal>,
+    /// The backend reported dropped events (notify's Rescan flag, e.g. an
+    /// inotify queue overflow). Per-path events are incomplete from that
+    /// moment, so the next flush emits a single rescan event instead.
+    pending_rescan: bool,
     burst_start: Option<Instant>,
     flush_deadline: Option<Instant>,
 }
@@ -156,6 +160,7 @@ impl WatchPipeline {
             #[cfg(not(target_os = "macos"))]
             ignore_globs: build_ignore_glob_set(),
             accumulator: HashMap::new(),
+            pending_rescan: false,
             burst_start: None,
             flush_deadline: None,
         })
@@ -182,11 +187,24 @@ impl WatchPipeline {
     }
 
     fn snapshot_events(&self) -> Vec<WatchEvent> {
+        // A rescan supersedes the accumulated events: the consumer re-walks,
+        // which covers everything a per-path event could have said.
+        if self.pending_rescan {
+            return vec![WatchEvent {
+                path: String::new(),
+                r#type: EventType::rescan,
+            }];
+        }
         self.accumulator.values().map(|e| e.into()).collect()
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.accumulator.is_empty() || self.pending_rescan
     }
 
     fn reset_burst(&mut self) {
         self.accumulator.clear();
+        self.pending_rescan = false;
         self.burst_start = None;
         self.flush_deadline = None;
     }
@@ -265,6 +283,15 @@ impl WatchPipeline {
                 return Ok(());
             }
         };
+
+        if event.need_rescan() {
+            tracing::warn!("backend dropped events (rescan flag); scheduling a rescan flush");
+            self.pending_rescan = true;
+            let now = Instant::now();
+            let bs = *self.burst_start.get_or_insert(now);
+            self.flush_deadline = Some((now + IDLE_WINDOW).min(bs + MAX_WAIT));
+            return Ok(());
+        }
 
         let raw = RawWatchEvent::new(event);
 
@@ -353,7 +380,7 @@ impl WatchPipeline {
                         // FORCE_FLUSH_QUIET window so a trickle isn't cut
                         // mid-stream. Bounded by FORCE_FLUSH_MAX.
                         let deadline = handler_started_at + FORCE_FLUSH_MAX;
-                        let mut burst_in_progress = !self.accumulator.is_empty();
+                        let mut burst_in_progress = self.has_pending();
                         while fatal.is_none() {
                             let now = Instant::now();
                             if now >= deadline {
@@ -406,7 +433,7 @@ impl WatchPipeline {
                     Err(_) => break, // struct dropped or stop() called
                 },
                 default(idle_wait) => {
-                    if !self.accumulator.is_empty() {
+                    if self.has_pending() {
                         let events = self.snapshot_events();
                         debug!(count = events.len(), "idle-window emitting events");
                         for e in &events {
@@ -588,6 +615,37 @@ mod tests {
 
     fn find_event<'a>(events: &'a [WatchEvent], name: &str) -> Option<&'a WatchEvent> {
         events.iter().find(|e| e.path.ends_with(name))
+    }
+
+    #[test]
+    fn rescan_flag_supersedes_accumulated_events() {
+        use notify::event::{CreateKind, Flag};
+
+        let dir = tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        let mut pipeline = WatchPipeline::new(
+            canonical.to_str().expect("utf-8 path").to_string(),
+            &[],
+            false,
+        )
+        .expect("pipeline");
+
+        let file = canonical.join("file.txt");
+        fs::write(&file, "x").expect("write");
+        let create = notify::Event::new(notify::EventKind::Create(CreateKind::File)).add_path(file);
+        pipeline.ingest_event(Ok(create)).expect("ingest create");
+        assert!(pipeline.has_pending());
+
+        let overflow = notify::Event::new(notify::EventKind::Other).set_flag(Flag::Rescan);
+        pipeline.ingest_event(Ok(overflow)).expect("ingest rescan");
+
+        let events = pipeline.snapshot_events();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].r#type, EventType::rescan));
+        assert_eq!(events[0].path, "");
+
+        pipeline.reset_burst();
+        assert!(!pipeline.has_pending());
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -1,5 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+use std::collections::HashSet;
 use std::path::{MAIN_SEPARATOR, Path, PathBuf};
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -10,10 +13,10 @@ use notify::{RecursiveMode, Watcher as NotifyWatcher};
 use parking_lot::Mutex;
 use tracing::{debug, trace};
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use crate::native::glob::{NxGlobSet, build_glob_set};
 use crate::native::walker::HARDCODED_IGNORE_PATTERNS;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use crate::native::walker::create_walker;
 use crate::native::watch::types::{
     EventType, RawWatchEvent, WatchEvent, WatchEventInternal, transform_event_to_watch_events,
@@ -52,7 +55,7 @@ const FORCE_FLUSH_QUIET: Duration = Duration::from_millis(50);
 /// a late reply isn't read as "no changes".
 const FORCE_FLUSH_MAX: Duration = Duration::from_millis(250);
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn build_ignore_glob_set() -> Arc<NxGlobSet> {
     build_glob_set(HARDCODED_IGNORE_PATTERNS).expect("These static ignores always build")
 }
@@ -60,7 +63,7 @@ fn build_ignore_glob_set() -> Arc<NxGlobSet> {
 /// Returns Err on `MaxFilesWatch` — the inotify limit is fatal since
 /// every subsequent registration would fail too. Other errors are
 /// warn-logged and skipped.
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn register_watches<I, P>(
     watcher: &mut notify::RecommendedWatcher,
     paths: I,
@@ -81,7 +84,7 @@ where
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn enumerate_watch_paths<P: AsRef<Path>>(directory: P, use_ignores: bool) -> HashSet<PathBuf> {
     let walker = create_walker(&directory, use_ignores);
     let mut path_set: HashSet<PathBuf> = HashSet::new();
@@ -109,10 +112,12 @@ type ForceFlushReply = Sender<Vec<WatchEvent>>;
 struct WatchPipeline {
     filterer: watch_filterer::WatchFilterer,
     notify_rx: Receiver<NotifyResult>,
+    /// Held to keep the registrations alive — dropping it stops delivery.
+    #[cfg_attr(any(target_os = "macos", target_os = "windows"), allow(dead_code))]
     watcher: notify::RecommendedWatcher,
     /// `origin` with a trailing path separator.
     origin_path: String,
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     ignore_globs: Arc<NxGlobSet>,
 
     accumulator: HashMap<PathBuf, WatchEventInternal>,
@@ -135,11 +140,14 @@ impl WatchPipeline {
         })
         .map_err(|e| format!("failed to create file watcher: {e}"))?;
 
-        #[cfg(target_os = "macos")]
+        // FSEvents and ReadDirectoryChangesW recurse in the kernel. notify
+        // accepts RecursiveMode::Recursive on inotify and kqueue too, but
+        // emulates it by registering every directory - without nx's ignores.
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
         if let Err(e) = watcher.watch(Path::new(&origin), RecursiveMode::Recursive) {
             tracing::error!(?e, "failed to watch root directory");
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         register_watches(&mut watcher, enumerate_watch_paths(&origin, use_ignore))
             .map_err(|e| format!("failed to register initial watches: {e}"))?;
 
@@ -153,7 +161,7 @@ impl WatchPipeline {
             notify_rx,
             watcher,
             origin_path,
-            #[cfg(not(target_os = "macos"))]
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
             ignore_globs: build_ignore_glob_set(),
             accumulator: HashMap::new(),
             burst_start: None,
@@ -191,7 +199,7 @@ impl WatchPipeline {
         self.flush_deadline = None;
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     fn new_directories_from_event(&self, event: &RawWatchEvent) -> Vec<PathBuf> {
         use crate::native::watch::types::meta_is_dir;
         use notify::{EventKind, event::CreateKind};
@@ -213,7 +221,7 @@ impl WatchPipeline {
     /// Synchronously register watches for new directories, walk them to
     /// backfill files written before the watch was active, and recurse
     /// into any nested subdirectories. Returns Err on `MaxFilesWatch`.
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     fn register_and_backfill_new_dirs(
         &mut self,
         dirs: &[PathBuf],
@@ -285,7 +293,7 @@ impl WatchPipeline {
             );
         }
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         {
             let new_dirs = self.new_directories_from_event(&raw);
             if !new_dirs.is_empty() {
@@ -544,7 +552,7 @@ mod tests {
     use super::*;
     use crate::native::watch::types::EventType;
     use std::fs;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tempfile::tempdir;
 
@@ -558,8 +566,9 @@ mod tests {
         // Canonicalize: on macOS `/tmp` symlinks to `/private/tmp`, so
         // events arrive with the canonical prefix while origin would
         // not. The filterer's `path.starts_with(origin)` check needs
-        // them to agree.
-        let canonical = dir.canonicalize().expect("canonicalize tempdir");
+        // them to agree. dunce, not std: std returns a `\\?\` verbatim
+        // path on Windows, which no workspace root ever has.
+        let canonical = dunce::canonicalize(dir).expect("canonicalize tempdir");
         let mut w = Watcher::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             None,
@@ -588,6 +597,23 @@ mod tests {
 
     fn find_event<'a>(events: &'a [WatchEvent], name: &str) -> Option<&'a WatchEvent> {
         events.iter().find(|e| e.path.ends_with(name))
+    }
+
+    /// Poll both delivery paths until `path` shows up. Force-flush and the
+    /// idle-window callback race, and force-flush resets the accumulator, so
+    /// an event is reported through exactly one of them.
+    fn wait_for_path(watcher: &Watcher, captured: &Captured, path: &str, msg: &str) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let flushed = watcher.force_flush_pending();
+            let seen = flushed.iter().any(|e| e.path == path)
+                || captured.lock().unwrap().iter().any(|e| e.path == path);
+            if seen {
+                return;
+            }
+            assert!(Instant::now() < deadline, "{msg}");
+            std::thread::sleep(Duration::from_millis(50));
+        }
     }
 
     #[test]
@@ -809,7 +835,7 @@ mod tests {
         // watch() returns is never missed. No settling sleep on purpose —
         // start_watcher() is not used because it sleeps after registration.
         let dir = tempdir().expect("tempdir");
-        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        let canonical = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
         let mut watcher = Watcher::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             None,
@@ -826,24 +852,12 @@ mod tests {
 
         fs::write(canonical.join("boot.txt"), "x").expect("write");
 
-        let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            let flushed = watcher.force_flush_pending();
-            let seen = flushed.iter().any(|e| e.path == "boot.txt")
-                || captured
-                    .lock()
-                    .unwrap()
-                    .iter()
-                    .any(|e| e.path == "boot.txt");
-            if seen {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "write immediately after watch registration was never reported"
-            );
-            std::thread::sleep(Duration::from_millis(50));
-        }
+        wait_for_path(
+            &watcher,
+            &captured,
+            "boot.txt",
+            "write immediately after watch registration was never reported",
+        );
     }
 
     #[test]
@@ -905,6 +919,26 @@ mod tests {
             matches!(new_evt.r#type, EventType::create),
             "rename destination should classify as Create; got {:?}",
             new_evt.r#type
+        );
+    }
+
+    #[test]
+    fn files_in_directories_created_after_watch_start_are_reported() {
+        // Per-directory backends register new directories as they appear;
+        // recursive ones leave it to the kernel. Both have to report a file
+        // written into a directory that did not exist when watching began.
+        let dir = tempdir().expect("tempdir");
+        let (watcher, captured) = start_watcher(dir.path());
+
+        let nested = dir.path().join("libs/new-lib/src");
+        fs::create_dir_all(&nested).expect("mkdir nested");
+        fs::write(nested.join("index.ts"), "x").expect("write");
+
+        wait_for_path(
+            &watcher,
+            &captured,
+            "libs/new-lib/src/index.ts",
+            "file in a directory created after watch start was never reported",
         );
     }
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -1,5 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+use std::collections::HashSet;
 use std::path::{MAIN_SEPARATOR, Path, PathBuf};
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -10,10 +13,10 @@ use notify::{RecursiveMode, Watcher as NotifyWatcher};
 use parking_lot::Mutex;
 use tracing::{debug, trace};
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use crate::native::glob::{NxGlobSet, build_glob_set};
 use crate::native::walker::HARDCODED_IGNORE_PATTERNS;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use crate::native::walker::create_walker;
 use crate::native::watch::types::{
     EventType, RawWatchEvent, WatchEvent, WatchEventInternal, transform_event_to_watch_events,
@@ -52,7 +55,7 @@ const FORCE_FLUSH_QUIET: Duration = Duration::from_millis(50);
 /// a late reply isn't read as "no changes".
 const FORCE_FLUSH_MAX: Duration = Duration::from_millis(250);
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn build_ignore_glob_set() -> Arc<NxGlobSet> {
     build_glob_set(HARDCODED_IGNORE_PATTERNS).expect("These static ignores always build")
 }
@@ -60,7 +63,7 @@ fn build_ignore_glob_set() -> Arc<NxGlobSet> {
 /// Returns Err on `MaxFilesWatch` — the inotify limit is fatal since
 /// every subsequent registration would fail too. Other errors are
 /// warn-logged and skipped.
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn register_watches<I, P>(
     watcher: &mut notify::RecommendedWatcher,
     paths: I,
@@ -81,7 +84,7 @@ where
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn enumerate_watch_paths<P: AsRef<Path>>(directory: P, use_ignores: bool) -> HashSet<PathBuf> {
     let walker = create_walker(&directory, use_ignores);
     let mut path_set: HashSet<PathBuf> = HashSet::new();
@@ -109,10 +112,12 @@ type ForceFlushReply = Sender<Vec<WatchEvent>>;
 struct WatchPipeline {
     filterer: watch_filterer::WatchFilterer,
     notify_rx: Receiver<NotifyResult>,
+    /// Held to keep the registrations alive — dropping it stops delivery.
+    #[cfg_attr(any(target_os = "macos", target_os = "windows"), allow(dead_code))]
     watcher: notify::RecommendedWatcher,
     /// `origin` with a trailing path separator.
     origin_path: String,
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     ignore_globs: Arc<NxGlobSet>,
 
     accumulator: HashMap<PathBuf, WatchEventInternal>,
@@ -139,11 +144,14 @@ impl WatchPipeline {
         })
         .map_err(|e| format!("failed to create file watcher: {e}"))?;
 
-        #[cfg(target_os = "macos")]
-        if let Err(e) = watcher.watch(Path::new(&origin), RecursiveMode::Recursive) {
-            tracing::error!(?e, "failed to watch root directory");
-        }
-        #[cfg(not(target_os = "macos"))]
+        // FSEvents and ReadDirectoryChangesW recurse in the kernel. notify
+        // accepts RecursiveMode::Recursive on inotify and kqueue too, but
+        // emulates it by registering every directory - without nx's ignores.
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        watcher
+            .watch(Path::new(&origin), RecursiveMode::Recursive)
+            .map_err(|e| format!("failed to watch root directory: {e}"))?;
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         register_watches(&mut watcher, enumerate_watch_paths(&origin, use_ignore))
             .map_err(|e| format!("failed to register initial watches: {e}"))?;
 
@@ -157,7 +165,7 @@ impl WatchPipeline {
             notify_rx,
             watcher,
             origin_path,
-            #[cfg(not(target_os = "macos"))]
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
             ignore_globs: build_ignore_glob_set(),
             accumulator: HashMap::new(),
             pending_rescan: false,
@@ -209,7 +217,7 @@ impl WatchPipeline {
         self.flush_deadline = None;
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     fn new_directories_from_event(&self, event: &RawWatchEvent) -> Vec<PathBuf> {
         use crate::native::watch::types::meta_is_dir;
         use notify::{EventKind, event::CreateKind};
@@ -231,7 +239,7 @@ impl WatchPipeline {
     /// Synchronously register watches for new directories, walk them to
     /// backfill files written before the watch was active, and recurse
     /// into any nested subdirectories. Returns Err on `MaxFilesWatch`.
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     fn register_and_backfill_new_dirs(
         &mut self,
         dirs: &[PathBuf],
@@ -312,7 +320,7 @@ impl WatchPipeline {
             );
         }
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         {
             let new_dirs = self.new_directories_from_event(&raw);
             if !new_dirs.is_empty() {
@@ -343,6 +351,11 @@ impl WatchPipeline {
     /// Drives the pipeline until force_flush_rx disconnects.
     fn run(mut self, force_flush_rx: Receiver<ForceFlushReply>, callback: WatchEventCallback) {
         loop {
+            // A continuously ready notify channel prevents select!'s default arm
+            // from running, even with a zero timeout. Honor MAX_WAIT explicitly.
+            if self.flush_deadline.is_some_and(|d| Instant::now() >= d) {
+                self.flush_pending(&callback);
+            }
             let idle_wait = self
                 .flush_deadline
                 .map(|d| d.saturating_duration_since(Instant::now()))
@@ -433,18 +446,19 @@ impl WatchPipeline {
                     Err(_) => break, // struct dropped or stop() called
                 },
                 default(idle_wait) => {
-                    if self.has_pending() {
-                        let events = self.snapshot_events();
-                        debug!(count = events.len(), "idle-window emitting events");
-                        for e in &events {
-                            debug!("  [{:?}] {}", e.r#type, e.path);
-                        }
-                        callback(Ok(events));
-                    }
-                    self.reset_burst();
+                    self.flush_pending(&callback);
                 }
             }
         }
+    }
+
+    fn flush_pending(&mut self, callback: &WatchEventCallback) {
+        if self.has_pending() {
+            let events = self.snapshot_events();
+            debug!(count = events.len(), "idle-window emitting events");
+            callback(Ok(events));
+        }
+        self.reset_burst();
     }
 }
 
@@ -571,7 +585,7 @@ mod tests {
     use super::*;
     use crate::native::watch::types::EventType;
     use std::fs;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tempfile::tempdir;
 
@@ -585,8 +599,9 @@ mod tests {
         // Canonicalize: on macOS `/tmp` symlinks to `/private/tmp`, so
         // events arrive with the canonical prefix while origin would
         // not. The filterer's `path.starts_with(origin)` check needs
-        // them to agree.
-        let canonical = dir.canonicalize().expect("canonicalize tempdir");
+        // them to agree. dunce, not std: std returns a `\\?\` verbatim
+        // path on Windows, which no workspace root ever has.
+        let canonical = dunce::canonicalize(dir).expect("canonicalize tempdir");
         let mut w = Watcher::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             None,
@@ -617,12 +632,29 @@ mod tests {
         events.iter().find(|e| e.path.ends_with(name))
     }
 
+    /// Poll both delivery paths until `path` shows up. Force-flush and the
+    /// idle-window callback race, and force-flush resets the accumulator, so
+    /// an event is reported through exactly one of them.
+    fn wait_for_path(watcher: &Watcher, captured: &Captured, path: &str, msg: &str) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let flushed = watcher.force_flush_pending();
+            let seen = flushed.iter().any(|e| e.path == path)
+                || captured.lock().unwrap().iter().any(|e| e.path == path);
+            if seen {
+                return;
+            }
+            assert!(Instant::now() < deadline, "{msg}");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
     #[test]
     fn rescan_flag_supersedes_accumulated_events() {
         use notify::event::{CreateKind, Flag};
 
         let dir = tempdir().expect("tempdir");
-        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        let canonical = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
         let mut pipeline = WatchPipeline::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             &[],
@@ -646,6 +678,70 @@ mod tests {
 
         pipeline.reset_burst();
         assert!(!pipeline.has_pending());
+    }
+
+    #[test]
+    fn pathless_rescan_reaches_callback_and_force_flush() {
+        for force_flush in [false, true] {
+            let dir = tempdir().expect("tempdir");
+            let origin = dunce::canonicalize(dir.path()).unwrap();
+            let mut pipeline =
+                WatchPipeline::new(origin.to_string_lossy().into_owned(), &[], false).unwrap();
+            pipeline
+                .ingest_event(Ok(notify::Event::new(notify::EventKind::Other)
+                    .set_flag(notify::event::Flag::Rescan)))
+                .unwrap();
+            let (flush_tx, flush_rx) = unbounded();
+            let (events_tx, events_rx) = unbounded();
+            let callback: WatchEventCallback = Box::new(move |events| {
+                events_tx.send(events.unwrap()).unwrap();
+            });
+            let thread = std::thread::spawn(move || pipeline.run(flush_rx, callback));
+            let events = if force_flush {
+                let (reply_tx, reply_rx) = bounded(1);
+                flush_tx.send(reply_tx).unwrap();
+                reply_rx.recv_timeout(Duration::from_secs(2)).unwrap()
+            } else {
+                events_rx.recv_timeout(Duration::from_secs(2)).unwrap()
+            };
+            assert_eq!(events.len(), 1);
+            assert!(matches!(events[0].r#type, EventType::rescan));
+            assert!(events[0].path.is_empty());
+            drop(flush_tx);
+            thread.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn expired_rescan_flushes_before_a_ready_notify_channel() {
+        let dir = tempdir().unwrap();
+        let origin = dunce::canonicalize(dir.path()).unwrap();
+        let mut pipeline =
+            WatchPipeline::new(origin.to_string_lossy().into_owned(), &[], false).unwrap();
+        pipeline.pending_rescan = true;
+        pipeline.flush_deadline = Some(Instant::now());
+        let (notify_tx, notify_rx) = unbounded();
+        let queued_events = notify_rx.clone();
+        pipeline.notify_rx = notify_rx;
+        notify_tx
+            .send(Err(notify::Error::generic("queued")))
+            .unwrap();
+        let (flush_tx, flush_rx) = unbounded();
+        let (events_tx, events_rx) = unbounded();
+        let callback: WatchEventCallback = Box::new(move |events| {
+            events_tx
+                .send((events.unwrap(), queued_events.len()))
+                .unwrap();
+        });
+        let thread = std::thread::spawn(move || pipeline.run(flush_rx, callback));
+        let (events, queued) = events_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(matches!(events[0].r#type, EventType::rescan));
+        assert_eq!(
+            queued, 1,
+            "An expired rescan must precede the next queued event"
+        );
+        drop(flush_tx);
+        thread.join().unwrap();
     }
 
     #[test]
@@ -867,7 +963,7 @@ mod tests {
         // watch() returns is never missed. No settling sleep on purpose —
         // start_watcher() is not used because it sleeps after registration.
         let dir = tempdir().expect("tempdir");
-        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        let canonical = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
         let mut watcher = Watcher::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             None,
@@ -884,24 +980,12 @@ mod tests {
 
         fs::write(canonical.join("boot.txt"), "x").expect("write");
 
-        let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            let flushed = watcher.force_flush_pending();
-            let seen = flushed.iter().any(|e| e.path == "boot.txt")
-                || captured
-                    .lock()
-                    .unwrap()
-                    .iter()
-                    .any(|e| e.path == "boot.txt");
-            if seen {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "write immediately after watch registration was never reported"
-            );
-            std::thread::sleep(Duration::from_millis(50));
-        }
+        wait_for_path(
+            &watcher,
+            &captured,
+            "boot.txt",
+            "write immediately after watch registration was never reported",
+        );
     }
 
     #[test]
@@ -963,6 +1047,26 @@ mod tests {
             matches!(new_evt.r#type, EventType::create),
             "rename destination should classify as Create; got {:?}",
             new_evt.r#type
+        );
+    }
+
+    #[test]
+    fn files_in_directories_created_after_watch_start_are_reported() {
+        // Per-directory backends register new directories as they appear;
+        // recursive ones leave it to the kernel. Both have to report a file
+        // written into a directory that did not exist when watching began.
+        let dir = tempdir().expect("tempdir");
+        let (watcher, captured) = start_watcher(dir.path());
+
+        let nested = dir.path().join("libs/new-lib/src");
+        fs::create_dir_all(&nested).expect("mkdir nested");
+        fs::write(nested.join("index.ts"), "x").expect("write");
+
+        wait_for_path(
+            &watcher,
+            &captured,
+            "libs/new-lib/src/index.ts",
+            "file in a directory created after watch start was never reported",
         );
     }
 

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -25,6 +25,7 @@ use xxhash_rust::xxh3;
 pub struct WorkspaceContext {
     pub workspace_root: String,
     workspace_root_path: PathBuf,
+    cache_dir: String,
     files_worker: FilesWorker,
 }
 
@@ -54,7 +55,7 @@ fn gather_and_hash_files(workspace_root: &Path, cache_dir: String) -> Vec<(PathB
 }
 
 #[derive(Default)]
-struct FilesWorker(Option<Arc<(NxMutex<Files>, NxCondvar)>>);
+struct FilesWorker(Option<Arc<(NxMutex<Option<Files>>, NxCondvar)>>);
 impl FilesWorker {
     #[cfg(not(target_arch = "wasm32"))]
     fn gather_files(workspace_root: &Path, cache_dir: String) -> Self {
@@ -66,7 +67,7 @@ impl FilesWorker {
             return FilesWorker(None);
         }
 
-        let files_lock = Arc::new((NxMutex::new(Vec::new()), NxCondvar::new()));
+        let files_lock = Arc::new((NxMutex::new(None), NxCondvar::new()));
         let files_lock_clone = Arc::clone(&files_lock);
         let workspace_root = workspace_root.to_owned();
 
@@ -77,8 +78,8 @@ impl FilesWorker {
 
             let files = gather_and_hash_files(&workspace_root, cache_dir);
 
-            *workspace_files = files;
-            let files_len = workspace_files.len();
+            let files_len = files.len();
+            *workspace_files = Some(files);
             trace!(?files_len, "files retrieved");
 
             drop(workspace_files);
@@ -104,7 +105,7 @@ impl FilesWorker {
 
         trace!("{} files retrieved", files.len());
 
-        let files_lock = Arc::new((NxMutex::new(files), NxCondvar::new()));
+        let files_lock = Arc::new((NxMutex::new(Some(files)), NxCondvar::new()));
 
         FilesWorker(Some(files_lock))
     }
@@ -116,17 +117,13 @@ impl FilesWorker {
             trace!("waiting for files to be available");
             let files = files_lock.lock().expect("Should be able to lock files");
 
-            #[cfg(target_arch = "wasm32")]
             let files = cvar
-                .wait(files, |guard| guard.len() == 0)
-                .expect("Should be able to wait for files");
-
-            #[cfg(not(target_arch = "wasm32"))]
-            let files = cvar
-                .wait(files, |guard| guard.len() == 0)
+                .wait(files, |guard| guard.is_none())
                 .expect("Should be able to wait for files");
 
             let file_data = files
+                .as_ref()
+                .expect("Initial scan completed")
                 .iter()
                 .map(|(path, hash)| FileData {
                     file: path.to_normalized_string(),
@@ -154,10 +151,14 @@ impl FilesWorker {
             return HashMap::new();
         };
 
-        let (files_lock, _) = &files_sync.deref();
-        let mut files = files_lock
+        let (files_lock, cvar) = &files_sync.deref();
+        let files = files_lock
             .lock()
             .expect("Should always be able to update files");
+        let mut files = cvar
+            .wait(files, |guard| guard.is_none())
+            .expect("Initial scan completed");
+        let files = files.as_mut().expect("Initial scan completed");
         let mut map: HashMap<PathBuf, String> = files.drain(..).collect();
 
         for deleted_path in deleted_files_and_directories {
@@ -222,6 +223,7 @@ impl WorkspaceContext {
             files_worker: FilesWorker::gather_files(&workspace_root_path, cache_dir.clone()),
             workspace_root,
             workspace_root_path,
+            cache_dir,
         }
     }
 
@@ -428,6 +430,29 @@ impl WorkspaceContext {
         self.files_worker.get_files()
     }
 
+    /// After event loss, timestamps cannot establish that cached hashes are fresh.
+    #[napi]
+    pub fn rescan(&self) -> Vec<FileData> {
+        let Some(files_sync) = &self.files_worker.0 else {
+            return vec![];
+        };
+        let (files_lock, cvar) = files_sync.deref();
+        let files = files_lock.lock().expect("Should be able to rescan files");
+        let mut files = cvar
+            .wait(files, |guard| guard.is_none())
+            .expect("Initial scan completed");
+        let hashes = full_files_hash(&self.workspace_root_path);
+        let mut refreshed: Files = hashes
+            .iter()
+            .map(|(path, hashed)| (PathBuf::from(path), hashed.0.clone()))
+            .collect();
+        refreshed.par_sort();
+        write_files_archive(&self.cache_dir, hashes);
+        *files = Some(refreshed);
+        drop(files);
+        self.files_worker.get_files()
+    }
+
     #[napi]
     pub fn get_files_in_directory(&self, directory: String) -> Vec<String> {
         get_child_files(directory, self.files_worker.get_files())
@@ -446,6 +471,76 @@ mod tests {
     use super::*;
     use assert_fs::TempDir;
     use assert_fs::prelude::*;
+
+    #[test]
+    fn rescan_rehashes_same_timestamp_edits_and_recovers_creates_and_deletes() {
+        let temp = TempDir::new().unwrap();
+        let cache = TempDir::new().unwrap();
+        let source = temp.child("source.ts");
+        source.write_str("before").unwrap();
+        temp.child("deleted.ts").write_str("deleted").unwrap();
+        let modified = source.path().metadata().unwrap().modified().unwrap();
+        let ctx = WorkspaceContext::new(
+            temp.path().to_string_lossy().into_owned(),
+            cache.path().to_string_lossy().into_owned(),
+        );
+        let before = ctx.all_file_data();
+        let original_hash = &before.iter().find(|f| f.file == "source.ts").unwrap().hash;
+
+        source.write_str("after!").unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(source.path())
+            .unwrap()
+            .set_modified(modified)
+            .unwrap();
+        std::fs::remove_file(temp.child("deleted.ts").path()).unwrap();
+        temp.child("created.ts").write_str("created").unwrap();
+
+        let after = ctx.rescan();
+        assert_eq!(after.len(), 2);
+        let refreshed_hash = &after.iter().find(|f| f.file == "source.ts").unwrap().hash;
+        assert_ne!(original_hash, refreshed_hash);
+        assert_eq!(refreshed_hash, &hash(b"after!"));
+        assert!(after.iter().any(|f| f.file == "created.ts"));
+        assert!(!after.iter().any(|f| f.file == "deleted.ts"));
+        assert_eq!(ctx.all_file_data().len(), 2);
+
+        let restarted = WorkspaceContext::new(
+            temp.path().to_string_lossy().into_owned(),
+            cache.path().to_string_lossy().into_owned(),
+        );
+        assert_eq!(
+            restarted
+                .all_file_data()
+                .iter()
+                .find(|f| f.file == "source.ts")
+                .unwrap()
+                .hash,
+            *refreshed_hash,
+            "The recovered hash must survive a new workspace context"
+        );
+
+        std::fs::remove_file(source.path()).unwrap();
+        std::fs::remove_file(temp.child("created.ts").path()).unwrap();
+        assert!(ctx.rescan().is_empty());
+        assert!(ctx.all_file_data().is_empty());
+    }
+
+    #[test]
+    fn completed_empty_scan_is_ready() {
+        let worker = FilesWorker(Some(Arc::new((
+            NxMutex::new(Some(Vec::new())),
+            NxCondvar::new(),
+        ))));
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || tx.send(worker.get_files()).unwrap());
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(2))
+                .expect("A completed empty scan must not wait for another notification")
+                .is_empty()
+        );
+    }
 
     /// Plugin createNodes pipelines (and therefore atomized target name
     /// insertion order) depend on the JS-visible `WorkspaceContext.glob`

--- a/packages/nx/src/utils/workspace-context.ts
+++ b/packages/nx/src/utils/workspace-context.ts
@@ -181,3 +181,10 @@ function ensureContextAvailable(workspaceRoot: string) {
 export function resetWorkspaceContext() {
   workspaceContext = undefined;
 }
+
+export function rescanWorkspaceContext(workspaceRoot: string) {
+  ensureContextAvailable(workspaceRoot);
+  const before = workspaceContext.allFileData();
+  const after = workspaceContext.rescan();
+  return { before, after };
+}

--- a/packages/nx/vitest.setup.mts
+++ b/packages/nx/vitest.setup.mts
@@ -134,6 +134,10 @@ vi.doMock(workspaceContextPath, async () => {
     getAllFileDataInContext: guarded('getAllFileDataInContext', () =>
       Promise.resolve([])
     ),
+    rescanWorkspaceContext: guarded('rescanWorkspaceContext', () => ({
+      before: [],
+      after: [],
+    })),
     getFilesInDirectoryUsingContext: guarded(
       'getFilesInDirectoryUsingContext',
       () => Promise.resolve([])


### PR DESCRIPTION
Submitted by Christopher Buss. This follow-up was implemented and verified by a Codex agent using GPT-6 Astra.

## Current Behavior

Windows registers one native watch per directory, causing handle growth and volume-wide filesystem overhead. A recursive root removes that cost, but the current notify8 backend can silently discard events when its Windows notification buffer overflows. The maintainer's fast-callback results establish that per-directory and recursive registrations can lose different amounts of data; stalled-callback measurements do not resolve that concern.

## Expected Behavior

Windows watches the workspace recursively with constant registrations. When Windows reports lost change details, Nx receives a rescan signal and reconciles the workspace against disk instead of continuing with silently stale state. Recorded output hashes are invalidated through the recovery logic from #36566.

This PR includes the recovery commit from #36566 with its original attribution and pins Windows to notify9.0.0-rc.5, which includes notify-rs/notify#964. Other platforms retain notify8. Recovery hashes current file contents and persists the repaired archive, handles completed empty scans, and refreshes the daemon's ignore rules when a missed ignore-file edit is recovered. Rescan delivery also honors its deadline when the incoming event queue remains continuously ready.

## Validation

- Windows Rust suite: 569 passed, 0 failed, 2 ignored; TypeScript checking and native binding/declaration generation pass. Native Clippy completes with existing/general warnings.
- Outputs-handler tests: 6 passed. Native rescan, same-timestamp, archive-restart, empty-scan, and flush-path regressions pass.
- A real daemon harness verifies missed project creation, deletion, same-timestamp metadata updates, and preservation of the cached graph after a no-change rescan.
- A bounded fast-callback comparison reproduces silent loss in notify8 recursive: 59 of 60 creates delivered, 330 fewer events than per-directory, with no error/rescan. Notify9 recursive delivers all 60 creates and the full event count in that run.
- The actual Nx watcher retains all 1,000 final paths and hashes after a 12.7-second, two-writer rename storm.

Neither bounded notify9 run overflowed, so actual kernel-triggered rescan recovery remains unverified on this host. The existing Vitest recovery fixture fails while discovering its initial project before recovery; the unchanged upstream test fails identically in this environment. Full Nx task/prepush validation is blocked by missing .NET tooling and workspace dependency resolution. The update depends on unmerged #36566 and a notify prerelease; it is not represented as independently merge-ready.

## Related Issue(s)

Fixes #36563 together with #36566.

Generated with Codex.

