### PR TITLE
fix(webpack): set optimization.minimize to its normalized object form

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -170,13 +170,18 @@ function applyNxIndependentConfig(
     ...(config.ignoreWarnings ?? []),
   ];
 
+  const shouldMinify =
+    typeof options.optimization === 'object'
+      ? !!options.optimization.scripts
+      : !!options.optimization;
+
   config.optimization = {
     ...config.optimization,
     sideEffects: true,
-    minimize:
-      typeof options.optimization === 'object'
-        ? !!options.optimization.scripts
-        : !!options.optimization,
+    // webpack normalizes `true` to `{}` before plugins run, so writing the
+    // boolean back onto normalized options trips 5.110.0's per-asset-type
+    // defaults. `{}` is equivalent on every webpack 5; the types widened in 5.110.
+    minimize: shouldMinify ? ({} as unknown as boolean) : false,
     minimizer: [
       options.compiler !== 'swc'
         ? new TerserPlugin({

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -31,6 +31,38 @@ const extensionAlias = {
 const extensions = ['.ts', '.tsx', '.mjs', '.js', '.jsx'];
 const mainFields = ['module', 'main'];
 
+// webpack 5.110 widened `optimization.minimize` to accept an object it fills per
+// asset type. The types shipped with 5.x still declare a boolean, so the real
+// shape is spelled out once here instead of being cast at the assignment.
+type MinimizeOption = boolean | Record<string, never>;
+
+type OptimizationWithMinimize = Omit<
+  NonNullable<Configuration['optimization']>,
+  'minimize'
+> & { minimize?: MinimizeOption };
+
+/**
+ * `withNx` builds a raw config that webpack validates, and only the boolean is
+ * schema-valid before 5.110. `NxAppWebpackPlugin` instead mutates options that
+ * are already normalized, which 5.110 fills by setting `.javascript` on
+ * `minimize`, so a boolean throws there.
+ */
+function setMinimizeValue(
+  optimization: OptimizationWithMinimize,
+  shouldMinify: boolean,
+  configIsNormalized: boolean
+): void {
+  if (!shouldMinify) {
+    optimization.minimize = false;
+    return;
+  }
+  if (configIsNormalized) {
+    optimization.minimize = {};
+    return;
+  }
+  optimization.minimize = true;
+}
+
 export function applyBaseConfig(
   options: NormalizedNxAppWebpackPluginOptions,
   config: Partial<WebpackOptionsNormalized | Configuration> = {},
@@ -50,7 +82,7 @@ export function applyBaseConfig(
   options.memoryLimit ??= 2048;
   options.transformers ??= [];
 
-  applyNxIndependentConfig(options, config);
+  applyNxIndependentConfig(options, config, !!useNormalizedEntry);
 
   // Some of the options only work during actual tasks, not when reading the webpack config during CreateNodes.
   if (global.NX_GRAPH_CREATION) return;
@@ -60,7 +92,8 @@ export function applyBaseConfig(
 
 function applyNxIndependentConfig(
   options: NormalizedNxAppWebpackPluginOptions,
-  config: Partial<WebpackOptionsNormalized | Configuration>
+  config: Partial<WebpackOptionsNormalized | Configuration>,
+  configIsNormalized: boolean
 ): void {
   const TerserPlugin =
     require('terser-webpack-plugin') as typeof import('terser-webpack-plugin');
@@ -178,10 +211,6 @@ function applyNxIndependentConfig(
   config.optimization = {
     ...config.optimization,
     sideEffects: true,
-    // webpack normalizes `true` to `{}` before plugins run, so writing the
-    // boolean back onto normalized options trips 5.110.0's per-asset-type
-    // defaults. `{}` is equivalent on every webpack 5; the types widened in 5.110.
-    minimize: shouldMinify ? ({} as unknown as boolean) : false,
     minimizer: [
       options.compiler !== 'swc'
         ? new TerserPlugin({
@@ -216,6 +245,8 @@ function applyNxIndependentConfig(
     runtimeChunk: false,
     concatenateModules: true,
   };
+
+  setMinimizeValue(config.optimization, shouldMinify, configIsNormalized);
 
   config.stats = {
     hash: true,


### PR DESCRIPTION
## Current Behavior

Every webpack production build fails on webpack 5.110.0:

```
TypeError: Cannot create property 'javascript' on boolean 'true'
    at F (webpack/lib/config/defaults.js:260:13)
    at applyOptimizationDefaults (webpack/lib/config/defaults.js:2471:3)
    at applyWebpackOptionsDefaults (webpack/lib/config/defaults.js:572:2)
    at createCompiler (webpack/lib/webpack.js:174:33)
```

webpack 5.110.0 published at 11:43 UTC today and generated workspaces resolve `^5.101.3` to it, so every webpack e2e task went red across master and every open PR at once while this repo's own catalog-pinned 5.105.2 stayed green.

`createCompiler` normalizes the config, then applies plugins, then fills defaults:

```js
let options = getNormalizedWebpackOptions(rawOptions);   // minimize: true -> {}
...
for (const plugin of options.plugins) plugin.apply(compiler);   // we run here
const resolvedDefaultOptions = applyWebpackOptionsDefaults(options, compilerIndex);
```

`NxAppWebpackPlugin` runs in that middle step, and `applyBaseConfig` wrote `minimize` back as a boolean via `!!`. That put a denormalized value onto options the normalizer had already been through. It was harmless until 5.110.0 started canonicalizing the option per asset type and reached `true.javascript = {}`.

## Expected Behavior

Builds succeed on every webpack 5.

`{}` is exactly what `getNormalizedOptimizationMinimize` produces for `true`, and it is equivalent across the supported range: 5.109.2 and earlier only ever test the option for truthiness (`WebpackOptionsApply.js:819`) and fill it with `D(optimization, "minimize", production)`, while 5.110.0 wants the object. Verified against both, emitting an identical minimized bundle.

The cast is needed because the published types only widened to `boolean | object` in 5.110.0, and `@nx/webpack` supports `webpack@^5.0.0`.

Reported upstream as https://github.com/webpack/webpack/issues/21844, since the boolean is still schema-valid in 5.110.0 and other plugins that mutate `compiler.options` are likely affected. This change stands on its own regardless of what upstream does.

## Related Issue(s)

NXC-4892
