### PR TITLE
fix(webpack): add development configuration to inferred build target

### DIFF
--- a/e2e/nx/src/__snapshots__/misc.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/misc.test.ts.snap
@@ -91,7 +91,7 @@ Options:
     {
       "NODE_ENV": "production"
     }
-Configurations: production
+Configurations: development, production
 
 "
 `;

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -51,23 +51,6 @@ describe('application generator', () => {
         "sourceRoot": "my-node-app/src",
         "tags": [],
         "targets": {
-          "build": {
-            "configurations": {
-              "development": {
-                "env": {
-                  "NODE_ENV": "development",
-                },
-              },
-            },
-            "executor": "nx:run-commands",
-            "options": {
-              "command": "webpack-cli build",
-              "cwd": "my-node-app",
-              "env": {
-                "NODE_ENV": "production",
-              },
-            },
-          },
           "copy-workspace-modules": {
             "cache": true,
             "dependsOn": [
@@ -422,23 +405,6 @@ describe('application generator', () => {
           "name": "@proj/myapp",
           "nx": {
             "targets": {
-              "build": {
-                "configurations": {
-                  "development": {
-                    "env": {
-                      "NODE_ENV": "development",
-                    },
-                  },
-                },
-                "executor": "nx:run-commands",
-                "options": {
-                  "command": "webpack-cli build",
-                  "cwd": "myapp",
-                  "env": {
-                    "NODE_ENV": "production",
-                  },
-                },
-              },
               "copy-workspace-modules": {
                 "cache": true,
                 "dependsOn": [
@@ -628,23 +594,6 @@ describe('application generator', () => {
           "sourceRoot": "myapp/src",
           "tags": [],
           "targets": {
-            "build": {
-              "configurations": {
-                "development": {
-                  "env": {
-                    "NODE_ENV": "development",
-                  },
-                },
-              },
-              "executor": "nx:run-commands",
-              "options": {
-                "command": "webpack-cli build",
-                "cwd": "myapp",
-                "env": {
-                  "NODE_ENV": "production",
-                },
-              },
-            },
             "copy-workspace-modules": {
               "cache": true,
               "dependsOn": [

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1254,7 +1254,7 @@ describe('app', () => {
   });
 
   describe('Nest.js with webpack bundler', () => {
-    it('should generate correct build target configuration with webpack-cli args', async () => {
+    it('should not write an explicit build target since the inferred one handles NODE_ENV', async () => {
       await applicationGenerator(tree, {
         directory: 'my-nest-app',
         bundler: 'webpack',
@@ -1263,15 +1263,7 @@ describe('app', () => {
       });
 
       const project = readProjectConfiguration(tree, 'my-nest-app');
-      const buildTarget = project.targets.build;
-
-      expect(buildTarget.executor).toBe('nx:run-commands');
-      expect(buildTarget.options.command).toBe('webpack-cli build');
-      expect(buildTarget.options.env).toEqual({ NODE_ENV: 'production' });
-      expect(buildTarget.options.cwd).toEqual(project.root);
-      expect(buildTarget.configurations.development.env).toEqual({
-        NODE_ENV: 'development',
-      });
+      expect(project.targets.build).toBeUndefined();
     });
   });
 

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -19,7 +19,6 @@ import { hasWebpackPlugin } from '../../../utils/has-webpack-plugin';
 import { NormalizedSchema } from './normalized-schema';
 import {
   getEsBuildConfig,
-  getNestWebpackBuildConfig,
   getServeConfig,
   getWebpackBuildConfig,
   getPruneTargets,
@@ -59,10 +58,6 @@ export function addProject(
       ]);
       project.targets.build = getWebpackBuildConfig(tree, project, options);
       ensurePnpmDeployInputs(tree, options, project.targets.build);
-    } else if (options.isNest) {
-      // If we are using Nest that has the webpack plugin we need to override the
-      // build target so that NODE_ENV can be set to production or development so the serve target can be run in development mode
-      project.targets.build = getNestWebpackBuildConfig(project);
     }
   }
   project.targets = {

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -117,24 +117,6 @@ export function getServeConfig(options: NormalizedSchema): TargetConfiguration {
   };
 }
 
-export function getNestWebpackBuildConfig(
-  project: ProjectConfiguration
-): TargetConfiguration {
-  return {
-    executor: 'nx:run-commands',
-    options: {
-      command: 'webpack-cli build',
-      env: { NODE_ENV: 'production' },
-      cwd: project.root,
-    },
-    configurations: {
-      development: {
-        env: { NODE_ENV: 'development' },
-      },
-    },
-  };
-}
-
 export function getPruneTargets(
   buildTarget: string,
   outputPath: string

--- a/packages/rspack/src/generators/convert-webpack/convert-webpack.ts
+++ b/packages/rspack/src/generators/convert-webpack/convert-webpack.ts
@@ -105,6 +105,21 @@ export default async function (tree: Tree, options: Schema) {
     webpackConfigsWithHelpersToConvert.length === 0 &&
     webpackConfigsWithPluginsToConvert.length === 0
   ) {
+    // Projects built by the inferred @nx/webpack/plugin target have no
+    // explicit webpack target to match, only a config file.
+    const webpackConfigPath = findWebpackConfigPath(tree, project.root);
+    if (webpackConfigPath) {
+      webpackConfigsWithPluginsToConvert.push([
+        webpackConfigPath,
+        webpackConfigPath.replace(/webpack(?!.*webpack)/, 'rspack'),
+      ]);
+    }
+  }
+
+  if (
+    webpackConfigsWithHelpersToConvert.length === 0 &&
+    webpackConfigsWithPluginsToConvert.length === 0
+  ) {
     console.error(
       `Project '${options.project}' does not have any webpack targets to convert.`
     );

--- a/packages/rspack/src/plugins/plugin.spec.ts
+++ b/packages/rspack/src/plugins/plugin.spec.ts
@@ -79,6 +79,13 @@ describe('@nx/rspack', () => {
                   "build": {
                     "cache": true,
                     "command": "rspack build",
+                    "configurations": {
+                      "development": {
+                        "args": [
+                          "--node-env=development",
+                        ],
+                      },
+                    },
                     "dependsOn": [
                       "^build",
                     ],

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -211,6 +211,11 @@ async function createRspackTargets(
       args: ['--node-env=production'],
       env,
     },
+    configurations: {
+      development: {
+        args: ['--node-env=development'],
+      },
+    },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
     inputs: [

--- a/packages/webpack/src/plugins/plugin.spec.ts
+++ b/packages/webpack/src/plugins/plugin.spec.ts
@@ -99,6 +99,13 @@ describe('@nx/webpack/plugin', () => {
                   "build-something": {
                     "cache": true,
                     "command": "webpack-cli build",
+                    "configurations": {
+                      "development": {
+                        "env": {
+                          "NODE_ENV": "development",
+                        },
+                      },
+                    },
                     "dependsOn": [
                       "^build-something",
                     ],

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -201,6 +201,11 @@ async function createWebpackTargets(
   targets[options.buildTargetName] = {
     command: `webpack-cli build`,
     options: { cwd: projectRoot, env: { NODE_ENV: 'production' } },
+    configurations: {
+      development: {
+        env: { NODE_ENV: 'development' },
+      },
+    },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
     inputs: [


### PR DESCRIPTION
## Current Behavior

The inferred `build` target from `@nx/webpack/plugin` hardcodes `NODE_ENV=production` and has no configurations. The generated node/express serve target already points at `build:development`, so that configuration exists in name only and the build still runs in production mode.

## Expected Behavior

The inferred build target defines the `development` configuration the serve target already references, with `NODE_ENV=development`. No new configuration is introduced.

## Related Issue(s)

Fixes #33004
