### PR TITLE
fix(core): raise the nx package vitest timeout to cover the graph recompute spec

### DIFF
--- a/packages/nx/vitest.config.mts
+++ b/packages/nx/vitest.config.mts
@@ -56,7 +56,11 @@ export default defineConfig({
     include: ['**/*.spec.ts'],
     exclude: ['src/native/tui/**', '**/node_modules/**'],
     setupFiles: ['./vitest.setup.mts'],
-    testTimeout: 35000,
+    // project-graph-incremental-recomputation.spec.ts stands up real native
+    // watchers and graph recomputes; its slowest test measured 42.4s on CI
+    // against the previous 35s limit, and the same test swings 7-23s locally
+    // depending on pool load. 90s clears the measured worst case by 2x.
+    testTimeout: 90_000,
     // Native .node bindings are not thread-safe across vitest worker threads.
     pool: 'forks',
     // Specs that stand up native workspace contexts leave their worker slow to


### PR DESCRIPTION
## Current Behavior

`project-graph-incremental-recomputation.spec.ts` times out at exactly 35,000ms on CI on every run that executes it. Three consecutive runs on one branch clipped at 35,009ms, 35,018ms and 35,070ms on the same test. Master rarely shows it: most commits do not touch `packages/nx`, so `nx:test` is served from cache, and 9 of the last 12 master commits never ran the spec.

## Expected Behavior

The spec has enough budget to finish on CI hardware. With the limit raised for measurement, the slowest test needs 42.4s and its neighbours land at 32s and 29s; the whole suite went green with no other change. Locally the same test swings between 7s and 23s depending on pool load, so a 35s ceiling sits inside the spec's own variance once CI's roughly 5x slowdown is applied. 90s clears the measured worst case by 2x.

This is not a vitest transform regression: the jest preset carried the same 35s before #36754.

## Related Issue(s)

Unblocks #36838, which is stacked on this branch and will be retargeted to `master` once this merges.
