### PR TITLE
docs(misc): add knowledge base guide for Rust in an Nx workspace

### DIFF
--- a/astro-docs/.vale/styles/Nx/Headings.yml
+++ b/astro-docs/.vale/styles/Nx/Headings.yml
@@ -53,6 +53,9 @@ exceptions:
   - Kubernetes
   - Gradle
   - Maven
+  - Rust
+  - Cargo
+  - Clippy
   - Node.js
   - Deno
   - Bun

--- a/astro-docs/src/content/docs/kb/add-rust-to-nx-workspace.mdoc
+++ b/astro-docs/src/content/docs/kb/add-rust-to-nx-workspace.mdoc
@@ -1,0 +1,251 @@
+---
+title: Add a Rust Application to an Nx Workspace
+description: 'Add Rust crates to an Nx workspace so Cargo builds, tests, and Clippy runs share the same task graph, cache, and CI distribution as your JavaScript projects.'
+filter: 'type:Guides'
+topics:
+  - 'Extending Nx'
+---
+
+Cargo already resolves and links your crates. Nx sits above it and runs Cargo tasks the same way it
+runs JavaScript ones, so your crates land in the same task graph, the same cache, and the same
+`nx affected` calculation as your web app. After the setup below, `nx run-many -t build lint test`
+covers your Vite builds and your `cargo build` calls in one command.
+
+{% github_repository url="https://github.com/juristr/nx-polyglot-rust" /%}
+
+## Install the Rust toolchain
+
+Pin the toolchain in the repository so contributors and CI agents resolve the same `rustc` and
+Clippy. [mise](https://mise.jdx.dev/) drives rustup for you and installs the pinned version on
+checkout:
+
+```toml {% fileName=".mise.toml" %}
+[tools]
+rust = "1.90.0"
+```
+
+Any toolchain manager works. Pick one that also runs in CI, so a Rust task you cache locally and the
+same task rebuilt on an agent come out of the same compiler.
+
+## Declare the Cargo workspace
+
+Nx doesn't link crates. The root `Cargo.toml` lists the members and centralizes shared versions,
+including the path dependencies between local crates:
+
+```toml {% fileName="Cargo.toml" %}
+[workspace]
+resolver = "2"
+members = ["apps/api", "packages/domain", "packages/store"]
+
+[workspace.dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+domain = { path = "packages/domain" }
+```
+
+Individual crates then pick those entries up:
+
+```toml {% fileName="packages/store/Cargo.toml" %}
+[dependencies]
+serde.workspace = true
+domain.workspace = true
+```
+
+Path dependencies are the Cargo counterpart to `workspace:*` in a pnpm workspace, and they're what
+Nx reads to draw edges between Rust projects in the graph.
+
+## Add the Rust plugin
+
+Cargo operations reach Nx through the community [`@monodon/rust`](https://github.com/Cammisuli/monodon)
+plugin:
+
+```shell
+nx add @monodon/rust
+```
+
+That registers the plugin in `nx.json` and gives you executors that wrap the Cargo commands.
+`@monodon/rust:build` runs `cargo build`, `:test` runs `cargo test`, `:lint` runs `cargo clippy`,
+and `:run` runs `cargo run`.
+
+Generate a new crate with the targets already wired up:
+
+```shell
+nx g @monodon/rust:binary apps/api
+nx g @monodon/rust:library packages/domain
+```
+
+For a crate that already exists, add a [`project.json`](/docs/reference/project-configuration) next
+to its `Cargo.toml`:
+
+```json {% fileName="apps/api/project.json" %}
+{
+  "name": "api",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "executor": "@monodon/rust:build",
+      "outputs": ["{options.target-dir}"],
+      "options": { "target-dir": "dist/target/api/build" }
+    },
+    "test": {
+      "executor": "@monodon/rust:test",
+      "outputs": ["{options.target-dir}"],
+      "options": { "target-dir": "dist/target/api/test" }
+    },
+    "lint": {
+      "executor": "@monodon/rust:lint",
+      "outputs": ["{options.target-dir}"],
+      "options": { "target-dir": "dist/target/api/lint" }
+    },
+    "run": {
+      "continuous": true,
+      "executor": "@monodon/rust:run",
+      "outputs": ["{options.target-dir}"],
+      "options": { "target-dir": "dist/target/api/run" }
+    }
+  }
+}
+```
+
+Copy the per-target `target-dir`. Cargo writes into one shared `target/` directory by default, so
+`build`, `test`, `lint`, and `run` overwrite each other's artifacts and the cached outputs stop
+matching the task that produced them. Giving each target its own directory under
+`dist/target/<project>/<target>` keeps them apart.
+
+{% aside type="note" title="The plugin is optional" %}
+Any directory with a `project.json` is an Nx project, so a plain `"command": "cargo build -p api"`
+target works without installing anything. See
+[multi-language support](/docs/features/multi-language-support) for that form, and
+[add language support to Nx](/docs/kb/add-language-support) if you want to build your own plugin
+instead.
+{% /aside %}
+
+## Cache Rust tasks
+
+Rust tasks cache like any other task once you tell Nx what a Rust build depends on. Define the
+toolchain and lockfiles as a [named input](/docs/reference/inputs), then apply it to the executors:
+
+```json {% fileName="nx.json" %}
+{
+  "namedInputs": {
+    "rust": [
+      "default",
+      "{workspaceRoot}/Cargo.toml",
+      "{workspaceRoot}/Cargo.lock",
+      "{workspaceRoot}/rust-toolchain.toml",
+      "{workspaceRoot}/.mise.toml"
+    ]
+  },
+  "targetDefaults": {
+    "@monodon/rust:build": {
+      "cache": true,
+      "inputs": ["rust", "^rust"],
+      "dependsOn": ["^build"]
+    },
+    "@monodon/rust:test": {
+      "cache": true,
+      "inputs": ["rust", "^rust"],
+      "dependsOn": ["^build"]
+    },
+    "@monodon/rust:lint": { "cache": true, "inputs": ["rust", "^rust"] }
+  }
+}
+```
+
+Miss the toolchain file in that list and a Rust version bump replays stale artifacts.
+[How caching works](/docs/concepts/how-caching-works) covers the hashing rules in full.
+
+## Run both stacks from one command
+
+With the crates in the graph, a single run covers Cargo, Vite, `tsc`, and ESLint in dependency order:
+
+```shell
+nx run-many -t build lint test typecheck
+```
+
+Task pipelines cross the language boundary too, because Nx treats every task the same regardless of
+what it shells out to. Starting a JavaScript dev server can start the Rust service it talks to:
+
+```json {% fileName="apps/web/package.json" %}
+{
+  "nx": {
+    "targets": {
+      "dev": {
+        "continuous": true,
+        "dependsOn": [{ "projects": ["api"], "target": "run" }]
+      }
+    }
+  }
+}
+```
+
+`nx dev web` now builds the crate's dependencies, starts `api:run`, and starts the web dev server.
+[Task pipeline configuration](/docs/concepts/task-pipeline-configuration) has the rest of the syntax.
+
+## Run Rust tasks in CI
+
+CI needs the Rust toolchain before it can run a Cargo task, and the same mise pin covers it:
+
+```yaml {% fileName=".github/workflows/ci.yml" %}
+- name: Setup Rust with mise
+  uses: jdx/mise-action@v3
+
+- name: Set affected SHAs
+  uses: nrwl/nx-set-shas@v5
+
+- name: Run Nx tasks
+  run: npx nx affected -t lint test build typecheck
+```
+
+[`nx affected`](/docs/features/ci-features/affected) reads the Cargo path dependencies, so a change
+to `packages/domain` schedules the crates that depend on it and skips the rest of the repository.
+
+To spread those tasks across machines with
+[Nx Agents](/docs/features/ci-features/distribute-task-execution), install the toolchain on the
+agents as well. A [launch template](/docs/kb/launch-templates) caches the Cargo registry and warms
+the dependency download:
+
+```yaml {% fileName=".nx/workflows/agents.yaml" %}
+launch-templates:
+  linux-medium-polyglot:
+    resource-class: 'docker_linux_amd64/medium'
+    image: 'ubuntu22.04-node24.14-v1'
+    init-steps:
+      - name: Checkout
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
+
+      - name: Restore Cargo cache
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/cache/main.yaml'
+        inputs:
+          key: 'Cargo.lock|rust-toolchain.toml|.mise.toml'
+          paths: |
+            ~/.cargo/git
+            ~/.cargo/registry
+          base-branch: 'main'
+
+      - name: Install Rust with mise
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-mise/main.yaml'
+
+      - name: Install dependencies
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
+
+      - name: Fetch Rust dependencies
+        script: cargo fetch --locked
+```
+
+Point the pipeline at that template and every agent can take any task, Cargo or JavaScript:
+
+```yaml {% fileName=".nx/ci-config.yaml" %}
+dte:
+  distribute-on: 2 linux-medium-polyglot
+lifecycle:
+  stop-after:
+    - lint
+    - test
+    - build
+    - typecheck
+```
+
+The [ci-config reference](/docs/reference/nx-cloud/ci-config) lists the remaining keys.
+
+To release the crates from the same workspace, follow
+[using Nx Release with Rust](/docs/kb/publish-rust-crates).

--- a/astro-docs/src/content/docs/kb/add-rust-to-nx-workspace.mdoc
+++ b/astro-docs/src/content/docs/kb/add-rust-to-nx-workspace.mdoc
@@ -19,7 +19,8 @@ Pin the toolchain in the repository so contributors and CI agents resolve the sa
 Clippy. [mise](https://mise.jdx.dev/) drives rustup for you and installs the pinned version on
 checkout:
 
-```toml {% fileName=".mise.toml" %}
+```toml
+# .mise.toml
 [tools]
 rust = "1.90.0"
 ```
@@ -32,7 +33,8 @@ same task rebuilt on an agent come out of the same compiler.
 Nx doesn't link crates. The root `Cargo.toml` lists the members and centralizes shared versions,
 including the path dependencies between local crates:
 
-```toml {% fileName="Cargo.toml" %}
+```toml
+# Cargo.toml
 [workspace]
 resolver = "2"
 members = ["apps/api", "packages/domain", "packages/store"]
@@ -44,7 +46,8 @@ domain = { path = "packages/domain" }
 
 Individual crates then pick those entries up:
 
-```toml {% fileName="packages/store/Cargo.toml" %}
+```toml
+# packages/store/Cargo.toml
 [dependencies]
 serde.workspace = true
 domain.workspace = true
@@ -76,7 +79,8 @@ nx g @monodon/rust:library packages/domain
 For a crate that already exists, add a [`project.json`](/docs/reference/project-configuration) next
 to its `Cargo.toml`:
 
-```json {% fileName="apps/api/project.json" %}
+```json
+// apps/api/project.json
 {
   "name": "api",
   "projectType": "application",
@@ -124,7 +128,8 @@ instead.
 Rust tasks cache like any other task once you tell Nx what a Rust build depends on. Define the
 toolchain and lockfiles as a [named input](/docs/reference/inputs), then apply it to the executors:
 
-```json {% fileName="nx.json" %}
+```json
+// nx.json
 {
   "namedInputs": {
     "rust": [
@@ -165,7 +170,8 @@ nx run-many -t build lint test typecheck
 Task pipelines cross the language boundary too, because Nx treats every task the same regardless of
 what it shells out to. Starting a JavaScript dev server can start the Rust service it talks to:
 
-```json {% fileName="apps/web/package.json" %}
+```json
+// apps/web/package.json
 {
   "nx": {
     "targets": {
@@ -185,7 +191,8 @@ what it shells out to. Starting a JavaScript dev server can start the Rust servi
 
 CI needs the Rust toolchain before it can run a Cargo task, and the same mise pin covers it:
 
-```yaml {% fileName=".github/workflows/ci.yml" %}
+```yaml
+# .github/workflows/ci.yml
 - name: Setup Rust with mise
   uses: jdx/mise-action@v3
 
@@ -204,7 +211,8 @@ To spread those tasks across machines with
 agents as well. A [launch template](/docs/kb/launch-templates) caches the Cargo registry and warms
 the dependency download:
 
-```yaml {% fileName=".nx/workflows/agents.yaml" %}
+```yaml
+# .nx/workflows/agents.yaml
 launch-templates:
   linux-medium-polyglot:
     resource-class: 'docker_linux_amd64/medium'
@@ -234,7 +242,8 @@ launch-templates:
 
 Point the pipeline at that template and every agent can take any task, Cargo or JavaScript:
 
-```yaml {% fileName=".nx/ci-config.yaml" %}
+```yaml
+# .nx/ci-config.yaml
 dte:
   distribute-on: 2 linux-medium-polyglot
 lifecycle:

--- a/astro-docs/src/content/docs/kb/add-rust-to-nx-workspace.mdoc
+++ b/astro-docs/src/content/docs/kb/add-rust-to-nx-workspace.mdoc
@@ -6,9 +6,22 @@ topics:
   - 'Extending Nx'
 ---
 
-Nx is able to process your Rust crates as part of the its task graph, allowing you benefit from caching (locally and on CI), affected calculation as well as allowing to run Rust projects in a polyglot monorepo setup alongside other languages.
+Nx integrates your Rust crates into its project and task graph, so they benefit from the same Nx
+features as the rest of the workspace: task pipelines, local and remote caching, affected
+calculation, and distribution on CI. That's what lets you add a Rust-based application to an
+existing monorepo.
+
+{% youtube
+src="https://youtu.be/lyHbNUdLQhI"
+title="Polyglot Nx Monorepo with Rust and TanStack"
+/%}
 
 {% github_repository title="Example repository with JavaScript and Rust projects" url="https://github.com/juristr/nx-polyglot-rust" /%}
+
+{% callout title="Point your agent at this page" %}
+This article lists the main building blocks for integrating Rust projects into your Nx monorepo.
+Point an AI agent at this page and let it handle the setup.
+{% /callout %}
 
 ## Install the Rust toolchain
 
@@ -27,8 +40,8 @@ same task rebuilt on an agent come out of the same compiler.
 
 ## Declare the Cargo workspace
 
-Nx doesn't link crates. The root `Cargo.toml` lists the members and centralizes shared versions,
-including the path dependencies between local crates:
+Nx doesn't manage the linking of crates. The root `Cargo.toml` lists the members and centralizes
+shared versions, including the path dependencies between local crates:
 
 ```toml
 # Cargo.toml
@@ -55,14 +68,15 @@ Nx reads to draw edges between Rust projects in the graph.
 
 ## Add the Rust plugin
 
-Cargo operations reach Nx through the community [`@monodon/rust`](https://github.com/Cammisuli/monodon)
-plugin:
+Nx has an [extensibility API](/docs/kb/extending-nx) that lets you develop plugins integrating new
+technologies into Nx. This example uses the
+[`@monodon/rust`](https://github.com/Cammisuli/monodon) community plugin.
 
 ```shell
 nx add @monodon/rust
 ```
 
-That registers the plugin in `nx.json` and gives you executors that wrap the Cargo commands.
+This command registers the plugin in `nx.json` and gives you executors that wrap the Cargo commands.
 `@monodon/rust:build` runs `cargo build`, `:test` runs `cargo test`, `:lint` runs `cargo clippy`,
 and `:run` runs `cargo run`.
 

--- a/astro-docs/src/content/docs/kb/add-rust-to-nx-workspace.mdoc
+++ b/astro-docs/src/content/docs/kb/add-rust-to-nx-workspace.mdoc
@@ -6,12 +6,9 @@ topics:
   - 'Extending Nx'
 ---
 
-Cargo already resolves and links your crates. Nx sits above it and runs Cargo tasks the same way it
-runs JavaScript ones, so your crates land in the same task graph, the same cache, and the same
-`nx affected` calculation as your web app. After the setup below, `nx run-many -t build lint test`
-covers your Vite builds and your `cargo build` calls in one command.
+Nx is able to process your Rust crates as part of the its task graph, allowing you benefit from caching (locally and on CI), affected calculation as well as allowing to run Rust projects in a polyglot monorepo setup alongside other languages.
 
-{% github_repository url="https://github.com/juristr/nx-polyglot-rust" /%}
+{% github_repository title="Example repository with JavaScript and Rust projects" url="https://github.com/juristr/nx-polyglot-rust" /%}
 
 ## Install the Rust toolchain
 


### PR DESCRIPTION
## Current Behavior

Nothing in the docs walks through adding a Rust project to an Nx workspace end to end. [Multi-language support](https://nx.dev/docs/features/multi-language-support) shows a Rust `project.json` snippet among four languages, [add language support to Nx](https://nx.dev/docs/kb/add-language-support) covers writing your own plugin with Python as the example, and [using Nx Release with Rust](https://nx.dev/docs/kb/publish-rust-crates) starts after the crates are already wired up. A reader with a Cargo workspace and a JS app has to assemble the setup from all three, and the Rust-specific caching pitfall isn't documented anywhere.

## Expected Behavior

A new Knowledge Base guide, `kb/add-rust-to-nx-workspace`, covering the setup in one place:

- pinning the Rust toolchain with mise so local and CI runs share a compiler
- the Cargo workspace members and path dependencies Nx reads to draw graph edges
- adding `@monodon/rust`, its executors, and its `binary` / `library` generators
- a per-target `target-dir`, so `build`, `test`, `lint` and `run` stop overwriting each other in Cargo's shared `target/` directory and cached outputs keep matching the task that produced them
- `namedInputs` and `targetDefaults` for caching Rust tasks, including the toolchain files
- a `dependsOn` pipeline crossing the JS/Rust boundary
- CI with the mise action, plus an Nx Agents launch template that caches the Cargo registry

The article is adapted from an upcoming blog post and generalized away from the specific frameworks that post uses.

Also adds `Rust`, `Cargo` and `Clippy` to the Vale heading proper-noun exceptions in `astro-docs/.vale/styles/Nx/Headings.yml`. That list already carries `Gradle`, `Maven`, `Deno` and similar; without these three, Vale raises errors on correctly sentence-cased headings such as "Install the Rust toolchain".

`nx run astro-docs:vale` is clean on the new file.

## Related Issue(s)

DOC-639 (internal): https://linear.app/nxdev/issue/DOC-639/kb-article-on-nx-polyglot-with-rust

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/kb-nx-rust-2b76f453">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->