### PR TITLE
fix(nx-dev): show repository path in light mode

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/tags/github-repository.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/github-repository.component.tsx
@@ -33,7 +33,7 @@ export function GithubRepository({
               href={url}
               target="_blank"
               rel="noreferrer"
-              className="block text-sm font-medium text-white no-underline opacity-80"
+              className="block text-sm font-medium text-black no-underline opacity-80 group-hover:text-white dark:text-white"
             >
               <span className="absolute inset-0" aria-hidden="true"></span>
               {url.replace(/^.*\/\/[^\/]+/, '')}


### PR DESCRIPTION
## Current Behavior

The GitHub repository card renders its repository path as white text in light mode, making it unreadable against the light background.

<img width="645" height="204" alt="file-19cbe80cdc16c12d9c87f02603503669" src="https://github.com/user-attachments/assets/185a94f0-b73d-4a8f-862b-345c55ebb338" />


## Expected Behavior

The repository path uses dark text in light mode and white text in dark mode and on hover.

<img width="624" height="249" alt="file-685175cb86fe02defc9152628a5149a7" src="https://github.com/user-attachments/assets/e1126723-89c1-41a6-a566-7cb3f34a7dfb" />


## Related Issue(s)

[DOC-655](https://linear.app/nxdev/issue/DOC-655/astro-docs-github-repository-card-path-unreadable-in-light-mode)

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/fix-repo-link-component-f074d5af">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->