### PR TITLE
fix(core): prevent daemon client wedge on failed reconnect

### DIFF
--- a/packages/nx/src/daemon/client/client.spec.ts
+++ b/packages/nx/src/daemon/client/client.spec.ts
@@ -49,10 +49,49 @@ import { clientLogger } from '../logger';
 import { readDaemonProcessJsonCache } from '../cache';
 import { DAEMON_OUTPUT_LOG_FILE as logFile } from '../tmp-dir';
 import {
+  DaemonClient,
   daemonClient,
   daemonPermissionException,
   daemonProcessException,
 } from './client';
+import { VersionMismatchError } from './daemon-socket-messenger';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var NX_PLUGIN_WORKER: boolean | undefined;
+}
+
+// Mirrors the private enum in client.ts for test assertions.
+const enum DaemonStatus {
+  CONNECTING = 0,
+  DISCONNECTED = 1,
+  CONNECTED = 2,
+}
+
+type TestClient = {
+  _daemonStatus: DaemonStatus;
+  _waitForDaemonReady: Promise<void> | null;
+  _daemonReady: (() => void) | null;
+  currentMessage: unknown;
+  currentResolve: ((v: unknown) => void) | null;
+  currentReject: ((e: unknown) => void) | null;
+  startDaemonIfNecessary: () => Promise<void>;
+  handleConnectionError: (err: Error) => Promise<void>;
+  probeServer: () => Promise<{ available: boolean; refusal?: unknown }>;
+  startInBackground: (probeRefusal?: unknown) => Promise<number>;
+  setUpConnection: () => void;
+  waitForServerToBeAvailable: (opts: {
+    ignoreVersionMismatch: boolean;
+  }) => Promise<{ available: boolean; refusal?: unknown }>;
+  establishConnection: () => void;
+  registerDaemonProcessWithMetricsService: (
+    pid: number | null
+  ) => Promise<void>;
+};
+
+function asTest(client: DaemonClient): TestClient {
+  return client as unknown as TestClient;
+}
 
 // Both suites share the mocked log path, so the directory is torn down once at
 // the end rather than by whichever suite finishes first.
@@ -412,5 +451,128 @@ describe('startInBackground', () => {
 
     expect((error as any).daemonPermissionError).toBeUndefined();
     expect((error as any).internalDaemonError).toBe(true);
+  });
+});
+
+describe('DaemonClient state machine', () => {
+  let client: TestClient;
+
+  beforeEach(() => {
+    client = asTest(new DaemonClient());
+    // Never actually register with metrics during tests.
+    jest
+      .spyOn(
+        client as unknown as { registerDaemonProcessWithMetricsService: any },
+        'registerDaemonProcessWithMetricsService'
+      )
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    delete global.NX_PLUGIN_WORKER;
+    jest.restoreAllMocks();
+  });
+
+  describe('startDaemonIfNecessary()', () => {
+    it('does not wedge concurrent callers when the initial connect throws', async () => {
+      const err = new Error('spawn failed');
+      jest.spyOn(client, 'probeServer').mockResolvedValue({ available: false });
+      jest.spyOn(client, 'startInBackground').mockRejectedValue(err);
+
+      // Kick off caller A synchronously; it flips status DISCONNECTED -> CONNECTING.
+      const first = client.startDaemonIfNecessary();
+      // Caller B now enters the CONNECTING branch and awaits _waitForDaemonReady.
+      const second = client.startDaemonIfNecessary();
+
+      await expect(first).rejects.toThrow('spawn failed');
+      await expect(second).rejects.toThrow('spawn failed');
+
+      // A failed attempt must leave the client DISCONNECTED so the next
+      // caller can retry instead of parking on a pending promise forever.
+      expect(client._daemonStatus).toBe(DaemonStatus.DISCONNECTED);
+    });
+
+    it('lets a future caller retry after a failed connect attempt', async () => {
+      const err = new Error('spawn failed');
+      const probeServer = jest
+        .spyOn(client, 'probeServer')
+        .mockResolvedValue({ available: false });
+      const startInBackground = jest
+        .spyOn(client, 'startInBackground')
+        .mockRejectedValueOnce(err)
+        .mockResolvedValueOnce(1234);
+      jest.spyOn(client, 'setUpConnection').mockImplementation(() => {
+        /* no-op */
+      });
+
+      await expect(client.startDaemonIfNecessary()).rejects.toThrow(
+        'spawn failed'
+      );
+      expect(client._daemonStatus).toBe(DaemonStatus.DISCONNECTED);
+
+      await expect(client.startDaemonIfNecessary()).resolves.toBeUndefined();
+      expect(client._daemonStatus).toBe(DaemonStatus.CONNECTED);
+      expect(probeServer).toHaveBeenCalledTimes(2);
+      expect(startInBackground).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('handleConnectionError() inside a plugin worker', () => {
+    beforeEach(() => {
+      global.NX_PLUGIN_WORKER = true;
+    });
+
+    it('does not attempt reconnection', async () => {
+      const waitSpy = jest
+        .spyOn(client, 'waitForServerToBeAvailable')
+        .mockResolvedValue({ available: true });
+      const currentReject = jest.fn();
+      client.currentReject = currentReject;
+
+      await client.handleConnectionError(new Error('daemon gone'));
+
+      expect(waitSpy).not.toHaveBeenCalled();
+      expect(currentReject).toHaveBeenCalledTimes(1);
+      const rejectedError = currentReject.mock.calls[0][0] as Error;
+      expect(rejectedError.message).toMatch(/plugin worker/i);
+    });
+
+    it('unblocks concurrent callers parked on _waitForDaemonReady', async () => {
+      // Capture the ready promise that was created in reset().
+      const pendingReady = client._waitForDaemonReady!;
+      client.currentReject = jest.fn();
+
+      await client.handleConnectionError(new Error('daemon gone'));
+
+      // The promise concurrent callers were awaiting must not be left
+      // hanging — it must surface the plugin-worker error.
+      await expect(pendingReady).rejects.toThrow(/plugin worker/i);
+      expect(client._daemonStatus).toBe(DaemonStatus.DISCONNECTED);
+    });
+  });
+
+  describe('handleConnectionError() with a version mismatch on reconnect', () => {
+    it('surfaces the error to concurrent callers awaiting _waitForDaemonReady', async () => {
+      jest
+        .spyOn(client, 'waitForServerToBeAvailable')
+        .mockRejectedValue(new VersionMismatchError());
+      const currentReject = jest.fn();
+      client.currentReject = currentReject;
+
+      // Drive handleConnectionError; it will create a new _waitForDaemonReady
+      // and replace the existing reference. Grab that new one after the fact.
+      const settle = client.handleConnectionError(new Error('daemon gone'));
+      // Wait for it to create the new promise; handleConnectionError is
+      // synchronous up to the first await.
+      const newReady = client._waitForDaemonReady!;
+
+      await settle;
+
+      await expect(newReady).rejects.toBeInstanceOf(VersionMismatchError);
+      expect(client._daemonStatus).toBe(DaemonStatus.DISCONNECTED);
+      expect(currentReject).toHaveBeenCalledWith(
+        expect.any(VersionMismatchError)
+      );
+    });
   });
 });

--- a/packages/nx/src/daemon/client/client.spec.ts
+++ b/packages/nx/src/daemon/client/client.spec.ts
@@ -56,7 +56,7 @@ import { connect } from 'net';
 
 import { waitForSocketConnection } from '../../utils/wait-for-socket-connection';
 import { clientLogger } from '../logger';
-import { readDaemonProcessJsonCache } from '../cache';
+import { getDaemonProcessIdSync, readDaemonProcessJsonCache } from '../cache';
 import { DAEMON_OUTPUT_LOG_FILE as logFile } from '../tmp-dir';
 import {
   DaemonClient,
@@ -541,6 +541,25 @@ describe('DaemonClient state machine', () => {
       expect(client._daemonStatus).toBe(DaemonStatus.CONNECTED);
       expect(probeServer).toHaveBeenCalledTimes(2);
       expect(startInBackground).toHaveBeenCalledTimes(2);
+    });
+
+    // Metrics registration happens after the connection is established, so a
+    // throw there must not send an already-CONNECTED client back to
+    // DISCONNECTED.
+    it('keeps an established connection when the metrics lookup throws', async () => {
+      jest.spyOn(client, 'probeServer').mockResolvedValue({ available: false });
+      jest.spyOn(client, 'startInBackground').mockResolvedValue(undefined);
+      jest.spyOn(client, 'setUpConnection').mockImplementation(() => {
+        /* no-op */
+      });
+      (getDaemonProcessIdSync as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('no process json');
+      });
+
+      await expect(client.startDaemonIfNecessary()).rejects.toThrow(
+        'no process json'
+      );
+      expect(client._daemonStatus).toBe(DaemonStatus.CONNECTED);
     });
   });
 

--- a/packages/nx/src/daemon/client/client.spec.ts
+++ b/packages/nx/src/daemon/client/client.spec.ts
@@ -632,6 +632,28 @@ describe('DaemonClient state machine', () => {
     });
   });
 
+  describe('handleConnectionError() when the reconnect never succeeds', () => {
+    it('surfaces the original error to the in-flight message and to concurrent callers', async () => {
+      jest
+        .spyOn(client, 'waitForServerToBeAvailable')
+        .mockResolvedValue({ available: false });
+      const currentReject = jest.fn();
+      client.currentReject = currentReject;
+      const error = new Error('daemon gone');
+
+      const settle = client.handleConnectionError(error);
+      // handleConnectionError installs its own ready promise before its first
+      // await; that is the one concurrent callers park on.
+      const newReady = client._waitForDaemonReady!;
+
+      await settle;
+
+      await expect(newReady).rejects.toBe(error);
+      expect(currentReject).toHaveBeenCalledWith(error);
+      expect(client._daemonStatus).toBe(DaemonStatus.DISCONNECTED);
+    });
+  });
+
   describe('handleConnectionError() with a version mismatch on reconnect', () => {
     it('surfaces the error to concurrent callers awaiting _waitForDaemonReady', async () => {
       vi

--- a/packages/nx/src/daemon/client/client.spec.ts
+++ b/packages/nx/src/daemon/client/client.spec.ts
@@ -63,19 +63,13 @@ import {
   daemonClient,
   daemonPermissionException,
   daemonProcessException,
+  DaemonStatus,
 } from './client';
 import { VersionMismatchError } from './daemon-socket-messenger';
 
 declare global {
   // eslint-disable-next-line no-var
   var NX_PLUGIN_WORKER: boolean | undefined;
-}
-
-// Mirrors the private enum in client.ts for test assertions.
-const enum DaemonStatus {
-  CONNECTING = 0,
-  DISCONNECTED = 1,
-  CONNECTED = 2,
 }
 
 type TestClient = {
@@ -104,7 +98,11 @@ function asTest(client: DaemonClient): TestClient {
   return client as unknown as TestClient;
 }
 
-type FakeSocket = EventEmitter & { unref: Mock; write: Mock };
+type FakeSocket = EventEmitter & {
+  unref: Mock;
+  write: Mock;
+  destroy: Mock;
+};
 
 // Lets `setUpConnection` run for real, so the close handler under test is the
 // one production installs. Only the members that handler's path touches exist.
@@ -444,7 +442,7 @@ describe('startInBackground', () => {
         // By hand, not via reset(): reset() would clear any instance-held
         // refusal, which is exactly the regression this checks for.
         (readDaemonProcessJsonCache as Mock).mockReturnValue(undefined);
-        (daemonClient as any)._daemonStatus = 1; // DISCONNECTED
+        (daemonClient as any)._daemonStatus = DaemonStatus.DISCONNECTED;
         const error = await (daemonClient as any)
           .startDaemonIfNecessary()
           .catch((e: any) => e);
@@ -487,12 +485,10 @@ describe('DaemonClient state machine', () => {
     daemon = new DaemonClient();
     client = asTest(daemon);
     // Never actually register with metrics during tests.
-    vi
-      .spyOn(
-        client as unknown as { registerDaemonProcessWithMetricsService: any },
-        'registerDaemonProcessWithMetricsService'
-      )
-      .mockResolvedValue(undefined);
+    vi.spyOn(
+      client as unknown as { registerDaemonProcessWithMetricsService: any },
+      'registerDaemonProcessWithMetricsService'
+    ).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -547,12 +543,12 @@ describe('DaemonClient state machine', () => {
     // throw there must not send an already-CONNECTED client back to
     // DISCONNECTED.
     it('keeps an established connection when the metrics lookup throws', async () => {
-      jest.spyOn(client, 'probeServer').mockResolvedValue({ available: false });
-      jest.spyOn(client, 'startInBackground').mockResolvedValue(undefined);
-      jest.spyOn(client, 'setUpConnection').mockImplementation(() => {
+      vi.spyOn(client, 'probeServer').mockResolvedValue({ available: false });
+      vi.spyOn(client, 'startInBackground').mockResolvedValue(undefined);
+      vi.spyOn(client, 'setUpConnection').mockImplementation(() => {
         /* no-op */
       });
-      (getDaemonProcessIdSync as jest.Mock).mockImplementationOnce(() => {
+      (getDaemonProcessIdSync as Mock).mockImplementationOnce(() => {
         throw new Error('no process json');
       });
 
@@ -653,10 +649,10 @@ describe('DaemonClient state machine', () => {
 
   describe('handleConnectionError() when the reconnect never succeeds', () => {
     it('surfaces the original error to the in-flight message and to concurrent callers', async () => {
-      jest
-        .spyOn(client, 'waitForServerToBeAvailable')
-        .mockResolvedValue({ available: false });
-      const currentReject = jest.fn();
+      vi.spyOn(client, 'waitForServerToBeAvailable').mockResolvedValue({
+        available: false,
+      });
+      const currentReject = vi.fn();
       client.currentReject = currentReject;
       const error = new Error('daemon gone');
 
@@ -675,9 +671,9 @@ describe('DaemonClient state machine', () => {
 
   describe('handleConnectionError() with a version mismatch on reconnect', () => {
     it('surfaces the error to concurrent callers awaiting _waitForDaemonReady', async () => {
-      vi
-        .spyOn(client, 'waitForServerToBeAvailable')
-        .mockRejectedValue(new VersionMismatchError());
+      vi.spyOn(client, 'waitForServerToBeAvailable').mockRejectedValue(
+        new VersionMismatchError()
+      );
       const currentReject = vi.fn();
       client.currentReject = currentReject;
 

--- a/packages/nx/src/daemon/client/client.spec.ts
+++ b/packages/nx/src/daemon/client/client.spec.ts
@@ -1,4 +1,4 @@
-import type { Mock } from 'vitest';
+import type { Mock, MockInstance } from 'vitest';
 import {
   chmodSync,
   mkdirSync,
@@ -38,11 +38,21 @@ vi.mock('../logger', () => ({
   clientLogger: { log: vi.fn() },
 }));
 
+// Real by default — the probe tests below need a genuine connect errno — and
+// replaced with a fake socket only where the close handler is under test.
+vi.mock('net', async () => {
+  const actual = await vi.importActual<typeof import('net')>('net');
+  return { ...actual, connect: vi.fn(actual.connect) };
+});
+
 vi.mock('../cache', async () => ({
   ...(await vi.importActual('../cache')),
   readDaemonProcessJsonCache: vi.fn(),
   getDaemonProcessIdSync: vi.fn(() => undefined),
 }));
+
+import { EventEmitter } from 'node:events';
+import { connect } from 'net';
 
 import { waitForSocketConnection } from '../../utils/wait-for-socket-connection';
 import { clientLogger } from '../logger';
@@ -72,6 +82,7 @@ type TestClient = {
   _daemonStatus: DaemonStatus;
   _waitForDaemonReady: Promise<void> | null;
   _daemonReady: (() => void) | null;
+  _pluginWorkerConnectionLost: Error | null;
   currentMessage: unknown;
   currentResolve: ((v: unknown) => void) | null;
   currentReject: ((e: unknown) => void) | null;
@@ -92,6 +103,20 @@ type TestClient = {
 function asTest(client: DaemonClient): TestClient {
   return client as unknown as TestClient;
 }
+
+type FakeSocket = EventEmitter & { unref: Mock; write: Mock };
+
+// Lets `setUpConnection` run for real, so the close handler under test is the
+// one production installs. Only the members that handler's path touches exist.
+function createFakeSocket(): FakeSocket {
+  return Object.assign(new EventEmitter(), {
+    unref: vi.fn(),
+    write: vi.fn(),
+    destroy: vi.fn(),
+  });
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
 
 // Both suites share the mocked log path, so the directory is torn down once at
 // the end rather than by whichever suite finishes first.
@@ -455,12 +480,14 @@ describe('startInBackground', () => {
 });
 
 describe('DaemonClient state machine', () => {
+  let daemon: DaemonClient;
   let client: TestClient;
 
   beforeEach(() => {
-    client = asTest(new DaemonClient());
+    daemon = new DaemonClient();
+    client = asTest(daemon);
     // Never actually register with metrics during tests.
-    jest
+    vi
       .spyOn(
         client as unknown as { registerDaemonProcessWithMetricsService: any },
         'registerDaemonProcessWithMetricsService'
@@ -470,14 +497,14 @@ describe('DaemonClient state machine', () => {
 
   afterEach(() => {
     delete global.NX_PLUGIN_WORKER;
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   describe('startDaemonIfNecessary()', () => {
     it('does not wedge concurrent callers when the initial connect throws', async () => {
       const err = new Error('spawn failed');
-      jest.spyOn(client, 'probeServer').mockResolvedValue({ available: false });
-      jest.spyOn(client, 'startInBackground').mockRejectedValue(err);
+      vi.spyOn(client, 'probeServer').mockResolvedValue({ available: false });
+      vi.spyOn(client, 'startInBackground').mockRejectedValue(err);
 
       // Kick off caller A synchronously; it flips status DISCONNECTED -> CONNECTING.
       const first = client.startDaemonIfNecessary();
@@ -494,14 +521,14 @@ describe('DaemonClient state machine', () => {
 
     it('lets a future caller retry after a failed connect attempt', async () => {
       const err = new Error('spawn failed');
-      const probeServer = jest
+      const probeServer = vi
         .spyOn(client, 'probeServer')
         .mockResolvedValue({ available: false });
-      const startInBackground = jest
+      const startInBackground = vi
         .spyOn(client, 'startInBackground')
         .mockRejectedValueOnce(err)
         .mockResolvedValueOnce(1234);
-      jest.spyOn(client, 'setUpConnection').mockImplementation(() => {
+      vi.spyOn(client, 'setUpConnection').mockImplementation(() => {
         /* no-op */
       });
 
@@ -517,46 +544,100 @@ describe('DaemonClient state machine', () => {
     });
   });
 
-  describe('handleConnectionError() inside a plugin worker', () => {
-    beforeEach(() => {
+  // Production reaches handleConnectionError only through the close handler
+  // `setUpConnection` installs, by which point the connect has already set
+  // CONNECTED and resolved the ready promise. So the whole sequence is driven
+  // here — connect, send, lose the socket — rather than calling the handler on
+  // a fresh client, which starts from a state production never reaches.
+  describe('a plugin worker losing its daemon connection', () => {
+    let socket: FakeSocket;
+    let probeServer: MockInstance;
+    let startInBackground: MockInstance;
+    let waitForServerToBeAvailable: MockInstance;
+
+    beforeEach(async () => {
       global.NX_PLUGIN_WORKER = true;
-    });
-
-    it('does not attempt reconnection', async () => {
-      const waitSpy = jest
-        .spyOn(client, 'waitForServerToBeAvailable')
+      socket = createFakeSocket();
+      (connect as Mock).mockReturnValue(socket);
+      (readDaemonProcessJsonCache as Mock).mockReturnValue({
+        socketPath: '/tmp/nx-spec-plugin-worker/d.sock',
+      });
+      probeServer = vi
+        .spyOn(client, 'probeServer')
         .mockResolvedValue({ available: true });
-      const currentReject = jest.fn();
-      client.currentReject = currentReject;
+      // Left calling through: the real ones are what a reconnect attempt would
+      // hit, and neither may be reached again after the connection is lost.
+      startInBackground = vi.spyOn(client, 'startInBackground');
+      waitForServerToBeAvailable = vi.spyOn(
+        client,
+        'waitForServerToBeAvailable'
+      );
 
-      await client.handleConnectionError(new Error('daemon gone'));
-
-      expect(waitSpy).not.toHaveBeenCalled();
-      expect(currentReject).toHaveBeenCalledTimes(1);
-      const rejectedError = currentReject.mock.calls[0][0] as Error;
-      expect(rejectedError.message).toMatch(/plugin worker/i);
+      await client.startDaemonIfNecessary();
+      expect(client._daemonStatus).toBe(DaemonStatus.CONNECTED);
     });
 
-    it('unblocks concurrent callers parked on _waitForDaemonReady', async () => {
-      // Capture the ready promise that was created in reset().
-      const pendingReady = client._waitForDaemonReady!;
-      client.currentReject = jest.fn();
+    afterEach(async () => {
+      const actual = await vi.importActual<typeof import('net')>('net');
+      (connect as Mock).mockImplementation(actual.connect);
+    });
 
-      await client.handleConnectionError(new Error('daemon gone'));
+    it('fails the in-flight message rather than polling for a replacement daemon', async () => {
+      const inFlight = daemon.requestShutdown();
+      // Let the queue put the message on the socket, so the close below lands
+      // on a client with work in flight.
+      await tick();
 
-      // The promise concurrent callers were awaiting must not be left
-      // hanging — it must surface the plugin-worker error.
-      await expect(pendingReady).rejects.toThrow(/plugin worker/i);
+      socket.emit('close');
+
+      await expect(inFlight).rejects.toThrow(
+        /Plugin worker lost its daemon connection/
+      );
+      expect(waitForServerToBeAvailable).not.toHaveBeenCalled();
+    });
+
+    it('fails later messages with the plugin-worker error even though a daemon is reachable', async () => {
+      const inFlight = daemon.requestShutdown();
+      await tick();
+      socket.emit('close');
+      await expect(inFlight).rejects.toThrow(/Plugin worker/);
+      probeServer.mockClear();
+
+      // The gate every queued and future message awaits before it reaches the
+      // socket. Without the guard the reachable daemon is connected to and the
+      // worker carries on against a daemon it never asked for.
+      await expect(client.startDaemonIfNecessary()).rejects.toThrow(
+        /Plugin worker lost its daemon connection/
+      );
+      expect(probeServer).not.toHaveBeenCalled();
       expect(client._daemonStatus).toBe(DaemonStatus.DISCONNECTED);
+    });
+
+    it('fails later messages with the plugin-worker error, not the startInBackground guard, when no daemon is reachable', async () => {
+      const inFlight = daemon.requestShutdown();
+      await tick();
+      socket.emit('close');
+      await expect(inFlight).rejects.toThrow(/Plugin worker/);
+      probeServer.mockResolvedValue({ available: false });
+
+      const error = await daemon.requestShutdown().catch((e) => e);
+
+      expect(error.message).toContain(
+        'Plugin worker lost its daemon connection'
+      );
+      // What the message got before: startInBackground's guard text, which
+      // tells the user to report a bug they did not hit.
+      expect(error.message).not.toContain('Please report this issue');
+      expect(startInBackground).not.toHaveBeenCalled();
     });
   });
 
   describe('handleConnectionError() with a version mismatch on reconnect', () => {
     it('surfaces the error to concurrent callers awaiting _waitForDaemonReady', async () => {
-      jest
+      vi
         .spyOn(client, 'waitForServerToBeAvailable')
         .mockRejectedValue(new VersionMismatchError());
-      const currentReject = jest.fn();
+      const currentReject = vi.fn();
       client.currentReject = currentReject;
 
       // Drive handleConnectionError; it will create a new _waitForDaemonReady

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -194,6 +194,8 @@ export class DaemonClient {
   private _waitForDaemonReady: Promise<void> | null = null;
   private _daemonReady: () => void | null = null;
   private _daemonReadyFailed: (err: Error) => void | null = null;
+  // Terminal once set — see `handleConnectionError`.
+  private _pluginWorkerConnectionLost: Error | null = null;
 
   // Shared file watcher connection state
   private fileWatcherMessenger: DaemonSocketMessenger | undefined;
@@ -296,6 +298,7 @@ export class DaemonClient {
     this.projectGraphListenerMessenger = undefined;
 
     this._daemonStatus = DaemonStatus.DISCONNECTED;
+    this._pluginWorkerConnectionLost = null;
     this._waitForDaemonReady = this.createReadyPromise();
   }
 
@@ -1070,6 +1073,9 @@ export class DaemonClient {
   }
 
   private async startDaemonIfNecessary() {
+    if (this._pluginWorkerConnectionLost) {
+      throw this._pluginWorkerConnectionLost;
+    }
     if (this._daemonStatus == DaemonStatus.CONNECTED) {
       return;
     }
@@ -1188,17 +1194,17 @@ export class DaemonClient {
   private async handleConnectionError(error: Error) {
     clientLogger.log(`[Reconnect] Connection error detected: ${error.message}`);
 
-    // Plugin workers can't survive the daemon going away: their view of
-    // the workspace is tied to the dead daemon (graph state, cached
-    // context, plugin module state). Reconnecting to a new daemon —
-    // potentially a different version — can't produce a correct result,
-    // and `startInBackground` would throw anyway. Fail every queued and
-    // future message with a clear error so callers see a fast failure
-    // instead of hanging on a reconnect path that can't succeed.
+    // A plugin worker cannot bring a daemon back — `startInBackground` throws
+    // in one — and it is usually hosted by the daemon that just died, so the
+    // 60s reconnect poll almost always ends in the same failure. Make the loss
+    // terminal instead: the in-flight message and every later one fail fast
+    // with a clear error. The cost is that a CLI-hosted worker no longer
+    // survives a daemon restart, and that command fails.
     if (global.NX_PLUGIN_WORKER) {
       const pluginWorkerError = daemonProcessException(
         `Plugin worker lost its daemon connection and cannot reconnect: ${error.message}`
       );
+      this._pluginWorkerConnectionLost = pluginWorkerError;
       if (this.currentReject) {
         this.currentReject(pluginWorkerError);
       }

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -142,7 +142,7 @@ export type ChangedFile = {
   type: 'create' | 'update' | 'delete';
 };
 
-enum DaemonStatus {
+export enum DaemonStatus {
   CONNECTING,
   DISCONNECTED,
   CONNECTED,
@@ -192,8 +192,8 @@ export class DaemonClient {
   private _enabled: boolean | undefined;
   private _daemonStatus: DaemonStatus = DaemonStatus.DISCONNECTED;
   private _waitForDaemonReady: Promise<void> | null = null;
-  private _daemonReady: () => void | null = null;
-  private _daemonReadyFailed: (err: Error) => void | null = null;
+  private _daemonReady: (() => void) | null = null;
+  private _daemonReadyFailed: ((err: Error) => void) | null = null;
   // Terminal once set — see `handleConnectionError`.
   private _pluginWorkerConnectionLost: Error | null = null;
 

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1218,25 +1218,14 @@ export class DaemonClient {
     // Set status to CONNECTING so new requests will wait for reconnection
     this._daemonStatus = DaemonStatus.CONNECTING;
 
-    let serverAvailable: boolean;
     try {
-      ({ available: serverAvailable } = await this.waitForServerToBeAvailable({
+      const { available } = await this.waitForServerToBeAvailable({
         ignoreVersionMismatch: false,
-      }));
-    } catch (err) {
-      if (err instanceof VersionMismatchError) {
-        // New daemon has different version - reject with error so caller can handle
-        if (this.currentReject) {
-          this.currentReject(err);
-        }
-        this.failDaemonReady(err);
-        return;
+      });
+      if (!available) {
+        // Out of reconnect attempts, so the error that started this stands.
+        throw error;
       }
-      this.failDaemonReady(err);
-      throw err;
-    }
-
-    if (serverAvailable) {
       clientLogger.log(
         `[Reconnect] Reconnection successful, re-establishing connection`
       );
@@ -1253,12 +1242,18 @@ export class DaemonClient {
         const rej = this.currentReject;
         this.sendMessageToDaemon(msg).then(res, rej);
       }
-    } else {
-      // Failed to reconnect after all attempts, reject the pending request
-      if (this.currentReject) {
-        this.currentReject(error);
+    } catch (err) {
+      this.failDaemonReady(err);
+      // A new daemon on a different version and an exhausted reconnect are
+      // both answers for the in-flight caller; anything else is unexpected
+      // and propagates.
+      if (err instanceof VersionMismatchError || err === error) {
+        if (this.currentReject) {
+          this.currentReject(err);
+        }
+        return;
       }
-      this.failDaemonReady(error);
+      throw err;
     }
   }
 

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1086,8 +1086,8 @@ export class DaemonClient {
       this._waitForDaemonReady = this.createReadyPromise();
       this._daemonStatus = DaemonStatus.CONNECTING;
 
+      let daemonPid: number | null = null;
       try {
-        let daemonPid: number | null = null;
         let probe: { available: boolean; refusal?: ConnectRefusal };
         try {
           probe = await this.probeServer();
@@ -1106,10 +1106,6 @@ export class DaemonClient {
         this.setUpConnection();
         this._daemonStatus = DaemonStatus.CONNECTED;
         this._daemonReady();
-
-        daemonPid ??= getDaemonProcessIdSync();
-        // Fire-and-forget - don't block daemon connection by waiting for metrics registration
-        this.registerDaemonProcessWithMetricsService(daemonPid);
       } catch (err) {
         // Reset to DISCONNECTED and reject the ready promise so every
         // concurrent caller parked on the CONNECTING branch gets the
@@ -1117,6 +1113,12 @@ export class DaemonClient {
         this.failDaemonReady(err);
         throw err;
       }
+
+      // Outside the try: the connection is established by now, and a throw
+      // from here must not undo it.
+      daemonPid ??= getDaemonProcessIdSync();
+      // Fire-and-forget - don't block daemon connection by waiting for metrics registration
+      this.registerDaemonProcessWithMetricsService(daemonPid);
     } else if (this._daemonStatus == DaemonStatus.CONNECTING) {
       await this._waitForDaemonReady;
       const daemonPid = getDaemonProcessIdSync();

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -193,6 +193,7 @@ export class DaemonClient {
   private _daemonStatus: DaemonStatus = DaemonStatus.DISCONNECTED;
   private _waitForDaemonReady: Promise<void> | null = null;
   private _daemonReady: () => void | null = null;
+  private _daemonReadyFailed: (err: Error) => void | null = null;
 
   // Shared file watcher connection state
   private fileWatcherMessenger: DaemonSocketMessenger | undefined;
@@ -295,9 +296,27 @@ export class DaemonClient {
     this.projectGraphListenerMessenger = undefined;
 
     this._daemonStatus = DaemonStatus.DISCONNECTED;
-    this._waitForDaemonReady = new Promise<void>(
-      (resolve) => (this._daemonReady = resolve)
-    );
+    this._waitForDaemonReady = this.createReadyPromise();
+  }
+
+  private createReadyPromise(): Promise<void> {
+    const promise = new Promise<void>((resolve, reject) => {
+      this._daemonReady = resolve;
+      this._daemonReadyFailed = reject;
+    });
+    // Callers don't always await — swallow the unhandled-rejection warning
+    // so a rejected ready promise that no one observes doesn't crash the
+    // process. Real awaiters still see the rejection.
+    promise.catch(() => {});
+    return promise;
+  }
+
+  // Move out of CONNECTING and surface an error to every caller parked on
+  // `_waitForDaemonReady`. Without this, a failure while CONNECTING leaves
+  // concurrent callers waiting on a promise that will never settle.
+  private failDaemonReady(err: Error) {
+    this._daemonStatus = DaemonStatus.DISCONNECTED;
+    this._daemonReadyFailed?.(err);
   }
 
   private getSocketPath(): string {
@@ -1056,31 +1075,42 @@ export class DaemonClient {
     }
     // Ensure daemon is running and socket path is available
     if (this._daemonStatus == DaemonStatus.DISCONNECTED) {
+      // Create a fresh ready promise for any concurrent caller that hits
+      // the CONNECTING branch below before this attempt resolves.
+      this._waitForDaemonReady = this.createReadyPromise();
       this._daemonStatus = DaemonStatus.CONNECTING;
 
-      let daemonPid: number | null = null;
-      let probe: { available: boolean; refusal?: ConnectRefusal };
       try {
-        probe = await this.probeServer();
-      } catch (err) {
-        // Version mismatch - treat as server not available, start new one
-        if (err instanceof VersionMismatchError) {
-          probe = { available: false };
-        } else {
-          throw err;
+        let daemonPid: number | null = null;
+        let probe: { available: boolean; refusal?: ConnectRefusal };
+        try {
+          probe = await this.probeServer();
+        } catch (err) {
+          // Version mismatch - treat as server not available, start new one
+          if (err instanceof VersionMismatchError) {
+            probe = { available: false };
+          } else {
+            throw err;
+          }
         }
-      }
-      if (!probe.available) {
-        // Carried as a value so no other caller's probe can substitute for it.
-        daemonPid = await this.startInBackground(probe.refusal);
-      }
-      this.setUpConnection();
-      this._daemonStatus = DaemonStatus.CONNECTED;
-      this._daemonReady();
+        if (!probe.available) {
+          // Carried as a value so no other caller's probe can substitute for it.
+          daemonPid = await this.startInBackground(probe.refusal);
+        }
+        this.setUpConnection();
+        this._daemonStatus = DaemonStatus.CONNECTED;
+        this._daemonReady();
 
-      daemonPid ??= getDaemonProcessIdSync();
-      // Fire-and-forget - don't block daemon connection by waiting for metrics registration
-      this.registerDaemonProcessWithMetricsService(daemonPid);
+        daemonPid ??= getDaemonProcessIdSync();
+        // Fire-and-forget - don't block daemon connection by waiting for metrics registration
+        this.registerDaemonProcessWithMetricsService(daemonPid);
+      } catch (err) {
+        // Reset to DISCONNECTED and reject the ready promise so every
+        // concurrent caller parked on the CONNECTING branch gets the
+        // error instead of hanging forever.
+        this.failDaemonReady(err);
+        throw err;
+      }
     } else if (this._daemonStatus == DaemonStatus.CONNECTING) {
       await this._waitForDaemonReady;
       const daemonPid = getDaemonProcessIdSync();
@@ -1158,10 +1188,26 @@ export class DaemonClient {
   private async handleConnectionError(error: Error) {
     clientLogger.log(`[Reconnect] Connection error detected: ${error.message}`);
 
+    // Plugin workers can't survive the daemon going away: their view of
+    // the workspace is tied to the dead daemon (graph state, cached
+    // context, plugin module state). Reconnecting to a new daemon —
+    // potentially a different version — can't produce a correct result,
+    // and `startInBackground` would throw anyway. Fail every queued and
+    // future message with a clear error so callers see a fast failure
+    // instead of hanging on a reconnect path that can't succeed.
+    if (global.NX_PLUGIN_WORKER) {
+      const pluginWorkerError = daemonProcessException(
+        `Plugin worker lost its daemon connection and cannot reconnect: ${error.message}`
+      );
+      if (this.currentReject) {
+        this.currentReject(pluginWorkerError);
+      }
+      this.failDaemonReady(pluginWorkerError);
+      return;
+    }
+
     // Create a new ready promise for new requests to wait on
-    this._waitForDaemonReady = new Promise<void>(
-      (resolve) => (this._daemonReady = resolve)
-    );
+    this._waitForDaemonReady = this.createReadyPromise();
 
     // Set status to CONNECTING so new requests will wait for reconnection
     this._daemonStatus = DaemonStatus.CONNECTING;
@@ -1177,8 +1223,10 @@ export class DaemonClient {
         if (this.currentReject) {
           this.currentReject(err);
         }
+        this.failDaemonReady(err);
         return;
       }
+      this.failDaemonReady(err);
       throw err;
     }
 
@@ -1204,6 +1252,7 @@ export class DaemonClient {
       if (this.currentReject) {
         this.currentReject(error);
       }
+      this.failDaemonReady(error);
     }
   }
 


### PR DESCRIPTION
## Current Behavior

`DaemonClient` mutates `_daemonStatus` to `CONNECTING` before doing any async work, but several exit paths leave it stuck there without ever settling `_waitForDaemonReady`. Concurrent callers that land in the `CONNECTING` branch then `await` a promise that can never resolve or reject.

Two triggers in the wild:

1. **`startDaemonIfNecessary` DISCONNECTED branch** — if `isServerAvailable()` throws something other than `VersionMismatchError`, or `startInBackground()` throws (e.g. the `global.NX_PLUGIN_WORKER` guard), status stays `CONNECTING` and `_daemonReady` is never called. The first caller correctly sees the error; everyone else parks forever.
2. **`handleConnectionError`** — on `VersionMismatchError` or a failed reconnect, only the current in-flight message is rejected. The freshly-created `_waitForDaemonReady` is never settled and status stays `CONNECTING`.

In plugin workers (where `startInBackground` always throws) this manifested as `createNodes` hanging until the isolated-plugin 10-minute timeout fired. The end-user symptom was a daemon that reported "Reusing in-memory cached project graph because no files changed" and then never responded, because the cached promise itself was wedged on plugin-worker helper calls that would never return.

## Expected Behavior

- **State-machine hygiene:** every transition into `CONNECTING` is paired with a fresh `_waitForDaemonReady`, and every failure path rejects it and returns status to `DISCONNECTED`. Concurrent callers get the error; the next caller can retry.
- **Plugin-worker fast-fail:** `handleConnectionError` short-circuits when `global.NX_PLUGIN_WORKER` is set. A plugin worker can't coherently reconnect to a replacement daemon (graph state, cached context, version skew), so every queued and future message fails immediately with a clear *"plugin worker lost its daemon connection and cannot reconnect"* error instead of hanging until timeout.

## Implementation

* Added `_daemonReadyFailed` to pair with `_daemonReady`, and helpers `createReadyPromise()` / `failDaemonReady()` so every failure path can unblock awaiters in one place.
* Wrapped `startDaemonIfNecessary` DISCONNECTED body in try/catch → `failDaemonReady` on any error.
* Rejected `_waitForDaemonReady` from every failure branch of `handleConnectionError` (VersionMismatchError, non-VME throw, `!serverAvailable`).
* Short-circuited `handleConnectionError` for `NX_PLUGIN_WORKER`.
* Added `client.spec.ts` with five tests covering both wedge modes and the plugin-worker fast-fail. All five fail against `master` and pass after the fix.

## Related Issue(s)

Fixes #

---

Moved off my fork so CI can run with a write token. Supersedes #35336, which carries the earlier review history.
