### PR TITLE
chore(repo): add PR stats and ages to weekly issue report

### DIFF
--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -5,8 +5,12 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: Skip the Slack message and leave the cached report data untouched. The report still goes to the job summary.
+      skip_slack:
+        description: Skip the Slack message. The report still goes to the job summary.
+        type: boolean
+        default: true
+      skip_cache_upload:
+        description: Leave the cached report data untouched, so the next scheduled run still diffs against the last real report.
         type: boolean
         default: true
 
@@ -61,14 +65,14 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.skip_cache_upload }}
         with:
           name: cached-issue-data
           path: ./scripts/issues-scraper/cached/data.json
 
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.skip_slack }}
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_ISSUES_REPORT_URL }}

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -37,14 +37,6 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
 
-      - name: Cache node_modules
-        id: cache-modules
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          lookup-only: true
-          path: '**/node_modules'
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-
       - name: Install packages
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Skip the Slack message and leave the cached report data untouched. The report still goes to the job summary.
+        type: boolean
+        default: true
 
 permissions:
   issues: read
@@ -56,12 +61,14 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !inputs.dry_run }}
         with:
           name: cached-issue-data
           path: ./scripts/issues-scraper/cached/data.json
 
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack
+        if: ${{ !inputs.dry_run }}
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_ISSUES_REPORT_URL }}

--- a/scripts/issues-scraper/format-slack-message.spec.ts
+++ b/scripts/issues-scraper/format-slack-message.spec.ts
@@ -5,7 +5,7 @@ import {
   getSlackMessageJson,
   splitIntoBlocks,
   toMarkdown,
-  toSlackSections,
+  toSlackBlocks,
 } from './format-slack-message';
 import { ReportData, ScopeData, ScopeTrend, TrendData } from './model';
 
@@ -124,32 +124,85 @@ describe('formatGhReport', () => {
   });
 });
 
-describe('toSlackSections', () => {
-  const sections = toSlackSections(
+describe('toSlackBlocks', () => {
+  const blocks = toSlackBlocks(
     formatGhReport(current, trends, previous, links)
   );
+  const types = blocks.map((b) => b.type);
 
-  it('emits header, a bold label plus fenced chunks per table, then the footer', () => {
-    assert.equal(sections.length, 6);
-    const [header, issuesLabel, issues, prsLabel, prs, footer] = sections;
-    assert.equal(
-      header,
-      [
-        '*Issue & PR Report for Aug 30 2026* <https://example.com/issues|[view unlabeled issues]> <https://example.com/prs|[view unlabeled PRs]>',
-        'Previous Report: Aug 23 2026',
-        'Closed, created and merged counts are since Aug 23 2026. Ages are for open items, in days.',
-      ].join('\n')
-    );
-    assert.equal(issuesLabel, '*Issues*');
-    assert.equal(prsLabel, '*Pull requests*');
-    for (const section of [issues, prs]) {
-      assert.ok(section.startsWith('```\n| Scope'));
-      assert.ok(section.endsWith('\n```'));
+  it('lays out header, context notes, links, then a labelled fenced table per section, then a context footer', () => {
+    assert.deepEqual(types, [
+      'header',
+      'context',
+      'section',
+      'section',
+      'divider',
+      'section',
+      'section',
+      'divider',
+      'section',
+      'section',
+      'context',
+    ]);
+  });
+
+  it('puts the title in a plain_text header and the notes in a context block', () => {
+    assert.deepEqual(blocks[0], {
+      type: 'header',
+      text: { type: 'plain_text', text: 'Issue & PR Report for Aug 30 2026' },
+    });
+    assert.deepEqual(blocks[1], {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: 'Previous Report: Aug 23 2026\nClosed, created and merged counts are since Aug 23 2026. Ages are for open items, in days.',
+        },
+      ],
+    });
+  });
+
+  it('renders each link as its own mrkdwn section and the footer as a context link', () => {
+    assert.deepEqual(blocks[2], {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '<https://example.com/issues|view unlabeled issues>',
+      },
+    });
+    assert.deepEqual(blocks[3], {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '<https://example.com/prs|view unlabeled PRs>',
+      },
+    });
+    assert.deepEqual(blocks[10], {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: '<https://npm-burst.com/package/nx/health/|nx package health on npm-burst>',
+        },
+      ],
+    });
+  });
+
+  it('labels each table in bold and fences its chunks', () => {
+    assert.deepEqual(blocks[5], {
+      type: 'section',
+      text: { type: 'mrkdwn', text: '*Issues*' },
+    });
+    assert.deepEqual(blocks[8], {
+      type: 'section',
+      text: { type: 'mrkdwn', text: '*Pull requests*' },
+    });
+    for (const block of [blocks[6], blocks[9]]) {
+      assert.equal(block.type, 'section');
+      const text = (block as { text: { text: string } }).text.text;
+      assert.ok(text.startsWith('```\n| Scope'));
+      assert.ok(text.endsWith('\n```'));
     }
-    assert.equal(
-      footer,
-      '<https://npm-burst.com/package/nx/health/|nx package health on npm-burst>'
-    );
   });
 });
 
@@ -214,13 +267,10 @@ describe('splitIntoBlocks', () => {
 });
 
 describe('getSlackMessageJson', () => {
-  it('emits a notification fallback and one mrkdwn section block per text section', () => {
-    assert.deepEqual(getSlackMessageJson('Report title', ['one', 'two']), {
-      text: 'Report title',
-      blocks: [
-        { type: 'section', text: { type: 'mrkdwn', text: 'one' } },
-        { type: 'section', text: { type: 'mrkdwn', text: 'two' } },
-      ],
-    });
+  it('uses the title as the notification fallback and the rendered blocks', () => {
+    const report = formatGhReport(current, trends, previous, links);
+    const json = getSlackMessageJson(report);
+    assert.equal(json.text, 'Issue & PR Report for Aug 30 2026');
+    assert.deepEqual(json.blocks, toSlackBlocks(report));
   });
 });

--- a/scripts/issues-scraper/format-slack-message.spec.ts
+++ b/scripts/issues-scraper/format-slack-message.spec.ts
@@ -4,6 +4,8 @@ import {
   formatGhReport,
   getSlackMessageJson,
   splitIntoBlocks,
+  toMarkdown,
+  toSlackSections,
 } from './format-slack-message';
 import { ReportData, ScopeData, ScopeTrend, TrendData } from './model';
 
@@ -29,10 +31,7 @@ const current: ReportData = {
   scopes: {
     'scope: small': stats(1),
     'scope: big': stats(5),
-    'scope: none': {
-      ...stats(0),
-      issues: { ...stats(0).issues, closed: 1 },
-    },
+    'scope: none': { ...stats(0), issues: { ...stats(0).issues, closed: 1 } },
   },
   collectedDate: 'Aug 30 2026',
 };
@@ -52,75 +51,129 @@ const links = {
 };
 
 const squash = (s: string) => s.replace(/ +/g, ' ');
+const rowLabels = (table: string) =>
+  table
+    .split('\n')
+    .filter((l) => l.startsWith('|'))
+    .slice(2)
+    .map((l) => l.split('|')[1].trim());
 
 describe('formatGhReport', () => {
-  const sections = formatGhReport(current, trends, previous, links);
-  const [header, issues, prs, footer] = sections;
+  const report = formatGhReport(current, trends, previous, links);
+  const [issues, prs] = report.tables;
 
-  it('returns the header, issue table, PR table and footer as separate sections', () => {
-    assert.equal(sections.length, 4);
-    assert.match(header, /Aug 30 2026/);
-    assert.match(
-      header,
-      /<https:\/\/example.com\/issues\|\[view unlabeled issues\]>/
-    );
-    assert.match(
-      header,
-      /<https:\/\/example.com\/prs\|\[view unlabeled PRs\]>/
-    );
-    assert.match(header, /Previous Report: Aug 23 2026/);
-    assert.match(issues, /Issues.*Bugs.*Closed.*Avg Age.*P95 Age/);
-    assert.match(prs, /Open.*Created.*Merged.*Closed.*Avg Age.*P95 Age/);
+  it('describes the report with a title, links, notes, two titled tables and a footer link', () => {
+    assert.equal(report.title, 'Issue & PR Report for Aug 30 2026');
+    assert.deepEqual(report.links, [
+      { label: 'view unlabeled issues', url: 'https://example.com/issues' },
+      { label: 'view unlabeled PRs', url: 'https://example.com/prs' },
+    ]);
+    assert.deepEqual(report.notes, [
+      'Previous Report: Aug 23 2026',
+      'Closed, created and merged counts are since Aug 23 2026. Ages are for open items, in days.',
+    ]);
+    assert.equal(issues.title, 'Issues');
+    assert.equal(prs.title, 'Pull requests');
+    assert.deepEqual(report.footer, {
+      label: 'nx package health on npm-burst',
+      url: 'https://npm-burst.com/package/nx/health/',
+    });
+  });
+
+  it('omits the previous-report note on a first run', () => {
+    const first = formatGhReport(current, trends, {}, links);
+    assert.equal(first.notes.length, 1);
+    assert.doesNotMatch(first.notes[0], /Previous/);
   });
 
   it('lists Everything, then Unscoped, then scopes by descending open count', () => {
-    const rows = (table: string) =>
-      table
-        .split('\n')
-        .filter((l) => l.startsWith('|'))
-        .slice(2)
-        .map((l) => l.split('|')[1].trim());
     const expected = ['Everything', 'Unscoped', 'scope: big', 'scope: small'];
-    assert.deepEqual(rows(issues), [...expected, 'scope: none']);
-    assert.deepEqual(rows(prs), expected);
+    assert.deepEqual(rowLabels(issues.markdown), [...expected, 'scope: none']);
+    assert.deepEqual(rowLabels(prs.markdown), expected);
   });
 
   it('renders counts with deltas and ages in days', () => {
-    const issues = squash(sections[1]);
-    const prs = squash(sections[2]);
+    assert.match(issues.markdown, /Issues.*Bugs.*Closed.*Avg Age.*P95 Age/);
     assert.match(
-      issues,
+      prs.markdown,
+      /Open.*Created.*Merged.*Closed.*Avg Age.*P95 Age/
+    );
+    assert.match(
+      squash(issues.markdown),
       /\| Everything \| 9 \(\+1\) \| 9 \(\+1\) \| 9 \(\+1\) \| 90d \(\+1\) \| 180d \(\+1\) \|/
     );
     assert.match(
-      issues,
+      squash(issues.markdown),
       /\| Unscoped \| 2 \(-1\) \| 2 \(-1\) \| 2 \(-1\) \| 20d \(-1\) \| 40d \(-1\) \|/
     );
-    assert.match(prs, /\| scope: small \| 1 \| 1 \| 1 \| 1 \| 3d \| 4d \|/);
+    assert.match(
+      squash(prs.markdown),
+      /\| scope: small \| 1 \| 1 \| 1 \| 1 \| 3d \| 4d \|/
+    );
   });
 
   it('shows a dash for ages when nothing is open', () => {
-    const issues = squash(sections[1]);
-    const prs = squash(sections[2]);
-    assert.match(issues, /\| scope: none \| 0 \| 0 \| 1 \| - \| - \|/);
-  });
-
-  it('omits scope rows with no activity at all from a table', () => {
-    assert.doesNotMatch(prs, /scope: none/);
-  });
-
-  it('links to the npm-burst package health page in the footer', () => {
     assert.match(
-      footer,
-      /<https:\/\/npm-burst.com\/package\/nx\/health\/\|[^>]+>/
+      squash(issues.markdown),
+      /\| scope: none \| 0 \| 0 \| 1 \| - \| - \|/
     );
   });
 
-  it('wraps every table section in a code fence', () => {
+  it('omits scope rows with no activity at all from a table', () => {
+    assert.doesNotMatch(prs.markdown, /scope: none/);
+  });
+});
+
+describe('toSlackSections', () => {
+  const sections = toSlackSections(
+    formatGhReport(current, trends, previous, links)
+  );
+
+  it('emits header, a bold label plus fenced chunks per table, then the footer', () => {
+    assert.equal(sections.length, 6);
+    const [header, issuesLabel, issues, prsLabel, prs, footer] = sections;
+    assert.equal(
+      header,
+      [
+        '*Issue & PR Report for Aug 30 2026* <https://example.com/issues|[view unlabeled issues]> <https://example.com/prs|[view unlabeled PRs]>',
+        'Previous Report: Aug 23 2026',
+        'Closed, created and merged counts are since Aug 23 2026. Ages are for open items, in days.',
+      ].join('\n')
+    );
+    assert.equal(issuesLabel, '*Issues*');
+    assert.equal(prsLabel, '*Pull requests*');
     for (const section of [issues, prs]) {
-      assert.ok(section.startsWith('```\n'));
+      assert.ok(section.startsWith('```\n| Scope'));
       assert.ok(section.endsWith('\n```'));
     }
+    assert.equal(
+      footer,
+      '<https://npm-burst.com/package/nx/health/|nx package health on npm-burst>'
+    );
+  });
+});
+
+describe('toMarkdown', () => {
+  const markdown = toMarkdown(formatGhReport(current, trends, previous, links));
+
+  it('renders headings, plain links and unfenced tables for GitHub', () => {
+    assert.match(markdown, /^# Issue & PR Report for Aug 30 2026\n/);
+    assert.match(
+      markdown,
+      /\[view unlabeled issues\]\(https:\/\/example.com\/issues\)/
+    );
+    assert.match(
+      markdown,
+      /\[view unlabeled PRs\]\(https:\/\/example.com\/prs\)/
+    );
+    assert.match(markdown, /\n## Issues\n\n\| Scope/);
+    assert.match(markdown, /\n## Pull requests\n\n\| Scope/);
+    assert.match(
+      markdown,
+      /\[nx package health on npm-burst\]\(https:\/\/npm-burst.com\/package\/nx\/health\/\)/
+    );
+    assert.doesNotMatch(markdown, /```/);
+    assert.doesNotMatch(markdown, /<https/);
   });
 });
 
@@ -161,8 +214,9 @@ describe('splitIntoBlocks', () => {
 });
 
 describe('getSlackMessageJson', () => {
-  it('emits one mrkdwn section block per text section', () => {
-    assert.deepEqual(getSlackMessageJson(['one', 'two']), {
+  it('emits a notification fallback and one mrkdwn section block per text section', () => {
+    assert.deepEqual(getSlackMessageJson('Report title', ['one', 'two']), {
+      text: 'Report title',
       blocks: [
         { type: 'section', text: { type: 'mrkdwn', text: 'one' } },
         { type: 'section', text: { type: 'mrkdwn', text: 'two' } },

--- a/scripts/issues-scraper/format-slack-message.spec.ts
+++ b/scripts/issues-scraper/format-slack-message.spec.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  formatGhReport,
+  getSlackMessageJson,
+  splitIntoBlocks,
+} from './format-slack-message';
+import { ReportData, ScopeData, ScopeTrend, TrendData } from './model';
+
+const stats = (n: number): ScopeData => ({
+  issues: { count: n, bugCount: n, closed: n, avgAge: n * 10, p95Age: n * 20 },
+  prs: {
+    open: n,
+    created: n,
+    merged: n,
+    closed: n,
+    avgAge: n * 3,
+    p95Age: n * 4,
+  },
+});
+const trend = (n: number | null): ScopeTrend => ({
+  issues: { count: n, bugCount: n, closed: n, avgAge: n, p95Age: n },
+  prs: { open: n, created: n, merged: n, closed: n, avgAge: n, p95Age: n },
+});
+
+const current: ReportData = {
+  all: stats(9),
+  unscoped: stats(2),
+  scopes: {
+    'scope: small': stats(1),
+    'scope: big': stats(5),
+    'scope: none': {
+      ...stats(0),
+      issues: { ...stats(0).issues, closed: 1 },
+    },
+  },
+  collectedDate: 'Aug 30 2026',
+};
+const trends: TrendData = {
+  all: trend(1),
+  unscoped: trend(-1),
+  scopes: {
+    'scope: small': trend(0),
+    'scope: big': trend(2),
+    'scope: none': trend(null),
+  },
+};
+const previous: Partial<ReportData> = { collectedDate: 'Aug 23 2026' };
+const links = {
+  unlabeledIssuesUrl: 'https://example.com/issues',
+  unlabeledPrsUrl: 'https://example.com/prs',
+};
+
+const squash = (s: string) => s.replace(/ +/g, ' ');
+
+describe('formatGhReport', () => {
+  const sections = formatGhReport(current, trends, previous, links);
+  const [header, issues, prs, footer] = sections;
+
+  it('returns the header, issue table, PR table and footer as separate sections', () => {
+    assert.equal(sections.length, 4);
+    assert.match(header, /Aug 30 2026/);
+    assert.match(
+      header,
+      /<https:\/\/example.com\/issues\|\[view unlabeled issues\]>/
+    );
+    assert.match(
+      header,
+      /<https:\/\/example.com\/prs\|\[view unlabeled PRs\]>/
+    );
+    assert.match(header, /Previous Report: Aug 23 2026/);
+    assert.match(issues, /Issues.*Bugs.*Closed.*Avg Age.*P95 Age/);
+    assert.match(prs, /Open.*Created.*Merged.*Closed.*Avg Age.*P95 Age/);
+  });
+
+  it('lists Everything, then Unscoped, then scopes by descending open count', () => {
+    const rows = (table: string) =>
+      table
+        .split('\n')
+        .filter((l) => l.startsWith('|'))
+        .slice(2)
+        .map((l) => l.split('|')[1].trim());
+    const expected = ['Everything', 'Unscoped', 'scope: big', 'scope: small'];
+    assert.deepEqual(rows(issues), [...expected, 'scope: none']);
+    assert.deepEqual(rows(prs), expected);
+  });
+
+  it('renders counts with deltas and ages in days', () => {
+    const issues = squash(sections[1]);
+    const prs = squash(sections[2]);
+    assert.match(
+      issues,
+      /\| Everything \| 9 \(\+1\) \| 9 \(\+1\) \| 9 \(\+1\) \| 90d \(\+1\) \| 180d \(\+1\) \|/
+    );
+    assert.match(
+      issues,
+      /\| Unscoped \| 2 \(-1\) \| 2 \(-1\) \| 2 \(-1\) \| 20d \(-1\) \| 40d \(-1\) \|/
+    );
+    assert.match(prs, /\| scope: small \| 1 \| 1 \| 1 \| 1 \| 3d \| 4d \|/);
+  });
+
+  it('shows a dash for ages when nothing is open', () => {
+    const issues = squash(sections[1]);
+    const prs = squash(sections[2]);
+    assert.match(issues, /\| scope: none \| 0 \| 0 \| 1 \| - \| - \|/);
+  });
+
+  it('omits scope rows with no activity at all from a table', () => {
+    assert.doesNotMatch(prs, /scope: none/);
+  });
+
+  it('links to the npm-burst package health page in the footer', () => {
+    assert.match(
+      footer,
+      /<https:\/\/npm-burst.com\/package\/nx\/health\/\|[^>]+>/
+    );
+  });
+
+  it('wraps every table section in a code fence', () => {
+    for (const section of [issues, prs]) {
+      assert.ok(section.startsWith('```\n'));
+      assert.ok(section.endsWith('\n```'));
+    }
+  });
+});
+
+describe('splitIntoBlocks', () => {
+  it('leaves short text as a single fenced block', () => {
+    assert.deepEqual(splitIntoBlocks('a\nb'), ['```\na\nb\n```']);
+  });
+
+  it('repeats the table header at the top of every continuation block', () => {
+    const header = ['| Scope | N |', '| ----- | - |'];
+    const rows = Array.from(
+      { length: 200 },
+      (_, i) => `| row ${i} | ${'x'.repeat(60)} |`
+    );
+    const blocks = splitIntoBlocks([...header, ...rows].join('\n'), 2);
+    assert.ok(blocks.length > 1);
+    for (const block of blocks) {
+      assert.deepEqual(block.split('\n').slice(1, 3), header);
+    }
+    const rejoined = blocks.flatMap((b) => b.split('\n').slice(3, -1));
+    assert.deepEqual(rejoined, rows);
+  });
+
+  it('splits on line boundaries so each fenced block fits in a Slack section', () => {
+    const lines = Array.from(
+      { length: 200 },
+      (_, i) => `row ${i} ${'x'.repeat(60)}`
+    );
+    const blocks = splitIntoBlocks(lines.join('\n'));
+    assert.ok(blocks.length > 1);
+    for (const block of blocks) {
+      assert.ok(block.length <= 3000, `block of ${block.length} chars`);
+      assert.ok(block.startsWith('```\n') && block.endsWith('\n```'));
+    }
+    const rejoined = blocks.map((b) => b.slice(4, -4)).join('\n');
+    assert.equal(rejoined, lines.join('\n'));
+  });
+});
+
+describe('getSlackMessageJson', () => {
+  it('emits one mrkdwn section block per text section', () => {
+    assert.deepEqual(getSlackMessageJson(['one', 'two']), {
+      blocks: [
+        { type: 'section', text: { type: 'mrkdwn', text: 'one' } },
+        { type: 'section', text: { type: 'mrkdwn', text: 'two' } },
+      ],
+    });
+  });
+});

--- a/scripts/issues-scraper/format-slack-message.ts
+++ b/scripts/issues-scraper/format-slack-message.ts
@@ -128,22 +128,32 @@ export function formatGhReport(
   };
 }
 
-export function toSlackSections(report: FormattedReport): string[] {
+type SlackBlock =
+  | { type: 'header'; text: { type: 'plain_text'; text: string } }
+  | { type: 'section'; text: { type: 'mrkdwn'; text: string } }
+  | { type: 'context'; elements: { type: 'mrkdwn'; text: string }[] }
+  | { type: 'divider' };
+
+export function toSlackBlocks(report: FormattedReport): SlackBlock[] {
   const slackLink = (l: Link) => `<${l.url}|${l.label}>`;
-  const header = [
-    [
-      `*${report.title}*`,
-      ...report.links.map((l) => `<${l.url}|[${l.label}]>`),
-    ].join(' '),
-    ...report.notes,
-  ].join('\n');
+  const section = (text: string): SlackBlock => ({
+    type: 'section',
+    text: { type: 'mrkdwn', text },
+  });
+  const context = (text: string): SlackBlock => ({
+    type: 'context',
+    elements: [{ type: 'mrkdwn', text }],
+  });
   return [
-    header,
+    { type: 'header', text: { type: 'plain_text', text: report.title } },
+    context(report.notes.join('\n')),
+    ...report.links.map((l) => section(slackLink(l))),
     ...report.tables.flatMap((t) => [
-      `*${t.title}*`,
-      ...splitIntoBlocks(t.markdown, TABLE_HEADER_LINES),
+      { type: 'divider' } as SlackBlock,
+      section(`*${t.title}*`),
+      ...splitIntoBlocks(t.markdown, TABLE_HEADER_LINES).map(section),
     ]),
-    slackLink(report.footer),
+    context(slackLink(report.footer)),
   ];
 }
 
@@ -158,14 +168,8 @@ export function toMarkdown(report: FormattedReport): string {
   ].join('\n\n');
 }
 
-export function getSlackMessageJson(fallbackText: string, sections: string[]) {
-  return {
-    text: fallbackText,
-    blocks: sections.map((text) => ({
-      type: 'section',
-      text: { type: 'mrkdwn', text },
-    })),
-  };
+export function getSlackMessageJson(report: FormattedReport) {
+  return { text: report.title, blocks: toSlackBlocks(report) };
 }
 
 function count(label: string, pick: (r: Row) => [number, number | null]) {

--- a/scripts/issues-scraper/format-slack-message.ts
+++ b/scripts/issues-scraper/format-slack-message.ts
@@ -1,88 +1,173 @@
-import { ReportData, TrendData } from './model';
-import { getSinceDate } from './scrape-issues';
 import { table } from 'markdown-factory';
+import { ReportData, ScopeData, ScopeTrend, TrendData } from './model';
+import { getSinceDate } from './scrape-issues';
 
-export function getSlackMessageJson(body: string) {
+const SLACK_SECTION_TEXT_LIMIT = 3000;
+const TABLE_HEADER_LINES = 2;
+const NPM_HEALTH_URL = 'https://npm-burst.com/package/nx/health/';
+
+export function getSlackMessageJson(sections: string[]) {
   return {
-    blocks: [
-      {
-        type: 'section',
-        text: {
-          text: body,
-          type: 'mrkdwn',
-        },
-      },
-    ],
+    blocks: sections.map((text) => ({
+      type: 'section',
+      text: { type: 'mrkdwn', text },
+    })),
   };
 }
+
+export interface ReportLinks {
+  unlabeledIssuesUrl: string;
+  unlabeledPrsUrl: string;
+}
+
+type Row = {
+  label: string;
+  data: ScopeData;
+  trend: ScopeTrend;
+};
 
 export function formatGhReport(
   currentData: ReportData,
   trendData: TrendData,
-  prevData: ReportData,
-  unlabeledIssuesUrl: string
-): string {
-  const formattedIssueDelta = formatDelta(trendData.totalIssueCount);
-  const formattedBugDelta = formatDelta(trendData.totalBugCount);
-
-  const header = `Issue Report for ${currentData.collectedDate} <${unlabeledIssuesUrl}|[view unlabeled]>
-\`\`\`
-Totals, Issues: ${currentData.totalIssueCount} ${formattedIssueDelta} Bugs: ${currentData.totalBugCount} ${formattedBugDelta}\n\n`;
-
+  prevData: Partial<ReportData>,
+  links: ReportLinks
+): string[] {
   const prevDate = prevData.collectedDate
     ? new Date(prevData.collectedDate)
     : undefined;
-  const closedSinceDate = getSinceDate(prevDate)
-    .toDateString()
-    .split(' ')
-    .slice(1)
-    .join(' ');
+  const sinceDate = formatDate(getSinceDate(prevDate));
 
-  const bodyLines: string[] = [
+  const header = [
+    `Issue & PR Report for ${currentData.collectedDate} <${links.unlabeledIssuesUrl}|[view unlabeled issues]> <${links.unlabeledPrsUrl}|[view unlabeled PRs]>`,
     ...(prevData.collectedDate
       ? [`Previous Report: ${prevData.collectedDate}`]
       : []),
-    `Untriaged: ${currentData.untriagedIssueCount} ${formatDelta(
-      trendData.untriagedIssueCount
-    )}`,
-    `Closed since ${closedSinceDate}: ${currentData.totalClosed} ${formatDelta(
-      trendData.totalClosed
-    )}`,
+    `Closed, created and merged counts are since ${sinceDate}. Ages are for open items, in days.`,
+  ].join('\n');
+
+  const rows = (
+    sortBy: (d: ScopeData) => number,
+    activity: (d: ScopeData) => number[]
+  ): Row[] => [
+    { label: 'Everything', data: currentData.all, trend: trendData.all },
+    {
+      label: 'Unscoped',
+      data: currentData.unscoped,
+      trend: trendData.unscoped,
+    },
+    ...Object.entries(currentData.scopes)
+      .filter(([, data]) => activity(data).some((n) => n > 0))
+      .sort(([, a], [, b]) => sortBy(b) - sortBy(a))
+      .map(([scope, data]) => ({
+        label: scope,
+        data,
+        trend: trendData.scopes[scope],
+      })),
   ];
 
-  const sorted = Object.entries(currentData.scopes)
-    .sort(([, a], [, b]) => b.count - a.count)
-    .map(([scope, x]) => ({
-      ...x,
-      scope,
-    }));
-
-  bodyLines.push(
-    table(sorted, [
-      {
-        field: 'scope',
-        label: 'Scope',
-      },
-      {
-        label: 'Issues',
-        mapFn: (el) =>
-          `${el.count} ${formatDelta(trendData.scopes[el.scope].count)}`,
-      },
-      {
-        label: 'Bugs',
-        mapFn: (el) =>
-          `${el.bugCount} ${formatDelta(trendData.scopes[el.scope].bugCount)}`,
-      },
-      {
-        label: 'Closed',
-        mapFn: (el) =>
-          `${el.closed} ${formatDelta(trendData.scopes[el.scope].closed)}`,
-      },
-    ])
+  const issueTable = table<Row>(
+    rows(
+      (d) => d.issues.count,
+      (d) => [d.issues.count, d.issues.bugCount, d.issues.closed]
+    ),
+    [
+      { label: 'Scope', field: 'label' },
+      count('Issues', (r) => [r.data.issues.count, r.trend.issues.count]),
+      count('Bugs', (r) => [r.data.issues.bugCount, r.trend.issues.bugCount]),
+      count('Closed', (r) => [r.data.issues.closed, r.trend.issues.closed]),
+      age('Avg Age', (r) => [
+        r.data.issues.count,
+        r.data.issues.avgAge,
+        r.trend.issues.avgAge,
+      ]),
+      age('P95 Age', (r) => [
+        r.data.issues.count,
+        r.data.issues.p95Age,
+        r.trend.issues.p95Age,
+      ]),
+    ]
   );
 
-  const footer = '```';
-  return header + bodyLines.join('\n') + footer;
+  const prTable = table<Row>(
+    rows(
+      (d) => d.prs.open,
+      (d) => [d.prs.open, d.prs.created, d.prs.merged, d.prs.closed]
+    ),
+    [
+      { label: 'Scope', field: 'label' },
+      count('Open', (r) => [r.data.prs.open, r.trend.prs.open]),
+      count('Created', (r) => [r.data.prs.created, r.trend.prs.created]),
+      count('Merged', (r) => [r.data.prs.merged, r.trend.prs.merged]),
+      count('Closed', (r) => [r.data.prs.closed, r.trend.prs.closed]),
+      age('Avg Age', (r) => [
+        r.data.prs.open,
+        r.data.prs.avgAge,
+        r.trend.prs.avgAge,
+      ]),
+      age('P95 Age', (r) => [
+        r.data.prs.open,
+        r.data.prs.p95Age,
+        r.trend.prs.p95Age,
+      ]),
+    ]
+  );
+
+  const footer = `<${NPM_HEALTH_URL}|nx package health on npm-burst>`;
+
+  return [
+    header,
+    ...splitIntoBlocks(issueTable, TABLE_HEADER_LINES),
+    ...splitIntoBlocks(prTable, TABLE_HEADER_LINES),
+    footer,
+  ];
+}
+
+function count(label: string, pick: (r: Row) => [number, number | null]) {
+  return {
+    label,
+    mapFn: (r: Row) => {
+      const [value, delta] = pick(r);
+      return `${value} ${formatDelta(delta)}`.trim();
+    },
+  };
+}
+
+function age(label: string, pick: (r: Row) => [number, number, number | null]) {
+  return {
+    label,
+    mapFn: (r: Row) => {
+      const [openCount, value, delta] = pick(r);
+      if (openCount === 0) {
+        return '-';
+      }
+      return `${value}d ${formatDelta(delta)}`.trim();
+    },
+  };
+}
+
+export function splitIntoBlocks(text: string, headerLines = 0): string[] {
+  const lines = text.split('\n');
+  const header = lines.slice(0, headerLines);
+  const fence = (body: string[]) => `\`\`\`\n${body.join('\n')}\n\`\`\``;
+  const blocks: string[] = [];
+  let current = [...header];
+  for (const line of lines.slice(headerLines)) {
+    if (
+      current.length > header.length &&
+      fence([...current, line]).length > SLACK_SECTION_TEXT_LIMIT
+    ) {
+      blocks.push(fence(current));
+      current = [...header];
+    }
+    current.push(line);
+  }
+  blocks.push(fence(current));
+  return blocks;
+}
+
+function formatDate(date: Date): string {
+  // Format is like: Mar 03 2023
+  return date.toDateString().split(' ').slice(1).join(' ');
 }
 
 function formatDelta(delta: number | null): string {

--- a/scripts/issues-scraper/format-slack-message.ts
+++ b/scripts/issues-scraper/format-slack-message.ts
@@ -6,13 +6,17 @@ const SLACK_SECTION_TEXT_LIMIT = 3000;
 const TABLE_HEADER_LINES = 2;
 const NPM_HEALTH_URL = 'https://npm-burst.com/package/nx/health/';
 
-export function getSlackMessageJson(sections: string[]) {
-  return {
-    blocks: sections.map((text) => ({
-      type: 'section',
-      text: { type: 'mrkdwn', text },
-    })),
-  };
+export interface Link {
+  label: string;
+  url: string;
+}
+
+export interface FormattedReport {
+  title: string;
+  links: Link[];
+  notes: string[];
+  tables: { title: string; markdown: string }[];
+  footer: Link;
 }
 
 export interface ReportLinks {
@@ -31,19 +35,11 @@ export function formatGhReport(
   trendData: TrendData,
   prevData: Partial<ReportData>,
   links: ReportLinks
-): string[] {
+): FormattedReport {
   const prevDate = prevData.collectedDate
     ? new Date(prevData.collectedDate)
     : undefined;
   const sinceDate = formatDate(getSinceDate(prevDate));
-
-  const header = [
-    `Issue & PR Report for ${currentData.collectedDate} <${links.unlabeledIssuesUrl}|[view unlabeled issues]> <${links.unlabeledPrsUrl}|[view unlabeled PRs]>`,
-    ...(prevData.collectedDate
-      ? [`Previous Report: ${prevData.collectedDate}`]
-      : []),
-    `Closed, created and merged counts are since ${sinceDate}. Ages are for open items, in days.`,
-  ].join('\n');
 
   const rows = (
     sortBy: (d: ScopeData) => number,
@@ -112,14 +108,64 @@ export function formatGhReport(
     ]
   );
 
-  const footer = `<${NPM_HEALTH_URL}|nx package health on npm-burst>`;
+  return {
+    title: `Issue & PR Report for ${currentData.collectedDate}`,
+    links: [
+      { label: 'view unlabeled issues', url: links.unlabeledIssuesUrl },
+      { label: 'view unlabeled PRs', url: links.unlabeledPrsUrl },
+    ],
+    notes: [
+      ...(prevData.collectedDate
+        ? [`Previous Report: ${prevData.collectedDate}`]
+        : []),
+      `Closed, created and merged counts are since ${sinceDate}. Ages are for open items, in days.`,
+    ],
+    tables: [
+      { title: 'Issues', markdown: issueTable },
+      { title: 'Pull requests', markdown: prTable },
+    ],
+    footer: { label: 'nx package health on npm-burst', url: NPM_HEALTH_URL },
+  };
+}
 
+export function toSlackSections(report: FormattedReport): string[] {
+  const slackLink = (l: Link) => `<${l.url}|${l.label}>`;
+  const header = [
+    [
+      `*${report.title}*`,
+      ...report.links.map((l) => `<${l.url}|[${l.label}]>`),
+    ].join(' '),
+    ...report.notes,
+  ].join('\n');
   return [
     header,
-    ...splitIntoBlocks(issueTable, TABLE_HEADER_LINES),
-    ...splitIntoBlocks(prTable, TABLE_HEADER_LINES),
-    footer,
+    ...report.tables.flatMap((t) => [
+      `*${t.title}*`,
+      ...splitIntoBlocks(t.markdown, TABLE_HEADER_LINES),
+    ]),
+    slackLink(report.footer),
   ];
+}
+
+export function toMarkdown(report: FormattedReport): string {
+  const mdLink = (l: Link) => `[${l.label}](${l.url})`;
+  return [
+    `# ${report.title}`,
+    report.notes.join('  \n'),
+    report.links.map(mdLink).join(' · '),
+    ...report.tables.flatMap((t) => [`## ${t.title}`, t.markdown]),
+    mdLink(report.footer),
+  ].join('\n\n');
+}
+
+export function getSlackMessageJson(fallbackText: string, sections: string[]) {
+  return {
+    text: fallbackText,
+    blocks: sections.map((text) => ({
+      type: 'section',
+      text: { type: 'mrkdwn', text },
+    })),
+  };
 }
 
 function count(label: string, pick: (r: Row) => [number, number | null]) {

--- a/scripts/issues-scraper/index.ts
+++ b/scripts/issues-scraper/index.ts
@@ -6,7 +6,6 @@ import {
   formatGhReport,
   getSlackMessageJson,
   toMarkdown,
-  toSlackSections,
 } from './format-slack-message';
 import { ReportData } from './model';
 import { getScopeLabels, scrapeIssues } from './scrape-issues';
@@ -27,10 +26,7 @@ async function main() {
   });
   const markdown = toMarkdown(report);
   if (process.env.GITHUB_ACTIONS) {
-    setOutput(
-      'SLACK_MESSAGE',
-      getSlackMessageJson(report.title, toSlackSections(report))
-    );
+    setOutput('SLACK_MESSAGE', getSlackMessageJson(report));
   }
   if (process.env.GITHUB_STEP_SUMMARY) {
     await summary.addRaw(markdown).write();

--- a/scripts/issues-scraper/index.ts
+++ b/scripts/issues-scraper/index.ts
@@ -1,8 +1,13 @@
-import { setOutput } from '@actions/core';
+import { setOutput, summary } from '@actions/core';
 import { ensureDirSync, readJsonSync, writeJsonSync } from 'fs-extra';
 import isCI from 'is-ci';
 import { dirname, join } from 'path';
-import { formatGhReport, getSlackMessageJson } from './format-slack-message';
+import {
+  formatGhReport,
+  getSlackMessageJson,
+  toMarkdown,
+  toSlackSections,
+} from './format-slack-message';
 import { ReportData } from './model';
 import { getScopeLabels, scrapeIssues } from './scrape-issues';
 import { getTrendData } from './stats';
@@ -16,14 +21,21 @@ async function main() {
   );
   const trendData = getTrendData(currentData, oldData);
   const scopeLabels = await getScopeLabels();
-  const sections = formatGhReport(currentData, trendData, oldData, {
+  const report = formatGhReport(currentData, trendData, oldData, {
     unlabeledIssuesUrl: getUnlabeledUrl('issue', scopeLabels),
     unlabeledPrsUrl: getUnlabeledUrl('pr', scopeLabels),
   });
+  const markdown = toMarkdown(report);
   if (process.env.GITHUB_ACTIONS) {
-    setOutput('SLACK_MESSAGE', getSlackMessageJson(sections));
+    setOutput(
+      'SLACK_MESSAGE',
+      getSlackMessageJson(report.title, toSlackSections(report))
+    );
   }
-  console.log(sections.join('\n').replace(/\<(.*?)\|(.*?)\>/g, '[$2]($1)'));
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await summary.addRaw(markdown).write();
+  }
+  console.log(markdown);
   saveCacheData(currentData);
 }
 

--- a/scripts/issues-scraper/index.ts
+++ b/scripts/issues-scraper/index.ts
@@ -3,8 +3,9 @@ import { ensureDirSync, readJsonSync, writeJsonSync } from 'fs-extra';
 import isCI from 'is-ci';
 import { dirname, join } from 'path';
 import { formatGhReport, getSlackMessageJson } from './format-slack-message';
-import { ReportData, ScopeData, TrendData } from './model';
+import { ReportData } from './model';
 import { getScopeLabels, scrapeIssues } from './scrape-issues';
+import { getTrendData } from './stats';
 
 const CACHE_FILE = join(__dirname, 'cached', 'data.json');
 
@@ -14,16 +15,15 @@ async function main() {
     oldData.collectedDate ? new Date(oldData.collectedDate) : undefined
   );
   const trendData = getTrendData(currentData, oldData);
-  const formatted = formatGhReport(
-    currentData,
-    trendData,
-    oldData,
-    getUnlabeledIssuesUrl(await getScopeLabels())
-  );
+  const scopeLabels = await getScopeLabels();
+  const sections = formatGhReport(currentData, trendData, oldData, {
+    unlabeledIssuesUrl: getUnlabeledUrl('issue', scopeLabels),
+    unlabeledPrsUrl: getUnlabeledUrl('pr', scopeLabels),
+  });
   if (process.env.GITHUB_ACTIONS) {
-    setOutput('SLACK_MESSAGE', getSlackMessageJson(formatted));
+    setOutput('SLACK_MESSAGE', getSlackMessageJson(sections));
   }
-  console.log(formatted.replace(/\<(.*)\|(.*)\>/g, '[$2]($1)'));
+  console.log(sections.join('\n').replace(/\<(.*?)\|(.*?)\>/g, '[$2]($1)'));
   saveCacheData(currentData);
 }
 
@@ -34,31 +34,12 @@ if (require.main === module) {
   });
 }
 
-function getUnlabeledIssuesUrl(scopeLabels: string[]) {
+function getUnlabeledUrl(type: 'issue' | 'pr', scopeLabels: string[]) {
   const labelFilters = scopeLabels.map((s) => `-label:"${s}"`);
-  return `https://github.com/nrwl/nx/issues/?q=is%3Aopen+is%3Aissue+sort%3Aupdated-desc+${encodeURIComponent(
+  const path = type === 'issue' ? 'issues' : 'pulls';
+  return `https://github.com/nrwl/nx/${path}?q=is%3Aopen+is%3A${type}+sort%3Aupdated-desc+${encodeURIComponent(
     labelFilters.join(' ')
   )}`;
-}
-
-function getTrendData(newData: ReportData, oldData: ReportData): TrendData {
-  const scopeTrends: Record<string, Partial<ScopeData>> = {};
-  for (const [scope, data] of Object.entries(newData.scopes)) {
-    scopeTrends[scope] ??= {};
-    scopeTrends[scope].count = data.count - (oldData.scopes[scope]?.count ?? 0);
-    scopeTrends[scope].bugCount =
-      data.bugCount - (oldData.scopes[scope]?.bugCount ?? 0);
-    scopeTrends[scope].closed =
-      data.closed - (oldData.scopes[scope]?.closed ?? 0);
-  }
-  return {
-    scopes: scopeTrends as Record<string, ScopeData>,
-    totalBugCount: newData.totalBugCount - oldData.totalBugCount,
-    totalIssueCount: newData.totalIssueCount - oldData.totalIssueCount,
-    totalClosed: newData.totalClosed - oldData.totalClosed,
-    untriagedIssueCount:
-      newData.untriagedIssueCount - oldData.untriagedIssueCount,
-  };
 }
 
 function saveCacheData(report: ReportData) {
@@ -68,16 +49,10 @@ function saveCacheData(report: ReportData) {
   }
 }
 
-function getOldData(): ReportData {
+function getOldData(): Partial<ReportData> {
   try {
     return readJsonSync(CACHE_FILE);
   } catch (e) {
-    return {
-      scopes: {},
-      totalBugCount: 0,
-      totalIssueCount: 0,
-      untriagedIssueCount: 0,
-      totalClosed: 0,
-    };
+    return {};
   }
 }

--- a/scripts/issues-scraper/model.ts
+++ b/scripts/issues-scraper/model.ts
@@ -1,16 +1,61 @@
-export interface ScopeData {
-  bugCount: number;
+export interface IssueStats {
   count: number;
+  bugCount: number;
   closed: number;
+  avgAge: number;
+  p95Age: number;
+}
+
+export interface PrStats {
+  open: number;
+  created: number;
+  merged: number;
+  closed: number;
+  avgAge: number;
+  p95Age: number;
+}
+
+export interface ScopeData {
+  issues: IssueStats;
+  prs: PrStats;
 }
 
 export interface ReportData {
+  all: ScopeData;
+  unscoped: ScopeData;
   scopes: Record<string, ScopeData>;
-  totalBugCount: number;
-  totalIssueCount: number;
-  totalClosed: number;
-  untriagedIssueCount: number;
   collectedDate?: string;
 }
 
-export type TrendData = Omit<ReportData, 'collectedDate'>;
+export type StatsTrend<T> = Record<keyof T, number | null>;
+
+export interface ScopeTrend {
+  issues: StatsTrend<IssueStats>;
+  prs: StatsTrend<PrStats>;
+}
+
+export interface TrendData {
+  all: ScopeTrend;
+  unscoped: ScopeTrend;
+  scopes: Record<string, ScopeTrend>;
+}
+
+export interface ScrapedItem {
+  scopes: string[];
+  createdAt: Date;
+}
+
+export interface ScrapedIssue extends ScrapedItem {
+  bug: boolean;
+}
+
+export interface ScrapedPr extends ScrapedItem {
+  merged: boolean;
+}
+
+export interface ScrapedData {
+  openIssues: ScrapedIssue[];
+  closedIssues: ScrapedIssue[];
+  openPrs: ScrapedPr[];
+  closedPrs: ScrapedPr[];
+}

--- a/scripts/issues-scraper/scrape-issues.ts
+++ b/scripts/issues-scraper/scrape-issues.ts
@@ -1,66 +1,61 @@
 import { Octokit } from 'octokit';
-import { ReportData, ScopeData } from './model';
+import { ReportData, ScrapedData, ScrapedIssue, ScrapedPr } from './model';
+import { buildReport } from './stats';
 
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 const now = new Date();
 
 export async function scrapeIssues(prevDate?: Date): Promise<ReportData> {
-  let total = 0;
-  let totalBugs = 0;
-  let untriagedIssueCount = 0;
-  let totalClosed = 0;
   const scopeLabels = await getScopeLabels();
-  const scopes: Record<string, ScopeData> = {};
-
-  for await (const { data: slice } of getOpenIssueIterator()) {
-    for (const issue of slice.filter(isNotPullRequest)) {
-      const bug = hasLabel(issue, 'type: bug');
-
-      if (bug) {
-        totalBugs += 1;
-      }
-      total += 1;
-
-      let triaged = false;
-      for (const scope of scopeLabels) {
-        if (hasLabel(issue, scope)) {
-          scopes[scope] ??= { bugCount: 0, count: 0, closed: 0 };
-          if (bug) {
-            scopes[scope].bugCount += 1;
-          }
-          scopes[scope].count += 1;
-          triaged = true;
-        }
-      }
-      if (!triaged) {
-        untriagedIssueCount += 1;
-      }
-    }
-  }
-
   const sinceDate = getSinceDate(prevDate);
-  for await (const { data: slice } of getClosedIssueIterator(sinceDate)) {
-    for (const issue of slice.filter(isNotPullRequest)) {
-      totalClosed += 1;
 
-      for (const scope of scopeLabels) {
-        if (hasLabel(issue, scope)) {
-          scopes[scope] ??= { bugCount: 0, count: 0, closed: 0 };
-          scopes[scope].closed += 1;
-        }
-      }
-    }
+  const open: IssueItem[] = [];
+  for await (const { data: slice } of getOpenIssueIterator()) {
+    open.push(...slice);
+  }
+  const closed: IssueItem[] = [];
+  for await (const { data: slice } of getClosedIssueIterator(sinceDate)) {
+    closed.push(...slice);
   }
 
   return {
-    scopes: scopes,
-    totalBugCount: totalBugs,
-    totalIssueCount: total,
-    totalClosed,
-    untriagedIssueCount,
+    ...buildReport(
+      toScrapedData(open, closed, scopeLabels, sinceDate),
+      sinceDate,
+      now
+    ),
     // Format is like: Mar 03 2023
-    collectedDate: new Date().toDateString().split(' ').slice(1).join(' '),
+    collectedDate: now.toDateString().split(' ').slice(1).join(' '),
   };
+}
+
+export function toScrapedData(
+  open: IssueItem[],
+  closed: IssueItem[],
+  scopeLabels: string[],
+  sinceDate: Date
+): ScrapedData {
+  const data: ScrapedData = {
+    openIssues: [],
+    closedIssues: [],
+    openPrs: [],
+    closedPrs: [],
+  };
+  for (const item of open) {
+    if (isPullRequest(item)) {
+      data.openPrs.push(toPr(item, scopeLabels));
+    } else {
+      data.openIssues.push(toIssue(item, scopeLabels));
+    }
+  }
+  for (const item of closed) {
+    if (!isPullRequest(item)) {
+      data.closedIssues.push(toIssue(item, scopeLabels));
+    } else if (prClosedAt(item) >= sinceDate) {
+      data.closedPrs.push(toPr(item, scopeLabels));
+    }
+  }
+  return data;
 }
 
 export function getSinceDate(prevDate?: Date, referenceDate = now): Date {
@@ -83,6 +78,8 @@ const getOpenIssueIterator = () =>
     state: 'open',
   });
 
+// `since` filters on updated_at, so closed PRs are re-checked against
+// their merged_at / closed_at before being counted.
 const getClosedIssueIterator = (since: Date) =>
   octokit.paginate.iterator('GET /repos/{owner}/{repo}/issues', {
     owner: 'nrwl',
@@ -114,12 +111,36 @@ async function getAllLabels(): Promise<string[]> {
   return labels;
 }
 
-type IssueItem = Awaited<
+export type IssueItem = Awaited<
   ReturnType<typeof octokit.rest.issues.listForRepo>
 >['data'][number];
 
-function isNotPullRequest(issue: IssueItem): boolean {
-  return !('pull_request' in issue) || issue.pull_request == null;
+function isPullRequest(issue: IssueItem): boolean {
+  return issue.pull_request != null;
+}
+
+function prClosedAt(pr: IssueItem): Date {
+  return new Date(pr.pull_request?.merged_at ?? pr.closed_at);
+}
+
+function toIssue(issue: IssueItem, scopeLabels: string[]): ScrapedIssue {
+  return {
+    scopes: scopesOn(issue, scopeLabels),
+    createdAt: new Date(issue.created_at),
+    bug: hasLabel(issue, 'type: bug'),
+  };
+}
+
+function toPr(pr: IssueItem, scopeLabels: string[]): ScrapedPr {
+  return {
+    scopes: scopesOn(pr, scopeLabels),
+    createdAt: new Date(pr.created_at),
+    merged: pr.pull_request?.merged_at != null,
+  };
+}
+
+function scopesOn(issue: IssueItem, scopeLabels: string[]): string[] {
+  return scopeLabels.filter((scope) => hasLabel(issue, scope));
 }
 
 function hasLabel(issue: IssueItem, labelName: string): boolean {

--- a/scripts/issues-scraper/stats.spec.ts
+++ b/scripts/issues-scraper/stats.spec.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ReportData, ScrapedData } from './model';
+import { average, buildReport, getTrendData, percentile } from './stats';
+
+const now = new Date('2026-08-30T00:00:00Z');
+const since = new Date('2026-08-23T00:00:00Z');
+const daysAgo = (days: number) =>
+  new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+
+describe('percentile', () => {
+  it('uses nearest-rank so the result is always a real sample', () => {
+    const values = Array.from({ length: 20 }, (_, i) => i + 1);
+    assert.equal(percentile(values, 0.95), 19);
+    assert.equal(percentile([5], 0.95), 5);
+  });
+
+  it('is 0 for an empty sample', () => {
+    assert.equal(percentile([], 0.95), 0);
+  });
+});
+
+describe('average', () => {
+  it('rounds to whole days', () => {
+    assert.equal(average([1, 2, 4]), 2);
+    assert.equal(average([]), 0);
+  });
+});
+
+describe('buildReport', () => {
+  const data: ScrapedData = {
+    openIssues: [
+      { scopes: ['scope: core'], bug: true, createdAt: daysAgo(10) },
+      {
+        scopes: ['scope: core', 'scope: react'],
+        bug: false,
+        createdAt: daysAgo(30),
+      },
+      { scopes: [], bug: true, createdAt: daysAgo(2) },
+    ],
+    closedIssues: [
+      { scopes: ['scope: core'], bug: false, createdAt: daysAgo(100) },
+      { scopes: [], bug: false, createdAt: daysAgo(100) },
+    ],
+    openPrs: [
+      { scopes: ['scope: core'], merged: false, createdAt: daysAgo(3) },
+      { scopes: [], merged: false, createdAt: daysAgo(40) },
+    ],
+    closedPrs: [
+      { scopes: ['scope: core'], merged: true, createdAt: daysAgo(4) },
+      { scopes: ['scope: react'], merged: false, createdAt: daysAgo(20) },
+    ],
+  };
+  const report = buildReport(data, since, now);
+
+  it('fills the Everything row from every item', () => {
+    assert.deepEqual(report.all.issues, {
+      count: 3,
+      bugCount: 2,
+      closed: 2,
+      avgAge: 14,
+      p95Age: 30,
+    });
+    assert.deepEqual(report.all.prs, {
+      open: 2,
+      created: 2,
+      merged: 1,
+      closed: 1,
+      avgAge: 22,
+      p95Age: 40,
+    });
+  });
+
+  it('fills the Unscoped row from items with no scope label', () => {
+    assert.deepEqual(report.unscoped.issues, {
+      count: 1,
+      bugCount: 1,
+      closed: 1,
+      avgAge: 2,
+      p95Age: 2,
+    });
+    assert.deepEqual(report.unscoped.prs, {
+      open: 1,
+      created: 0,
+      merged: 0,
+      closed: 0,
+      avgAge: 40,
+      p95Age: 40,
+    });
+  });
+
+  it('creates one row per scope label seen on any item', () => {
+    assert.deepEqual(Object.keys(report.scopes).sort(), [
+      'scope: core',
+      'scope: react',
+    ]);
+    assert.deepEqual(report.scopes['scope: core'].issues, {
+      count: 2,
+      bugCount: 1,
+      closed: 1,
+      avgAge: 20,
+      p95Age: 30,
+    });
+    assert.deepEqual(report.scopes['scope: core'].prs, {
+      open: 1,
+      created: 2,
+      merged: 1,
+      closed: 0,
+      avgAge: 3,
+      p95Age: 3,
+    });
+    assert.deepEqual(report.scopes['scope: react'].prs, {
+      open: 0,
+      created: 0,
+      merged: 0,
+      closed: 1,
+      avgAge: 0,
+      p95Age: 0,
+    });
+  });
+});
+
+describe('getTrendData', () => {
+  const stats = (n: number) => ({
+    issues: { count: n, bugCount: n, closed: n, avgAge: n, p95Age: n },
+    prs: { open: n, created: n, merged: n, closed: n, avgAge: n, p95Age: n },
+  });
+  const current: ReportData = {
+    all: stats(10),
+    unscoped: stats(4),
+    scopes: { 'scope: core': stats(6), 'scope: new': stats(2) },
+  };
+
+  it('subtracts the previous report field by field', () => {
+    const prev: ReportData = {
+      all: stats(7),
+      unscoped: stats(5),
+      scopes: { 'scope: core': stats(6) },
+    };
+    const trend = getTrendData(current, prev);
+    assert.equal(trend.all.issues.count, 3);
+    assert.equal(trend.all.prs.avgAge, 3);
+    assert.equal(trend.unscoped.issues.bugCount, -1);
+    assert.equal(trend.scopes['scope: core'].prs.merged, 0);
+  });
+
+  it('reports no delta when there is no previous row', () => {
+    const trend = getTrendData(current, {});
+    assert.equal(trend.all.issues.count, null);
+    assert.equal(trend.all.issues.avgAge, null);
+    assert.equal(trend.scopes['scope: new'].prs.open, null);
+    assert.equal(trend.scopes['scope: new'].prs.p95Age, null);
+  });
+});

--- a/scripts/issues-scraper/stats.ts
+++ b/scripts/issues-scraper/stats.ts
@@ -1,0 +1,157 @@
+import {
+  IssueStats,
+  PrStats,
+  ReportData,
+  ScopeData,
+  ScopeTrend,
+  ScrapedData,
+  ScrapedIssue,
+  ScrapedItem,
+  ScrapedPr,
+  StatsTrend,
+  TrendData,
+} from './model';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return Math.round(values.reduce((sum, v) => sum + v, 0) / values.length);
+}
+
+export function percentile(values: number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.max(0, Math.ceil(p * sorted.length) - 1)];
+}
+
+export function buildReport(
+  data: ScrapedData,
+  since: Date,
+  now: Date
+): ReportData {
+  const scopeLabels = new Set<string>();
+  for (const items of Object.values(data)) {
+    for (const item of items) {
+      item.scopes.forEach((s) => scopeLabels.add(s));
+    }
+  }
+
+  const scopes: Record<string, ScopeData> = {};
+  for (const scope of scopeLabels) {
+    scopes[scope] = computeScopeData(
+      filterData(data, (item) => item.scopes.includes(scope)),
+      since,
+      now
+    );
+  }
+
+  return {
+    all: computeScopeData(data, since, now),
+    unscoped: computeScopeData(
+      filterData(data, (item) => item.scopes.length === 0),
+      since,
+      now
+    ),
+    scopes,
+  };
+}
+
+function filterData(
+  data: ScrapedData,
+  predicate: (item: ScrapedItem) => boolean
+): ScrapedData {
+  return {
+    openIssues: data.openIssues.filter(predicate),
+    closedIssues: data.closedIssues.filter(predicate),
+    openPrs: data.openPrs.filter(predicate),
+    closedPrs: data.closedPrs.filter(predicate),
+  };
+}
+
+function computeScopeData(
+  data: ScrapedData,
+  since: Date,
+  now: Date
+): ScopeData {
+  return {
+    issues: computeIssueStats(data.openIssues, data.closedIssues, now),
+    prs: computePrStats(data.openPrs, data.closedPrs, since, now),
+  };
+}
+
+function computeIssueStats(
+  open: ScrapedIssue[],
+  closed: ScrapedIssue[],
+  now: Date
+): IssueStats {
+  const ages = open.map((i) => ageInDays(i, now));
+  return {
+    count: open.length,
+    bugCount: open.filter((i) => i.bug).length,
+    closed: closed.length,
+    avgAge: average(ages),
+    p95Age: percentile(ages, 0.95),
+  };
+}
+
+function computePrStats(
+  open: ScrapedPr[],
+  closed: ScrapedPr[],
+  since: Date,
+  now: Date
+): PrStats {
+  const ages = open.map((pr) => ageInDays(pr, now));
+  const createdSince = (pr: ScrapedPr) => pr.createdAt >= since;
+  return {
+    open: open.length,
+    created:
+      open.filter(createdSince).length + closed.filter(createdSince).length,
+    merged: closed.filter((pr) => pr.merged).length,
+    closed: closed.filter((pr) => !pr.merged).length,
+    avgAge: average(ages),
+    p95Age: percentile(ages, 0.95),
+  };
+}
+
+function ageInDays(item: ScrapedItem, now: Date): number {
+  return Math.floor((now.getTime() - item.createdAt.getTime()) / MS_PER_DAY);
+}
+
+export function getTrendData(
+  current: ReportData,
+  previous: Partial<ReportData>
+): TrendData {
+  const scopes: Record<string, ScopeTrend> = {};
+  for (const [scope, data] of Object.entries(current.scopes)) {
+    scopes[scope] = scopeTrend(data, previous.scopes?.[scope]);
+  }
+  return {
+    all: scopeTrend(current.all, previous.all),
+    unscoped: scopeTrend(current.unscoped, previous.unscoped),
+    scopes,
+  };
+}
+
+function scopeTrend(current: ScopeData, previous?: ScopeData): ScopeTrend {
+  return {
+    issues: statsTrend(current.issues, previous?.issues),
+    prs: statsTrend(current.prs, previous?.prs),
+  };
+}
+
+function statsTrend<T extends Record<keyof T, number>>(
+  current: T,
+  previous?: T
+): StatsTrend<T> {
+  const trend = {} as StatsTrend<T>;
+  for (const field of Object.keys(current) as (keyof T)[]) {
+    const prev = previous?.[field];
+    trend[field] = prev === undefined ? null : current[field] - prev;
+  }
+  return trend;
+}


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

The weekly report only covers issues. There is no PR data, no age data, and no row for everything or for unscoped items. It only goes to Slack, as one section block.

The job also runs for 4 to 6 hours after the message is sent. The `Cache node_modules` step is lookup-only and nothing reads it, but its post step still saves on every miss: globbing `**/node_modules` over the pnpm checkout takes over four hours, then it tars a 943 MB archive that the cache quota evicts before the next run. The last three scheduled runs were cancelled at the job limit.

````
Issue Report for Aug 29 2026 [view unlabeled](https://github.com/nrwl/nx/issues/?q=...)
```
Totals, Issues: 279 (-2) Bugs: 220 (+2)

Previous Report: Aug 23 2026
Untriaged: 52 (-3)
Closed since Aug 23 2026: 33 (+3)
| Scope           | Issues  | Bugs | Closed |
| --------------- | ------- | ---- | ------ |
| scope: core     | 75 (+2) | 63   | 5 (+1) |
| scope: bundlers | 29 (-1) | 23   | 5      |
| scope: js       | 14      | 12   | 5      |
| scope: release  | 14      | 11   | 1      |
| scope: angular  | 13      | 9    | 0      |```
````

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Issues get avg / p95 age columns. PRs get their own table: open, created / merged / closed since the last report, avg / p95 age. Both tables start with `Everything` and `Unscoped` rows. Scope rows with no activity in a table are dropped, a missing previous value shows no delta instead of `(+total)`, and the footer links to the nx package health page on npm-burst.

The same report is written to the workflow's job summary as real markdown (headings, tables, links), so there is a readable copy outside Slack.

PRs come from the same issues endpoints we already paginate, we were filtering them out. In Slack the title is a header block, the notes and the footer are context blocks, and each table sits under a bold label in its own section blocks to stay under the 3000 character limit. The payload passes `blocks.validate`.

The cache step is gone; `setup-node` already caches the pnpm store and the install takes under a minute. The job should finish in about 90 seconds.

`workflow_dispatch` gets two inputs, both on by default: `skip_slack` and `skip_cache_upload`. A manual run neither pings the channel nor moves the window the next scheduled run diffs against unless you untick one. Unticking only `skip_cache_upload` uploads the new-shape cache and sets the baseline for the new columns quietly. The job summary is always written, so that is where to look at a test run.

Output from a run against live data, with last week's cache, as it prints to the log:

````
# Issue & PR Report for Aug 29 2026

Previous Report: Aug 23 2026
Closed, created and merged counts are since Aug 23 2026. Ages are for open items, in days.

[view unlabeled issues](https://github.com/nrwl/nx/issues?q=...) · [view unlabeled PRs](https://github.com/nrwl/nx/pulls?q=...)

## Issues

| Scope                    | Issues | Bugs | Closed    | Avg Age | P95 Age |
| ------------------------ | ------ | ---- | --------- | ------- | ------- |
| Everything               | 279    | 220  | 33 (-152) | 291d    | 1060d   |
| Unscoped                 | 52     | 29   | 9 (-23)   | 28d     | 54d     |
| scope: core              | 75     | 63   | 5 (-44)   | 421d    | 1290d   |
| scope: bundlers          | 29     | 23   | 5 (-16)   | 292d    | 542d    |
| scope: js                | 14     | 12   | 5 (-7)    | 237d    | 533d    |
| scope: release           | 14     | 11   | 1 (-20)   | 332d    | 960d    |
| scope: angular           | 13     | 9    | 0 (-10)   | 351d    | 567d    |
| scope: node              | 12     | 10   | 0 (-3)    | 504d    | 2500d   |
| scope: misc              | 12     | 10   | 1 (-8)    | 665d    | 2278d   |
| scope: linter            | 8      | 7    | 0 (-3)    | 302d    | 641d    |
| scope: react             | 7      | 7    | 0 (-1)    | 235d    | 459d    |
| scope: nx-cloud          | 6      | 6    | 0 (-2)    | 141d    | 256d    |
| scope: module federation | 6      | 6    | 1 (-2)    | 133d    | 184d    |
| scope: react-native      | 6      | 6    | 0 (-2)    | 238d    | 483d    |
| scope: docs              | 5      | 1    | 3 (-3)    | 172d    | 308d    |
| scope: java              | 5      | 4    | 0 (-1)    | 208d    | 237d    |
| scope: nextjs            | 4      | 2    | 1         | 760d    | 2102d   |
| scope: storybook         | 4      | 4    | 1 (-2)    | 266d    | 348d    |
| scope: dotnet            | 3      | 3    | 0         | 219d    | 289d    |
| scope:gradle             | 2      | 1    | 1 (-2)    | 96d     | 172d    |
| scope: self-hosted cache | 2      | 2    | 0 (-1)    | 69d     | 73d     |
| scope: devkit            | 2      | 2    | 0         | 234d    | 274d    |
| scope: vue               | 1      | 1    | 0         | 81d     | 81d     |
| scope: repo              | 1      | 1    | 0         | 104d    | 104d    |
| scope: powerpack         | 1      | 1    | 0         | 127d    | 127d    |
| scope: testing tools     | 1      | 1    | 1 (-4)    | 185d    | 185d    |
| scope: console           | 1      | 1    | 0         | 242d    | 242d    |

## Pull requests

| Scope          | Open | Created   | Merged    | Closed   | Avg Age | P95 Age |
| -------------- | ---- | --------- | --------- | -------- | ------- | ------- |
| Everything     | 169  | 74 (-458) | 69 (-335) | 14 (-90) | 71d     | 190d    |
| Unscoped       | 168  | 74 (-458) | 69 (-334) | 14 (-89) | 70d     | 190d    |
| scope: release | 1    | 0         | 0         | 0 (-1)   | 114d    | 114d    |

[nx package health on npm-burst](https://npm-burst.com/package/nx/health/)
````

The big negative deltas on the closed / created / merged columns are an artifact of that run: the "previous" report was a cold run over the whole of July and August. In steady state both windows are a week.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #



