### PR TITLE
fix(repo): stop pnpm from installing inside nx script tasks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,10 @@ packages:
   - 'astro-docs'
   # examples/ contains standalone pnpm workspaces with their own lockfiles
   - 'packages/nx/native-packages/*'
+# pnpm 11 defaults this to "install", so `pnpm run <script>` silently installs -
+# preinstall/postinstall included - when it thinks node_modules drifted. Nx runs
+# script targets through `pnpm run`, so that lands inside unrelated tasks.
+verifyDepsBeforeRun: warn
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - 'nx'


### PR DESCRIPTION
## Current Behavior

<!-- This is the behavior we have today -->

pnpm 11 changed the `verify-deps-before-run` default from off to `"install"`. Nx runs package.json script targets through `pnpm run`, so when pnpm decides `node_modules` drifted from the lockfile it runs a full `pnpm install`, preinstall and postinstall included, inside the task. It logs nothing to say why.

Process tree from the sandbox report for `@nx/nx-source:lint-pnpm-lock` in run `33179015451-1`:

```
node .../nx/dist/bin/run-executor.js
└ /bin/sh -c pnpm run lint-pnpm-lock
  └ node .../corepack/pnpm run lint-pnpm-lock
    ├ node .../pnpm/11.22.0/bin/pnpm.mjs install
    │  ├ node ./scripts/preinstall.js
    │  ├ node -e require('./dist/bin/post-install')
    │  ├ sh -c dotnet restore || echo 'needs dotnet restore'
    │  │  └ dotnet restore
    │  ├ sh -c is-ci || husky
    │  └ node ./patch/patch-angular-build.js
    └ sh -c eslint pnpm-lock.yaml
```

218 unexpected reads, 207 of them from nx's own post-install, against 10 from eslint.

It only fires when something already mutated the workspace on that agent. `populate-local-registry-storage` does that: `nx-release --local` rewrites `packages/*/package.json`. The same CI run ran the task a second time cleanly, so it presents as intermittent.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

No Nx task triggers an install. `warn` rather than `false` keeps the drift reported and names the condition that tripped the check. The setting has to live in `pnpm-workspace.yaml`; pnpm 11 ignores it in `.pnpmrc`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
