### PR TITLE
fix(expo): gate the sdk 54 jest migration on the jest config instead of package.json

### DIFF
--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -9,7 +9,10 @@ import {
   writeJson,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { expoApplicationGenerator } from './application';
+import {
+  expoApplicationGenerator,
+  expoApplicationGeneratorInternal,
+} from './application';
 
 describe('app', () => {
   let appTree: Tree;
@@ -576,6 +579,21 @@ describe('app', () => {
       `);
 
       expect(packageJson).toHaveProperty('dependencies.expo');
+    });
+
+    it('should default to package.json through the cli entry point', async () => {
+      // generators.json registers the internal entry, so this is what `nx g` runs
+      await expoApplicationGeneratorInternal(tree, {
+        directory: 'my-app',
+        linter: 'eslint',
+        e2eTestRunner: 'none',
+        unitTestRunner: 'none',
+        js: false,
+        skipFormat: true,
+      });
+
+      expect(tree.exists('my-app/project.json')).toBeFalsy();
+      expect(tree.exists('my-app/package.json')).toBeTruthy();
     });
 
     it('should generate project.json if useProjectJson is true', async () => {

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { hasPlugin as hasRollupPlugin } from '@nx/rollup/internal';
-import { expoLibraryGenerator } from './library';
+import { expoLibraryGenerator, expoLibraryGeneratorInternal } from './library';
 import { Schema } from './schema';
 
 describe('lib', () => {
@@ -755,6 +755,17 @@ describe('lib', () => {
       });
 
       expect(readJson(appTree, 'my-lib/package.json').nx).toBeUndefined();
+    });
+
+    it('should default to package.json through the cli entry point', async () => {
+      // generators.json registers the internal entry, so this is what `nx g` runs
+      await expoLibraryGeneratorInternal(appTree, {
+        ...defaultSchema,
+        strict: false,
+      });
+
+      expect(appTree.exists('my-lib/project.json')).toBeFalsy();
+      expect(appTree.exists('my-lib/package.json')).toBeTruthy();
     });
 
     it('should generate project.json if useProjectJson is true', async () => {

--- a/packages/expo/src/migrations/update-22-2-0/update-jest-for-expo-54.spec.ts
+++ b/packages/expo/src/migrations/update-22-2-0/update-jest-for-expo-54.spec.ts
@@ -487,4 +487,229 @@ module.exports = defaultResolver;`
     expect(testSetupContent).toContain('ImportMetaRegistry');
     expect(testSetupContent).toContain('structuredClone');
   });
+
+  it('should update expo libraries without a project-level package.json', async () => {
+    // formatter none: assert exactly what the migration wrote
+    tree = createTreeWithEmptyWorkspace({ formatter: 'none' });
+    addProjectConfiguration(tree, 'my-forms', {
+      root: 'libs/my-forms',
+      projectType: 'library',
+      targets: {
+        test: {
+          executor: '@nx/jest:jest',
+          options: {
+            jestConfig: 'libs/my-forms/jest.config.cts',
+          },
+        },
+      },
+    });
+
+    // no libs/my-forms/package.json: integrated-style @nx/expo:library
+    tree.write(
+      'libs/my-forms/jest.config.cts',
+      `module.exports = {
+  displayName: 'my-forms',
+  resolver: require.resolve('./jest.resolver.js'),
+  preset: 'jest-expo',
+  moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../coverage/libs/my-forms',
+};`
+    );
+
+    tree.write(
+      'libs/my-forms/jest.resolver.js',
+      `const defaultResolver = require('@nx/jest/plugins/resolver');
+module.exports = defaultResolver;`
+    );
+
+    tree.write('libs/my-forms/src/test-setup.ts', '');
+
+    tree.write(
+      'libs/my-forms/tsconfig.lib.json',
+      JSON.stringify({
+        compilerOptions: {},
+        exclude: ['jest.config.ts', 'jest.resolver.js', 'src/**/*.spec.ts'],
+      })
+    );
+
+    tree.write(
+      'libs/my-forms/tsconfig.spec.json',
+      JSON.stringify({
+        compilerOptions: {},
+        include: ['jest.config.ts', 'jest.resolver.js', 'src/**/*.spec.ts'],
+      })
+    );
+
+    await updateJestForExpo54(tree);
+
+    expect(tree.exists('libs/my-forms/jest.resolver.js')).toBe(false);
+
+    const updatedConfig = tree.read('libs/my-forms/jest.config.cts', 'utf-8');
+    // '  ' is the indent left behind where the resolver property was removed
+    expect(updatedConfig).toBe(
+      [
+        'module.exports = {',
+        "  displayName: 'my-forms',",
+        '  ',
+        "  preset: 'jest-expo',",
+        "  moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],",
+        "  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],",
+        "  coverageDirectory: '../../coverage/libs/my-forms',",
+        '};',
+      ].join('\n')
+    );
+
+    const testSetupContent = tree.read(
+      'libs/my-forms/src/test-setup.ts',
+      'utf-8'
+    );
+    expect(testSetupContent).toMatchInlineSnapshot(`
+"jest.mock('expo/src/winter/ImportMetaRegistry', () => ({
+  ImportMetaRegistry: {
+    get url() {
+      return null;
+    },
+  },
+}));
+
+
+if (typeof global.structuredClone === 'undefined') {
+  global.structuredClone = (object) => JSON.parse(JSON.stringify(object));
+}
+"
+`);
+
+    const libTsConfig = JSON.parse(
+      tree.read('libs/my-forms/tsconfig.lib.json', 'utf-8')
+    );
+    expect(libTsConfig.exclude).toEqual(['jest.config.ts', 'src/**/*.spec.ts']);
+
+    const specTsConfig = JSON.parse(
+      tree.read('libs/my-forms/tsconfig.spec.json', 'utf-8')
+    );
+    expect(specTsConfig.include).toEqual([
+      'jest.config.ts',
+      'src/**/*.spec.ts',
+    ]);
+  });
+
+  it('should update expo libraries whose package.json has no expo dependency', async () => {
+    addProjectConfiguration(tree, 'my-forms', {
+      root: 'libs/my-forms',
+      projectType: 'library',
+      targets: {
+        test: {
+          executor: '@nx/jest:jest',
+          options: {
+            jestConfig: 'libs/my-forms/jest.config.cts',
+          },
+        },
+      },
+    });
+
+    // buildable/publishable library: package.json with react peer deps only
+    tree.write(
+      'libs/my-forms/package.json',
+      JSON.stringify({
+        name: '@proj/my-forms',
+        version: '0.0.1',
+        peerDependencies: {
+          react: '19.0.0',
+          'react-native': '0.81.0',
+        },
+      })
+    );
+
+    tree.write(
+      'libs/my-forms/jest.config.cts',
+      `module.exports = {
+  displayName: 'my-forms',
+  resolver: require.resolve('./jest.resolver.js'),
+  preset: 'jest-expo',
+};`
+    );
+
+    tree.write(
+      'libs/my-forms/jest.resolver.js',
+      `const defaultResolver = require('@nx/jest/plugins/resolver');
+module.exports = defaultResolver;`
+    );
+
+    tree.write('libs/my-forms/src/test-setup.ts', '');
+
+    await updateJestForExpo54(tree);
+
+    expect(tree.exists('libs/my-forms/jest.resolver.js')).toBe(false);
+    const updatedConfig = tree.read('libs/my-forms/jest.config.cts', 'utf-8');
+    expect(updatedConfig).not.toContain('jest.resolver.js');
+    expect(updatedConfig).toContain('jest-expo');
+    expect(tree.read('libs/my-forms/src/test-setup.ts', 'utf-8')).toContain(
+      'ImportMetaRegistry'
+    );
+  });
+
+  it('should not modify projects without a package.json when the jest config does not use jest-expo', async () => {
+    // formatter none: assert the file is byte-for-byte untouched
+    tree = createTreeWithEmptyWorkspace({ formatter: 'none' });
+    addProjectConfiguration(tree, 'my-node-lib', {
+      root: 'libs/my-node-lib',
+      projectType: 'library',
+      targets: {
+        test: {
+          executor: '@nx/jest:jest',
+          options: {
+            jestConfig: 'libs/my-node-lib/jest.config.ts',
+          },
+        },
+      },
+    });
+
+    const jestConfig = `module.exports = {
+  displayName: 'my-node-lib',
+  resolver: require.resolve('./jest.resolver.js'),
+  preset: '../../jest.preset.js',
+};`;
+    tree.write('libs/my-node-lib/jest.config.ts', jestConfig);
+    tree.write('libs/my-node-lib/jest.resolver.js', 'module.exports = {};');
+
+    await updateJestForExpo54(tree);
+
+    expect(tree.read('libs/my-node-lib/jest.config.ts', 'utf-8')).toBe(
+      jestConfig
+    );
+    expect(tree.exists('libs/my-node-lib/jest.resolver.js')).toBe(true);
+    expect(tree.exists('libs/my-node-lib/src/test-setup.ts')).toBe(false);
+  });
+
+  it('should not modify projects whose preset only looks like jest-expo', async () => {
+    tree = createTreeWithEmptyWorkspace({ formatter: 'none' });
+    addProjectConfiguration(tree, 'my-lib', {
+      root: 'libs/my-lib',
+      projectType: 'library',
+      targets: {
+        test: {
+          executor: '@nx/jest:jest',
+          options: {
+            jestConfig: 'libs/my-lib/jest.config.cts',
+          },
+        },
+      },
+    });
+
+    // local preset file named after jest-expo, plus an unrelated resolver
+    const jestConfig = `module.exports = {
+  displayName: 'my-lib',
+  preset: './jest-expo.preset.js',
+  resolver: require.resolve('./jest.resolver.js'),
+};`;
+    tree.write('libs/my-lib/jest.config.cts', jestConfig);
+    tree.write('libs/my-lib/jest.resolver.js', 'module.exports = {};');
+
+    await updateJestForExpo54(tree);
+
+    expect(tree.read('libs/my-lib/jest.config.cts', 'utf-8')).toBe(jestConfig);
+    expect(tree.exists('libs/my-lib/jest.resolver.js')).toBe(true);
+    expect(tree.exists('libs/my-lib/src/test-setup.ts')).toBe(false);
+  });
 });

--- a/packages/expo/src/migrations/update-22-2-0/update-jest-for-expo-54.ts
+++ b/packages/expo/src/migrations/update-22-2-0/update-jest-for-expo-54.ts
@@ -1,14 +1,12 @@
-import {
-  Tree,
-  getProjects,
-  updateJson,
-  logger,
-  readJson,
-  joinPathFragments,
-  formatFiles,
-} from '@nx/devkit';
+import { Tree, getProjects, updateJson, logger, formatFiles } from '@nx/devkit';
 import { removePropertyFromJestConfig } from '@nx/jest';
 import { join } from 'path';
+
+// `preset: 'jest-expo'` or a `jest-expo/<variant>` subpath
+const JEST_EXPO_PRESET_REGEX = /preset:\s*['"]jest-expo(\/[^'"]*)?['"]/;
+// the resolver line the SDK 53 generator wrote (see utils/jest/add-jest.ts)
+const SDK_53_RESOLVER_REGEX =
+  /resolver:\s*require\.resolve\(\s*['"]\.\/jest\.resolver\.js['"]\s*\)/;
 
 /**
  * Update Jest configuration for Expo SDK 54.
@@ -23,10 +21,6 @@ export default async function update(tree: Tree) {
   const projects = getProjects(tree);
 
   for (const [projectName, config] of projects.entries()) {
-    if (!isExpoProject(tree, config.root)) {
-      continue;
-    }
-
     // Check if this project has Jest configured
     const jestConfigPath = findJestConfigPath(tree, config.root);
     if (!jestConfigPath) {
@@ -35,10 +29,12 @@ export default async function update(tree: Tree) {
 
     const jestConfigContent = tree.read(jestConfigPath, 'utf-8');
 
-    // Only process if this is an Expo project with jest-expo preset and custom resolver
+    // No package.json check: expo libraries often have no project-level
+    // package.json (or one without expo), which skipped real expo projects.
+    // Only the jest config is reliable: jest-expo preset + custom resolver.
     if (
-      !jestConfigContent.includes('jest-expo') ||
-      !jestConfigContent.includes('jest.resolver.js')
+      !JEST_EXPO_PRESET_REGEX.test(jestConfigContent) ||
+      !SDK_53_RESOLVER_REGEX.test(jestConfigContent)
     ) {
       continue;
     }
@@ -166,21 +162,5 @@ function updateTsConfigFilesForV54(tree: Tree, projectRoot: string): void {
     } catch {
       // Skip if JSON is invalid
     }
-  }
-}
-
-function isExpoProject(tree: Tree, projectRoot: string): boolean {
-  const packageJsonPath = joinPathFragments(projectRoot, 'package.json');
-  if (!tree.exists(packageJsonPath)) {
-    return false;
-  }
-
-  try {
-    const packageJson = readJson(tree, packageJsonPath);
-    return Boolean(
-      packageJson.dependencies?.expo || packageJson.devDependencies?.expo
-    );
-  } catch {
-    return false;
   }
 }


### PR DESCRIPTION
## Current Behavior

The Expo SDK 54 jest migration gated on a project-level `package.json` with an `expo` dependency. Expo libraries in integrated workspaces have no project `package.json` (project.json layout), and buildable libraries only declare react peers, so the migration silently skipped them and `jest-expo` broke.

## Expected Behavior

The migration gates only on the jest config itself (`preset: 'jest-expo'` plus the SDK 53 `jest.resolver.js` line), so every expo jest project is migrated regardless of manifest shape. Specs also pin that `nx g @nx/expo:app|lib` default to `package.json` in TS solution workspaces.

## Related Issue(s)

Fixes #35669
