### PR TITLE
fix(vitest): do not set projectType when inferring targets

### DIFF
--- a/packages/vitest/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vitest/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -8,7 +8,6 @@ exports[`@nx/vitest root project should create nodes 1`] = `
       "projects": {
         ".": {
           "metadata": {},
-          "projectType": "library",
           "root": ".",
           "targets": {
             "test": {
@@ -84,7 +83,6 @@ exports[`@nx/vitest root project should create nodes with ci target name 1`] = `
               ],
             },
           },
-          "projectType": "library",
           "root": ".",
           "targets": {
             "e2e-ci": {
@@ -308,7 +306,6 @@ exports[`@nx/vitest root project should create nodes with ci target name and ci 
               ],
             },
           },
-          "projectType": "library",
           "root": ".",
           "targets": {
             "e2e-ci": {

--- a/packages/vitest/src/plugins/plugin-vitest.spec.ts
+++ b/packages/vitest/src/plugins/plugin-vitest.spec.ts
@@ -135,6 +135,18 @@ describe('@nx/vitest', () => {
       expect(nodes).toMatchSnapshot();
     });
 
+    it('should not set projectType so it does not override the type from other plugins', async () => {
+      const nodes = await createNodesFunction(
+        ['vitest.config.ts'],
+        {
+          testTargetName: 'test',
+        },
+        context
+      );
+
+      expect(nodes[0][1].projects!['.'].projectType).toBeUndefined();
+    });
+
     it('should create nodes with ci target name', async () => {
       const nodes = await createNodesFunction(
         ['vitest.config.ts'],

--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -73,10 +73,7 @@ export interface VitestPluginOptions {
   discoverTestFiles?: 'glob' | 'vitest';
 }
 
-type VitestTargets = Pick<
-  ProjectConfiguration,
-  'targets' | 'metadata' | 'projectType'
->;
+type VitestTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
 /**
  * @deprecated The 'createDependencies' function is now a no-op. This functionality is included in 'createNodesV2'.
@@ -166,13 +163,12 @@ export const createNodes: CreateNodes<VitestPluginOptions> = [
           if (!cached) {
             return { projects: {} };
           }
-          const { projectType, metadata, targets } = cached;
+          const { metadata, targets } = cached;
 
           const project: ProjectConfiguration = {
             root: projectRoot,
             targets,
             metadata,
-            projectType,
           };
 
           return {
@@ -395,7 +391,7 @@ async function buildVitestTargets(
     }
   }
 
-  return { targets, metadata, projectType: 'library' };
+  return { targets, metadata };
 }
 
 async function testTarget(


### PR DESCRIPTION
## Current Behavior

`@nx/vitest/plugin` always returns `projectType: 'library'` for any project it infers a test target for. Plugin merge is last-wins, so applications with a vitest config get flipped to libraries, which breaks `@nx/enforce-module-boundaries` buildable-lib rules.

## Expected Behavior

The plugin only infers a test target, so it does not set `projectType`. Explicit config or the core heuristics decide, matching how `@nx/vite/plugin` behaves.

## Related Issue(s)

Fixes #33989
