### PR TITLE
fix(bundling): allow overriding the css module hash algorithm

### DIFF
--- a/packages/rspack/src/executors/rspack/schema.d.ts
+++ b/packages/rspack/src/executors/rspack/schema.d.ts
@@ -7,6 +7,7 @@ export interface RspackExecutorSchema {
   buildLibsFromSource?: boolean;
   deployUrl?: string;
   extractCss?: boolean;
+  cssModuleHashFunction?: string;
   extractLicenses?: boolean;
   externalDependencies?: 'all' | 'none' | string[];
   fileReplacements?: FileReplacement[];

--- a/packages/rspack/src/executors/rspack/schema.json
+++ b/packages/rspack/src/executors/rspack/schema.json
@@ -185,6 +185,10 @@
       "type": "boolean",
       "description": "Extract CSS into a `.css` file."
     },
+    "cssModuleHashFunction": {
+      "type": "string",
+      "description": "Hash algorithm used to generate CSS module class names. Defaults to `md5`, which FIPS-restricted OpenSSL rejects. Changing it renames generated class names."
+    },
     "externalDependencies": {
       "oneOf": [
         {

--- a/packages/rspack/src/plugins/utils/get-css-module-local-ident.spec.ts
+++ b/packages/rspack/src/plugins/utils/get-css-module-local-ident.spec.ts
@@ -1,0 +1,40 @@
+import { getCSSModuleLocalIdent } from './get-css-module-local-ident';
+
+describe('getCSSModuleLocalIdent', () => {
+  const ctx = {
+    rootContext: '/root',
+    resourcePath: '/root/apps/demo/src/app/app.module.css',
+  };
+
+  afterEach(() => {
+    delete process.env.NX_CSS_MODULE_HASH_FUNCTION;
+  });
+
+  it('should hash with md5 by default', () => {
+    expect(getCSSModuleLocalIdent(ctx, '', 'title', {})).toBe(
+      'app_title__FKeAg'
+    );
+  });
+
+  it('should hash with the algorithm passed by the plugin', () => {
+    expect(getCSSModuleLocalIdent(ctx, '', 'title', {}, 'sha256')).toBe(
+      'app_title__L7+IP'
+    );
+  });
+
+  it('should hash with the algorithm from NX_CSS_MODULE_HASH_FUNCTION', () => {
+    process.env.NX_CSS_MODULE_HASH_FUNCTION = 'sha256';
+
+    expect(getCSSModuleLocalIdent(ctx, '', 'title', {})).toBe(
+      'app_title__L7+IP'
+    );
+  });
+
+  it('should prefer the plugin algorithm over NX_CSS_MODULE_HASH_FUNCTION', () => {
+    process.env.NX_CSS_MODULE_HASH_FUNCTION = 'sha512';
+
+    expect(getCSSModuleLocalIdent(ctx, '', 'title', {}, 'sha256')).toBe(
+      'app_title__L7+IP'
+    );
+  });
+});

--- a/packages/rspack/src/plugins/utils/get-css-module-local-ident.ts
+++ b/packages/rspack/src/plugins/utils/get-css-module-local-ident.ts
@@ -5,7 +5,8 @@ export function getCSSModuleLocalIdent(
   ctx,
   localIdentName,
   localName,
-  options
+  options,
+  hashFunction?: string
 ) {
   // Use the filename or folder name, based on some uses the index.js / index.module.(css|scss|sass) project style
   const fileNameOrFolder = ctx.resourcePath.match(
@@ -16,7 +17,9 @@ export function getCSSModuleLocalIdent(
   // Create a hash based on a the file location and class name. Will be unique across a project, and close to globally unique.
   const hash = getHashDigest(
     posix.relative(ctx.rootContext, ctx.resourcePath) + localName,
-    'md5',
+    // md5 is unavailable under FIPS-restricted OpenSSL (nx#36829). Env var stays
+    // undocumented on purpose - `cssModuleHashFunction` is the documented option.
+    hashFunction || process.env.NX_CSS_MODULE_HASH_FUNCTION || 'md5',
     'base64',
     5
   );

--- a/packages/rspack/src/plugins/utils/loaders/stylesheet-loaders.ts
+++ b/packages/rspack/src/plugins/utils/loaders/stylesheet-loaders.ts
@@ -30,7 +30,14 @@ export function getCommonLoadersForCssModules(
       options: {
         modules: {
           mode: 'local',
-          getLocalIdent: getCSSModuleLocalIdent,
+          getLocalIdent: (ctx, localIdentName, localName, loaderOptions) =>
+            getCSSModuleLocalIdent(
+              ctx,
+              localIdentName,
+              localName,
+              loaderOptions,
+              options.cssModuleHashFunction
+            ),
           // css-loader 7 defaults namedExport to true, and to camel-case-only
           // locals when it is off. Generated components import the default
           // export and reference class names as authored, so pin both.

--- a/packages/rspack/src/plugins/utils/models.ts
+++ b/packages/rspack/src/plugins/utils/models.ts
@@ -71,6 +71,12 @@ export interface NxAppRspackPluginOptions {
   commonChunk?: boolean;
 
   /**
+   * Hash algorithm used to generate CSS module class names. Defaults to `md5`,
+   * which FIPS-restricted OpenSSL rejects. Changing it renames generated class names.
+   */
+  cssModuleHashFunction?: string;
+
+  /**
    * The deploy path for the application. e.g. `/my-app/`
    */
   deployUrl?: string;

--- a/packages/webpack/src/executors/webpack/schema.d.ts
+++ b/packages/webpack/src/executors/webpack/schema.d.ts
@@ -82,6 +82,7 @@ export interface WebpackExecutorOptions {
   crossOrigin?: 'none' | 'anonymous' | 'use-credentials';
   deployUrl?: string;
   extractCss?: boolean;
+  cssModuleHashFunction?: string;
   generateIndexHtml?: boolean;
   index?: string;
   postcssConfig?: string;

--- a/packages/webpack/src/executors/webpack/schema.json
+++ b/packages/webpack/src/executors/webpack/schema.json
@@ -265,6 +265,10 @@
       "type": "boolean",
       "description": "Extract CSS into a `.css` file."
     },
+    "cssModuleHashFunction": {
+      "type": "string",
+      "description": "Hash algorithm used to generate CSS module class names. Defaults to `md5`, which FIPS-restricted OpenSSL rejects. Changing it renames generated class names."
+    },
     "subresourceIntegrity": {
       "type": "boolean",
       "description": "Enables the use of subresource integrity validation."

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/stylesheet-loaders.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/stylesheet-loaders.ts
@@ -32,7 +32,14 @@ export function getCommonLoadersForCssModules(
       options: {
         modules: {
           mode: 'local',
-          getLocalIdent: getCSSModuleLocalIdent,
+          getLocalIdent: (ctx, localIdentName, localName, loaderOptions) =>
+            getCSSModuleLocalIdent(
+              ctx,
+              localIdentName,
+              localName,
+              loaderOptions,
+              options.cssModuleHashFunction
+            ),
           // css-loader 7 defaults namedExport to true, and to camel-case-only
           // locals when it is off. Generated components import the default
           // export and reference class names as authored, so pin both.

--- a/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
@@ -85,6 +85,11 @@ export interface NxAppWebpackPluginOptions {
    */
   crossOrigin?: 'none' | 'anonymous' | 'use-credentials';
   /**
+   * Hash algorithm used to generate CSS module class names. Defaults to `md5`,
+   * which FIPS-restricted OpenSSL rejects. Changing it renames generated class names.
+   */
+  cssModuleHashFunction?: string;
+  /**
    * The deploy path for the application. e.g. `/my-app/`
    */
   deployUrl?: string;

--- a/packages/webpack/src/utils/get-css-module-local-ident.spec.ts
+++ b/packages/webpack/src/utils/get-css-module-local-ident.spec.ts
@@ -1,0 +1,40 @@
+import { getCSSModuleLocalIdent } from './get-css-module-local-ident';
+
+describe('getCSSModuleLocalIdent', () => {
+  const ctx = {
+    rootContext: '/root',
+    resourcePath: '/root/apps/demo/src/app/app.module.css',
+  };
+
+  afterEach(() => {
+    delete process.env.NX_CSS_MODULE_HASH_FUNCTION;
+  });
+
+  it('should hash with md5 by default', () => {
+    expect(getCSSModuleLocalIdent(ctx, '', 'title', {})).toBe(
+      'app_title__FKeAg'
+    );
+  });
+
+  it('should hash with the algorithm passed by the plugin', () => {
+    expect(getCSSModuleLocalIdent(ctx, '', 'title', {}, 'sha256')).toBe(
+      'app_title__L7+IP'
+    );
+  });
+
+  it('should hash with the algorithm from NX_CSS_MODULE_HASH_FUNCTION', () => {
+    process.env.NX_CSS_MODULE_HASH_FUNCTION = 'sha256';
+
+    expect(getCSSModuleLocalIdent(ctx, '', 'title', {})).toBe(
+      'app_title__L7+IP'
+    );
+  });
+
+  it('should prefer the plugin algorithm over NX_CSS_MODULE_HASH_FUNCTION', () => {
+    process.env.NX_CSS_MODULE_HASH_FUNCTION = 'sha512';
+
+    expect(getCSSModuleLocalIdent(ctx, '', 'title', {}, 'sha256')).toBe(
+      'app_title__L7+IP'
+    );
+  });
+});

--- a/packages/webpack/src/utils/get-css-module-local-ident.ts
+++ b/packages/webpack/src/utils/get-css-module-local-ident.ts
@@ -5,7 +5,8 @@ export function getCSSModuleLocalIdent(
   ctx,
   localIdentName,
   localName,
-  options
+  options,
+  hashFunction?: string
 ) {
   // Use the filename or folder name, based on some uses the index.js / index.module.(css|scss|sass) project style
   const fileNameOrFolder = ctx.resourcePath.match(
@@ -16,7 +17,9 @@ export function getCSSModuleLocalIdent(
   // Create a hash based on a the file location and class name. Will be unique across a project, and close to globally unique.
   const hash = getHashDigest(
     posix.relative(ctx.rootContext, ctx.resourcePath) + localName,
-    'md5',
+    // md5 is unavailable under FIPS-restricted OpenSSL (nx#36829). Env var stays
+    // undocumented on purpose - `cssModuleHashFunction` is the documented option.
+    hashFunction || process.env.NX_CSS_MODULE_HASH_FUNCTION || 'md5',
     'base64',
     5
   );


### PR DESCRIPTION
## Current Behavior

`getCSSModuleLocalIdent` in `@nx/webpack` and `@nx/rspack` hardcodes md5. FIPS-restricted OpenSSL rejects md5, so builds that touch a CSS/SCSS module fail.

## Expected Behavior

`cssModuleHashFunction` build option picks the digest. `NX_CSS_MODULE_HASH_FUNCTION` covers custom configs that call the exported helper. Both default to md5, so class names are unchanged.

## Related Issue(s)

Fixes #36829

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/jolly-walrus-8435f778">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->