### PR TITLE
docs(misc): give nx cloud seekers a tagged path from the intro page

### DIFF
--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -474,13 +474,13 @@ const currentVersion = versions.find((v) => v.current);
       </a>
       <a
         id="header-get-started-btn"
-        href="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=documentation-header&utm_campaign=try-nx-cloud"
+        href="https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=website&utm_campaign=docs-header"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center justify-center rounded-md bg-zinc-950 px-2.5 py-1.5 text-sm font-medium text-white no-underline shadow-sm transition hover:bg-zinc-900 dark:bg-zinc-100 dark:text-zinc-950 dark:hover:bg-white"
-        title="Get started"
+        class="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-zinc-950 px-2.5 py-1.5 text-sm font-medium text-white no-underline shadow-sm transition hover:bg-zinc-900 dark:bg-zinc-100 dark:text-zinc-950 dark:hover:bg-white"
+        title="Try Nx Cloud for Free"
       >
-        Get started
+        Try Nx Cloud for Free
       </a>
     </div>
     <!-- Social Icons - Hide on screens smaller than 2xl (1536px) -->

--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -49,7 +49,7 @@ const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUnti
                     Contact
                   </a>
                   <a
-                    href="https://cloud.nx.app?utm_source=nx-dev&utm_medium=header&utm_campaign=try-nx-cloud"
+                    href="https://cloud.nx.app?utm_source=nx-docs&utm_medium=website&utm_campaign=docs-header&utm_content=login"
                     target="_blank"
                     rel="noopener noreferrer"
                     class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition no-underline bg-blue-500 dark:bg-sky-500 text-white hover:bg-blue-600 dark:hover:bg-sky-600 shadow-sm"

--- a/astro-docs/src/content/docs/features/CI Features/index.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/index.mdoc
@@ -37,6 +37,8 @@ npx nx connect
 
 This connects your workspace to Nx Cloud and enables remote caching and CI features. For more details, [follow our in-depth guide](/docs/kb/setup-ci) for setting up CI with Nx.
 
+{% call_to_action title="Connect from your browser" url="https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=website&utm_campaign=ci-features" icon="nxcloud" description="Sign in to Nx Cloud and connect your repository without the CLI" /%}
+
 ## How Nx Cloud improves CI
 
 In traditional CI models, work is statically assigned to CI machines. This creates inefficiencies that many teams experience at scale.

--- a/astro-docs/src/content/docs/features/cache-task-results.mdoc
+++ b/astro-docs/src/content/docs/features/cache-task-results.mdoc
@@ -43,11 +43,13 @@ the result of the test run.
 
 By default, Nx caches task results locally. The biggest benefit of caching comes from using remote caching in CI, where you can **share the cache between different runs**. Nx comes with a managed remote caching solution built on top of Nx Cloud.
 
-To enable remote caching, connect your workspace to [Nx Cloud](https://nx.dev/nx-cloud) by running the following command:
+To enable remote caching, connect your workspace to [Nx Cloud](https://nx.dev/nx-cloud?utm_source=nx-docs&utm_medium=website&utm_campaign=cache-task-results) by running the following command:
 
 ```shell
 npx nx@latest connect
 ```
+
+{% call_to_action title="Connect from your browser" url="https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=website&utm_campaign=cache-task-results" icon="nxcloud" description="Sign in to Nx Cloud and connect your repository without the CLI" /%}
 
 Learn more about [remote caching with Nx Cloud](/docs/features/ci-features/remote-cache).
 

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -30,21 +30,23 @@ Nx:
 2. **Understands your codebase** - Builds [project and task graphs](/docs/features/explore-graph) showing how everything connects.
 3. **Orchestrates intelligently** - Runs tasks in the [right order](/docs/concepts/task-pipeline-configuration), parallelizing when possible.
 4. **Enforces boundaries** - [Module boundary rules](/docs/features/enforce-module-boundaries) prevent unwanted dependencies between projects.
-5. **Handles flakiness** - [Automatically detects and re-runs flaky tests](/docs/features/ci-features/flaky-tasks) and [self-heals CI failures](/docs/features/ci-features/self-healing-ci).
+5. **Makes CI fast** - [Remote caching](/docs/features/ci-features/remote-cache), [distributed task execution](/docs/features/ci-features/distribute-task-execution), and [task splitting](/docs/features/ci-features/split-e2e-tasks) across machines.
+6. **Handles flakiness** - [Automatically detects and re-runs flaky tests](/docs/features/ci-features/flaky-tasks) and [self-heals CI failures](/docs/features/ci-features/self-healing-ci).
 
 ## Start small, grow as needed
 
 Nx is modular. Start with the CLI and add capabilities as your needs grow.
 
-| Component                                  | What It Does                                                                                                                                                 |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Nx Core**                                | Task runner with [local caching](/docs/features/cache-task-results) and [affected commands](/docs/features/ci-features/affected). Works with any tech stack. |
-| [**Nx Plugins**](/docs/plugin-registry)    | Technology-specific automation (generators, auto-configured projects and tasks, dependency detection).                                                       |
-| [**Nx Cloud**](/docs/features/ci-features) | [Remote caching](/docs/features/ci-features/remote-cache) and [self-healing CI](/docs/features/ci-features/self-healing-ci).                                 |
+| Component                                  | What It Does                                                                                                                                                                                                                                                                                                                                                                                     |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Nx Core**                                | Task runner with [local caching](/docs/features/cache-task-results) and [affected commands](/docs/features/ci-features/affected). Works with any tech stack.                                                                                                                                                                                                                                     |
+| [**Nx Plugins**](/docs/plugin-registry)    | Technology-specific automation (generators, auto-configured projects and tasks, dependency detection).                                                                                                                                                                                                                                                                                           |
+| [**Nx Cloud**](/docs/features/ci-features) | [Remote caching](/docs/features/ci-features/remote-cache), [task distribution](/docs/features/ci-features/distribute-task-execution), [task splitting](/docs/features/ci-features/split-e2e-tasks), and [self-healing CI](/docs/features/ci-features/self-healing-ci). [Try it for free](https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=website&utm_campaign=intro-cloud-table). |
 
 ## Where to go from here
 
 - **Starting fresh?** → [Create a new workspace](/docs/getting-started/start-new-project)
 - **Have an existing project?** → [Add Nx to your project](/docs/getting-started/start-with-existing-project)
+- **Already using Nx?** → [Keep your CI fast with Nx Cloud](https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=website&utm_campaign=intro-next-steps)
 
 **Stay up to date** with our latest news by [⭐️ starring us on Github](https://github.com/nrwl/nx), [subscribing to our Youtube channel](https://www.youtube.com/@nxdevtools), [joining our Discord](https://go.nx.dev/community), [subscribing to our monthly tech newsletter](https://go.nrwl.io/nx-newsletter) or follow us [on X](https://x.com/nxdevtools), [Bluesky](https://bsky.app/profile/nx.dev) and [LinkedIn](https://www.linkedin.com/company/nxdevtools).

--- a/astro-docs/src/content/docs/getting-started/nx-cloud.mdoc
+++ b/astro-docs/src/content/docs/getting-started/nx-cloud.mdoc
@@ -19,7 +19,7 @@ Nx Cloud improves many aspects of the CI/CD process:
 
 To connect your Nx workspace with Nx Cloud, use the web application:
 
-{% call_to_action variant="default" title="Create a new or connect an existing repo" url="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=website&utm_campaign=nx-cloud-intro" description="Setup takes less than 2 minutes" /%}
+{% call_to_action variant="default" title="Create a new or connect an existing repo" url="https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=website&utm_campaign=nx-cloud-intro" description="Setup takes less than 2 minutes" /%}
 
 Alternatively, you can also run the following command in your Nx workspace (make sure you have it pushed to a remote repository first):
 

--- a/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
@@ -38,7 +38,7 @@ Page: {pageUrl}
 Connect your workspace to Nx Cloud and run your CI tasks through `nx`. That turns on remote caching, affected, distribution, and self-healing CI.
 Each section below covers one of those in isolation. If you would rather start from a working pipeline, jump to the [complete example](#complete-example).
 
-{% call_to_action variant="default" title="Tour an Nx Cloud workspace" url="https://cloud.nx.app/demo/intro?utm_source=nx-dev&utm_medium=website&utm_campaign=ci-setup" description="See distributed task execution, caching, and run analytics on a live workspace before you wire up your own CI." /%}
+{% call_to_action variant="default" title="Tour an Nx Cloud workspace" url="https://cloud.nx.app/demo/intro?utm_source=nx-docs&utm_medium=website&utm_campaign=ci-setup" description="See distributed task execution, caching, and run analytics on a live workspace before you wire up your own CI." /%}
 
 ## Make sure you have Nx
 
@@ -84,7 +84,7 @@ Supported `--ci` values: `github`, `circleci`, `gitlab`, `azure`, `bitbucket-pip
 
 Remote cache allows your CI runs to benefit from previous runs. It takes less than 5 minutes to set up and is free to start. For what the free plan covers and what Nx Cloud adds on top of Nx Core, see [Orchestration & CI with Nx Cloud](/docs/features/ci-features).
 
-{% call_to_action variant="default" title="Connect your workspace" url="https://cloud.nx.app/setup/connect-workspace/guide?utm_source=nx-dev&utm_medium=website&utm_campaign=ci-setup" description="Setup takes less than 5 minutes" /%}
+{% call_to_action variant="default" title="Connect your workspace" url="https://cloud.nx.app/setup/connect-workspace/guide?utm_source=nx-docs&utm_medium=website&utm_campaign=ci-setup" description="Setup takes less than 5 minutes" /%}
 
 See [Remote Caching](/docs/features/ci-features/remote-cache) for details on the security model and eviction. For more granular control in CI, with separate read-only and read-write tokens and branch-scoped permissions, see [CI access tokens](/docs/kb/access-tokens).
 


### PR DESCRIPTION
## Current Behavior

The intro page has no links to the Nx Cloud app, and the cache and ci-features pages have no browser CTA. The docs header button says "Get started" and is tagged `utm_source=nx-dev`, so docs traffic is indistinguishable from the marketing site.

## Expected Behavior

The intro page describes what Nx Cloud does and links the app from the feature table and from "Where to go from here". The cache and ci-features pages get the browser CTA used on the other caching pages. The header button reads "Try Nx Cloud for Free", matching the homepage. Every docs app link uses `utm_source=nx-docs&utm_medium=website` with a per-placement `utm_campaign`.

## Preview

- https://deploy-preview-36842--nx-docs.netlify.app/docs/getting-started/intro
- https://deploy-preview-36842--nx-docs.netlify.app/docs/features/ci-features
- https://deploy-preview-36842--nx-docs.netlify.app/docs/features/cache-task-results
- https://deploy-preview-36842--nx-docs.netlify.app/docs/getting-started/nx-cloud (UTM retag only)
- https://deploy-preview-36842--nx-docs.netlify.app/docs/getting-started/setup-ci (UTM retag only)

The header button change is site chrome, visible on every page.

## Related Issue(s)

DOC-662
