### PR TITLE
docs(misc): name developer resources for agent discovery

### DIFF
--- a/astro-docs/e2e/cli-subcommand-formatting.spec.ts
+++ b/astro-docs/e2e/cli-subcommand-formatting.spec.ts
@@ -4,7 +4,10 @@ test.describe('CLI sub-command formatting', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/docs/reference/nx-commands');
     await expect(
-      page.getByRole('heading', { name: 'Nx Commands' })
+      page.getByRole('heading', {
+        name: 'Nx CLI Command Reference',
+        level: 1,
+      })
     ).toBeVisible();
   });
 

--- a/astro-docs/src/content/docs/getting-started/installation.mdoc
+++ b/astro-docs/src/content/docs/getting-started/installation.mdoc
@@ -1,5 +1,5 @@
 ---
-title: Installation
+title: Install the Nx CLI
 description: Install Nx globally via npm, Homebrew, Chocolatey, or apt. Add Nx to existing repos with nx init.
 sidebar:
   order: 2

--- a/astro-docs/src/pages/llms.txt.ts
+++ b/astro-docs/src/pages/llms.txt.ts
@@ -40,9 +40,10 @@ export const GET: APIRoute = async ({ site }) => {
     '',
     'Use Nx when a repository holds more than one buildable or testable project and you need to know what depends on what, run only the affected tasks, or reuse cached results. Reach for these entry points rather than scraping the docs:',
     '',
-    `- Nx CLI: the \`nx\` package on npm. Run any command with \`npx nx <command>\`. Commands are documented at ${siteUrl}/docs/reference/nx-commands.md`,
-    `- [Nx MCP server](${siteUrl}/docs/reference/nx-mcp.md): run \`nx mcp\` to expose the workspace project graph, generators, and CI results as MCP tools`,
-    `- [Agent skills](${siteUrl}/.well-known/agent-skills/index.json): task-scoped instructions for navigating a workspace, running tasks, scaffolding code, and monitoring CI`,
+    `- Nx CLI (command-line tool): the \`nx\` package on npm, https://www.npmjs.com/package/nx. Run any command with \`npx nx <command>\`. Command reference at ${siteUrl}/docs/reference/nx-commands.md, install guide at ${siteUrl}/docs/getting-started/installation.md`,
+    `- Nx MCP server (Model Context Protocol): run \`nx mcp\` to expose the workspace project graph, generators, and CI results as MCP tools. Reference at ${siteUrl}/docs/reference/nx-mcp.md`,
+    `- Nx agent skills (Agent Skills Discovery index): ${siteUrl}/.well-known/agent-skills/index.json, task-scoped instructions for navigating a workspace, running tasks, scaffolding code, and monitoring CI`,
+    `- Developer portal (all Nx documentation): ${siteUrl}/docs`,
     `- [Set up AI agents](${siteUrl}/docs/getting-started/ai-setup.md): run \`nx configure-ai-agents\` to write agent rules, skills, and MCP config into a workspace`,
     '',
   ];

--- a/astro-docs/src/pages/reference/nx-commands.astro
+++ b/astro-docs/src/pages/reference/nx-commands.astro
@@ -13,8 +13,8 @@ const { Content, headings } = await render(nxCli);
 <StarlightPage
   frontmatter={{
     ...nxCli.data,
-    title: 'Nx Commands',
-    description: 'Complete reference for Nx CLI',
+    title: 'Nx CLI Command Reference',
+    description: 'Complete reference for Nx CLI commands',
     tableOfContents: { minHeadingLevel: 2, maxHeadingLevel: 3 },
   }}
   headings={headings || []}


### PR DESCRIPTION
## Current Behavior

llms.txt lists the CLI, MCP server, and skills index without naming what kind of resource each is, and without the npm package or install guide. The CLI reference and install page titles do not carry the product name. is-agentic reports `Developer resource discoverability` at Partial (33%) — "found 2 pages by name but no recognizable developer-resource type" — and `CLI tool available` at Partial (67%) — "CLI tool mentioned in llms.txt".

## Expected Behavior

Each entry in the `## When to use Nx` block leads with a named resource type and a stable URL, the CLI entry links the npm package plus the command reference and install guide, and a developer portal line is added. Page titles name the product: `Nx CLI Commands Reference` and `Install the Nx CLI`.

Titles change the H1 and `<title>` only. Slugs come from file paths, and the sidebar labels stay `Nx Commands` and `Installation` so `desiredSectionOrder` in `sidebar-reference-updater.middleware.ts` still matches and the reference sidebar keeps its ordering. Verified in the built HTML.

Worth noting for anyone measuring: this check runs a web search, so the title half only registers after reindexing. A re-scan right after deploy will not move.

## Preview

- https://deploy-preview-36822--nx-docs.netlify.app/docs/llms.txt
- https://deploy-preview-36822--nx-docs.netlify.app/docs/reference/nx-commands
- https://deploy-preview-36822--nx-docs.netlify.app/docs/getting-started/installation

## Related Issue(s)

DOC-657 (deliberately not `Fixes` - this PR covers only the `CLI tool available` and `Developer resource discoverability` rows of that issue; the Framer items remain open).

DOC-654 was closed as a duplicate of DOC-657.

