### PR TITLE
chore(repo): enable incremental compilation for local release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_CLOUD_ENABLE_METRICS_COLLECTION: 'true'
   PNPM_HOME: ~/.pnpm
+  # See the root Cargo.toml: the release profile is incremental for local dev.
+  # CI builds cold, so incremental only inflates the cargo cache.
+  # Note this does NOT reach Nx Agents - see .nx/workflows/agents.yaml.
+  CARGO_INCREMENTAL: '0'
   # Pin corepack to the pnpm version from packageManager. Without this, corepack
   # falls back to "latest" in directories that have no packageManager field
   # (e.g. e2e temp dirs) instead of the repo's pinned pnpm.

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -13,6 +13,9 @@ on:
 
 env:
   CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cypress
+  # See the root Cargo.toml: the release profile is incremental for local dev.
+  # CI builds cold, so incremental only inflates the cargo cache.
+  CARGO_INCREMENTAL: '0'
   # Pin corepack to the pnpm version from packageManager. Without this, corepack
   # falls back to "latest" in directories that have no packageManager field
   # (e.g. e2e temp dirs) instead of the repo's pinned pnpm.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,11 @@ run-name: ${{ github.event.inputs.pr && format('PR Release for {0}', github.even
 
 env:
   DEBUG: napi:*
+  # Published binaries must never be built incrementally: the root Cargo.toml
+  # turns incremental on for the release profile so local rebuilds are fast, and
+  # incremental partitioning changes codegen. This must reach every build below,
+  # including the docker and FreeBSD ones, which forward env explicitly.
+  CARGO_INCREMENTAL: '0'
   NX_RUN_GROUP: ${{ github.run_id }}-${{ github.run_attempt }}
   CYPRESS_INSTALL_BINARY: 0
   NODE_VERSION: 26.7.0
@@ -396,6 +401,7 @@ jobs:
             -e PNPM_VERSION \
             -e NX_GRADLE_PROJECT_GRAPH_TIMEOUT \
             -e NX_VERBOSE_LOGGING \
+            -e CARGO_INCREMENTAL \
             -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db \
             -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache \
             -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index \
@@ -449,6 +455,7 @@ jobs:
         env:
           DEBUG: napi:*
           RUSTUP_IO_THREADS: 1
+          CARGO_INCREMENTAL: '0'
           PLAYWRIGHT_BROWSERS_PATH: 0
           NODE_VERSION: 26.7.0
           NX_GRADLE_DISABLE: 'true'
@@ -458,7 +465,7 @@ jobs:
           operating_system: freebsd
           version: '14.0'
           architecture: x86-64
-          environment_variables: DEBUG RUSTUP_IO_THREADS CI PLAYWRIGHT_BROWSERS_PATH NODE_VERSION NX_GRADLE_DISABLE NX_DOTNET_DISABLE NODE_OPTIONS
+          environment_variables: DEBUG RUSTUP_IO_THREADS CARGO_INCREMENTAL CI PLAYWRIGHT_BROWSERS_PATH NODE_VERSION NX_GRADLE_DISABLE NX_DOTNET_DISABLE NODE_OPTIONS
           shell: bash
           run: |
             env

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -5,6 +5,10 @@ common-env-vars: &common-env-vars
   GIT_COMMITTER_NAME: Test
   SELECTED_PM: 'pnpm'
   NX_NATIVE_LOGGING: 'nx::native::db'
+  # The release profile enables incremental compilation for local dev (see the
+  # root Cargo.toml). Agents build each task once from a cold cache, so
+  # incremental buys nothing here and only inflates the cargo cache.
+  CARGO_INCREMENTAL: '0'
   # Pin corepack to the pnpm version from packageManager. Without this, corepack
   # falls back to "latest" in directories that have no packageManager field
   # (e.g. e2e temp dirs created by create-nx-workspace) instead of the repo's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ members = ['packages/nx']
 
 [profile.release]
 lto = true
+# Rebuilding after a one-line Rust change drops from ~21s to ~4.5s. CI opts out
+# via CARGO_INCREMENTAL=0 (.nx/workflows/agents.yaml and the GitHub workflows) so
+# published binaries are never built incrementally.
+incremental = true


### PR DESCRIPTION
## Current Behavior

Rebuilding the native module after a one-line Rust change takes **~21s**.

`build-native` builds with `release: true`, and cargo's release profile leaves incremental compilation off by default. rustc's compilation unit is the *crate*, and `packages/nx` is a single 54,213-line crate — so touching one file recompiles all of it, every time. Editing a 91-line file costs exactly as much as editing the 29,830-line `tui` module.

## Expected Behavior

The same rebuild takes **~4.5s**. CI and published binaries are unchanged.

### Build time

Measured on a clean `origin/master` worktree, 24-core Linux, rustc 1.95.0. Three consecutive **real code edits** (a unique `fn` appended to `packages/nx/src/native/tui/mod.rs`):

| | edit 1 | edit 2 | edit 3 | median |
| --- | --- | --- | --- | --- |
| incremental off (today) | 18.77s | 21.09s | 22.20s | **21.09s** |
| incremental on | 5.55s | 4.55s | 4.48s | **4.55s** |

**4.6× faster.** Cold builds are unaffected (~85s either way; the critical path there is `libsqlite3-sys` compiling the bundled SQLite amalgamation, not Rust).

> Benchmarking note: `touch` is **not** a valid edit here. rustc's incremental cache hashes source *content*, so a touched-but-unchanged file replays straight from cache and reports a fake ~4s regardless. Every number above comes from real content changes.

### Runtime performance of the produced `.node`

Incremental compilation changes codegen-unit partitioning and can inhibit cross-CGU inlining, so the obvious worry is a slower binary — and this binary is the nx CLI's hot path. Measured it rather than assuming.

Both `.node` files were loaded **directly by absolute path**, bypassing nx's size-keyed native-file-cache (the two builds differ by only 0.7% in size, so that cache would happily have served a stale binary). Baseline and incremental alternate across 5 rounds each so machine drift hits both equally.

| path | Δ best-min | Δ median-p50 |
| --- | --- | --- |
| `hashArray` — pure CPU (xxhash), no I/O | +1.6% | +0.8% |
| `findImports` — swc TypeScript parsing, 1,030 files | −3.6% | −0.5% |
| `WorkspaceContext` walk + hash of the whole repo | −3.8% | +2.7% |

**No measurable regression.** The signs are inconsistent and the magnitudes sit inside run-to-run noise — two of the three paths came out *faster* on best-min. Artifact size grows 0.7% (25,041,056 → 25,218,792 bytes).

## Why CI opts out in four places

`CARGO_INCREMENTAL=0` overrides the profile setting, verified in this repo (`-C incremental` present locally, absent under the env var). CI opts out because cold builds gain nothing from incremental, it adds **~390 MB** to the cargo cache, and published binaries should not be built with different codegen than they are today.

Four sites are required because env does not cross these boundaries on its own:

| File | Why it is needed separately |
| --- | --- |
| `.nx/workflows/agents.yaml` | **Most CI cargo work runs on Nx Agents**, which take env only from the `common-env-vars` anchor. Nothing in `ci.yml` reaches these machines. Verified the anchor resolves into both `linux-large` and `linux-extra-large`. |
| `.github/workflows/ci.yml` | Non-distributed tasks that run on the GitHub runner, plus `main-macos`. |
| `.github/workflows/e2e-matrix.yml` | Nightly e2e builds every public package, which pulls in `build-native`. |
| `.github/workflows/publish.yml` | Builds the **published** binaries. Needs three edits: the workflow `env:`, `-e CARGO_INCREMENTAL` on the `docker run` (it forwards only explicit `-e` flags), and both the FreeBSD step `env:` and its `environment_variables:` allowlist (the VM needs both). |

The failure mode if a site is missed is silent — that build just becomes incremental — which is why `publish.yml`'s container and VM boundaries are called out explicitly.

## Related finding, deliberately not changed here

While measuring this I found that **`lto = true` in this same profile has never actually taken effect.** rustc receives no `-C lto`: `packages/nx` declares `crate-type = ['cdylib', 'rlib']`, and rustc skips LTO when an rlib shares the unit, since rlibs must retain their bitcode for downstream consumers. Confirmed three ways — the verbose rustc invocation, identical rebuild times across `lto` fat/thin/off, and near-identical artifact sizes.

So the published `.node` is not LTO-optimized today. Fixing that means dropping `rlib` from the release crate-type, which trades build time for runtime performance in the opposite direction from this PR. Left alone deliberately; worth its own change.

## Related Issue(s)

N/A — internal build-time improvement.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Enable-cargo-incremental-for-local-nx-native-builds-5085c67c">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->