### PR TITLE
fix(bundling): resolve esbuild paths from workspace root instead of cwd

### DIFF
--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -1,13 +1,7 @@
 import * as pc from 'picocolors';
 import type { ExecutorContext } from '@nx/devkit';
 import { createAsyncIterable } from '@nx/devkit/internal';
-import {
-  cacheDir,
-  joinPathFragments,
-  logger,
-  stripIndents,
-  writeJsonFile,
-} from '@nx/devkit';
+import { cacheDir, logger, stripIndents, writeJsonFile } from '@nx/devkit';
 import {
   copyAssets,
   copyPackageJson,
@@ -30,7 +24,7 @@ import {
 } from './lib/build-esbuild-options';
 import { getExtraDependencies } from './lib/get-extra-dependencies';
 import { DependentBuildableProjectNode } from '@nx/js/internal';
-import { rmSync } from 'node:fs';
+import { deleteOutputDir } from '../../utils/fs';
 import { join, relative } from 'path';
 
 const BUILD_WATCH_FAILED = `[ ${pc.red(
@@ -53,7 +47,7 @@ export async function* esbuildExecutor(
 
   const options = await normalizeOptions(_options, context);
   if (options.deleteOutputPath)
-    rmSync(options.outputPath, { recursive: true, force: true });
+    deleteOutputDir(context.root, options.outputPath);
 
   const assetsResult = await copyAssets(options, context);
 
@@ -215,7 +209,7 @@ export async function* esbuildExecutor(
             ? 'meta.json'
             : `meta.${options.format[i]}.json`;
         writeJsonFile(
-          joinPathFragments(options.outputPath, filename),
+          join(context.root, options.outputPath, filename),
           buildResult.metafile
         );
       }

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -59,13 +59,13 @@ describe('buildEsbuildOptions', () => {
       define: expect.objectContaining({
         'process.env.NODE_ENV': '"test"',
       }),
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'browser',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: [],
       outExtension: {
         '.js': '.js',
@@ -102,13 +102,13 @@ describe('buildEsbuildOptions', () => {
       define: expect.objectContaining({
         'process.env.NODE_ENV': '"test"',
       }),
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts', 'apps/myapp/src/extra-entry.ts'],
       format: 'esm',
       platform: 'browser',
       outdir: 'dist/apps/myapp',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: [],
       outExtension: {
         '.js': '.js',
@@ -144,13 +144,13 @@ describe('buildEsbuildOptions', () => {
       define: expect.objectContaining({
         'process.env.NODE_ENV': '"test"',
       }),
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'cjs',
       platform: 'browser',
       outfile: 'dist/apps/myapp/index.cjs',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: [],
       outExtension: {
         '.js': '.cjs',
@@ -183,13 +183,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: true,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'cjs',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.cjs',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: [],
       outExtension: {
         '.js': '.cjs',
@@ -226,13 +226,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: true,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.mjs',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: [],
       outExtension: {
         '.js': '.mjs',
@@ -267,13 +267,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: true,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'cjs',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: [],
       outExtension: {
         '.js': '.js',
@@ -309,13 +309,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: true,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: [],
       outExtension: {
         '.js': '.js',
@@ -350,13 +350,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: true,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: ['bar', 'foo'],
       outExtension: {
         '.js': '.js',
@@ -388,13 +388,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: false,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: undefined,
       outExtension: {
         '.js': '.js',
@@ -427,13 +427,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: true,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: ['foo', 'baz'],
       outExtension: {
         '.js': '.js',
@@ -468,13 +468,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: true,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outfile: 'dist/apps/myapp/index.js',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: ['bar', 'foo'],
       outExtension: {
         '.js': '.js',
@@ -508,13 +508,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: false,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: undefined,
       sourcemap: true,
       outExtension: {
@@ -547,13 +547,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: false,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: undefined,
       metafile: undefined,
       minify: undefined,
@@ -588,13 +588,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: false,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: undefined,
       sourcemap: true,
       metafile: undefined,
@@ -630,13 +630,13 @@ describe('buildEsbuildOptions', () => {
       )
     ).toEqual({
       bundle: false,
+      absWorkingDir: context.root,
       entryNames: '[dir]/[name]',
       entryPoints: ['apps/myapp/src/index.ts'],
       format: 'esm',
       platform: 'node',
       outdir: 'dist/apps/myapp',
-      tsconfig:
-        'src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json',
+      tsconfig: path.join(context.root, 'apps/myapp/tsconfig.app.json'),
       external: undefined,
       sourcemap: true,
       metafile: undefined,

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -13,7 +13,7 @@ import {
 import { getClientEnvironment } from '../../../utils/environment-variables';
 import { NormalizedEsBuildExecutorOptions } from '../schema';
 import { getEntryPoints } from '../../../utils/get-entry-points';
-import { join, relative } from 'path';
+import { join } from 'path';
 
 const ESM_FILE_EXTENSION = '.js';
 const CJS_FILE_EXTENSION = '.cjs';
@@ -35,6 +35,8 @@ export function buildEsbuildOptions(
 
   const esbuildOptions: esbuild.BuildOptions = {
     ...options.userDefinedBuildOptions,
+    // Nx-computed paths are workspace-root-relative, not cwd-relative.
+    absWorkingDir: context.root,
     entryNames:
       options.outputHashing === 'all' ? '[dir]/[name].[hash]' : '[dir]/[name]',
     bundle: options.bundle,
@@ -44,7 +46,7 @@ export function buildEsbuildOptions(
     platform: options.platform,
     target: options.target,
     metafile: options.metafile,
-    tsconfig: relative(process.cwd(), join(context.root, options.tsConfig)),
+    tsconfig: join(context.root, options.tsConfig),
     sourcemap:
       (options.sourcemap ?? options.userDefinedBuildOptions?.sourcemap) ||
       false,

--- a/packages/esbuild/src/utils/get-entry-points.spec.ts
+++ b/packages/esbuild/src/utils/get-entry-points.spec.ts
@@ -1,0 +1,67 @@
+import type { ExecutorContext } from '@nx/devkit';
+import { TempFs } from '@nx/devkit/internal-testing-utils';
+import * as path from 'path';
+import { getEntryPoints } from './get-entry-points';
+
+describe('getEntryPoints', () => {
+  let tempFs: TempFs;
+  let context: ExecutorContext;
+  const originalCwd = process.cwd();
+
+  beforeEach(async () => {
+    tempFs = new TempFs('get-entry-points');
+    await tempFs.createFiles({
+      'apps/myapp/tsconfig.app.json': JSON.stringify({
+        include: ['src/**/*.ts'],
+      }),
+      'apps/myapp/src/main.ts': '',
+      'apps/myapp/src/lib/util.ts': '',
+    });
+    context = {
+      root: tempFs.tempDir,
+      cwd: tempFs.tempDir,
+      isVerbose: false,
+      projectName: 'myapp',
+      nxJsonConfiguration: {},
+      projectsConfigurations: {
+        version: 2,
+        projects: {
+          myapp: { root: 'apps/myapp' },
+        },
+      },
+      projectGraph: {
+        nodes: {
+          myapp: {
+            type: 'app',
+            name: 'myapp',
+            data: { root: 'apps/myapp' },
+          },
+        },
+        dependencies: { myapp: [] },
+      },
+    };
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    tempFs.cleanup();
+  });
+
+  it('should find project files when cwd is the workspace root', () => {
+    process.chdir(tempFs.tempDir);
+
+    expect(getEntryPoints('myapp', context).sort()).toEqual([
+      path.join('apps/myapp', 'src/lib/util.ts'),
+      path.join('apps/myapp', 'src/main.ts'),
+    ]);
+  });
+
+  it('should find project files when cwd is a project subdirectory', () => {
+    process.chdir(path.join(tempFs.tempDir, 'apps/myapp'));
+
+    expect(getEntryPoints('myapp', context).sort()).toEqual([
+      path.join('apps/myapp', 'src/lib/util.ts'),
+      path.join('apps/myapp', 'src/main.ts'),
+    ]);
+  });
+});

--- a/packages/esbuild/src/utils/get-entry-points.ts
+++ b/packages/esbuild/src/utils/get-entry-points.ts
@@ -30,6 +30,9 @@ export function getEntryPoints(
     const project = context.projectGraph?.nodes[projectName];
     if (!project) return;
 
+    // Anchor to the workspace root so results do not depend on the invoking cwd.
+    const absProjectRoot = path.join(context.root, project.data.root);
+
     // Known files we generate from our generators. Only one of these should be used to build the project.
     const tsconfigCandidates = [
       'tsconfig.app.json',
@@ -39,7 +42,7 @@ export function getEntryPoints(
     if (tsConfigFileName) tsconfigCandidates.unshift(tsConfigFileName);
     const foundTsConfig = tsconfigCandidates.find((f) => {
       try {
-        return fs.statSync(path.join(project.data.root, f)).isFile();
+        return fs.statSync(path.join(absProjectRoot, f)).isFile();
       } catch {
         return false;
       }
@@ -47,11 +50,9 @@ export function getEntryPoints(
 
     // Workspace projects may not be a TS project, so skip reading source files if tsconfig is not found.
     if (foundTsConfig) {
-      const tsconfig = readJsonFile(
-        path.join(project.data.root, foundTsConfig)
-      );
+      const tsconfig = readJsonFile(path.join(absProjectRoot, foundTsConfig));
       const projectFiles = globSync(tsconfig.include ?? [], {
-        cwd: project.data.root,
+        cwd: absProjectRoot,
         ignore: tsconfig.exclude ?? [],
         expandDirectories: false,
       }).map((f) => path.join(project.data.root, f));


### PR DESCRIPTION
## Current Behavior

`@nx/esbuild:esbuild` fails when `nx` is invoked from a workspace subdirectory. Entry points, outputs and tsconfig are workspace-root-relative, but esbuild resolves them against `process.cwd()`. Output cleanup and the metafile write have the same cwd dependence.

## Expected Behavior

Builds work from any directory. esbuild runs with `absWorkingDir: context.root`, tsconfig is passed as an absolute path, and cleanup plus metafile output are anchored to the workspace root.

## Related Issue(s)

Fixes #34027
