### PR TITLE
feat(core): select affected tasks instead of affected projects

### DIFF
--- a/astro-docs/src/content/docs/reference/inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/inputs.mdoc
@@ -240,6 +240,7 @@ Files such as `dist/libs/my-lib/index.d.ts` would be matched by patterns `**/*.d
 
 A [continuous task](/docs/kb/defining-task-pipeline#continuous-task-dependencies), such as the `serve` task an `e2e` task depends on, runs in its own process.
 What it reads still decides what the task it serves observes, so that task also hashes whatever each of its continuous dependencies hashes, based on the declared inputs of those tasks.
+Nx follows the chain: a server the `serve` task itself depends on counts too, since it runs alongside.
 There's nothing to declare for this.
 Only continuous dependencies are included.
 

--- a/astro-docs/src/content/docs/reference/inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/inputs.mdoc
@@ -238,11 +238,10 @@ Files such as `dist/libs/my-lib/index.d.ts` would be matched by patterns `**/*.d
 
 ### Inputs of continuous dependencies
 
-A [continuous task](/docs/kb/defining-task-pipeline#continuous-task-dependencies), such as the `serve` task an `e2e` task depends on, runs in its own process.
-What it reads still decides what the task it serves observes, so that task also hashes whatever each of its continuous dependencies hashes, based on the declared inputs of those tasks.
-Nx follows the chain: a server the `serve` task itself depends on counts too, since it runs alongside.
-There's nothing to declare for this.
-Only continuous dependencies are included.
+A [continuous task](/docs/kb/defining-task-pipeline#continuous-task-dependencies), such as the `serve` task an `e2e` task depends on, runs in its own process, yet what it reads still decides what the task it serves observes.
+A task therefore also hashes the declared inputs of every continuous dependency it has, and of the servers those depend on in turn: files, environment variables, runtime commands and external dependencies alike.
+There's nothing to declare, and only continuous dependencies count.
+The outputs of a server's own build dependencies aren't included, since those builds haven't run when the task is hashed.
 
 ### A subset of the root `tsconfig.json` or `tsconfig.base.json`
 

--- a/astro-docs/src/content/docs/reference/inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/inputs.mdoc
@@ -241,6 +241,7 @@ Files such as `dist/libs/my-lib/index.d.ts` would be matched by patterns `**/*.d
 A [continuous task](/docs/kb/defining-task-pipeline#continuous-task-dependencies), such as the `serve` task an `e2e` task depends on, runs in its own process, yet what it reads still decides what the task it serves observes.
 A task therefore also hashes the declared inputs of every continuous dependency it has, and of the servers those depend on in turn: files, environment variables, runtime commands and external dependencies alike.
 There's nothing to declare, and only continuous dependencies count.
+A server that declares no inputs contributes its whole project, so declare inputs on servers that live at the workspace root, such as a local registry.
 When a server reads the outputs of its own build dependencies, Nx hashes the task it serves once the server is running, so those outputs count too.
 
 ### A subset of the root `tsconfig.json` or `tsconfig.base.json`

--- a/astro-docs/src/content/docs/reference/inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/inputs.mdoc
@@ -239,16 +239,8 @@ Files such as `dist/libs/my-lib/index.d.ts` would be matched by patterns `**/*.d
 ### Inputs of continuous dependencies
 
 A [continuous task](/docs/kb/defining-task-pipeline#continuous-task-dependencies), such as the `serve` task an `e2e` task depends on, runs in its own process.
-Its inputs aren't part of the hash of the task it serves unless that task declares them.
-Set `continuousDependenciesInputs` to hash them along with the task's own inputs:
-
-```jsonc
-{
-  "inputs": ["default", { "continuousDependenciesInputs": true }],
-}
-```
-
-The task then also hashes whatever each of its continuous dependencies hashes, based on the declared inputs of those tasks.
+What it reads still decides what the task it serves observes, so that task also hashes whatever each of its continuous dependencies hashes, based on the declared inputs of those tasks.
+There's nothing to declare for this.
 Only continuous dependencies are included.
 
 ### A subset of the root `tsconfig.json` or `tsconfig.base.json`

--- a/astro-docs/src/content/docs/reference/inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/inputs.mdoc
@@ -241,7 +241,7 @@ Files such as `dist/libs/my-lib/index.d.ts` would be matched by patterns `**/*.d
 A [continuous task](/docs/kb/defining-task-pipeline#continuous-task-dependencies), such as the `serve` task an `e2e` task depends on, runs in its own process, yet what it reads still decides what the task it serves observes.
 A task therefore also hashes the declared inputs of every continuous dependency it has, and of the servers those depend on in turn: files, environment variables, runtime commands and external dependencies alike.
 There's nothing to declare, and only continuous dependencies count.
-The outputs of a server's own build dependencies aren't included, since those builds haven't run when the task is hashed.
+When a server reads the outputs of its own build dependencies, Nx hashes the task it serves once the server is running, so those outputs count too.
 
 ### A subset of the root `tsconfig.json` or `tsconfig.base.json`
 

--- a/astro-docs/src/content/docs/reference/inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/inputs.mdoc
@@ -236,6 +236,21 @@ When a task depends on another task, it is possible that the outputs of the depe
 The glob pattern is matched against the file paths resolved from workspace root. For example, if a dependent task has `outputs: ["{workspaceRoot}/dist/{projectRoot}"]` and the project root is `libs/my-lib`, the output path becomes `dist/libs/my-lib`.
 Files such as `dist/libs/my-lib/index.d.ts` would be matched by patterns `**/*.d.ts`, `dist/**/*.d.ts`, or `dist/libs/my-lib/**/*.d.ts`. Setting `transitive` to `true` will also include outputs of all task dependencies of this task in the [task pipeline](/docs/concepts/task-pipeline-configuration). It's possible the dependent tasks can change over time, so be careful to not overly scope the matching glob to prevent accidental false cache hits.
 
+### Inputs of continuous dependencies
+
+A [continuous task](/docs/kb/defining-task-pipeline#continuous-task-dependencies), such as the `serve` task an `e2e` task depends on, runs in its own process.
+Its inputs aren't part of the hash of the task it serves unless that task declares them.
+Set `continuousDependenciesInputs` to hash them along with the task's own inputs:
+
+```jsonc
+{
+  "inputs": ["default", { "continuousDependenciesInputs": true }],
+}
+```
+
+The task then also hashes whatever each of its continuous dependencies hashes, based on the declared inputs of those tasks.
+Only continuous dependencies are included.
+
 ### A subset of the root `tsconfig.json` or `tsconfig.base.json`
 
 When a root `tsconfig.json` or `tsconfig.base.json` is present, Nx will always consider parts of the file which apply to the project of a task being run.

--- a/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -48,6 +48,19 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
             "my-serve": {
               "command": "next dev",
               "continuous": true,
+              "inputs": [
+                "default",
+                "^default",
+                {
+                  "externalDependencies": [
+                    "next",
+                  ],
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.d.ts",
+                  "transitive": true,
+                },
+              ],
               "options": {
                 "cwd": "my-app",
               },
@@ -61,6 +74,19 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
               "dependsOn": [
                 "my-build",
               ],
+              "inputs": [
+                "default",
+                "^default",
+                {
+                  "externalDependencies": [
+                    "next",
+                  ],
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.d.ts",
+                  "transitive": true,
+                },
+              ],
               "options": {
                 "cwd": "my-app",
               },
@@ -70,6 +96,19 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
               "continuous": true,
               "dependsOn": [
                 "my-build",
+              ],
+              "inputs": [
+                "default",
+                "^default",
+                {
+                  "externalDependencies": [
+                    "next",
+                  ],
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.d.ts",
+                  "transitive": true,
+                },
               ],
               "options": {
                 "cwd": "my-app",
@@ -138,6 +177,19 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
             "dev": {
               "command": "next dev",
               "continuous": true,
+              "inputs": [
+                "default",
+                "^default",
+                {
+                  "externalDependencies": [
+                    "next",
+                  ],
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.d.ts",
+                  "transitive": true,
+                },
+              ],
               "options": {
                 "cwd": ".",
               },
@@ -151,6 +203,19 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
               "dependsOn": [
                 "build",
               ],
+              "inputs": [
+                "default",
+                "^default",
+                {
+                  "externalDependencies": [
+                    "next",
+                  ],
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.d.ts",
+                  "transitive": true,
+                },
+              ],
               "options": {
                 "cwd": ".",
               },
@@ -160,6 +225,19 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
               "continuous": true,
               "dependsOn": [
                 "build",
+              ],
+              "inputs": [
+                "default",
+                "^default",
+                {
+                  "externalDependencies": [
+                    "next",
+                  ],
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.d.ts",
+                  "transitive": true,
+                },
               ],
               "options": {
                 "cwd": ".",

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -170,11 +170,12 @@ async function buildNextTargets(
   );
 
   targets[options.devTargetName] = getDevTargetConfig(
+    namedInputs,
     projectRoot,
     isTsSolutionSetup
   );
 
-  const startTarget = getStartTargetConfig(options, projectRoot);
+  const startTarget = getStartTargetConfig(namedInputs, options, projectRoot);
 
   targets[options.startTargetName] = startTarget;
 
@@ -223,13 +224,18 @@ async function getBuildTargetConfig(
   return targetConfig;
 }
 
-function getDevTargetConfig(projectRoot: string, isTsSolutionSetup: boolean) {
+function getDevTargetConfig(
+  namedInputs: { [inputName: string]: any[] },
+  projectRoot: string,
+  isTsSolutionSetup: boolean
+) {
   const targetConfig: TargetConfiguration = {
     continuous: true,
     command: `next dev`,
     options: {
       cwd: projectRoot,
     },
+    inputs: getInputs(namedInputs),
   };
 
   if (isTsSolutionSetup) {
@@ -239,7 +245,11 @@ function getDevTargetConfig(projectRoot: string, isTsSolutionSetup: boolean) {
   return targetConfig;
 }
 
-function getStartTargetConfig(options: NextPluginOptions, projectRoot: string) {
+function getStartTargetConfig(
+  namedInputs: { [inputName: string]: any[] },
+  options: NextPluginOptions,
+  projectRoot: string
+) {
   const targetConfig: TargetConfiguration = {
     continuous: true,
     command: `next start`,
@@ -247,6 +257,7 @@ function getStartTargetConfig(options: NextPluginOptions, projectRoot: string) {
       cwd: projectRoot,
     },
     dependsOn: [options.buildTargetName],
+    inputs: getInputs(namedInputs),
   };
 
   return targetConfig;

--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -38,6 +38,15 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
                 "acme-build-static",
               ],
               "executor": "@nx/web:file-server",
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "nuxt",
+                  ],
+                },
+              ],
               "options": {
                 "buildTarget": "acme-build-static",
                 "port": 4200,
@@ -76,6 +85,15 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
             "my-serve": {
               "command": "nuxt dev",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "nuxt",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": "my-app",
               },
@@ -158,6 +176,15 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
             "serve": {
               "command": "nuxt dev",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "nuxt",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": ".",
               },
@@ -168,6 +195,15 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
                 "build-static",
               ],
               "executor": "@nx/web:file-server",
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "nuxt",
+                  ],
+                },
+              ],
               "options": {
                 "buildTarget": "build-static",
                 "port": 4200,

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -143,9 +143,12 @@ async function buildNuxtTargets(
     projectRoot
   );
 
-  targets[options.serveTargetName] = serveTarget(projectRoot);
+  targets[options.serveTargetName] = serveTarget(projectRoot, namedInputs);
 
-  targets[options.serveStaticTargetName] = serveStaticTarget(options);
+  targets[options.serveStaticTargetName] = serveStaticTarget(
+    options,
+    namedInputs
+  );
 
   targets[options.buildStaticTargetName] = buildStaticTarget(
     options.buildStaticTargetName,
@@ -178,35 +181,48 @@ function buildTarget(
     options: { cwd: projectRoot },
     cache: true,
     dependsOn: [`^${buildTargetName}`],
-    inputs: [
-      ...('production' in namedInputs
-        ? ['production', '^production']
-        : ['default', '^default']),
-
-      {
-        externalDependencies: ['nuxt'],
-      },
-    ],
+    inputs: buildInputs(namedInputs),
     outputs: buildOutputs,
   };
 }
 
-function serveTarget(projectRoot: string) {
+function buildInputs(namedInputs: {
+  [inputName: string]: any[];
+}): TargetConfiguration['inputs'] {
+  return [
+    ...('production' in namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+    {
+      externalDependencies: ['nuxt'],
+    },
+  ];
+}
+
+function serveTarget(
+  projectRoot: string,
+  namedInputs: { [inputName: string]: any[] }
+) {
   const targetConfig: TargetConfiguration = {
     command: `nuxt dev`,
     options: {
       cwd: projectRoot,
     },
     continuous: true,
+    inputs: buildInputs(namedInputs),
   };
 
   return targetConfig;
 }
 
-function serveStaticTarget(options: NuxtPluginOptions) {
+function serveStaticTarget(
+  options: NuxtPluginOptions,
+  namedInputs: { [inputName: string]: any[] }
+) {
   const targetConfig: TargetConfiguration = {
     dependsOn: [`${options.buildStaticTargetName}`],
     continuous: true,
+    inputs: buildInputs(namedInputs),
     executor: '@nx/web:file-server',
     options: {
       buildTarget: `${options.buildStaticTargetName}`,

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -791,17 +791,6 @@
             },
             "required": ["json"],
             "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "properties": {
-              "continuousDependenciesInputs": {
-                "type": "boolean",
-                "description": "Whether to also hash the inputs of the task's continuous dependencies, such as a dev server it depends on. Those tasks run in their own process, so their inputs are otherwise not part of this task's hash."
-              }
-            },
-            "required": ["continuousDependenciesInputs"],
-            "additionalProperties": false
           }
         ]
       }

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -791,6 +791,17 @@
             },
             "required": ["json"],
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "continuousDependenciesInputs": {
+                "type": "boolean",
+                "description": "Whether to also hash the inputs of the task's continuous dependencies, such as a dev server it depends on. Those tasks run in their own process, so their inputs are otherwise not part of this task's hash."
+              }
+            },
+            "required": ["continuousDependenciesInputs"],
+            "additionalProperties": false
           }
         ]
       }

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -347,17 +347,6 @@
             },
             "required": ["json"],
             "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "properties": {
-              "continuousDependenciesInputs": {
-                "type": "boolean",
-                "description": "Whether to also hash the inputs of the task's continuous dependencies, such as a dev server it depends on. Those tasks run in their own process, so their inputs are otherwise not part of this task's hash."
-              }
-            },
-            "required": ["continuousDependenciesInputs"],
-            "additionalProperties": false
           }
         ]
       }

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -347,6 +347,17 @@
             },
             "required": ["json"],
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "continuousDependenciesInputs": {
+                "type": "boolean",
+                "description": "Whether to also hash the inputs of the task's continuous dependencies, such as a dev server it depends on. Those tasks run in their own process, so their inputs are otherwise not part of this task's hash."
+              }
+            },
+            "required": ["continuousDependenciesInputs"],
+            "additionalProperties": false
           }
         ]
       }

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -217,7 +217,6 @@ export type InputDefinition =
   | { runtime: string }
   | { externalDependencies: string[] }
   | { dependentTasksOutputFiles: string; transitive?: boolean }
-  | { continuousDependenciesInputs: boolean }
   | { env: string }
   | { workingDirectory: 'relative' | 'absolute' }
   | JsonInput;

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -217,6 +217,7 @@ export type InputDefinition =
   | { runtime: string }
   | { externalDependencies: string[] }
   | { dependentTasksOutputFiles: string; transitive?: boolean }
+  | { continuousDependenciesInputs: boolean }
   | { env: string }
   | { workingDirectory: 'relative' | 'absolute' }
   | JsonInput;

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -178,6 +178,32 @@ export class WatcherFailedError extends Error {
  */
 const MAX_CONSECUTIVE_FRAMING_FAILURES = 3;
 
+// Task results get written back onto these task objects as the run
+// progresses — hash/hashDetails/timestamps by hashing and the orchestrator,
+// terminalOutput by the Nx Cloud life cycle (untyped) — so a later message
+// would otherwise re-ship every earlier result.
+function withoutTaskResults(
+  tasks: Task[],
+  taskGraph: TaskGraph
+): { tasks: Task[]; taskGraph: TaskGraph } {
+  const trimmedTasks: Record<string, Task> = {};
+  for (const [id, t] of Object.entries(taskGraph.tasks)) {
+    const {
+      hash,
+      hashDetails,
+      startTime,
+      endTime,
+      terminalOutput,
+      ...strippedTask
+    } = t as Task & { terminalOutput?: string };
+    trimmedTasks[id] = strippedTask as Task;
+  }
+  return {
+    tasks: tasks.map((t) => trimmedTasks[t.id]),
+    taskGraph: { ...taskGraph, tasks: trimmedTasks },
+  };
+}
+
 export class DaemonClient {
   private readonly nxJson: NxJsonConfiguration | null;
 
@@ -374,28 +400,29 @@ export class DaemonClient {
     cwd: string,
     collectInputs?: boolean
   ): Promise<Hash[]> {
-    // Task results get written back onto these task objects as the run
-    // progresses — hash/hashDetails/timestamps by hashing and the
-    // orchestrator, terminalOutput by the Nx Cloud life cycle (untyped) —
-    // so a later message would otherwise re-ship every earlier result.
-    const trimmedTasks: Record<string, Task> = {};
-    for (const [id, t] of Object.entries(taskGraph.tasks)) {
-      const {
-        hash,
-        hashDetails,
-        startTime,
-        endTime,
-        terminalOutput,
-        ...strippedTask
-      } = t as Task & { terminalOutput?: string };
-      trimmedTasks[id] = strippedTask as Task;
-    }
     return this.sendToDaemonViaQueue({
       type: 'HASH_TASKS',
       runnerOptions,
       perTaskEnvs,
-      tasks: tasks.map((t) => trimmedTasks[t.id]),
-      taskGraph: { ...taskGraph, tasks: trimmedTasks },
+      ...withoutTaskResults(tasks, taskGraph),
+      cwd,
+      collectInputs,
+    });
+  }
+
+  hashTasksUpfront(
+    runnerOptions: any,
+    tasks: Task[],
+    taskGraph: TaskGraph,
+    perTaskEnvs: Record<string, NodeJS.ProcessEnv>,
+    cwd: string,
+    collectInputs?: boolean
+  ): Promise<Record<string, Hash>> {
+    return this.sendToDaemonViaQueue({
+      type: 'HASH_TASKS_UPFRONT',
+      runnerOptions,
+      perTaskEnvs,
+      ...withoutTaskResults(tasks, taskGraph),
       cwd,
       collectInputs,
     });

--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -10,14 +10,16 @@ import { readNxJson } from '../../config/configuration';
 let storedProjectGraph: any = null;
 let storedHasher: InProcessTaskHasher | null = null;
 
-export async function handleHashTasks(payload: {
+interface HashTasksPayload {
   runnerOptions: any;
   tasks: Task[];
   taskGraph: TaskGraph;
   perTaskEnvs: Record<string, NodeJS.ProcessEnv>;
   cwd: string;
   collectInputs?: boolean;
-}) {
+}
+
+async function getHasher(runnerOptions: any): Promise<InProcessTaskHasher> {
   const { error, projectGraph, rustReferences } =
     await getCachedSerializedProjectGraphPromise();
 
@@ -33,10 +35,15 @@ export async function handleHashTasks(payload: {
       projectGraph,
       nxJson,
       rustReferences,
-      payload.runnerOptions
+      runnerOptions
     );
   }
-  const response = await storedHasher.hashTasks(
+  return storedHasher;
+}
+
+export async function handleHashTasks(payload: HashTasksPayload) {
+  const hasher = await getHasher(payload.runnerOptions);
+  const response = await hasher.hashTasks(
     payload.tasks,
     payload.taskGraph,
     payload.perTaskEnvs,
@@ -46,5 +53,20 @@ export async function handleHashTasks(payload: {
   return {
     response,
     description: 'handleHashTasks',
+  };
+}
+
+export async function handleHashTasksUpfront(payload: HashTasksPayload) {
+  const hasher = await getHasher(payload.runnerOptions);
+  const response = await hasher.hashTasksUpfront(
+    payload.tasks,
+    payload.taskGraph,
+    payload.perTaskEnvs,
+    payload.cwd,
+    payload.collectInputs
+  );
+  return {
+    response,
+    description: 'handleHashTasksUpfront',
   };
 }

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -118,7 +118,7 @@ import { handleGetRegisteredSyncGenerators } from './handle-get-registered-sync-
 import { handleGetSyncGeneratorChanges } from './handle-get-sync-generator-changes';
 import { handleGlob, handleMultiGlob } from './handle-glob';
 import { handleHashGlob, handleHashMultiGlob } from './handle-hash-glob';
-import { handleHashTasks } from './handle-hash-tasks';
+import { handleHashTasks, handleHashTasksUpfront } from './handle-hash-tasks';
 import {
   handleGetNxConsoleStatus,
   handleSetNxConsolePreferenceAndInstall,
@@ -317,6 +317,13 @@ async function handleMessage(socket: Socket, data: Buffer) {
       socket,
       'HASH_TASKS',
       () => handleHashTasks(payload),
+      mode
+    );
+  } else if (payload.type === 'HASH_TASKS_UPFRONT') {
+    await handleResult(
+      socket,
+      'HASH_TASKS_UPFRONT',
+      () => handleHashTasksUpfront(payload),
       mode
     );
   } else if (payload.type === 'PROCESS_IN_BACKGROUND') {

--- a/packages/nx/src/hasher/hash-plan-inspector.spec.ts
+++ b/packages/nx/src/hasher/hash-plan-inspector.spec.ts
@@ -477,3 +477,122 @@ describe('HashPlanInspector', () => {
     });
   });
 });
+
+describe('HashPlanInspector with continuous dependencies', () => {
+  // e2e depends on web:serve, which depends on api:serve. There is no project
+  // dependency between the three, so only the task graph links them.
+  let tempFs: TempFs;
+  let inspector: HashPlanInspector;
+
+  const serveTarget = (dependsOn?: { projects: string; target: string }[]) => ({
+    executor: 'nx:run-commands',
+    continuous: true,
+    inputs: ['production', '^production'],
+    ...(dependsOn ? { dependsOn } : {}),
+  });
+  const e2eTarget = {
+    executor: 'nx:run-commands',
+    inputs: ['{projectRoot}/**/*'],
+    dependsOn: [{ projects: 'web', target: 'serve' }],
+  };
+
+  beforeAll(async () => {
+    tempFs = new TempFs('hash-plan-inspector-continuous');
+    await tempFs.createFiles({
+      'package.json': JSON.stringify({
+        name: 'test-workspace',
+        devDependencies: { nx: '0.0.0' },
+      }),
+      'nx.json': JSON.stringify({
+        extends: 'nx/presets/npm.json',
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['default', '!{projectRoot}/**/*.spec.ts'],
+        },
+      }),
+      'apps/e2e/project.json': JSON.stringify({
+        name: 'e2e',
+        targets: { e2e: e2eTarget },
+      }),
+      'apps/e2e/src/app.spec.ts': '',
+      'apps/web/project.json': JSON.stringify({
+        name: 'web',
+        targets: {
+          serve: serveTarget([{ projects: 'api', target: 'serve' }]),
+        },
+      }),
+      'apps/web/src/main.ts': '',
+      'apps/web/src/main.spec.ts': '',
+      'apps/api/project.json': JSON.stringify({
+        name: 'api',
+        targets: { serve: serveTarget() },
+      }),
+      'apps/api/src/server.ts': '',
+    });
+
+    const builder = new ProjectGraphBuilder();
+    builder.addNode({
+      name: 'api',
+      type: 'app',
+      data: { root: 'apps/api', targets: { serve: serveTarget() } },
+    });
+    builder.addNode({
+      name: 'web',
+      type: 'app',
+      data: {
+        root: 'apps/web',
+        targets: {
+          serve: serveTarget([{ projects: 'api', target: 'serve' }]),
+        },
+      },
+    });
+    builder.addNode({
+      name: 'e2e',
+      type: 'app',
+      data: { root: 'apps/e2e', targets: { e2e: e2eTarget } },
+    });
+
+    inspector = new HashPlanInspector(
+      builder.getUpdatedProjectGraph(),
+      tempFs.tempDir
+    );
+    await inspector.init();
+  });
+
+  afterAll(() => {
+    tempFs.reset();
+  });
+
+  it('reports the files of every server in the chain as inputs of the served task', () => {
+    const plan = inspector.inspectTask({ project: 'e2e', target: 'e2e' })[
+      'e2e:e2e'
+    ];
+
+    expect(plan).toContain('file:apps/e2e/src/app.spec.ts');
+    expect(plan).toContain('file:apps/web/src/main.ts');
+    expect(plan).toContain('file:apps/api/src/server.ts');
+
+    const { files } = inspector.inspectTaskInputs({
+      project: 'e2e',
+      target: 'e2e',
+    })['e2e:e2e'];
+    expect(files).toEqual(
+      expect.arrayContaining([
+        'apps/e2e/src/app.spec.ts',
+        'apps/web/src/main.ts',
+        'apps/api/src/server.ts',
+      ])
+    );
+  });
+
+  it("honors each server's own declared inputs", () => {
+    const plan = inspector.inspectTask({ project: 'e2e', target: 'e2e' })[
+      'e2e:e2e'
+    ];
+
+    // web:serve declares `production`, which excludes its spec files; e2e's
+    // own `{projectRoot}/**/*` still brings in e2e's.
+    expect(plan).not.toContain('file:apps/web/src/main.spec.ts');
+    expect(plan).toContain('file:apps/e2e/src/app.spec.ts');
+  });
+});

--- a/packages/nx/src/hasher/hash-task.spec.ts
+++ b/packages/nx/src/hasher/hash-task.spec.ts
@@ -1,11 +1,12 @@
 import { hashTasksThatDoNotDependOnOutputsOfOtherTasks } from './hash-task';
-import type { TaskHasher } from './task-hasher';
+import type { Hash, TaskHasher } from './task-hasher';
 import { ProjectGraphBuilder } from '../project-graph/project-graph-builder';
 import { createTaskGraph } from '../tasks-runner/create-task-graph';
 
 vi.mock('../tasks-runner/utils', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../tasks-runner/utils')>()),
-  getCustomHasher: () => null,
+  getCustomHasher: (task: { target: { target: string } }) =>
+    task.target.target === 'custom' ? () => null : null,
 }));
 // The real implementation reads the workspace's .env files.
 vi.mock('../tasks-runner/task-env', () => ({
@@ -13,11 +14,13 @@ vi.mock('../tasks-runner/task-env', () => ({
 }));
 
 describe('hashTasksThatDoNotDependOnOutputsOfOtherTasks', () => {
-  const nxJson = {
-    namedInputs: { default: ['{projectRoot}/**/*'] },
-  } as any;
+  const nxJson = { namedInputs: { default: ['{projectRoot}/**/*'] } } as any;
+  const hashOf = (id: string): Hash => ({
+    value: `hash-${id}`,
+    details: {} as any,
+  });
 
-  function graphWithServer(serveInputs: unknown[]) {
+  function graph() {
     const builder = new ProjectGraphBuilder();
     builder.addNode({
       name: 'app',
@@ -29,52 +32,57 @@ describe('hashTasksThatDoNotDependOnOutputsOfOtherTasks', () => {
             executor: 'nx:run-commands',
             outputs: ['{workspaceRoot}/dist/apps/app'],
           },
-          serve: {
-            executor: 'nx:run-commands',
-            continuous: true,
-            dependsOn: ['build'],
-            inputs: serveInputs,
-          },
-        },
-      },
-    });
-    builder.addNode({
-      name: 'e2e',
-      type: 'app',
-      data: {
-        root: 'apps/e2e',
-        targets: {
           e2e: {
             executor: 'nx:run-commands',
-            dependsOn: [{ projects: 'app', target: 'serve' }],
+            dependsOn: ['build'],
+            inputs: [
+              '{projectRoot}/**/*',
+              { dependentTasksOutputFiles: '**/*.d.ts' },
+            ],
           },
+          custom: { executor: 'nx:run-commands' },
         },
-      },
-    });
-    builder.addNode({
-      name: 'other',
-      type: 'lib',
-      data: {
-        root: 'libs/other',
-        targets: { test: { executor: 'nx:run-commands' } },
       },
     });
     const projectGraph = builder.getUpdatedProjectGraph();
     const taskGraph = createTaskGraph(
       projectGraph,
       {},
-      ['e2e', 'other'],
-      ['e2e', 'test'],
+      ['app'],
+      ['build', 'e2e', 'custom'],
       undefined,
       {}
     );
     return { projectGraph, taskGraph };
   }
 
-  async function eagerlyHashed(serveInputs: unknown[]) {
-    const { projectGraph, taskGraph } = graphWithServer(serveInputs);
+  it('assigns the hashes the hasher returns and leaves the rest for run time', async () => {
+    const { projectGraph, taskGraph } = graph();
+    const hashTasksUpfront = vi.fn(async (tasks: { id: string }[]) => ({
+      'app:build': hashOf('app:build'),
+    }));
+    await hashTasksThatDoNotDependOnOutputsOfOtherTasks(
+      { hashTasksUpfront } as unknown as TaskHasher,
+      projectGraph,
+      taskGraph,
+      nxJson,
+      null
+    );
+
+    // Everything without a custom hasher is offered; the hasher decides.
+    expect(hashTasksUpfront.mock.calls[0][0].map((t) => t.id).sort()).toEqual([
+      'app:build',
+      'app:e2e',
+    ]);
+    expect(taskGraph.tasks['app:build'].hash).toBe('hash-app:build');
+    expect(taskGraph.tasks['app:e2e'].hash).toBeUndefined();
+    expect(taskGraph.tasks['app:custom'].hash).toBeUndefined();
+  });
+
+  it('keeps a hasher without hashTasksUpfront to tasks that read no dependency outputs', async () => {
+    const { projectGraph, taskGraph } = graph();
     const hashTasks = vi.fn(async (tasks: { id: string }[]) =>
-      tasks.map(() => ({ value: 'hash', details: {} as any }))
+      tasks.map((t) => hashOf(t.id))
     );
     await hashTasksThatDoNotDependOnOutputsOfOtherTasks(
       { hashTasks } as unknown as TaskHasher,
@@ -83,23 +91,9 @@ describe('hashTasksThatDoNotDependOnOutputsOfOtherTasks', () => {
       nxJson,
       null
     );
-    return hashTasks.mock.calls[0][0].map((t) => t.id).sort();
-  }
 
-  it('defers a task whose continuous dependency reads the outputs of its own dependencies', async () => {
-    const eager = await eagerlyHashed([
-      '{projectRoot}/**/*',
-      { dependentTasksOutputFiles: '**/*.d.ts', transitive: true },
-    ]);
-
-    // app:serve waits for app:build as it always did; e2e:e2e now waits too,
-    // since its hash carries app:serve's dependentTasksOutputFiles.
-    expect(eager).toEqual(['app:build', 'other:test']);
-  });
-
-  it('hashes a served task eagerly when its continuous dependency declares no outputs of other tasks', async () => {
-    const eager = await eagerlyHashed(['{projectRoot}/**/*']);
-
-    expect(eager).toEqual(['app:build', 'app:serve', 'e2e:e2e', 'other:test']);
+    expect(hashTasks.mock.calls[0][0].map((t) => t.id)).toEqual(['app:build']);
+    expect(taskGraph.tasks['app:build'].hash).toBe('hash-app:build');
+    expect(taskGraph.tasks['app:e2e'].hash).toBeUndefined();
   });
 });

--- a/packages/nx/src/hasher/hash-task.spec.ts
+++ b/packages/nx/src/hasher/hash-task.spec.ts
@@ -78,22 +78,4 @@ describe('hashTasksThatDoNotDependOnOutputsOfOtherTasks', () => {
     expect(taskGraph.tasks['app:e2e'].hash).toBeUndefined();
     expect(taskGraph.tasks['app:custom'].hash).toBeUndefined();
   });
-
-  it('keeps a hasher without hashTasksUpfront to tasks that read no dependency outputs', async () => {
-    const { projectGraph, taskGraph } = graph();
-    const hashTasks = vi.fn(async (tasks: { id: string }[]) =>
-      tasks.map((t) => hashOf(t.id))
-    );
-    await hashTasksThatDoNotDependOnOutputsOfOtherTasks(
-      { hashTasks } as unknown as TaskHasher,
-      projectGraph,
-      taskGraph,
-      nxJson,
-      null
-    );
-
-    expect(hashTasks.mock.calls[0][0].map((t) => t.id)).toEqual(['app:build']);
-    expect(taskGraph.tasks['app:build'].hash).toBe('hash-app:build');
-    expect(taskGraph.tasks['app:e2e'].hash).toBeUndefined();
-  });
 });

--- a/packages/nx/src/hasher/hash-task.spec.ts
+++ b/packages/nx/src/hasher/hash-task.spec.ts
@@ -7,6 +7,10 @@ vi.mock('../tasks-runner/utils', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../tasks-runner/utils')>()),
   getCustomHasher: () => null,
 }));
+// The real implementation reads the workspace's .env files.
+vi.mock('../tasks-runner/task-env', () => ({
+  getTaskSpecificEnv: () => ({}),
+}));
 
 describe('hashTasksThatDoNotDependOnOutputsOfOtherTasks', () => {
   const nxJson = {

--- a/packages/nx/src/hasher/hash-task.spec.ts
+++ b/packages/nx/src/hasher/hash-task.spec.ts
@@ -1,0 +1,101 @@
+import { hashTasksThatDoNotDependOnOutputsOfOtherTasks } from './hash-task';
+import type { TaskHasher } from './task-hasher';
+import { ProjectGraphBuilder } from '../project-graph/project-graph-builder';
+import { createTaskGraph } from '../tasks-runner/create-task-graph';
+
+vi.mock('../tasks-runner/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../tasks-runner/utils')>()),
+  getCustomHasher: () => null,
+}));
+
+describe('hashTasksThatDoNotDependOnOutputsOfOtherTasks', () => {
+  const nxJson = {
+    namedInputs: { default: ['{projectRoot}/**/*'] },
+  } as any;
+
+  function graphWithServer(serveInputs: unknown[]) {
+    const builder = new ProjectGraphBuilder();
+    builder.addNode({
+      name: 'app',
+      type: 'app',
+      data: {
+        root: 'apps/app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            outputs: ['{workspaceRoot}/dist/apps/app'],
+          },
+          serve: {
+            executor: 'nx:run-commands',
+            continuous: true,
+            dependsOn: ['build'],
+            inputs: serveInputs,
+          },
+        },
+      },
+    });
+    builder.addNode({
+      name: 'e2e',
+      type: 'app',
+      data: {
+        root: 'apps/e2e',
+        targets: {
+          e2e: {
+            executor: 'nx:run-commands',
+            dependsOn: [{ projects: 'app', target: 'serve' }],
+          },
+        },
+      },
+    });
+    builder.addNode({
+      name: 'other',
+      type: 'lib',
+      data: {
+        root: 'libs/other',
+        targets: { test: { executor: 'nx:run-commands' } },
+      },
+    });
+    const projectGraph = builder.getUpdatedProjectGraph();
+    const taskGraph = createTaskGraph(
+      projectGraph,
+      {},
+      ['e2e', 'other'],
+      ['e2e', 'test'],
+      undefined,
+      {}
+    );
+    return { projectGraph, taskGraph };
+  }
+
+  async function eagerlyHashed(serveInputs: unknown[]) {
+    const { projectGraph, taskGraph } = graphWithServer(serveInputs);
+    const hashTasks = vi.fn(async (tasks: { id: string }[]) =>
+      tasks.map(() => ({ value: 'hash', details: {} as any }))
+    );
+    await hashTasksThatDoNotDependOnOutputsOfOtherTasks(
+      { hashTasks } as unknown as TaskHasher,
+      projectGraph,
+      taskGraph,
+      nxJson,
+      null
+    );
+    return hashTasks.mock.calls[0][0].map((t) => t.id).sort();
+  }
+
+  it('defers a task whose continuous dependency reads the outputs of its own dependencies', async () => {
+    const eager = await eagerlyHashed([
+      '{projectRoot}/**/*',
+      { dependentTasksOutputFiles: '**/*.d.ts', transitive: true },
+    ]);
+
+    // app:serve waits for app:build as it always did; e2e:e2e now waits too,
+    // since its hash carries app:serve's dependentTasksOutputFiles.
+    expect(eager).toEqual(['app:build', 'other:test']);
+  });
+
+  it('hashes a served task eagerly when its continuous dependency declares no outputs of other tasks', async () => {
+    const eager = await eagerlyHashed(['{projectRoot}/**/*']);
+
+    expect(eager).toEqual(['app:build', 'app:serve', 'e2e:e2e', 'other:test']);
+  });
+});

--- a/packages/nx/src/hasher/hash-task.ts
+++ b/packages/nx/src/hasher/hash-task.ts
@@ -7,7 +7,7 @@ import { getTaskIOService } from '../tasks-runner/task-io-service';
 import { getTaskSpecificEnv } from '../tasks-runner/task-env';
 import { getCustomHasher } from '../tasks-runner/utils';
 import { getDbConnection } from '../utils/db-connection';
-import { getInputs, Hash, TaskHasher } from './task-hasher';
+import { TaskHasher } from './task-hasher';
 
 let taskDetails: TaskDetails;
 
@@ -50,16 +50,11 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
   for (const task of candidates) {
     perTaskEnvs[task.id] = getTaskSpecificEnv(task, projectGraph);
   }
-  const hashes = hasher.hashTasksUpfront
-    ? await hasher.hashTasksUpfront(candidates, taskGraph, perTaskEnvs)
-    : await hashTasksWithoutDependencyOutputs(
-        hasher,
-        candidates,
-        taskGraph,
-        perTaskEnvs,
-        projectGraph,
-        nxJson
-      );
+  const hashes = await hasher.hashTasksUpfront(
+    candidates,
+    taskGraph,
+    perTaskEnvs
+  );
   const tasksToHash = candidates.filter((task) => task.id in hashes);
   const ioService = getTaskIOService();
   const hasInputSubscribers = ioService.hasTaskInputSubscribers();
@@ -90,28 +85,6 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
     'hashMultipleTasks:start',
     'hashMultipleTasks:end'
   );
-}
-
-// Hashers built against an older Nx lack `hashTasksUpfront`. They get the
-// tasks that declare no outputs of their own dependencies; a task served by
-// one that does is hashed as if those outputs were already in place.
-async function hashTasksWithoutDependencyOutputs(
-  hasher: TaskHasher,
-  tasks: Task[],
-  taskGraph: TaskGraph,
-  perTaskEnvs: Record<string, NodeJS.ProcessEnv>,
-  projectGraph: ProjectGraph,
-  nxJson: NxJsonConfiguration
-): Promise<Record<string, Hash>> {
-  const eager = tasks.filter(
-    (task) =>
-      !(
-        taskGraph.dependencies[task.id]?.length > 0 &&
-        getInputs(task, projectGraph, nxJson).depsOutputs.length > 0
-      )
-  );
-  const hashes = await hasher.hashTasks(eager, taskGraph, perTaskEnvs);
-  return Object.fromEntries(eager.map((task, i) => [task.id, hashes[i]]));
 }
 
 export async function hashTask(

--- a/packages/nx/src/hasher/hash-task.ts
+++ b/packages/nx/src/hasher/hash-task.ts
@@ -7,7 +7,7 @@ import { getTaskIOService } from '../tasks-runner/task-io-service';
 import { getTaskSpecificEnv } from '../tasks-runner/task-env';
 import { getCustomHasher } from '../tasks-runner/utils';
 import { getDbConnection } from '../utils/db-connection';
-import { getInputs, TaskHasher } from './task-hasher';
+import { getInputs, Hash, TaskHasher } from './task-hasher';
 
 let taskDetails: TaskDetails;
 
@@ -41,36 +41,36 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
     })
   );
 
-  const tasksToHash = tasksWithHashers
-    .filter(({ task, customHasher }) => {
-      // If a task has a custom hasher, it might depend on the outputs of other tasks
-      if (customHasher) {
-        return false;
-      }
-
-      return !dependsOnOutputsOfOtherTasks(
-        task,
-        taskGraph,
-        projectGraph,
-        nxJson
-      );
-    })
+  // Custom hashers can read other tasks' outputs, so they hash at run time.
+  const candidates = tasksWithHashers
+    .filter(({ customHasher }) => !customHasher)
     .map((t) => t.task);
 
   const perTaskEnvs: Record<string, NodeJS.ProcessEnv> = {};
-  for (const task of tasksToHash) {
+  for (const task of candidates) {
     perTaskEnvs[task.id] = getTaskSpecificEnv(task, projectGraph);
   }
-  const hashes = await hasher.hashTasks(tasksToHash, taskGraph, perTaskEnvs);
+  const hashes = hasher.hashTasksUpfront
+    ? await hasher.hashTasksUpfront(candidates, taskGraph, perTaskEnvs)
+    : await hashTasksWithoutDependencyOutputs(
+        hasher,
+        candidates,
+        taskGraph,
+        perTaskEnvs,
+        projectGraph,
+        nxJson
+      );
+  const tasksToHash = candidates.filter((task) => task.id in hashes);
   const ioService = getTaskIOService();
   const hasInputSubscribers = ioService.hasTaskInputSubscribers();
-  for (let i = 0; i < tasksToHash.length; i++) {
-    tasksToHash[i].hash = hashes[i].value;
-    tasksToHash[i].hashDetails = hashes[i].details;
+  for (const task of tasksToHash) {
+    const hash = hashes[task.id];
+    task.hash = hash.value;
+    task.hashDetails = hash.details;
 
     // Notify TaskIOService of hash inputs
-    if (hasInputSubscribers && hashes[i].inputs) {
-      ioService.notifyTaskInputs(tasksToHash[i].id, hashes[i].inputs);
+    if (hasInputSubscribers && hash.inputs) {
+      ioService.notifyTaskInputs(task.id, hash.inputs);
     }
   }
   if (tasksDetails?.recordTaskDetails) {
@@ -92,32 +92,26 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
   );
 }
 
-// A task hashes the inputs of its continuous dependencies too, so it must
-// wait for their builds as well as its own before its hash is stable.
-function dependsOnOutputsOfOtherTasks(
-  task: Task,
+// Hashers built against an older Nx lack `hashTasksUpfront`. They get the
+// tasks that declare no outputs of their own dependencies; a task served by
+// one that does is hashed as if those outputs were already in place.
+async function hashTasksWithoutDependencyOutputs(
+  hasher: TaskHasher,
+  tasks: Task[],
   taskGraph: TaskGraph,
+  perTaskEnvs: Record<string, NodeJS.ProcessEnv>,
   projectGraph: ProjectGraph,
   nxJson: NxJsonConfiguration
-): boolean {
-  const seen = new Set<string>();
-  const pending = [task.id];
-  while (pending.length) {
-    const id = pending.pop();
-    if (seen.has(id) || !taskGraph.tasks[id]) {
-      continue;
-    }
-    seen.add(id);
-    if (
-      taskGraph.dependencies[id]?.length > 0 &&
-      getInputs(taskGraph.tasks[id], projectGraph, nxJson).depsOutputs.length >
-        0
-    ) {
-      return true;
-    }
-    pending.push(...(taskGraph.continuousDependencies[id] ?? []));
-  }
-  return false;
+): Promise<Record<string, Hash>> {
+  const eager = tasks.filter(
+    (task) =>
+      !(
+        taskGraph.dependencies[task.id]?.length > 0 &&
+        getInputs(task, projectGraph, nxJson).depsOutputs.length > 0
+      )
+  );
+  const hashes = await hasher.hashTasks(eager, taskGraph, perTaskEnvs);
+  return Object.fromEntries(eager.map((task, i) => [task.id, hashes[i]]));
 }
 
 export async function hashTask(

--- a/packages/nx/src/hasher/hash-task.ts
+++ b/packages/nx/src/hasher/hash-task.ts
@@ -48,9 +48,11 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
         return false;
       }
 
-      return !(
-        taskGraph.dependencies[task.id].length > 0 &&
-        getInputs(task, projectGraph, nxJson).depsOutputs.length > 0
+      return !dependsOnOutputsOfOtherTasks(
+        task,
+        taskGraph,
+        projectGraph,
+        nxJson
       );
     })
     .map((t) => t.task);
@@ -88,6 +90,34 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
     'hashMultipleTasks:start',
     'hashMultipleTasks:end'
   );
+}
+
+// A task hashes the inputs of its continuous dependencies too, so it must
+// wait for their builds as well as its own before its hash is stable.
+function dependsOnOutputsOfOtherTasks(
+  task: Task,
+  taskGraph: TaskGraph,
+  projectGraph: ProjectGraph,
+  nxJson: NxJsonConfiguration
+): boolean {
+  const seen = new Set<string>();
+  const pending = [task.id];
+  while (pending.length) {
+    const id = pending.pop();
+    if (seen.has(id) || !taskGraph.tasks[id]) {
+      continue;
+    }
+    seen.add(id);
+    if (
+      taskGraph.dependencies[id]?.length > 0 &&
+      getInputs(taskGraph.tasks[id], projectGraph, nxJson).depsOutputs.length >
+        0
+    ) {
+      return true;
+    }
+    pending.push(...(taskGraph.continuousDependencies[id] ?? []));
+  }
+  return false;
 }
 
 export async function hashTask(

--- a/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
@@ -1391,4 +1391,118 @@ describe('native task hasher', () => {
   //   );
   //   console.dir(hashes, { depth: null });
   // });
+
+  it('hashes up front only the tasks whose plan holds no output of another task', async () => {
+    await tempFs.createFiles({
+      'apps/app/project.json': JSON.stringify({ name: 'app' }),
+      'apps/app/main.ts': 'app',
+      'apps/e2e/project.json': JSON.stringify({ name: 'e2e' }),
+      'apps/e2e/app.spec.ts': 'e2e',
+    });
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+      'libs/child': 'child',
+      'apps/app': 'app',
+      'apps/e2e': 'e2e',
+    });
+    const builder = new ProjectGraphBuilder(
+      undefined,
+      workspaceFiles.fileMap.projectFileMap
+    );
+    builder.addNode({
+      name: 'child',
+      type: 'lib',
+      data: {
+        root: 'libs/child',
+        targets: { compile: { executor: 'nx:run-commands' } },
+      },
+    });
+    // parent reads its dependency's outputs but child:compile emits none
+    // (a `build` target would get the legacy default outputs).
+    builder.addNode({
+      name: 'parent',
+      type: 'lib',
+      data: {
+        root: 'libs/parent',
+        targets: {
+          compile: {
+            executor: 'nx:run-commands',
+            inputs: ['default', { dependentTasksOutputFiles: '**/*.d.ts' }],
+          },
+        },
+      },
+    });
+    builder.addStaticDependency('parent', 'child', 'libs/parent/src/index.ts');
+    // app:serve reads app:build's outputs; e2e is served by app:serve.
+    builder.addNode({
+      name: 'app',
+      type: 'app',
+      data: {
+        root: 'apps/app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            outputs: ['{workspaceRoot}/dist/apps/app'],
+          },
+          serve: {
+            executor: 'nx:run-commands',
+            continuous: true,
+            dependsOn: ['build'],
+            inputs: ['default', { dependentTasksOutputFiles: '**/*.d.ts' }],
+          },
+        },
+      },
+    });
+    builder.addNode({
+      name: 'e2e',
+      type: 'app',
+      data: {
+        root: 'apps/e2e',
+        targets: {
+          e2e: {
+            executor: 'nx:run-commands',
+            inputs: ['default'],
+            dependsOn: [{ projects: 'app', target: 'serve' }],
+          },
+        },
+      },
+    });
+    const projectGraph = builder.getUpdatedProjectGraph();
+    const taskGraph = createTaskGraph(
+      projectGraph,
+      { compile: ['^compile'] },
+      ['parent', 'e2e'],
+      ['compile', 'e2e'],
+      undefined,
+      {}
+    );
+    const tasks = Object.values(taskGraph.tasks);
+    const hashes = await new NativeTaskHasherImpl(
+      tempFs.tempDir,
+      nxJson,
+      projectGraph,
+      workspaceFiles.rustReferences,
+      { selectivelyHashTsConfig: false }
+    ).hashTasksUpfront(
+      tasks,
+      taskGraph,
+      Object.fromEntries(tasks.map((t) => [t.id, {}]))
+    );
+
+    // parent:compile depends on child:compile, which emits nothing, so its
+    // plan holds no outputs; app:serve reads app:build's, and e2e inherits that.
+    expect(Object.keys(taskGraph.tasks).sort()).toEqual([
+      'app:build',
+      'app:serve',
+      'child:compile',
+      'e2e:e2e',
+      'parent:compile',
+    ]);
+    expect(Object.keys(hashes).sort()).toEqual([
+      'app:build',
+      'child:compile',
+      'parent:compile',
+    ]);
+    expect(taskGraph.dependencies['e2e:e2e']).toEqual([]);
+  });
 });

--- a/packages/nx/src/hasher/native-task-hasher-impl.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.ts
@@ -102,4 +102,25 @@ export class NativeTaskHasherImpl implements TaskHasherImpl {
     );
     return tasks.map((t) => hashes[t.id]);
   }
+
+  async hashTasksUpfront(
+    tasks: Task[],
+    taskGraph: TaskGraph,
+    perTaskEnvs: Record<string, NodeJS.ProcessEnv>,
+    cwd?: string,
+    collectInputs?: boolean
+  ): Promise<Record<string, PartialHash>> {
+    const plans = this.planner.getPlansReference(
+      tasks.map((t) => t.id),
+      taskGraph
+    );
+    const shouldCollectInputs =
+      collectInputs ?? getTaskIOService().hasTaskInputSubscribers();
+    return this.hasher.hashPlansUpfront(
+      plans,
+      perTaskEnvs as Record<string, Record<string, string>>,
+      cwd ?? process.cwd(),
+      shouldCollectInputs
+    );
+  }
 }

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -90,10 +90,10 @@ export interface TaskHasher {
 
   /**
    * Hash the tasks whose hash needs no output of another task, keyed by
-   * task id; a task absent from the result hashes once the tasks it reads
-   * from have run. Optional: hashers built against older Nx lack it.
+   * task id. A task absent from the result hashes once the tasks it reads
+   * from have run.
    */
-  hashTasksUpfront?(
+  hashTasksUpfront(
     tasks: Task[],
     taskGraph: TaskGraph,
     perTaskEnvs: Record<string, NodeJS.ProcessEnv>,
@@ -268,13 +268,13 @@ export class InProcessTaskHasher implements TaskHasher {
       cwd ?? process.cwd(),
       collectInputs
     );
-    const tasksById = new Map(tasks.map((task) => [task.id, task]));
-    return Object.fromEntries(
-      Object.entries(hashes).map(([id, hash]) => [
-        id,
-        this.createHashDetails(tasksById.get(id), hash),
-      ])
-    );
+    const result: Record<string, Hash> = {};
+    for (const task of tasks) {
+      if (hashes[task.id]) {
+        result[task.id] = this.createHashDetails(task, hashes[task.id]);
+      }
+    }
+    return result;
   }
 
   async hashTask(

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -87,6 +87,18 @@ export interface TaskHasher {
     perTaskEnvs: Record<string, NodeJS.ProcessEnv>,
     cwd?: string
   ): Promise<Hash[]>;
+
+  /**
+   * Hash the tasks whose hash needs no output of another task, keyed by
+   * task id; a task absent from the result hashes once the tasks it reads
+   * from have run. Optional: hashers built against older Nx lack it.
+   */
+  hashTasksUpfront?(
+    tasks: Task[],
+    taskGraph: TaskGraph,
+    perTaskEnvs: Record<string, NodeJS.ProcessEnv>,
+    cwd?: string
+  ): Promise<Record<string, Hash>>;
 }
 
 export interface TaskHasherImpl {
@@ -111,6 +123,14 @@ export interface TaskHasherImpl {
     cwd?: string,
     collectInputs?: boolean
   ): Promise<PartialHash>;
+
+  hashTasksUpfront(
+    tasks: Task[],
+    taskGraph: TaskGraph,
+    perTaskEnvs: Record<string, NodeJS.ProcessEnv>,
+    cwd?: string,
+    collectInputs?: boolean
+  ): Promise<Record<string, PartialHash>>;
 }
 
 export type Hasher = TaskHasher;
@@ -166,6 +186,22 @@ export class DaemonBasedTaskHasher implements TaskHasher {
     );
   }
 
+  async hashTasksUpfront(
+    tasks: Task[],
+    taskGraph: TaskGraph,
+    perTaskEnvs: Record<string, NodeJS.ProcessEnv>
+  ): Promise<Record<string, Hash>> {
+    const collectInputs = getTaskIOService().hasTaskInputSubscribers();
+    return this.daemonClient.hashTasksUpfront(
+      this.runnerOptions,
+      tasks,
+      taskGraph,
+      perTaskEnvs,
+      process.cwd(),
+      collectInputs
+    );
+  }
+
   async hashTask(
     task: Task,
     taskGraph?: TaskGraph,
@@ -215,6 +251,29 @@ export class InProcessTaskHasher implements TaskHasher {
     );
     return tasks.map((task, index) =>
       this.createHashDetails(task, hashes[index])
+    );
+  }
+
+  async hashTasksUpfront(
+    tasks: Task[],
+    taskGraph: TaskGraph,
+    perTaskEnvs: Record<string, NodeJS.ProcessEnv>,
+    cwd?: string,
+    collectInputs?: boolean
+  ): Promise<Record<string, Hash>> {
+    const hashes = await this.taskHasher.hashTasksUpfront(
+      tasks,
+      taskGraph,
+      perTaskEnvs,
+      cwd ?? process.cwd(),
+      collectInputs
+    );
+    const tasksById = new Map(tasks.map((task) => [task.id, task]));
+    return Object.fromEntries(
+      Object.entries(hashes).map(([id, hash]) => [
+        id,
+        this.createHashDetails(tasksById.get(id), hash),
+      ])
     );
   }
 

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -214,6 +214,12 @@ export declare class TaskHasher {
    * every task id.
    */
   hashPlans(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>, perTaskEnvs: Record<string, Record<string, string>>, cwd: string, collectTaskInputs?: boolean | undefined | null): Record<string, HashDetails>
+  /**
+   * Like `hash_plans`, but only for the plans that hold no output of another
+   * task. The rest are left out and hash once those tasks have run; their
+   * ids are absent from the result and need no entry in `per_task_envs`.
+   */
+  hashPlansUpfront(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>, perTaskEnvs: Record<string, Record<string, string>>, cwd: string, collectTaskInputs?: boolean | undefined | null): Record<string, HashDetails>
 }
 
 export declare class TaskInvocationTracker {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -328,14 +328,6 @@ export declare function closeDbConnection(connection: ExternalObject<NxDbConnect
 
 export declare function connectToNxDb(cacheDir: string, dbName?: string | undefined | null): ExternalObject<NxDbConnection>
 
-/**
- * Hash everything the task's continuous dependencies hash. A trace sees one
- * process, so a dev server's reads are otherwise absent from the task.
- */
-export interface ContinuousDependenciesInputsInput {
-  continuousDependenciesInputs: boolean
-}
-
 export declare function copy(src: string, dest: string): number
 
 export interface DepsOutputsInput {
@@ -646,7 +638,7 @@ export interface MetricsUpdate {
 
 /** Stripped version of the NxJson interface for use in rust */
 export interface NxJson {
-  namedInputs?: Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>>
+  namedInputs?: Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>>
 }
 
 export interface NxWorkspaceFiles {
@@ -708,7 +700,7 @@ export interface ProcessMetrics {
 
 export interface Project {
   root: string
-  namedInputs?: Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>>
+  namedInputs?: Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>>
   tags?: Array<string>
   targets: Record<string, Target>
 }
@@ -756,7 +748,7 @@ export interface SystemInfo {
 
 export interface Target {
   executor?: string
-  inputs?: Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>
+  inputs?: Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>
   outputs?: Array<string>
   options?: string
   configurations?: string

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -328,6 +328,14 @@ export declare function closeDbConnection(connection: ExternalObject<NxDbConnect
 
 export declare function connectToNxDb(cacheDir: string, dbName?: string | undefined | null): ExternalObject<NxDbConnection>
 
+/**
+ * Hash everything the task's continuous dependencies hash. A trace sees one
+ * process, so a dev server's reads are otherwise absent from the task.
+ */
+export interface ContinuousDependenciesInputsInput {
+  continuousDependenciesInputs: boolean
+}
+
 export declare function copy(src: string, dest: string): number
 
 export interface DepsOutputsInput {
@@ -638,7 +646,7 @@ export interface MetricsUpdate {
 
 /** Stripped version of the NxJson interface for use in rust */
 export interface NxJson {
-  namedInputs?: Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>>
+  namedInputs?: Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>>
 }
 
 export interface NxWorkspaceFiles {
@@ -700,7 +708,7 @@ export interface ProcessMetrics {
 
 export interface Project {
   root: string
-  namedInputs?: Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>>
+  namedInputs?: Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>>
   tags?: Array<string>
   targets: Record<string, Target>
 }
@@ -748,7 +756,7 @@ export interface SystemInfo {
 
 export interface Target {
   executor?: string
-  inputs?: Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>
+  inputs?: Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>
   outputs?: Array<string>
   options?: string
   configurations?: string

--- a/packages/nx/src/native/project_graph/types.rs
+++ b/packages/nx/src/native/project_graph/types.rs
@@ -13,7 +13,7 @@ pub struct ExternalNode {
 pub struct Target {
     pub executor: Option<String>,
     #[napi(
-        ts_type = "Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>"
+        ts_type = "Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>"
     )]
     pub inputs: Option<Vec<JsInputs>>,
     pub outputs: Option<Vec<String>>,
@@ -27,7 +27,7 @@ pub struct Target {
 pub struct Project {
     pub root: String,
     #[napi(
-        ts_type = "Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>>"
+        ts_type = "Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>>"
     )]
     pub named_inputs: Option<HashMap<String, Vec<JsInputs>>>,
     pub tags: Option<Vec<String>>,

--- a/packages/nx/src/native/project_graph/types.rs
+++ b/packages/nx/src/native/project_graph/types.rs
@@ -13,7 +13,7 @@ pub struct ExternalNode {
 pub struct Target {
     pub executor: Option<String>,
     #[napi(
-        ts_type = "Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>"
+        ts_type = "Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>"
     )]
     pub inputs: Option<Vec<JsInputs>>,
     pub outputs: Option<Vec<String>>,
@@ -27,7 +27,7 @@ pub struct Target {
 pub struct Project {
     pub root: String,
     #[napi(
-        ts_type = "Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>>"
+        ts_type = "Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>>"
     )]
     pub named_inputs: Option<HashMap<String, Vec<JsInputs>>>,
     pub tags: Option<Vec<String>>,

--- a/packages/nx/src/native/tasks/dep_outputs.rs
+++ b/packages/nx/src/native/tasks/dep_outputs.rs
@@ -1,24 +1,52 @@
 use crate::native::tasks::types::HashInstruction;
 use crate::native::tasks::types::{Task, TaskGraph};
 use rayon::prelude::*;
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use tracing::{debug, trace};
 
 /// Collects all dependent tasks using BFS traversal
 /// Note: Only processes regular dependencies, not continuous_dependencies.
 /// Continuous tasks (like watch/serve) don't produce outputs that need to be hashed.
-fn collect_task_dependencies<'a>(
+pub(super) fn collect_task_dependencies<'a>(
     task_graph: &'a TaskGraph,
     initial_task_id: &str,
     transitive: bool,
 ) -> Vec<&'a Task> {
+    collect_over(
+        task_graph,
+        &task_graph.dependencies,
+        initial_task_id,
+        transitive,
+    )
+}
+
+/// Collects every continuous dependency in the chain: the servers of this
+/// task, their servers, and so on. Cycles and the task itself are skipped.
+pub(super) fn collect_continuous_dependencies<'a>(
+    task_graph: &'a TaskGraph,
+    initial_task_id: &str,
+) -> Vec<&'a Task> {
+    collect_over(
+        task_graph,
+        &task_graph.continuous_dependencies,
+        initial_task_id,
+        true,
+    )
+}
+
+fn collect_over<'a>(
+    task_graph: &'a TaskGraph,
+    edges: &'a HashMap<String, Vec<String>>,
+    initial_task_id: &str,
+    transitive: bool,
+) -> Vec<&'a Task> {
     let mut result = Vec::new();
-    let mut visited = HashSet::new();
+    let mut visited = HashSet::from([initial_task_id]);
     let mut queue = VecDeque::from([initial_task_id]);
 
     while let Some(task_id) = queue.pop_front() {
         // Get dependencies for this task
-        let Some(deps) = task_graph.dependencies.get(task_id) else {
+        let Some(deps) = edges.get(task_id) else {
             continue;
         };
 
@@ -178,6 +206,39 @@ mod tests {
         let ids: Vec<&str> = result.iter().map(|t| t.id.as_str()).collect();
         assert!(ids.contains(&"task2:build"));
         assert!(ids.contains(&"task3:build"));
+    }
+
+    #[test]
+    fn collects_the_chain_of_continuous_dependencies_once_each() {
+        let mut task_graph = TaskGraph {
+            roots: vec![],
+            tasks: HashMap::new(),
+            dependencies: HashMap::new(),
+            continuous_dependencies: HashMap::new(),
+        };
+        for project in ["e2e", "web", "api"] {
+            let task = create_test_task(project, vec![]);
+            task_graph.dependencies.insert(task.id.clone(), vec![]);
+            task_graph.tasks.insert(task.id.clone(), task);
+        }
+        // e2e -> web -> api -> e2e closes a loop back to the served task.
+        task_graph
+            .continuous_dependencies
+            .insert("e2e:build".into(), vec!["web:build".into()]);
+        task_graph
+            .continuous_dependencies
+            .insert("web:build".into(), vec!["api:build".into()]);
+        task_graph
+            .continuous_dependencies
+            .insert("api:build".into(), vec!["e2e:build".into()]);
+
+        let mut ids: Vec<&str> = collect_continuous_dependencies(&task_graph, "e2e:build")
+            .iter()
+            .map(|t| t.id.as_str())
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["api:build", "web:build"]);
+        assert!(collect_task_dependencies(&task_graph, "e2e:build", true).is_empty());
     }
 
     #[test]

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -166,9 +166,9 @@ impl HashPlanner {
                     &mut VisitedTracker::new(task.target.project.as_str()),
                 )?);
 
-                // A continuous dependency serves this task from its own process,
-                // so what it reads is hashed here through its declared inputs --
-                // and so is whatever serves that server, since it runs alongside.
+                // A continuous dependency serves this task from its own process, so
+                // its declared inputs and externals are hashed here, and its own
+                // servers' in turn. Not its builds' outputs: they have not run yet.
                 let mut served_by: Vec<&String> = Vec::new();
                 let mut seen: HashSet<&str> = HashSet::from([*id]);
                 let mut pending: Vec<&String> = task_graph
@@ -194,7 +194,21 @@ impl HashPlanner {
                     let Some(dep_task) = task_graph.tasks.get(dep_id) else {
                         continue;
                     };
-                    let dep_inputs = get_inputs(dep_task, &self.project_graph, &self.nx_json)?;
+                    let dep_inputs = SplitInputs {
+                        deps_outputs: Vec::new(),
+                        ..get_inputs(dep_task, &self.project_graph, &self.nx_json)?
+                    };
+                    ids.extend(
+                        self.target_input(
+                            &dep_task.target.project,
+                            &dep_task.target.target,
+                            &dep_inputs.self_inputs,
+                            external_deps_mapped,
+                        )?
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|instruction| pool.intern(instruction)),
+                    );
                     ids.extend(self.self_and_deps_inputs(
                         &dep_task.target.project,
                         dep_task,

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -168,8 +168,8 @@ impl HashPlanner {
 
                 // A continuous dependency serves this task from its own process, so
                 // its declared inputs and externals are hashed here, and its own
-                // servers' in turn. Its builds' outputs land in this plan too, which
-                // is what holds the task back from the up-front hashing batch.
+                // servers' in turn. When it reads its builds' outputs, those land in
+                // this plan too, which holds the task back from the up-front batch.
                 for dep_task in collect_continuous_dependencies(&task_graph, id) {
                     let dep_inputs = get_inputs(dep_task, &self.project_graph, &self.nx_json)?;
                     ids.extend(

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -9,7 +9,7 @@ use crate::native::{
 };
 use napi::bindgen_prelude::External;
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tracing::trace;
 
 use crate::native::tasks::hashers::OnceCache;
@@ -167,13 +167,30 @@ impl HashPlanner {
                 )?);
 
                 // A continuous dependency serves this task from its own process,
-                // so what it reads is hashed here through its declared inputs.
-                for dep_id in task_graph
+                // so what it reads is hashed here through its declared inputs --
+                // and so is whatever serves that server, since it runs alongside.
+                let mut served_by: Vec<&String> = Vec::new();
+                let mut seen: HashSet<&str> = HashSet::from([*id]);
+                let mut pending: Vec<&String> = task_graph
                     .continuous_dependencies
                     .get(*id)
                     .into_iter()
                     .flatten()
-                {
+                    .collect();
+                while let Some(dep_id) = pending.pop() {
+                    if !seen.insert(dep_id.as_str()) {
+                        continue;
+                    }
+                    served_by.push(dep_id);
+                    pending.extend(
+                        task_graph
+                            .continuous_dependencies
+                            .get(dep_id)
+                            .into_iter()
+                            .flatten(),
+                    );
+                }
+                for dep_id in served_by {
                     let Some(dep_task) = task_graph.tasks.get(dep_id) else {
                         continue;
                     };

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -168,7 +168,7 @@ impl HashPlanner {
 
                 // A continuous dependency serves this task from its own process, so
                 // its declared inputs and externals are hashed here, and its own
-                // servers' in turn. Not its builds' outputs: they have not run yet.
+                // servers' in turn. hash-task.ts defers the task past its builds.
                 let mut served_by: Vec<&String> = Vec::new();
                 let mut seen: HashSet<&str> = HashSet::from([*id]);
                 let mut pending: Vec<&String> = task_graph
@@ -194,10 +194,7 @@ impl HashPlanner {
                     let Some(dep_task) = task_graph.tasks.get(dep_id) else {
                         continue;
                     };
-                    let dep_inputs = SplitInputs {
-                        deps_outputs: Vec::new(),
-                        ..get_inputs(dep_task, &self.project_graph, &self.nx_json)?
-                    };
+                    let dep_inputs = get_inputs(dep_task, &self.project_graph, &self.nx_json)?;
                     ids.extend(
                         self.target_input(
                             &dep_task.target.project,

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -166,33 +166,26 @@ impl HashPlanner {
                     &mut VisitedTracker::new(task.target.project.as_str()),
                 )?);
 
-                // A continuous dependency runs in its own process, so its reads
-                // never reach this task. Its inputs are spliced in whole, from
-                // its declared inputs: a task that never finishes is never traced.
-                if inputs
-                    .self_inputs
-                    .iter()
-                    .any(|i| matches!(i, Input::ContinuousDependenciesInputs))
+                // A continuous dependency serves this task from its own process,
+                // so what it reads is hashed here through its declared inputs.
+                for dep_id in task_graph
+                    .continuous_dependencies
+                    .get(*id)
+                    .into_iter()
+                    .flatten()
                 {
-                    for dep_id in task_graph
-                        .continuous_dependencies
-                        .get(*id)
-                        .into_iter()
-                        .flatten()
-                    {
-                        let Some(dep_task) = task_graph.tasks.get(dep_id) else {
-                            continue;
-                        };
-                        let dep_inputs = get_inputs(dep_task, &self.project_graph, &self.nx_json)?;
-                        ids.extend(self.self_and_deps_inputs(
-                            &dep_task.target.project,
-                            dep_task,
-                            &dep_inputs,
-                            &task_graph,
-                            external_deps_mapped,
-                            &mut VisitedTracker::new(dep_task.target.project.as_str()),
-                        )?);
-                    }
+                    let Some(dep_task) = task_graph.tasks.get(dep_id) else {
+                        continue;
+                    };
+                    let dep_inputs = get_inputs(dep_task, &self.project_graph, &self.nx_json)?;
+                    ids.extend(self.self_and_deps_inputs(
+                        &dep_task.target.project,
+                        dep_task,
+                        &dep_inputs,
+                        &task_graph,
+                        external_deps_mapped,
+                        &mut VisitedTracker::new(dep_task.target.project.as_str()),
+                    )?);
                 }
 
                 ids.sort_unstable();

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -1,5 +1,5 @@
 use crate::native::tasks::{
-    dep_outputs::get_dep_output,
+    dep_outputs::{collect_continuous_dependencies, get_dep_output},
     types::{CwdMode, HashInstruction, HashPlans, InstructionPool, JsonFileSetInput, TaskGraph},
 };
 use crate::native::types::{Input, NxJson};
@@ -9,7 +9,7 @@ use crate::native::{
 };
 use napi::bindgen_prelude::External;
 use rayon::prelude::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use tracing::trace;
 
 use crate::native::tasks::hashers::OnceCache;
@@ -168,32 +168,9 @@ impl HashPlanner {
 
                 // A continuous dependency serves this task from its own process, so
                 // its declared inputs and externals are hashed here, and its own
-                // servers' in turn. hash-task.ts defers the task past its builds.
-                let mut served_by: Vec<&String> = Vec::new();
-                let mut seen: HashSet<&str> = HashSet::from([*id]);
-                let mut pending: Vec<&String> = task_graph
-                    .continuous_dependencies
-                    .get(*id)
-                    .into_iter()
-                    .flatten()
-                    .collect();
-                while let Some(dep_id) = pending.pop() {
-                    if !seen.insert(dep_id.as_str()) {
-                        continue;
-                    }
-                    served_by.push(dep_id);
-                    pending.extend(
-                        task_graph
-                            .continuous_dependencies
-                            .get(dep_id)
-                            .into_iter()
-                            .flatten(),
-                    );
-                }
-                for dep_id in served_by {
-                    let Some(dep_task) = task_graph.tasks.get(dep_id) else {
-                        continue;
-                    };
+                // servers' in turn. Its builds' outputs land in this plan too, which
+                // is what holds the task back from the up-front hashing batch.
+                for dep_task in collect_continuous_dependencies(&task_graph, id) {
                     let dep_inputs = get_inputs(dep_task, &self.project_graph, &self.nx_json)?;
                     ids.extend(
                         self.target_input(

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -166,6 +166,35 @@ impl HashPlanner {
                     &mut VisitedTracker::new(task.target.project.as_str()),
                 )?);
 
+                // A continuous dependency runs in its own process, so its reads
+                // never reach this task. Its inputs are spliced in whole, from
+                // its declared inputs: a task that never finishes is never traced.
+                if inputs
+                    .self_inputs
+                    .iter()
+                    .any(|i| matches!(i, Input::ContinuousDependenciesInputs))
+                {
+                    for dep_id in task_graph
+                        .continuous_dependencies
+                        .get(*id)
+                        .into_iter()
+                        .flatten()
+                    {
+                        let Some(dep_task) = task_graph.tasks.get(dep_id) else {
+                            continue;
+                        };
+                        let dep_inputs = get_inputs(dep_task, &self.project_graph, &self.nx_json)?;
+                        ids.extend(self.self_and_deps_inputs(
+                            &dep_task.target.project,
+                            dep_task,
+                            &dep_inputs,
+                            &task_graph,
+                            external_deps_mapped,
+                            &mut VisitedTracker::new(dep_task.target.project.as_str()),
+                        )?);
+                    }
+                }
+
                 ids.sort_unstable();
                 ids.dedup();
 

--- a/packages/nx/src/native/tasks/inputs.rs
+++ b/packages/nx/src/native/tasks/inputs.rs
@@ -140,7 +140,6 @@ fn split_inputs_into_self_and_deps<'a>(
                 | Input::DepsOutputs { .. }
                 | Input::ExternalDependency(_)
                 | Input::WorkingDirectory(_)
-                | Input::ContinuousDependenciesInputs
                 | Input::Json { .. } => {
                     acc.1.push(input);
                 }
@@ -203,9 +202,6 @@ pub(super) fn expand_single_project_inputs<'a>(
                     fileset,
                     dependencies: false,
                 });
-            }
-            Input::ContinuousDependenciesInputs => {
-                expanded.push(Input::ContinuousDependenciesInputs)
             }
             Input::Runtime(runtime) => expanded.push(Input::Runtime(runtime)),
             Input::Environment(env) => expanded.push(Input::Environment(env)),

--- a/packages/nx/src/native/tasks/inputs.rs
+++ b/packages/nx/src/native/tasks/inputs.rs
@@ -140,6 +140,7 @@ fn split_inputs_into_self_and_deps<'a>(
                 | Input::DepsOutputs { .. }
                 | Input::ExternalDependency(_)
                 | Input::WorkingDirectory(_)
+                | Input::ContinuousDependenciesInputs
                 | Input::Json { .. } => {
                     acc.1.push(input);
                 }
@@ -202,6 +203,9 @@ pub(super) fn expand_single_project_inputs<'a>(
                     fileset,
                     dependencies: false,
                 });
+            }
+            Input::ContinuousDependenciesInputs => {
+                expanded.push(Input::ContinuousDependenciesInputs)
             }
             Input::Runtime(runtime) => expanded.push(Input::Runtime(runtime)),
             Input::Environment(env) => expanded.push(Input::Environment(env)),

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -265,9 +265,47 @@ impl TaskHasher {
         })
     }
 
+    /// Like `hash_plans`, but only for the plans that hold no output of another
+    /// task. The rest are left out and hash once those tasks have run; their
+    /// ids are absent from the result and need no entry in `per_task_envs`.
+    #[napi(ts_return_type = "Record<string, HashDetails>")]
+    pub fn hash_plans_upfront(
+        &self,
+        #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
+        hash_plans: &External<HashPlans>,
+        per_task_envs: HashMap<String, HashMap<String, String>>,
+        cwd: String,
+        collect_task_inputs: Option<bool>,
+    ) -> anyhow::Result<TaskHashes> {
+        let pool = &hash_plans.pool;
+        let plans: HashMap<String, Vec<u32>> = hash_plans
+            .plans
+            .iter()
+            .filter(|(_, ids)| {
+                !ids.iter()
+                    .any(|id| matches!(*pool.get(*id), HashInstruction::TaskOutput(_, _)))
+            })
+            .map(|(task_id, ids)| (task_id.clone(), ids.clone()))
+            .collect();
+        for task_id in plans.keys() {
+            if !per_task_envs.contains_key(task_id) {
+                anyhow::bail!("hash_plans_upfront: missing env entry for task {}", task_id);
+            }
+        }
+        let upfront = HashPlans {
+            pool: pool.clone(),
+            plans,
+        };
+        self.hash_plans_impl(&upfront, cwd, collect_task_inputs, |task_id| {
+            per_task_envs
+                .get(task_id)
+                .expect("per-task env presence verified above")
+        })
+    }
+
     fn hash_plans_impl<'a, F>(
         &self,
-        hash_plans: &External<HashPlans>,
+        hash_plans: &HashPlans,
         cwd: String,
         collect_task_inputs: Option<bool>,
         resolve_env: F,

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -277,6 +277,7 @@ impl TaskHasher {
         cwd: String,
         collect_task_inputs: Option<bool>,
     ) -> anyhow::Result<TaskHashes> {
+        let function_start = std::time::Instant::now();
         let pool = &hash_plans.pool;
         let plans: HashMap<String, Vec<u32>> = hash_plans
             .plans
@@ -287,6 +288,15 @@ impl TaskHasher {
             })
             .map(|(task_id, ids)| (task_id.clone(), ids.clone()))
             .collect();
+        let partition_duration = function_start.elapsed();
+        let (upfront_count, total_count) = (plans.len(), hash_plans.plans.len());
+        trace!(
+            "hash_plans_upfront: {} of {} plans hash up front, {} wait for other tasks' outputs (partition: {:?})",
+            upfront_count,
+            total_count,
+            total_count - upfront_count,
+            partition_duration
+        );
         for task_id in plans.keys() {
             if !per_task_envs.contains_key(task_id) {
                 anyhow::bail!("hash_plans_upfront: missing env entry for task {}", task_id);
@@ -296,11 +306,21 @@ impl TaskHasher {
             pool: pool.clone(),
             plans,
         };
-        self.hash_plans_impl(&upfront, cwd, collect_task_inputs, |task_id| {
+        let hashes = self.hash_plans_impl(&upfront, cwd, collect_task_inputs, |task_id| {
             per_task_envs
                 .get(task_id)
                 .expect("per-task env presence verified above")
-        })
+        })?;
+        debug!(
+            "hash_plans_upfront COMPLETED in {:?} - hashed {} of {} plans up front, {} deferred (partition: {:?}, hashing: {:?})",
+            function_start.elapsed(),
+            upfront_count,
+            total_count,
+            total_count - upfront_count,
+            partition_duration,
+            function_start.elapsed() - partition_duration
+        );
+        Ok(hashes)
     }
 
     fn hash_plans_impl<'a, F>(

--- a/packages/nx/src/native/tests/planner.spec.ts
+++ b/packages/nx/src/native/tests/planner.spec.ts
@@ -1089,5 +1089,200 @@ describe('task planner', () => {
       expect(plan).toContain('child:libs/child/**/*');
       expect(plan).toContain('grandchild:libs/grandchild/**/*');
     });
+
+    // Builds the served/server pair the tests below vary: parent:test depends
+    // on child:serve, a continuous target with the given configuration.
+    function servedBy(
+      serve: Record<string, unknown>,
+      extraTargets: Record<string, unknown> = {},
+      externals: string[] = [],
+      testInputs: unknown[] = ['{projectRoot}/**/*']
+    ) {
+      const builder = new ProjectGraphBuilder(undefined, {
+        parent: [{ file: 'libs/parent/filea.ts', hash: 'a.hash' }],
+        child: [{ file: 'libs/child/fileb.ts', hash: 'b.hash' }],
+      });
+      for (const name of externals) {
+        builder.addExternalNode({
+          name: `npm:${name}`,
+          type: 'npm',
+          data: { packageName: name, version: '1.0.0', hash: `${name}.hash` },
+        });
+      }
+      builder.addNode({
+        name: 'child',
+        type: 'lib',
+        data: {
+          root: 'libs/child',
+          targets: {
+            serve: { executor: 'nx:run-commands', continuous: true, ...serve },
+            ...extraTargets,
+          },
+        },
+      });
+      builder.addNode({
+        name: 'parent',
+        type: 'lib',
+        data: {
+          root: 'libs/parent',
+          targets: {
+            test: {
+              executor: 'nx:run-commands',
+              inputs: testInputs,
+              dependsOn: [{ projects: 'child', target: 'serve' }],
+            },
+          },
+        },
+      });
+      const projectGraph = builder.getUpdatedProjectGraph();
+      const taskGraph = createTaskGraph(
+        projectGraph,
+        {},
+        ['parent'],
+        ['test'],
+        undefined,
+        {}
+      );
+      const planner = new HashPlanner(
+        {} as any,
+        transferProjectGraph(transformProjectGraphForRust(projectGraph))
+      );
+      return { planner, taskGraph };
+    }
+
+    it("hashes a continuous dependency's external dependencies", () => {
+      const { planner, taskGraph } = servedBy(
+        { inputs: ['{projectRoot}/**/*', { externalDependencies: ['vite'] }] },
+        {},
+        ['vite', 'cypress'],
+        ['{projectRoot}/**/*', { externalDependencies: ['cypress'] }]
+      );
+
+      const plan = planner.getPlans(['parent:test'], taskGraph)['parent:test'];
+      expect(plan).toContain('npm:cypress');
+      expect(plan).toContain('npm:vite');
+      expect(plan).not.toContain('AllExternalDependencies');
+    });
+
+    it('hashes all external dependencies for a continuous dependency that declares none', () => {
+      // The served task declares its own, so the fallback can only be the server's.
+      const { planner, taskGraph } = servedBy(
+        {},
+        {},
+        ['cypress'],
+        ['{projectRoot}/**/*', { externalDependencies: ['cypress'] }]
+      );
+
+      const plan = planner.getPlans(['parent:test'], taskGraph)['parent:test'];
+      expect(plan).toContain('npm:cypress');
+      expect(plan).toContain('AllExternalDependencies');
+    });
+
+    it("leaves out the outputs of a continuous dependency's own dependencies", () => {
+      const { planner, taskGraph } = servedBy(
+        {
+          dependsOn: ['build'],
+          inputs: [
+            '{projectRoot}/**/*',
+            { dependentTasksOutputFiles: '**/*.d.ts', transitive: true },
+          ],
+        },
+        {
+          build: {
+            executor: 'nx:run-commands',
+            outputs: ['{workspaceRoot}/dist/libs/child'],
+          },
+        }
+      );
+
+      // The served task is hashed before child:build runs, so its outputs
+      // cannot be part of the hash.
+      expect(taskGraph.dependencies['parent:test']).toEqual([]);
+      const plan = planner.getPlans(['parent:test'], taskGraph)['parent:test'];
+      expect(plan).toContain('child:libs/child/**/*');
+      expect(plan.some((entry) => entry.includes('**/*.d.ts'))).toBe(false);
+    });
+
+    it('terminates on a cycle of continuous dependencies and hashes each server once', () => {
+      const { planner, taskGraph } = servedBy({});
+      // child:serve is (nonsensically) served by parent:test, closing a loop.
+      taskGraph.continuousDependencies['child:serve'] = ['parent:test'];
+
+      const plan = planner.getPlans(['parent:test'], taskGraph)['parent:test'];
+      expect(
+        plan.filter((entry) => entry === 'child:libs/child/**/*')
+      ).toHaveLength(1);
+      expect(
+        plan.filter((entry) => entry === 'parent:libs/parent/**/*')
+      ).toHaveLength(1);
+    });
+
+    it('hashes a server shared by two continuous dependencies once', () => {
+      const builder = new ProjectGraphBuilder(undefined, {
+        parent: [{ file: 'libs/parent/filea.ts', hash: 'a.hash' }],
+        left: [{ file: 'libs/left/fileb.ts', hash: 'b.hash' }],
+        right: [{ file: 'libs/right/filec.ts', hash: 'c.hash' }],
+        shared: [{ file: 'libs/shared/filed.ts', hash: 'd.hash' }],
+      });
+      const serve = (dependsOn?: unknown[]) => ({
+        executor: 'nx:run-commands',
+        continuous: true,
+        ...(dependsOn ? { dependsOn } : {}),
+      });
+      builder.addNode({
+        name: 'shared',
+        type: 'lib',
+        data: { root: 'libs/shared', targets: { serve: serve() } },
+      });
+      for (const name of ['left', 'right']) {
+        builder.addNode({
+          name,
+          type: 'lib',
+          data: {
+            root: `libs/${name}`,
+            targets: {
+              serve: serve([{ projects: 'shared', target: 'serve' }]),
+            },
+          },
+        });
+      }
+      builder.addNode({
+        name: 'parent',
+        type: 'lib',
+        data: {
+          root: 'libs/parent',
+          targets: {
+            test: {
+              executor: 'nx:run-commands',
+              inputs: ['{projectRoot}/**/*'],
+              dependsOn: [
+                { projects: 'left', target: 'serve' },
+                { projects: 'right', target: 'serve' },
+              ],
+            },
+          },
+        },
+      });
+      const projectGraph = builder.getUpdatedProjectGraph();
+      const taskGraph = createTaskGraph(
+        projectGraph,
+        {},
+        ['parent'],
+        ['test'],
+        undefined,
+        {}
+      );
+      const planner = new HashPlanner(
+        {} as any,
+        transferProjectGraph(transformProjectGraphForRust(projectGraph))
+      );
+
+      const plan = planner.getPlans(['parent:test'], taskGraph)['parent:test'];
+      for (const name of ['left', 'right', 'shared']) {
+        expect(
+          plan.filter((entry) => entry === `${name}:libs/${name}/**/*`)
+        ).toHaveLength(1);
+      }
+    });
   });
 });

--- a/packages/nx/src/native/tests/planner.spec.ts
+++ b/packages/nx/src/native/tests/planner.spec.ts
@@ -968,7 +968,7 @@ describe('task planner', () => {
       expect(plans).toMatchSnapshot();
     });
   });
-  describe('continuousDependenciesInputs', () => {
+  describe('continuous dependencies', () => {
     it("hashes a continuous dependency's inputs into the task it serves", () => {
       const builder = new ProjectGraphBuilder(undefined, {
         parent: [{ file: 'libs/parent/filea.ts', hash: 'a.hash' }],
@@ -992,10 +992,7 @@ describe('task planner', () => {
           targets: {
             test: {
               executor: 'nx:run-commands',
-              inputs: [
-                '{projectRoot}/**/*',
-                { continuousDependenciesInputs: true },
-              ],
+              inputs: ['{projectRoot}/**/*'],
               dependsOn: [{ projects: 'child', target: 'serve' }],
             },
           },

--- a/packages/nx/src/native/tests/planner.spec.ts
+++ b/packages/nx/src/native/tests/planner.spec.ts
@@ -1178,7 +1178,7 @@ describe('task planner', () => {
       expect(plan).toContain('AllExternalDependencies');
     });
 
-    it("leaves out the outputs of a continuous dependency's own dependencies", () => {
+    it("hashes the outputs of a continuous dependency's own dependencies", () => {
       const { planner, taskGraph } = servedBy(
         {
           dependsOn: ['build'],
@@ -1195,12 +1195,12 @@ describe('task planner', () => {
         }
       );
 
-      // The served task is hashed before child:build runs, so its outputs
-      // cannot be part of the hash.
+      // parent:test has no task dependency of its own, so hash-task.ts must
+      // defer it past child:build for this entry to be hashed after the build.
       expect(taskGraph.dependencies['parent:test']).toEqual([]);
       const plan = planner.getPlans(['parent:test'], taskGraph)['parent:test'];
       expect(plan).toContain('child:libs/child/**/*');
-      expect(plan.some((entry) => entry.includes('**/*.d.ts'))).toBe(false);
+      expect(plan).toContain('**/*.d.ts:dist/libs/child');
     });
 
     it('terminates on a cycle of continuous dependencies and hashes each server once', () => {

--- a/packages/nx/src/native/tests/planner.spec.ts
+++ b/packages/nx/src/native/tests/planner.spec.ts
@@ -968,4 +968,61 @@ describe('task planner', () => {
       expect(plans).toMatchSnapshot();
     });
   });
+  describe('continuousDependenciesInputs', () => {
+    it("hashes a continuous dependency's inputs into the task it serves", () => {
+      const builder = new ProjectGraphBuilder(undefined, {
+        parent: [{ file: 'libs/parent/filea.ts', hash: 'a.hash' }],
+        child: [{ file: 'libs/child/fileb.ts', hash: 'b.hash' }],
+      });
+      builder.addNode({
+        name: 'child',
+        type: 'lib',
+        data: {
+          root: 'libs/child',
+          targets: {
+            serve: { executor: 'nx:run-commands', continuous: true },
+          },
+        },
+      });
+      builder.addNode({
+        name: 'parent',
+        type: 'lib',
+        data: {
+          root: 'libs/parent',
+          targets: {
+            test: {
+              executor: 'nx:run-commands',
+              inputs: [
+                '{projectRoot}/**/*',
+                { continuousDependenciesInputs: true },
+              ],
+              dependsOn: [{ projects: 'child', target: 'serve' }],
+            },
+          },
+        },
+      });
+      const projectGraph = builder.getUpdatedProjectGraph();
+      const taskGraph = createTaskGraph(
+        projectGraph,
+        {},
+        ['parent'],
+        ['test'],
+        undefined,
+        {}
+      );
+      const planner = new HashPlanner(
+        {} as any,
+        transferProjectGraph(transformProjectGraphForRust(projectGraph))
+      );
+
+      // The dependency serving this task runs in its own process, so only its
+      // declared inputs can stand in for what it reads.
+      expect(taskGraph.continuousDependencies['parent:test']).toContain(
+        'child:serve'
+      );
+      expect(
+        planner.getPlans(['parent:test'], taskGraph)['parent:test']
+      ).toContain('child:libs/child/**/*');
+    });
+  });
 });

--- a/packages/nx/src/native/tests/planner.spec.ts
+++ b/packages/nx/src/native/tests/planner.spec.ts
@@ -1021,5 +1021,73 @@ describe('task planner', () => {
         planner.getPlans(['parent:test'], taskGraph)['parent:test']
       ).toContain('child:libs/child/**/*');
     });
+
+    it('follows the servers that serve a continuous dependency', () => {
+      const builder = new ProjectGraphBuilder(undefined, {
+        parent: [{ file: 'libs/parent/filea.ts', hash: 'a.hash' }],
+        child: [{ file: 'libs/child/fileb.ts', hash: 'b.hash' }],
+        grandchild: [{ file: 'libs/grandchild/filec.ts', hash: 'c.hash' }],
+      });
+      // grandchild serves child over the network: no project dependency, so
+      // only the task graph links them.
+      builder.addNode({
+        name: 'grandchild',
+        type: 'lib',
+        data: {
+          root: 'libs/grandchild',
+          targets: {
+            serve: { executor: 'nx:run-commands', continuous: true },
+          },
+        },
+      });
+      builder.addNode({
+        name: 'child',
+        type: 'lib',
+        data: {
+          root: 'libs/child',
+          targets: {
+            serve: {
+              executor: 'nx:run-commands',
+              continuous: true,
+              dependsOn: [{ projects: 'grandchild', target: 'serve' }],
+            },
+          },
+        },
+      });
+      builder.addNode({
+        name: 'parent',
+        type: 'lib',
+        data: {
+          root: 'libs/parent',
+          targets: {
+            test: {
+              executor: 'nx:run-commands',
+              inputs: ['{projectRoot}/**/*'],
+              dependsOn: [{ projects: 'child', target: 'serve' }],
+            },
+          },
+        },
+      });
+      const projectGraph = builder.getUpdatedProjectGraph();
+      const taskGraph = createTaskGraph(
+        projectGraph,
+        {},
+        ['parent'],
+        ['test'],
+        undefined,
+        {}
+      );
+      const planner = new HashPlanner(
+        {} as any,
+        transferProjectGraph(transformProjectGraphForRust(projectGraph))
+      );
+
+      expect(taskGraph.continuousDependencies['child:serve']).toContain(
+        'grandchild:serve'
+      );
+      const plan = planner.getPlans(['parent:test'], taskGraph)['parent:test'];
+      expect(plan).toContain('child:libs/child/**/*');
+      expect(plan).toContain('grandchild:libs/grandchild/**/*');
+    });
   });
 });

--- a/packages/nx/src/native/types/inputs.rs
+++ b/packages/nx/src/native/types/inputs.rs
@@ -1,5 +1,5 @@
 use napi::Either;
-use napi::bindgen_prelude::Either9;
+use napi::bindgen_prelude::Either10;
 
 #[napi(object)]
 pub struct InputsInput {
@@ -35,6 +35,13 @@ pub struct DepsOutputsInput {
     pub transitive: Option<bool>,
 }
 
+/// Hash everything the task's continuous dependencies hash. A trace sees one
+/// process, so a dev server's reads are otherwise absent from the task.
+#[napi(object)]
+pub struct ContinuousDependenciesInputsInput {
+    pub continuous_dependencies_inputs: bool,
+}
+
 #[napi(object)]
 pub struct WorkingDirectoryInput {
     pub working_directory: String,
@@ -47,7 +54,7 @@ pub struct JsonInput {
     pub exclude_fields: Option<Vec<String>>,
 }
 
-pub(crate) type JsInputs = Either9<
+pub(crate) type JsInputs = Either10<
     InputsInput,
     String,
     FileSetInput,
@@ -57,12 +64,13 @@ pub(crate) type JsInputs = Either9<
     DepsOutputsInput,
     WorkingDirectoryInput,
     JsonInput,
+    ContinuousDependenciesInputsInput,
 >;
 
 impl<'a> From<&'a JsInputs> for Input<'a> {
     fn from(value: &'a JsInputs) -> Self {
         match value {
-            Either9::A(inputs) => {
+            Either10::A(inputs) => {
                 if let Some(projects) = &inputs.projects {
                     Input::Projects {
                         input: &inputs.input,
@@ -78,7 +86,7 @@ impl<'a> From<&'a JsInputs> for Input<'a> {
                     }
                 }
             }
-            Either9::B(string) => {
+            Either10::B(string) => {
                 if let Some(rest) = string.strip_prefix('^') {
                     // Check if this is a dependency fileset (starts with {projectRoot} or {workspaceRoot})
                     if rest.starts_with("{projectRoot}") || rest.starts_with("{workspaceRoot}") {
@@ -97,33 +105,36 @@ impl<'a> From<&'a JsInputs> for Input<'a> {
                     Input::String(string)
                 }
             }
-            Either9::C(file_set) => Input::FileSet {
+            Either10::C(file_set) => Input::FileSet {
                 fileset: &file_set.fileset,
                 dependencies: file_set.dependencies.unwrap_or(false),
             },
-            Either9::D(runtime) => Input::Runtime(&runtime.runtime),
-            Either9::E(environment) => Input::Environment(&environment.env),
-            Either9::F(external_dependencies) => {
+            Either10::D(runtime) => Input::Runtime(&runtime.runtime),
+            Either10::E(environment) => Input::Environment(&environment.env),
+            Either10::F(external_dependencies) => {
                 Input::ExternalDependency(&external_dependencies.external_dependencies)
             }
-            Either9::G(deps_outputs) => Input::DepsOutputs {
+            Either10::G(deps_outputs) => Input::DepsOutputs {
                 transitive: deps_outputs.transitive.unwrap_or(false),
                 dependent_tasks_output_files: &deps_outputs.dependent_tasks_output_files,
             },
-            Either9::H(working_directory) => {
+            Either10::H(working_directory) => {
                 Input::WorkingDirectory(&working_directory.working_directory)
             }
-            Either9::I(json_input) => Input::Json {
+            Either10::I(json_input) => Input::Json {
                 json: &json_input.json,
                 fields: json_input.fields.as_deref(),
                 exclude_fields: json_input.exclude_fields.as_deref(),
             },
+            Either10::J(_) => Input::ContinuousDependenciesInputs,
         }
     }
 }
 
 #[derive(Debug)]
 pub(crate) enum Input<'a> {
+    /// Everything this task's continuous dependencies hash.
+    ContinuousDependenciesInputs,
     Inputs {
         input: &'a str,
         dependencies: bool,

--- a/packages/nx/src/native/types/inputs.rs
+++ b/packages/nx/src/native/types/inputs.rs
@@ -1,5 +1,5 @@
 use napi::Either;
-use napi::bindgen_prelude::Either10;
+use napi::bindgen_prelude::Either9;
 
 #[napi(object)]
 pub struct InputsInput {
@@ -35,13 +35,6 @@ pub struct DepsOutputsInput {
     pub transitive: Option<bool>,
 }
 
-/// Hash everything the task's continuous dependencies hash. A trace sees one
-/// process, so a dev server's reads are otherwise absent from the task.
-#[napi(object)]
-pub struct ContinuousDependenciesInputsInput {
-    pub continuous_dependencies_inputs: bool,
-}
-
 #[napi(object)]
 pub struct WorkingDirectoryInput {
     pub working_directory: String,
@@ -54,7 +47,7 @@ pub struct JsonInput {
     pub exclude_fields: Option<Vec<String>>,
 }
 
-pub(crate) type JsInputs = Either10<
+pub(crate) type JsInputs = Either9<
     InputsInput,
     String,
     FileSetInput,
@@ -64,13 +57,12 @@ pub(crate) type JsInputs = Either10<
     DepsOutputsInput,
     WorkingDirectoryInput,
     JsonInput,
-    ContinuousDependenciesInputsInput,
 >;
 
 impl<'a> From<&'a JsInputs> for Input<'a> {
     fn from(value: &'a JsInputs) -> Self {
         match value {
-            Either10::A(inputs) => {
+            Either9::A(inputs) => {
                 if let Some(projects) = &inputs.projects {
                     Input::Projects {
                         input: &inputs.input,
@@ -86,7 +78,7 @@ impl<'a> From<&'a JsInputs> for Input<'a> {
                     }
                 }
             }
-            Either10::B(string) => {
+            Either9::B(string) => {
                 if let Some(rest) = string.strip_prefix('^') {
                     // Check if this is a dependency fileset (starts with {projectRoot} or {workspaceRoot})
                     if rest.starts_with("{projectRoot}") || rest.starts_with("{workspaceRoot}") {
@@ -105,36 +97,33 @@ impl<'a> From<&'a JsInputs> for Input<'a> {
                     Input::String(string)
                 }
             }
-            Either10::C(file_set) => Input::FileSet {
+            Either9::C(file_set) => Input::FileSet {
                 fileset: &file_set.fileset,
                 dependencies: file_set.dependencies.unwrap_or(false),
             },
-            Either10::D(runtime) => Input::Runtime(&runtime.runtime),
-            Either10::E(environment) => Input::Environment(&environment.env),
-            Either10::F(external_dependencies) => {
+            Either9::D(runtime) => Input::Runtime(&runtime.runtime),
+            Either9::E(environment) => Input::Environment(&environment.env),
+            Either9::F(external_dependencies) => {
                 Input::ExternalDependency(&external_dependencies.external_dependencies)
             }
-            Either10::G(deps_outputs) => Input::DepsOutputs {
+            Either9::G(deps_outputs) => Input::DepsOutputs {
                 transitive: deps_outputs.transitive.unwrap_or(false),
                 dependent_tasks_output_files: &deps_outputs.dependent_tasks_output_files,
             },
-            Either10::H(working_directory) => {
+            Either9::H(working_directory) => {
                 Input::WorkingDirectory(&working_directory.working_directory)
             }
-            Either10::I(json_input) => Input::Json {
+            Either9::I(json_input) => Input::Json {
                 json: &json_input.json,
                 fields: json_input.fields.as_deref(),
                 exclude_fields: json_input.exclude_fields.as_deref(),
             },
-            Either10::J(_) => Input::ContinuousDependenciesInputs,
         }
     }
 }
 
 #[derive(Debug)]
 pub(crate) enum Input<'a> {
-    /// Everything this task's continuous dependencies hash.
-    ContinuousDependenciesInputs,
     Inputs {
         input: &'a str,
         dependencies: bool,

--- a/packages/nx/src/native/types/nx_json.rs
+++ b/packages/nx/src/native/types/nx_json.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 /// Stripped version of the NxJson interface for use in rust
 pub struct NxJson {
     #[napi(
-        ts_type = "Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>>"
+        ts_type = "Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>>"
     )]
     pub named_inputs: Option<HashMap<String, Vec<JsInputs>>>,
 }

--- a/packages/nx/src/native/types/nx_json.rs
+++ b/packages/nx/src/native/types/nx_json.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 /// Stripped version of the NxJson interface for use in rust
 pub struct NxJson {
     #[napi(
-        ts_type = "Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput | ContinuousDependenciesInputsInput>>"
+        ts_type = "Record<string, Array<InputsInput | string | FileSetInput | RuntimeInput | EnvironmentInput | ExternalDependenciesInput | DepsOutputsInput | WorkingDirectoryInput | JsonInput>>"
     )]
     pub named_inputs: Option<HashMap<String, Vec<JsInputs>>>,
 }

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -1087,6 +1087,13 @@ export async function invokeTasksRunner({
             envOrPerTaskEnvs as NodeJS.ProcessEnv
           );
         },
+        hashTasksUpfront(
+          tasks: Task[],
+          taskGraph_: TaskGraph,
+          perTaskEnvs: Record<string, NodeJS.ProcessEnv>
+        ) {
+          return hasher.hashTasksUpfront(tasks, taskGraph_, perTaskEnvs);
+        },
       },
       daemon: daemonClient,
     }

--- a/packages/react/src/plugins/__snapshots__/router-plugin.spec.ts.snap
+++ b/packages/react/src/plugins/__snapshots__/router-plugin.spec.ts.snap
@@ -42,6 +42,15 @@ exports[`@nx/react/react-router-plugin React Router should create nodes by defau
             "dev": {
               "command": "react-router dev",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@react-router/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": "acme",
               },
@@ -51,6 +60,15 @@ exports[`@nx/react/react-router-plugin React Router should create nodes by defau
               "continuous": true,
               "dependsOn": [
                 "build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@react-router/dev",
+                  ],
+                },
               ],
               "options": {
                 "cwd": "acme",
@@ -142,6 +160,15 @@ exports[`@nx/react/react-router-plugin React Router should create nodes without 
             "dev": {
               "command": "react-router dev",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@react-router/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": "acme",
               },

--- a/packages/react/src/plugins/router-plugin.ts
+++ b/packages/react/src/plugins/router-plugin.ts
@@ -174,6 +174,7 @@ async function buildReactRouterTargets(
 
   targets[options.devTargetName] = await devTarget(
     projectRoot,
+    namedInputs,
     isUsingTsSolutionSetup
   );
 
@@ -182,6 +183,7 @@ async function buildReactRouterTargets(
       projectRoot,
       serverBuildPath,
       options.buildTargetName,
+      namedInputs,
       isUsingTsSolutionSetup
     );
   }
@@ -232,12 +234,7 @@ async function getBuildTargetConfig(
   const buildTarget: TargetConfiguration = {
     cache: true,
     dependsOn: [`^${buildTargetName}`],
-    inputs: [
-      ...('production' in namedInputs
-        ? ['production', '^production']
-        : ['default', '^default']),
-      { externalDependencies: ['@react-router/dev'] },
-    ],
+    inputs: buildInputs(namedInputs),
     outputs,
     command: 'react-router build',
     options: { cwd: projectRoot },
@@ -262,9 +259,25 @@ async function getBuildPaths(reactRouterConfig, isLibMode: boolean) {
   };
 }
 
-async function devTarget(projectRoot: string, isUsingTsSolutionSetup: boolean) {
+function buildInputs(namedInputs: {
+  [inputName: string]: any[];
+}): TargetConfiguration['inputs'] {
+  return [
+    ...('production' in namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+    { externalDependencies: ['@react-router/dev'] },
+  ];
+}
+
+async function devTarget(
+  projectRoot: string,
+  namedInputs: { [inputName: string]: any[] },
+  isUsingTsSolutionSetup: boolean
+) {
   const devTarget: TargetConfiguration = {
     continuous: true,
+    inputs: buildInputs(namedInputs),
     command: 'react-router dev',
     options: { cwd: projectRoot },
   };
@@ -279,6 +292,7 @@ async function startTarget(
   projectRoot: string,
   serverBuildPath: string,
   buildTargetName: string,
+  namedInputs: { [inputName: string]: any[] },
   isUsingTsSolutionSetup: boolean
 ) {
   const serverPath =
@@ -289,6 +303,7 @@ async function startTarget(
   const startTarget: TargetConfiguration = {
     continuous: true,
     dependsOn: [buildTargetName],
+    inputs: buildInputs(namedInputs),
     command: `react-router-serve ${serverPath}`,
     options: { cwd: projectRoot },
   };

--- a/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -41,6 +41,15 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create 
             "dev": {
               "command": "remix dev --manual",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": "my-app",
               },
@@ -51,6 +60,15 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create 
               "dependsOn": [
                 "build",
               ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": "my-app",
               },
@@ -60,6 +78,15 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create 
               "continuous": true,
               "dependsOn": [
                 "build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
               ],
               "options": {
                 "cwd": "my-app",
@@ -151,6 +178,15 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should infer w
             "dev": {
               "command": "remix dev --manual",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": "my-app",
               },
@@ -161,6 +197,15 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should infer w
               "dependsOn": [
                 "build",
               ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": "my-app",
               },
@@ -170,6 +215,15 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should infer w
               "continuous": true,
               "dependsOn": [
                 "build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
               ],
               "options": {
                 "cwd": "my-app",
@@ -256,6 +310,15 @@ exports[`@nx/remix/plugin Remix Classic Compiler root project should create node
             "dev": {
               "command": "remix dev --manual",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": ".",
               },
@@ -266,6 +329,15 @@ exports[`@nx/remix/plugin Remix Classic Compiler root project should create node
               "dependsOn": [
                 "build",
               ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": ".",
               },
@@ -275,6 +347,15 @@ exports[`@nx/remix/plugin Remix Classic Compiler root project should create node
               "continuous": true,
               "dependsOn": [
                 "build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
               ],
               "options": {
                 "cwd": ".",
@@ -358,6 +439,15 @@ exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nod
             "dev": {
               "command": "remix vite:dev",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": "my-app",
               },
@@ -368,6 +458,15 @@ exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nod
               "dependsOn": [
                 "build",
               ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": "my-app",
               },
@@ -377,6 +476,15 @@ exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nod
               "continuous": true,
               "dependsOn": [
                 "build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
               ],
               "options": {
                 "cwd": "my-app",
@@ -462,6 +570,15 @@ exports[`@nx/remix/plugin Remix Vite Compiler root project should create nodes 1
             "dev": {
               "command": "remix vite:dev",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": ".",
               },
@@ -472,6 +589,15 @@ exports[`@nx/remix/plugin Remix Vite Compiler root project should create nodes 1
               "dependsOn": [
                 "build",
               ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
+              ],
               "options": {
                 "cwd": ".",
               },
@@ -481,6 +607,15 @@ exports[`@nx/remix/plugin Remix Vite Compiler root project should create nodes 1
               "continuous": true,
               "dependsOn": [
                 "build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "@remix-run/dev",
+                  ],
+                },
               ],
               "options": {
                 "cwd": ".",

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -194,6 +194,7 @@ async function buildRemixTargets(
     serverBuildPath,
     projectRoot,
     remixCompiler,
+    namedInputs,
     isUsingTsSolutionSetup
   );
   targets[options.startTargetName] = startTarget(
@@ -201,6 +202,7 @@ async function buildRemixTargets(
     serverBuildPath,
     options.buildTargetName,
     remixCompiler,
+    namedInputs,
     isUsingTsSolutionSetup
   );
   targets[options.serveStaticTargetName] = startTarget(
@@ -208,6 +210,7 @@ async function buildRemixTargets(
     serverBuildPath,
     options.buildTargetName,
     remixCompiler,
+    namedInputs,
     isUsingTsSolutionSetup
   );
   targets[options.typecheckTargetName] = typecheckTarget(
@@ -261,12 +264,7 @@ function buildTarget(
   const buildTarget: TargetConfiguration = {
     cache: true,
     dependsOn: [`^${buildTargetName}`],
-    inputs: [
-      ...('production' in namedInputs
-        ? ['production', '^production']
-        : ['default', '^default']),
-      { externalDependencies: ['@remix-run/dev'] },
-    ],
+    inputs: buildInputs(namedInputs),
     outputs,
     command:
       remixCompiler === RemixCompiler.IsVte
@@ -282,14 +280,27 @@ function buildTarget(
   return buildTarget;
 }
 
+function buildInputs(namedInputs: {
+  [inputName: string]: any[];
+}): TargetConfiguration['inputs'] {
+  return [
+    ...('production' in namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+    { externalDependencies: ['@remix-run/dev'] },
+  ];
+}
+
 function devTarget(
   serverBuildPath: string,
   projectRoot: string,
   remixCompiler: RemixCompiler,
+  namedInputs: { [inputName: string]: any[] },
   isUsingTsSolutionSetup: boolean
 ): TargetConfiguration {
   const devTarget: TargetConfiguration = {
     continuous: true,
+    inputs: buildInputs(namedInputs),
     command:
       remixCompiler === RemixCompiler.IsVte
         ? 'remix vite:dev'
@@ -309,6 +320,7 @@ function startTarget(
   serverBuildPath: string,
   buildTargetName: string,
   remixCompiler: RemixCompiler,
+  namedInputs: { [inputName: string]: any[] },
   isUsingTsSolutionSetup: boolean
 ): TargetConfiguration {
   let serverPath = serverBuildPath;
@@ -321,6 +333,7 @@ function startTarget(
   const startTarget: TargetConfiguration = {
     dependsOn: [buildTargetName],
     continuous: true,
+    inputs: buildInputs(namedInputs),
     command: `remix-serve ${serverPath}`,
     options: {
       cwd: projectRoot,

--- a/packages/rsbuild/src/plugins/plugin.spec.ts
+++ b/packages/rsbuild/src/plugins/plugin.spec.ts
@@ -117,6 +117,15 @@ describe('@nx/rsbuild', () => {
                   "dev-serve": {
                     "command": "rsbuild dev",
                     "continuous": true,
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "@rsbuild/core",
+                        ],
+                      },
+                    ],
                     "options": {
                       "args": [
                         "--mode=development",
@@ -136,6 +145,15 @@ describe('@nx/rsbuild', () => {
                     "dependsOn": [
                       "build-something",
                       "^build-something",
+                    ],
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "@rsbuild/core",
+                        ],
+                      },
                     ],
                     "options": {
                       "args": [

--- a/packages/rsbuild/src/plugins/plugin.ts
+++ b/packages/rsbuild/src/plugins/plugin.ts
@@ -189,19 +189,21 @@ async function createRsbuildTargets(
 
   const targets: Record<string, TargetConfiguration> = {};
 
+  const buildInputs: TargetConfiguration['inputs'] = [
+    ...('production' in namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+    {
+      externalDependencies: ['@rsbuild/core'],
+    },
+  ];
+
   targets[options.buildTargetName] = {
     command: `rsbuild build`,
     options: { cwd: projectRoot, args: ['--mode=production'] },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
-    inputs: [
-      ...('production' in namedInputs
-        ? ['production', '^production']
-        : ['default', '^default']),
-      {
-        externalDependencies: ['@rsbuild/core'],
-      },
-    ],
+    inputs: [...buildInputs],
     outputs: buildOutputs,
     metadata: {
       technologies: ['rsbuild'],
@@ -219,6 +221,7 @@ async function createRsbuildTargets(
 
   targets[options.devTargetName] = {
     continuous: true,
+    inputs: [...buildInputs],
     command: `rsbuild dev`,
     options: {
       cwd: projectRoot,
@@ -228,6 +231,7 @@ async function createRsbuildTargets(
 
   targets[options.previewTargetName] = {
     continuous: true,
+    inputs: [...buildInputs],
     command: `rsbuild preview`,
     dependsOn: [`${options.buildTargetName}`, `^${options.buildTargetName}`],
     options: {

--- a/packages/rspack/src/plugins/plugin.spec.ts
+++ b/packages/rspack/src/plugins/plugin.spec.ts
@@ -117,6 +117,15 @@ describe('@nx/rspack', () => {
                   "preview": {
                     "command": "rspack serve",
                     "continuous": true,
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "@rspack/cli",
+                        ],
+                      },
+                    ],
                     "options": {
                       "args": [
                         "--node-env=production",
@@ -130,6 +139,15 @@ describe('@nx/rspack', () => {
                   "serve": {
                     "command": "rspack serve",
                     "continuous": true,
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "@rspack/cli",
+                        ],
+                      },
+                    ],
                     "options": {
                       "args": [
                         "--node-env=development",
@@ -146,6 +164,15 @@ describe('@nx/rspack', () => {
                       "build",
                     ],
                     "executor": "@nx/web:file-server",
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "@rspack/cli",
+                        ],
+                      },
+                    ],
                     "options": {
                       "buildTarget": "build",
                       "port": 9000,

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -17,6 +17,7 @@ import {
   workspaceRoot,
   hashArray,
   getPackageManagerCommand,
+  TargetConfiguration,
 } from '@nx/devkit';
 import { getLockFileName, getRootTsConfigPath } from '@nx/js';
 import {
@@ -204,6 +205,15 @@ async function createRspackTargets(
     });
   }
 
+  const buildInputs: TargetConfiguration['inputs'] = [
+    ...('production' in namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+    {
+      externalDependencies: ['@rspack/cli'],
+    },
+  ];
+
   targets[options.buildTargetName] = {
     command: `rspack build`,
     options: {
@@ -219,12 +229,7 @@ async function createRspackTargets(
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
     inputs: [
-      ...('production' in namedInputs
-        ? ['production', '^production']
-        : ['default', '^default']),
-      {
-        externalDependencies: ['@rspack/cli'],
-      },
+      ...buildInputs,
       // The build can emit a pruned pnpm deploy output (NxAppRspackPlugin
       // with generatePackageJson), whose install settings come from these
       // otherwise-unhashed root sources.
@@ -239,6 +244,7 @@ async function createRspackTargets(
 
   targets[options.serveTargetName] = {
     continuous: true,
+    inputs: [...buildInputs],
     command: `rspack serve`,
     options: {
       cwd: projectRoot,
@@ -249,6 +255,7 @@ async function createRspackTargets(
 
   targets[options.previewTargetName] = {
     continuous: true,
+    inputs: [...buildInputs],
     command: `rspack serve`,
     options: {
       cwd: projectRoot,
@@ -260,6 +267,7 @@ async function createRspackTargets(
   targets[options.serveStaticTargetName] = {
     dependsOn: [`${options.buildTargetName}`],
     continuous: true,
+    inputs: [...buildInputs],
     executor: '@nx/web:file-server',
     options: {
       buildTarget: options.buildTargetName,

--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -193,6 +193,15 @@ describe('@nx/storybook/plugin', () => {
                   "serve-storybook": {
                     "command": "storybook dev",
                     "continuous": true,
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "storybook",
+                        ],
+                      },
+                    ],
                     "options": {
                       "cwd": "my-app",
                     },
@@ -203,6 +212,15 @@ describe('@nx/storybook/plugin', () => {
                       "build-storybook",
                     ],
                     "executor": "@nx/web:file-server",
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "storybook",
+                        ],
+                      },
+                    ],
                     "options": {
                       "buildTarget": "build-storybook",
                       "staticFilePath": "my-app/storybook-static",
@@ -294,6 +312,16 @@ export default config;
                   "serve-storybook": {
                     "continuous": true,
                     "executor": "@storybook/angular:start-storybook",
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "storybook",
+                          "@storybook/angular",
+                        ],
+                      },
+                    ],
                     "options": {
                       "browserTarget": "my-ng-app:build",
                       "compodoc": false,
@@ -307,6 +335,16 @@ export default config;
                       "build-storybook",
                     ],
                     "executor": "@nx/web:file-server",
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "storybook",
+                          "@storybook/angular",
+                        ],
+                      },
+                    ],
                     "options": {
                       "buildTarget": "build-storybook",
                       "staticFilePath": "my-ng-app/storybook-static",
@@ -543,6 +581,15 @@ export default config;
                   "serve-storybook": {
                     "command": "storybook dev",
                     "continuous": true,
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "storybook",
+                        ],
+                      },
+                    ],
                     "options": {
                       "cwd": "my-react-lib",
                     },
@@ -553,6 +600,15 @@ export default config;
                       "build-storybook",
                     ],
                     "executor": "@nx/web:file-server",
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "storybook",
+                        ],
+                      },
+                    ],
                     "options": {
                       "buildTarget": "build-storybook",
                       "staticFilePath": "my-react-lib/storybook-static",

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -242,21 +242,27 @@ async function buildStorybookTargets(
     angularBuildTarget ?? options.buildStorybookTargetName
   }`;
 
-  targets[options.buildStorybookTargetName] = buildTarget(
+  const inputs = storybookInputs(
     namedInputs,
+    frameworkIsAngular,
+    hasTestRunner
+  );
+
+  targets[options.buildStorybookTargetName] = buildTarget(
+    inputs,
     buildOutputs,
     projectRoot,
     frameworkIsAngular,
     browserTarget,
-    configFilePath,
-    hasTestRunner
+    configFilePath
   );
 
   targets[options.serveStorybookTargetName] = serveTarget(
     projectRoot,
     frameworkIsAngular,
     browserTarget,
-    configFilePath
+    configFilePath,
+    inputs
   );
 
   if (usesVitestAddon) {
@@ -267,7 +273,8 @@ async function buildStorybookTargets(
 
   targets[options.staticStorybookTargetName] = serveStaticTarget(
     options,
-    projectRoot
+    projectRoot,
+    inputs
   );
 
   addBuildAndWatchDepsTargets(
@@ -281,16 +288,32 @@ async function buildStorybookTargets(
   return targets;
 }
 
+function storybookInputs(
+  namedInputs: { [inputName: string]: any[] },
+  frameworkIsAngular: boolean,
+  hasTestRunner: boolean
+): TargetConfiguration['inputs'] {
+  return [
+    ...('production' in namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+    {
+      externalDependencies: [
+        'storybook',
+        frameworkIsAngular ? '@storybook/angular' : undefined,
+        hasTestRunner ? '@storybook/test-runner' : undefined,
+      ].filter(Boolean),
+    },
+  ];
+}
+
 function buildTarget(
-  namedInputs: {
-    [inputName: string]: any[];
-  },
+  inputs: TargetConfiguration['inputs'],
   outputs: string[],
   projectRoot: string,
   frameworkIsAngular: boolean,
   browserTarget: string,
-  configFilePath: string,
-  hasTestRunner: boolean
+  configFilePath: string
 ) {
   let targetConfig: TargetConfiguration;
 
@@ -305,18 +328,7 @@ function buildTarget(
       },
       cache: true,
       outputs,
-      inputs: [
-        ...('production' in namedInputs
-          ? ['production', '^production']
-          : ['default', '^default']),
-        {
-          externalDependencies: [
-            'storybook',
-            '@storybook/angular',
-            hasTestRunner ? '@storybook/test-runner' : undefined,
-          ].filter(Boolean),
-        },
-      ],
+      inputs: [...inputs],
     };
   } else {
     targetConfig = {
@@ -324,17 +336,7 @@ function buildTarget(
       options: { cwd: projectRoot },
       cache: true,
       outputs,
-      inputs: [
-        ...('production' in namedInputs
-          ? ['production', '^production']
-          : ['default', '^default']),
-        {
-          externalDependencies: [
-            'storybook',
-            hasTestRunner ? '@storybook/test-runner' : undefined,
-          ].filter(Boolean),
-        },
-      ],
+      inputs: [...inputs],
     };
   }
 
@@ -345,11 +347,13 @@ function serveTarget(
   projectRoot: string,
   frameworkIsAngular: boolean,
   browserTarget: string,
-  configFilePath: string
+  configFilePath: string,
+  inputs: TargetConfiguration['inputs']
 ) {
   if (frameworkIsAngular) {
     return {
       continuous: true,
+      inputs: [...inputs],
       executor: '@storybook/angular:start-storybook',
       options: {
         configDir: `${dirname(configFilePath)}`,
@@ -363,6 +367,7 @@ function serveTarget(
   } else {
     return {
       continuous: true,
+      inputs: [...inputs],
       command: `storybook dev`,
       options: { cwd: projectRoot },
     };
@@ -405,11 +410,13 @@ function vitestTestTarget(projectRoot: string) {
 
 function serveStaticTarget(
   options: StorybookPluginOptions,
-  projectRoot: string
+  projectRoot: string,
+  inputs: TargetConfiguration['inputs']
 ) {
   const targetConfig: TargetConfiguration = {
     dependsOn: [`${options.buildStorybookTargetName}`],
     continuous: true,
+    inputs: [...inputs],
     executor: '@nx/web:file-server',
     options: {
       buildTarget: `${options.buildStorybookTargetName}`,

--- a/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -124,6 +124,15 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
             "dev": {
               "command": "vite",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "vite",
+                  ],
+                },
+              ],
               "metadata": {
                 "description": "Starts Vite dev server",
                 "help": {
@@ -145,6 +154,15 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
             "my-serve": {
               "command": "vite",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "vite",
+                  ],
+                },
+              ],
               "metadata": {
                 "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                 "description": "Starts Vite dev server",
@@ -170,6 +188,15 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
               "dependsOn": [
                 "build-something",
               ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "vite",
+                  ],
+                },
+              ],
               "metadata": {
                 "description": "Locally preview Vite production build",
                 "help": {
@@ -191,6 +218,15 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
             "serve-static": {
               "continuous": true,
               "executor": "@nx/web:file-server",
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "vite",
+                  ],
+                },
+              ],
               "options": {
                 "buildTarget": "build-something",
                 "spa": true,
@@ -262,6 +298,15 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             "dev": {
               "command": "vite",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "vite",
+                  ],
+                },
+              ],
               "metadata": {
                 "description": "Starts Vite dev server",
                 "help": {
@@ -286,6 +331,15 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               "dependsOn": [
                 "build",
               ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "vite",
+                  ],
+                },
+              ],
               "metadata": {
                 "description": "Locally preview Vite production build",
                 "help": {
@@ -307,6 +361,15 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             "serve": {
               "command": "vite",
               "continuous": true,
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "vite",
+                  ],
+                },
+              ],
               "metadata": {
                 "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                 "description": "Starts Vite dev server",
@@ -329,6 +392,15 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             "serve-static": {
               "continuous": true,
               "executor": "@nx/web:file-server",
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "vite",
+                  ],
+                },
+              ],
               "options": {
                 "buildTarget": "build",
                 "spa": true,

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -529,6 +529,15 @@ describe('@nx/vite/plugin', () => {
                     "dev": {
                       "command": "vite",
                       "continuous": true,
+                      "inputs": [
+                        "production",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "vite",
+                          ],
+                        },
+                      ],
                       "metadata": {
                         "description": "Starts Vite dev server",
                         "help": {
@@ -553,6 +562,15 @@ describe('@nx/vite/plugin', () => {
                       "dependsOn": [
                         "build",
                       ],
+                      "inputs": [
+                        "production",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "vite",
+                          ],
+                        },
+                      ],
                       "metadata": {
                         "description": "Locally preview Vite production build",
                         "help": {
@@ -574,6 +592,15 @@ describe('@nx/vite/plugin', () => {
                     "serve": {
                       "command": "vite",
                       "continuous": true,
+                      "inputs": [
+                        "production",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "vite",
+                          ],
+                        },
+                      ],
                       "metadata": {
                         "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                         "description": "Starts Vite dev server",
@@ -596,6 +623,15 @@ describe('@nx/vite/plugin', () => {
                     "serve-static": {
                       "continuous": true,
                       "executor": "@nx/web:file-server",
+                      "inputs": [
+                        "production",
+                        "^production",
+                        {
+                          "externalDependencies": [
+                            "vite",
+                          ],
+                        },
+                      ],
                       "options": {
                         "buildTarget": "build",
                         "spa": true,

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -257,7 +257,12 @@ async function buildViteTargets(
 
     // If running in library mode, then there is nothing to serve.
     if (!viteBuildConfig.build?.lib || hasServeConfig) {
-      const devTarget = serveTarget(projectRoot, isUsingTsSolutionSetup, pmc);
+      const devTarget = serveTarget(
+        projectRoot,
+        isUsingTsSolutionSetup,
+        pmc,
+        namedInputs
+      );
 
       targets[options.serveTargetName] = {
         ...devTarget,
@@ -271,11 +276,13 @@ async function buildViteTargets(
       targets[options.previewTargetName] = previewTarget(
         projectRoot,
         options.buildTargetName,
-        pmc
+        pmc,
+        namedInputs
       );
       targets[options.serveStaticTargetName] = serveStaticTarget(
         options,
-        isUsingTsSolutionSetup
+        isUsingTsSolutionSetup,
+        namedInputs
       );
     }
   }
@@ -368,14 +375,7 @@ async function buildTarget(
     options: { cwd: joinPathFragments(projectRoot) },
     cache: true,
     dependsOn: [`^${buildTargetName}`],
-    inputs: [
-      ...('production' in namedInputs
-        ? ['production', '^production']
-        : ['default', '^default']),
-      {
-        externalDependencies: ['vite'],
-      },
-    ],
+    inputs: buildInputs(namedInputs),
     outputs,
     metadata: {
       technologies: ['vite'],
@@ -399,13 +399,28 @@ async function buildTarget(
   return buildTarget;
 }
 
+function buildInputs(namedInputs: {
+  [inputName: string]: any[];
+}): TargetConfiguration['inputs'] {
+  return [
+    ...('production' in namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+    {
+      externalDependencies: ['vite'],
+    },
+  ];
+}
+
 function serveTarget(
   projectRoot: string,
   isUsingTsSolutionSetup: boolean,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  namedInputs: { [inputName: string]: any[] }
 ) {
   const targetConfig: TargetConfiguration = {
     continuous: true,
+    inputs: buildInputs(namedInputs),
     command: `vite`,
     options: {
       cwd: joinPathFragments(projectRoot),
@@ -434,10 +449,12 @@ function serveTarget(
 function previewTarget(
   projectRoot: string,
   buildTargetName: string,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  namedInputs: { [inputName: string]: any[] }
 ) {
   const targetConfig: TargetConfiguration = {
     continuous: true,
+    inputs: buildInputs(namedInputs),
     command: `vite preview`,
     dependsOn: [buildTargetName],
     options: {
@@ -462,10 +479,12 @@ function previewTarget(
 
 function serveStaticTarget(
   options: VitePluginOptions,
-  isUsingTsSolutionSetup: boolean
+  isUsingTsSolutionSetup: boolean,
+  namedInputs: { [inputName: string]: any[] }
 ) {
   const targetConfig: TargetConfiguration = {
     continuous: true,
+    inputs: buildInputs(namedInputs),
     executor: '@nx/web:file-server',
     options: {
       buildTarget: `${options.buildTargetName}`,

--- a/packages/webpack/src/plugins/plugin.spec.ts
+++ b/packages/webpack/src/plugins/plugin.spec.ts
@@ -156,6 +156,23 @@ describe('@nx/webpack/plugin', () => {
                   "my-serve": {
                     "command": "webpack-cli serve",
                     "continuous": true,
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "webpack-cli",
+                        ],
+                      },
+                      {
+                        "fields": [
+                          "extends",
+                          "files",
+                          "include",
+                        ],
+                        "json": "{workspaceRoot}/tsconfig.json",
+                      },
+                    ],
                     "metadata": {
                       "description": "Starts Webpack dev server",
                       "help": {
@@ -183,6 +200,23 @@ describe('@nx/webpack/plugin', () => {
                   "preview-site": {
                     "command": "webpack-cli serve",
                     "continuous": true,
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "webpack-cli",
+                        ],
+                      },
+                      {
+                        "fields": [
+                          "extends",
+                          "files",
+                          "include",
+                        ],
+                        "json": "{workspaceRoot}/tsconfig.json",
+                      },
+                    ],
                     "metadata": {
                       "description": "Starts Webpack dev server in production mode",
                       "help": {
@@ -213,6 +247,23 @@ describe('@nx/webpack/plugin', () => {
                       "build-something",
                     ],
                     "executor": "@nx/web:file-server",
+                    "inputs": [
+                      "production",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "webpack-cli",
+                        ],
+                      },
+                      {
+                        "fields": [
+                          "extends",
+                          "files",
+                          "include",
+                        ],
+                        "json": "{workspaceRoot}/tsconfig.json",
+                      },
+                    ],
                     "options": {
                       "buildTarget": "build-something",
                       "port": 9000,

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -198,6 +198,16 @@ async function createWebpackTargets(
 
   const targets: Record<string, TargetConfiguration> = {};
 
+  const buildInputs: TargetConfiguration['inputs'] = [
+    ...('production' in namedInputs
+      ? ['production', '^production']
+      : ['default', '^default']),
+    {
+      externalDependencies: ['webpack-cli'],
+    },
+    TS_SOLUTION_SETUP_TSCONFIG_INPUT,
+  ];
+
   targets[options.buildTargetName] = {
     command: `webpack-cli build`,
     options: { cwd: projectRoot, env: { NODE_ENV: 'production' } },
@@ -209,13 +219,7 @@ async function createWebpackTargets(
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
     inputs: [
-      ...('production' in namedInputs
-        ? ['production', '^production']
-        : ['default', '^default']),
-      {
-        externalDependencies: ['webpack-cli'],
-      },
-      TS_SOLUTION_SETUP_TSCONFIG_INPUT,
+      ...buildInputs,
       // The build can emit a pruned pnpm deploy output (NxAppWebpackPlugin
       // with generatePackageJson), whose install settings come from these
       // otherwise-unhashed root sources.
@@ -243,6 +247,7 @@ async function createWebpackTargets(
 
   targets[options.serveTargetName] = {
     continuous: true,
+    inputs: [...buildInputs],
     command: `webpack-cli serve`,
     options: {
       cwd: projectRoot,
@@ -264,6 +269,7 @@ async function createWebpackTargets(
 
   targets[options.previewTargetName] = {
     continuous: true,
+    inputs: [...buildInputs],
     command: `webpack-cli serve`,
     options: {
       cwd: projectRoot,
@@ -285,6 +291,7 @@ async function createWebpackTargets(
 
   targets[options.serveStaticTargetName] = {
     continuous: true,
+    inputs: [...buildInputs],
     dependsOn: [options.buildTargetName],
     executor: '@nx/web:file-server',
     options: {

--- a/project.json
+++ b/project.json
@@ -4,6 +4,10 @@
   "targets": {
     "local-registry": {
       "executor": "@nx/js:verdaccio",
+      "inputs": [
+        "{workspaceRoot}/.verdaccio/**/*",
+        { "externalDependencies": ["verdaccio"] }
+      ],
       "options": {
         "port": 4873,
         "config": ".verdaccio/config.yml",
@@ -13,6 +17,10 @@
     },
     "local-registry-e2e": {
       "executor": "@nx/js:verdaccio",
+      "inputs": [
+        "{workspaceRoot}/.verdaccio/**/*",
+        { "externalDependencies": ["verdaccio"] }
+      ],
       "options": {
         "port": 4873,
         "config": ".verdaccio/config.yml",


### PR DESCRIPTION
> Based on `master`. #36841 was rebase-merged into this branch, so it now carries both the locator port and task selection. The 33 commits up to `refactor(core): split the affected locators into one file each` are the port; the rest are selection.

[NXC-4859](https://linear.app/nxdev/issue/NXC-4859/task-level-nx-affected-backed-by-io-snapshots).

## Current Behavior

`nx affected` selects projects, so every target of every dependent runs whether or not the change can reach it. Changing one spec file in `packages/nx` selects all 45 `test` tasks here, including projects whose test inputs never see that file.

Two target configs also create a dependency the project graph never records:

```jsonc
{
  "inputs": [{ "input": "production", "projects": ["shared-config"] }],
  "dependsOn": [{ "projects": ["api"], "target": "build" }],
}
```

`gather_project_inputs` inlines the named project's filesets into the consumer's plan, and `processTasksForMultipleProjects` builds a task edge to it. Neither needs a project-graph edge, so the reverse walk misses both, and a change to a project referenced only this way selects nothing.

The locators themselves run in TypeScript and re-run `minimatch` per (pattern, file) pair, recompiling the pattern each call, so their cost grows with changeset size times the number of distinct `{workspaceRoot}` filesets.

## Expected Behavior

With `NX_LEGACY_AFFECTED=false`, `nx affected` selects tasks whose inputs the change reaches. We build the full task graph for the requested targets, as `run-many` does, resolve each task's hash plan, and match the changed paths against each instruction's globs. One native call does the matching, resolves which producer's outputs each task reads, and walks that from producer to consumer.

There is no project-grained pass in front of it. That bound rested on declared ownership, and once I/O snapshots land a task's observed reads can name a file no project the reverse walk finds would own, so bounding by it would miss the task. The two target-config shapes above come along for free, since the referenced project's filesets are in the consumer's plan.

A lockfile or dependency change reaches a hash as a package name rather than a path, so the JS locators' diff of it is matched the same way: each plan's `External` instructions against the packages that moved, and `AllExternalDependencies` against any. `projectsAffectedByDependencyUpdates: "all"`, the default, counts every package as moved, which selects every task that hashes externals rather than every task; a target with `externalDependencies: []` is left alone. Only the projects the option names outright are still seeded as whole projects.

This is opt-in. `NX_LEGACY_AFFECTED=false` turns it on; the default stays project selection while the task path settles. The variable keeps its meaning and flips its default rather than being replaced by a new one, so a workspace that already pinned it to `true` still gets whole projects, and flipping the default later leaves both values valid and no pinned script changing meaning. Env var rather than a flag, because a CI script that builds a list with `nx show projects --affected -t build` and then runs `nx affected -t build` needs both commands to agree.

### Selection

Changing one spec file in `packages/nx`:

| command                | legacy | this PR |
| ---------------------- | ------ | ------- |
| `-t test`, test tasks  | 45     | 4       |
| `-t test`, whole graph | 207    | 160     |

The first row is the win. The rest of each graph is the dependency closure of the selected tasks, which has to stay so the selected ones can run; those restore from cache. `lint` reads nearly every file in a project, so a graph dominated by `lint` narrows very little.

### `show projects --with-target` follows the granularity

With a target in hand, `show projects --affected --with-target test` answered "which affected projects define test", not "which projects have an affected test task". The two commands are meant to be chained, so they now answer the same thing:

```
nx show projects --affected -t test    ->  4
nx affected -t test                     ->  tasks for those same 4
```

Only with a target, and not with `--projects`, which is a name filter rather than a target question.

### The locators move to Rust

`getTouchedProjects`, `getImplicitlyTouchedProjects` and `getTouchedProjectsFromProjectGlobChanges` are pure path and glob matching and become a native `locateTouchedProjects`, one file each under `native/affected`. Same results, same locator order, same duplicate-emitting contract. The lockfile, npm-package and tsconfig locators stay in TypeScript, since they depend on the lockfile parsers, and cross the boundary as `ThreadsafeFunction` callbacks invoked once per run. Graph pruning stays in TypeScript too: the native `ProjectGraph` has no edge `type` or `source`, so it cannot rebuild what `filterAffected` returns.

Also deletes `workspace-json-changes.ts`, whose `angular.json` locator was already unregistered.

Routing `{workspaceRoot}` filesets through `build_glob_set` instead of minimatch changes a few things. Two narrow, and both are shapes the hasher already rejects, so no task hashing them ever ran:

| fileset                            | changed file       | base    | this branch             |
| ---------------------------------- | ------------------ | ------- | ----------------------- |
| `{workspaceRoot}/config/*.!(tmp)`  | `config/x.json`    | matched | no match                |
| `{workspaceRoot}/config/[dev.json` | `config/[dev.json` | matched | ignored, with a warning |

The rest are corrections:

- `{workspaceRoot}/!(dist)/**` matched _every_ file under minimatch; here it is a real extglob.
- `{workspaceRoot}/config/` now matches `config/app.json`, and `{workspaceRoot}/some-dir/` becomes `some-dir/**`.
- The "all projects" answer and the implicit-fileset hits come back sorted, so `nx show projects --affected` stops reordering between runs.
- A fileset named `{workspaceRoot}/__proto__` or `constructor` is no longer dropped by the old `implicits[input] ??= []`.
- A self-referencing named input terminates instead of overflowing the stack.
- One plugin's `createNodes` glob failing to parse no longer switches deletion detection off for every plugin.

### Cost

Planning every task of the targets is the price of dropping the bound. It runs once per invocation, about 3ms per task here, and the hasher narrows those plans to the survivors rather than planning again. Matching is bounded by the change rather than the workspace: the changed files are indexed by owning project once, so an instruction scoped to a project the change never touched is answered without compiling its globs. On a synthetic pool of 10k projects with three filesets each, a one-file change matches in 4ms. Task hashes are unchanged: this branch, master and the published nx all hit the same cache entries.

The locators on a synthetic 3000-project graph with many distinct filesets, min of 11:

| changed files | before   | after       |
| ------------- | -------- | ----------- |
| 10            | 373 ms   | **65 ms**   |
| 1000          | 12824 ms | **1239 ms** |

With few, shared filesets a one-file change goes from 9 ms to 40 ms, the fixed cost of marshalling the graph natively. That marshal is memoized per graph identity and shared with the task hasher through the planning context, so a run pays it once.

## Related Issue(s)

NXC-4859

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/task-based-affected-graph-f381a984">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->