### PR TITLE
docs(react-native): fix typo in the run-ios examples

### DIFF
--- a/packages/react-native/docs/run-ios-examples.md
+++ b/packages/react-native/docs/run-ios-examples.md
@@ -22,7 +22,7 @@ nx run mobile:run-ios
 
 ##### Build the Debug/Release app
 
-The `mode` option allows to specify the xcode configuartion schema, such as `Debug` or `Release`.
+The `mode` option allows to specify the xcode configuration schema, such as `Debug` or `Release`.
 
 ```json
     "run-ios": {


### PR DESCRIPTION
Corrects the misspelling `configuartion` -> `configuration` in `packages/react-native/docs/run-ios-examples.md`.

Documentation only, no behaviour change.