### PR TITLE
fix(nextjs): respect the src option when setting sourceRoot in the application generator

### DIFF
--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -175,7 +175,7 @@ export default defineConfig({
         `generate @nx/next:app apps/${appName} --e2eTestRunner=none --no-interactive `
       );
       runCLI(
-        `generate @nx/next:component apps/${appName}/components/btn --no-interactive`
+        `generate @nx/next:component apps/${appName}/src/components/btn --no-interactive`
       );
 
       runCLI(

--- a/packages/js/src/utils/swc/compile-swc.spec.ts
+++ b/packages/js/src/utils/swc/compile-swc.spec.ts
@@ -1,0 +1,44 @@
+import { NormalizedSwcExecutorOptions } from '../schema';
+import { getSwcCmd } from './compile-swc';
+
+describe('getSwcCmd', () => {
+  const baseOptions = {
+    swcCliOptions: {
+      swcrcPath: 'apps/demo/.swcrc',
+      destPath: '../../dist/apps/demo',
+      stripLeadingPaths: false,
+    },
+    root: '/root',
+    projectRoot: 'apps/demo',
+  } as NormalizedSwcExecutorOptions;
+
+  it('should compile from sourceRoot when the main entry is inside it', () => {
+    const cmd = getSwcCmd({
+      ...baseOptions,
+      sourceRoot: 'apps/demo/src',
+      main: 'apps/demo/src/index.ts',
+    });
+
+    expect(cmd).toContain(' src -d ');
+  });
+
+  it('should compile from the project root when the main entry is outside sourceRoot', () => {
+    const cmd = getSwcCmd({
+      ...baseOptions,
+      sourceRoot: 'apps/demo/src',
+      main: 'apps/demo/server/main.ts',
+    });
+
+    expect(cmd).toContain(' . -d ');
+  });
+
+  it('should compile from the project root when sourceRoot is the project root', () => {
+    const cmd = getSwcCmd({
+      ...baseOptions,
+      sourceRoot: 'apps/demo',
+      main: 'apps/demo/server/main.ts',
+    });
+
+    expect(cmd).toContain(' . -d ');
+  });
+});

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -8,12 +8,13 @@ import { printDiagnostics } from '../typescript/print-diagnostics';
 import { runTypeCheck, TypeCheckOptions } from '../typescript/run-type-check';
 import { relative } from 'path';
 
-function getSwcCmd(
+export function getSwcCmd(
   {
     swcCliOptions: { swcrcPath, destPath, stripLeadingPaths },
     root,
     projectRoot,
     sourceRoot,
+    main,
   }: NormalizedSwcExecutorOptions,
   watch = false
 ) {
@@ -21,7 +22,11 @@ function getSwcCmd(
   let inputDir: string;
 
   if (sourceRoot) {
-    inputDir = relative(projectRoot, sourceRoot);
+    // A main entry outside sourceRoot (e.g. Next.js custom server at <projectRoot>/server)
+    // is only emitted when compiling from the project root.
+    inputDir = relative(sourceRoot, main).startsWith('..')
+      ? '.'
+      : relative(projectRoot, sourceRoot);
   } else {
     // If sourceRoot is not provided, check if `src` exists and use that instead.
     // This is important for root projects to avoid compiling too many directories.

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -175,9 +175,23 @@ describe('app', () => {
       });
 
       expect(readProjectConfiguration(tree, name).root).toEqual(name);
+      expect(readProjectConfiguration(tree, name).sourceRoot).toEqual(
+        `${name}/src`
+      );
       expect(readProjectConfiguration(tree, `${name}-e2e`).root).toEqual(
         `${name}-e2e`
       );
+    });
+
+    it('should set sourceRoot to the project root when --src=false', async () => {
+      const name = uniq();
+      await applicationGenerator(tree, {
+        directory: name,
+        style: 'css',
+        src: false,
+      });
+
+      expect(readProjectConfiguration(tree, name).sourceRoot).toEqual(name);
     });
 
     it('should generate an unstyled component page', async () => {
@@ -892,7 +906,7 @@ describe('app', () => {
         `);
       const packageJson = readJson(tree, 'myapp/package.json');
       expect(packageJson.name).toBe('@proj/myapp');
-      expect(packageJson.nx).toBeUndefined();
+      expect(packageJson.nx).toEqual({ sourceRoot: 'myapp/src' });
       // Make sure keys are in idiomatic order
       expect(Object.keys(packageJson)).toMatchInlineSnapshot(`
           [
@@ -900,6 +914,7 @@ describe('app', () => {
             "version",
             "private",
             "dependencies",
+            "nx",
           ]
         `);
       expect(readJson(tree, 'myapp/tsconfig.json')).toMatchInlineSnapshot(`
@@ -1049,6 +1064,7 @@ describe('app', () => {
       const packageJson = readJson(tree, 'myapp/package.json');
       expect(packageJson.name).toBe('@proj/myapp');
       expect(packageJson.nx.name).toBe('myapp');
+      expect(packageJson.nx.sourceRoot).toBe('myapp/src');
       // Make sure keys are in idiomatic order
       expect(Object.keys(packageJson)).toMatchInlineSnapshot(`
         [
@@ -1082,7 +1098,7 @@ describe('app', () => {
           "name": "@proj/myapp",
           "projectType": "application",
           "root": "myapp",
-          "sourceRoot": "myapp",
+          "sourceRoot": "myapp/src",
           "tags": [],
           "targets": {},
         }
@@ -1105,6 +1121,64 @@ describe('app', () => {
         }
       `);
       expect(readJson(tree, 'myapp-e2e/package.json').nx).toBeUndefined();
+    });
+
+    it('should set sourceRoot in project.json to the project root when --src=false', async () => {
+      await applicationGenerator(tree, {
+        directory: 'myapp',
+        appDir: true,
+        unitTestRunner: 'jest',
+        style: 'css',
+        e2eTestRunner: 'none',
+        addPlugin: true,
+        useProjectJson: true,
+        src: false,
+        skipFormat: true,
+      });
+
+      expect(readProjectConfiguration(tree, '@proj/myapp').sourceRoot).toBe(
+        'myapp'
+      );
+      expect(tree.exists('myapp/app/page.tsx')).toBeTruthy();
+      expect(tree.exists('myapp/src/app/page.tsx')).toBeFalsy();
+    });
+
+    it('should set sourceRoot in package.json to the src directory by default', async () => {
+      await applicationGenerator(tree, {
+        directory: 'myapp',
+        appDir: true,
+        unitTestRunner: 'jest',
+        style: 'css',
+        e2eTestRunner: 'none',
+        addPlugin: true,
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      expect(readJson(tree, 'myapp/package.json').nx).toEqual({
+        sourceRoot: 'myapp/src',
+      });
+      expect(tree.exists('myapp/src/app/page.tsx')).toBeTruthy();
+    });
+
+    it('should set sourceRoot in package.json to the project root when --src=false', async () => {
+      await applicationGenerator(tree, {
+        directory: 'myapp',
+        appDir: true,
+        unitTestRunner: 'jest',
+        style: 'css',
+        e2eTestRunner: 'none',
+        addPlugin: true,
+        useProjectJson: false,
+        src: false,
+        skipFormat: true,
+      });
+
+      expect(readJson(tree, 'myapp/package.json').nx).toEqual({
+        sourceRoot: 'myapp',
+      });
+      expect(tree.exists('myapp/app/page.tsx')).toBeTruthy();
+      expect(tree.exists('myapp/src/app/page.tsx')).toBeFalsy();
     });
 
     it('should ignore "out-tsc" from eslint', async () => {

--- a/packages/next/src/generators/application/lib/add-project.ts
+++ b/packages/next/src/generators/application/lib/add-project.ts
@@ -65,9 +65,13 @@ export function addProject(host: Tree, options: NormalizedSchema) {
     };
   }
 
+  const sourceRoot = options.src
+    ? joinPathFragments(options.appProjectRoot, 'src')
+    : options.appProjectRoot;
+
   const project: ProjectConfiguration = {
     root: options.appProjectRoot,
-    sourceRoot: options.appProjectRoot,
+    sourceRoot,
     projectType: 'application',
     targets,
     tags: options.parsedTags,
@@ -88,8 +92,9 @@ export function addProject(host: Tree, options: NormalizedSchema) {
     if (options.projectName !== options.importPath) {
       packageJson.nx = { name: options.projectName };
     }
+    packageJson.nx ??= {};
+    packageJson.nx.sourceRoot = sourceRoot;
     if (options.parsedTags?.length) {
-      packageJson.nx ??= {};
       packageJson.nx.tags = options.parsedTags;
     }
   } else {

--- a/packages/react/src/generators/stories/stories.nextjs.spec.ts
+++ b/packages/react/src/generators/stories/stories.nextjs.spec.ts
@@ -13,7 +13,7 @@ describe('nextjs:stories for applications', () => {
   beforeEach(async () => {
     tree = await createTestUIApp('test-ui-app');
     tree.write(
-      'test-ui-app/components/test.tsx',
+      'test-ui-app/src/components/test.tsx',
       `import './test.module.scss';
 
       export interface TestProps {
@@ -37,7 +37,7 @@ describe('nextjs:stories for applications', () => {
     });
 
     expect(
-      tree.exists('test-ui-app/components/test.stories.tsx')
+      tree.exists('test-ui-app/src/components/test.stories.tsx')
     ).toMatchSnapshot();
 
     const packageJson = JSON.parse(tree.read('package.json', 'utf-8'));
@@ -50,7 +50,7 @@ describe('nextjs:stories for applications', () => {
     });
 
     expect(
-      tree.exists('test-ui-app/components/test.stories.tsx')
+      tree.exists('test-ui-app/src/components/test.stories.tsx')
     ).toMatchSnapshot();
     const packageJson = JSON.parse(tree.read('package.json', 'utf-8'));
     expect(
@@ -67,10 +67,12 @@ describe('nextjs:stories for applications', () => {
   it('should ignore paths', async () => {
     await storiesGenerator(tree, {
       project: 'test-ui-app',
-      ignorePaths: ['test-ui-app/components/**'],
+      ignorePaths: ['test-ui-app/src/components/**'],
     });
 
-    expect(tree.exists('test-ui-app/components/test.stories.tsx')).toBeFalsy();
+    expect(
+      tree.exists('test-ui-app/src/components/test.stories.tsx')
+    ).toBeFalsy();
   });
 });
 

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
@@ -129,7 +129,7 @@ describe('monorepo generator', () => {
     await monorepoGenerator(tree, {});
 
     expect(readProjectConfiguration(tree, 'demo')).toMatchObject({
-      sourceRoot: 'apps/demo',
+      sourceRoot: 'apps/demo/src',
     });
     expect(tree.read('apps/demo/src/app/page.tsx', 'utf-8')).toContain('demo');
     expect(readProjectConfiguration(tree, 'util')).toMatchObject({


### PR DESCRIPTION
## Current Behavior

`@nx/next:application` sets `sourceRoot` to the project root even when `--src` places files under `src/`. Package.json-based (TS solution) projects get no `sourceRoot` at all.

## Expected Behavior

`sourceRoot` follows the `src` option for both project.json and package.json (`nx.sourceRoot`) project shapes.

## Related Issue(s)

Fixes #35181
Related #35183
