### PR TITLE
fix(core): compare daemon workspace roots case-insensitively on Windows

### DIFF
--- a/packages/nx/src/daemon/message-types/daemon-message.spec.ts
+++ b/packages/nx/src/daemon/message-types/daemon-message.spec.ts
@@ -5,6 +5,11 @@ import {
 
 describe('isForeignWorkspaceMessage', () => {
   const daemonRoot = '/Users/me/workspace';
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
 
   it('should be false when the workspace roots match', () => {
     expect(
@@ -13,17 +18,6 @@ describe('isForeignWorkspaceMessage', () => {
         daemonRoot
       )
     ).toBe(false);
-  });
-
-  it('should be true when the workspace roots differ only by case', () => {
-    // The two roots are produced by the same workspace-root resolution, so they
-    // are compared directly (no case-insensitive sanitizing).
-    expect(
-      isForeignWorkspaceMessage(
-        { type: 'PING', workspaceRoot: '/Users/ME/Workspace' },
-        daemonRoot
-      )
-    ).toBe(true);
   });
 
   it('should be true when the workspace roots differ', () => {
@@ -37,6 +31,70 @@ describe('isForeignWorkspaceMessage', () => {
 
   it('should be false when the message has no workspace root', () => {
     expect(isForeignWorkspaceMessage({ type: 'PING' }, daemonRoot)).toBe(false);
+  });
+
+  describe('on POSIX', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+    });
+
+    it('should be true when the workspace roots differ only by case', () => {
+      // POSIX paths are case-sensitive, so /Users/ME really can be a second
+      // directory. Only Windows may fold case.
+      expect(
+        isForeignWorkspaceMessage(
+          { type: 'PING', workspaceRoot: '/Users/ME/Workspace' },
+          daemonRoot
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('on Windows', () => {
+    const windowsRoot = 'D:\\repo';
+
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+    });
+
+    it('should be false when only the drive letter case differs', () => {
+      // The reported failure: one side is handed NX_WORKSPACE_ROOT_PATH as
+      // 'd:\repo' verbatim while the other derives 'D:\repo' from process.cwd(),
+      // and the daemon refuses its own workspace.
+      expect(
+        isForeignWorkspaceMessage(
+          { type: 'PING', workspaceRoot: 'd:\\repo' },
+          windowsRoot
+        )
+      ).toBe(false);
+    });
+
+    it('should be false when the rest of the path differs by case', () => {
+      expect(
+        isForeignWorkspaceMessage(
+          { type: 'PING', workspaceRoot: 'D:\\Repo' },
+          windowsRoot
+        )
+      ).toBe(false);
+    });
+
+    it('should be false when the separators differ', () => {
+      expect(
+        isForeignWorkspaceMessage(
+          { type: 'PING', workspaceRoot: 'D:/repo' },
+          windowsRoot
+        )
+      ).toBe(false);
+    });
+
+    it('should still be true for a genuinely different workspace', () => {
+      expect(
+        isForeignWorkspaceMessage(
+          { type: 'PING', workspaceRoot: 'D:\\other-repo' },
+          windowsRoot
+        )
+      ).toBe(true);
+    });
   });
 });
 

--- a/packages/nx/src/daemon/message-types/daemon-message.ts
+++ b/packages/nx/src/daemon/message-types/daemon-message.ts
@@ -1,3 +1,5 @@
+import { posix, win32 } from 'node:path';
+
 export type DaemonMessage = {
   type: string;
   env?: Record<string, string>;
@@ -24,8 +26,30 @@ export function isDaemonMessage(msg: unknown): msg is DaemonMessage {
 type WorkspaceScopedMessage = { type: string; workspaceRoot?: string };
 
 /**
+ * Puts a workspace root into a form two independently-resolved spellings of the
+ * same directory agree on.
+ *
+ * The sender's root and the receiver's root do not always come out of the same
+ * branch of `workspaceRootInner`: one side can be handed `NX_WORKSPACE_ROOT_PATH`
+ * verbatim while the other walks up from `process.cwd()`. On Windows those two
+ * sources routinely disagree on the case of the drive letter — an editor or
+ * agent may export `d:\repo` while `process.cwd()` reports `D:\repo` — and on
+ * separators. Both address the same directory: Windows paths are
+ * case-insensitive, and a drive letter is case-insensitive without exception.
+ *
+ * POSIX roots keep their case, where `/repo` and `/REPO` really can be two
+ * directories.
+ */
+function normalizeWorkspaceRoot(workspaceRoot: string): string {
+  return process.platform === 'win32'
+    ? win32.normalize(workspaceRoot).toLowerCase()
+    : posix.normalize(workspaceRoot);
+}
+
+/**
  * A message from a different workspace — two sharing an NX_SOCKET_DIR — must not
- * be processed. Compared directly; both come from the same resolution.
+ * be processed. Roots are normalized first so that a workspace does not look
+ * foreign to itself; see {@link normalizeWorkspaceRoot}.
  */
 export function isForeignWorkspaceMessage(
   msg: WorkspaceScopedMessage,
@@ -34,7 +58,10 @@ export function isForeignWorkspaceMessage(
   if (msg.workspaceRoot === undefined) {
     return false;
   }
-  return msg.workspaceRoot !== receiverWorkspaceRoot;
+  return (
+    normalizeWorkspaceRoot(msg.workspaceRoot) !==
+    normalizeWorkspaceRoot(receiverWorkspaceRoot)
+  );
 }
 
 /**


### PR DESCRIPTION
`isForeignWorkspaceMessage` compared the sender's and the receiver's workspace root with a raw `!==`, on the assumption recorded in its own doc comment that "both come from the same resolution". They do not always come from the same branch of it: `workspaceRootInner` returns `NX_WORKSPACE_ROOT_PATH` verbatim when that variable is set, while the fallback walks up from `process.cwd()`.

On Windows those two sources routinely disagree on the case of the drive letter. An editor or coding agent exports `d:\repo` while `process.cwd()` reports `D:\repo`. Windows paths are case-insensitive, and a drive letter is case-insensitive without exception, so both spell the same directory - but the daemon read the second spelling as a foreign workspace and refused every message from whichever shell did not start it:

    The Nx Daemon for 'd:\repo' received a message from a different workspace
    ('D:\repo') and refused to process it.

The check is meant to catch two genuinely different workspaces sharing an NX_SOCKET_DIR. Here it made a workspace look foreign to itself, so the first shell to start the daemon locked out every other one.

Both roots are now normalized before they are compared: separators and `.`/`..` on either platform, plus case folding on win32 only. POSIX roots keep their case, where `/repo` and `/REPO` really can be two directories. A genuinely foreign workspace is still rejected.

Closes #36722

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #36722
