### PR TITLE
fix(release): redact the token in the GitHub and GitLab release error output

### DIFF
--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
@@ -256,10 +256,48 @@ describe('GithubRemoteReleaseClient', () => {
         process.exitCode = originalExitCode;
       }
 
+      // join() would stringify an object to [object Object], making the
+      // not.toContain() assertion below pass vacuously.
+      expect(typeof logSpy.mock.calls[0][0]).toBe('string');
       const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
       expect(logged).not.toContain(token);
       expect(logged).toContain('<redacted>');
       expect(logged).toContain('Network Error');
+      logSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should redact the token when it has trailing whitespace', async () => {
+      const token = 'ghp_secret';
+      // Axios trims header values, so the dump holds the trimmed token while
+      // tokenData still carries the untrimmed value read from the environment.
+      const clientWithToken = new GithubRemoteReleaseClient(repoData, false, {
+        token: `${token}\n`,
+        headerName: 'Authorization',
+      });
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      selectPromptMock.mockResolvedValue('No');
+      const originalExitCode = process.exitCode;
+
+      try {
+        await (clientWithToken as any).handleError(
+          {
+            message: 'Network Error',
+            config: { headers: { Authorization: `Bearer ${token}` } },
+            request: { _header: `Authorization: Bearer ${token}` },
+          },
+          { url: 'https://github.com/nrwl/nx/releases/new', requestData: {} }
+        );
+      } finally {
+        process.exitCode = originalExitCode;
+      }
+
+      const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(logged).not.toContain(token);
+      expect(logged).toContain('<redacted>');
       logSpy.mockRestore();
       consoleErrorSpy.mockRestore();
     });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
@@ -301,5 +301,41 @@ describe('GithubRemoteReleaseClient', () => {
       logSpy.mockRestore();
       consoleErrorSpy.mockRestore();
     });
+
+    it('should redact the token when it contains a line break', async () => {
+      const token = 'ghp_secret';
+      // Node strips CR/LF from outgoing header values, so the dump holds the
+      // stripped token while tokenData still carries the line break.
+      const clientWithToken = new GithubRemoteReleaseClient(repoData, false, {
+        token: `${token.slice(0, 4)}\r\n${token.slice(4)}`,
+        headerName: 'Authorization',
+      });
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      selectPromptMock.mockResolvedValue('No');
+      const originalExitCode = process.exitCode;
+
+      try {
+        await (clientWithToken as any).handleError(
+          {
+            message: 'Network Error',
+            config: { headers: { Authorization: `Bearer ${token}` } },
+            request: { _header: `Authorization: Bearer ${token}` },
+          },
+          { url: 'https://github.com/nrwl/nx/releases/new', requestData: {} }
+        );
+      } finally {
+        process.exitCode = originalExitCode;
+      }
+
+      expect(typeof logSpy.mock.calls[0][0]).toBe('string');
+      const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(logged).not.toContain(token);
+      expect(logged).toContain('<redacted>');
+      logSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
   });
 });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
@@ -229,5 +229,39 @@ describe('GithubRemoteReleaseClient', () => {
 
       expect(printed).toContain('Token Header: none');
     });
+
+    it('should redact the token in the unknown-error dump', async () => {
+      const token = 'ghp_secret';
+      const clientWithToken = new GithubRemoteReleaseClient(repoData, false, {
+        token,
+        headerName: 'Authorization',
+      });
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      selectPromptMock.mockResolvedValue('No');
+      const originalExitCode = process.exitCode;
+
+      try {
+        await (clientWithToken as any).handleError(
+          {
+            message: 'Network Error',
+            config: { headers: { Authorization: `Bearer ${token}` } },
+            request: { _header: `Authorization: Bearer ${token}` },
+          },
+          { url: 'https://github.com/nrwl/nx/releases/new', requestData: {} }
+        );
+      } finally {
+        process.exitCode = originalExitCode;
+      }
+
+      const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(logged).not.toContain(token);
+      expect(logged).toContain('<redacted>');
+      expect(logged).toContain('Network Error');
+      logSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
   });
 });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'node:util';
 import type { Mock } from 'vitest';
 import { output } from '../../../../utils/output';
 import { GithubRemoteReleaseClient } from './github';
@@ -295,6 +296,7 @@ describe('GithubRemoteReleaseClient', () => {
         process.exitCode = originalExitCode;
       }
 
+      expect(typeof logSpy.mock.calls[0][0]).toBe('string');
       const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
       expect(logged).not.toContain(token);
       expect(logged).toContain('<redacted>');
@@ -336,6 +338,42 @@ describe('GithubRemoteReleaseClient', () => {
       expect(logged).toContain('<redacted>');
       logSpy.mockRestore();
       consoleErrorSpy.mockRestore();
+    });
+
+    it('should leave the dump untouched when the token is blank', async () => {
+      const clientWithToken = new GithubRemoteReleaseClient(repoData, false, {
+        // a single space: the previous guard tested tokenData, not the token,
+        // so this split the dump on every space
+        token: ' ',
+        headerName: 'Authorization',
+      });
+
+      const inspected = (clientWithToken as any).inspectWithRedactedToken({
+        message: 'Network Error',
+      });
+
+      expect(inspected).toBe(inspect({ message: 'Network Error' }));
+      expect(inspected).not.toContain('<redacted>');
+    });
+
+    it('should redact a long token that inspect splits across lines', async () => {
+      // A wrapped paste: inspect() renders the header value as concatenated
+      // per-line chunks, which no whole-token needle spans.
+      const token = `ghp_secret_${'a'.repeat(60)}`;
+      const wrapped = `${token.slice(0, 40)}
+${token.slice(40)}`;
+      const clientWithToken = new GithubRemoteReleaseClient(repoData, false, {
+        token: wrapped,
+        headerName: 'Authorization',
+      });
+
+      const inspected = (clientWithToken as any).inspectWithRedactedToken({
+        config: { headers: { Authorization: `Bearer ${wrapped}` } },
+        request: { _header: `Authorization: Bearer ${wrapped}` },
+      });
+
+      expect(inspected).not.toContain(token.slice(40));
+      expect(inspected).toContain('<redacted>');
     });
   });
 });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
@@ -1,4 +1,5 @@
 import type { Mock } from 'vitest';
+import { output } from '../../../../utils/output';
 import { GithubRemoteReleaseClient } from './github';
 
 vi.mock('axios', () => {
@@ -12,10 +13,16 @@ vi.mock('node:child_process', async () => ({
   execSync: require('node:child_process').execSync,
 }));
 
+vi.mock('../../../../utils/prompt-helpers', () => ({
+  selectPrompt: vi.fn(),
+}));
+
 import { execFileSync } from 'node:child_process';
+import { selectPrompt } from '../../../../utils/prompt-helpers';
 
 const axiosGetMock = (await import('axios')).default.get as Mock;
 const execFileSyncMock = execFileSync as Mock;
+const selectPromptMock = selectPrompt as Mock;
 
 describe('GithubRemoteReleaseClient', () => {
   const client = new GithubRemoteReleaseClient(
@@ -167,5 +174,60 @@ describe('GithubRemoteReleaseClient', () => {
       client.applyUsernameToAuthors(authors)
     ).resolves.toBeUndefined();
     expect(authors.get('Test User')?.username).toBeUndefined();
+  });
+
+  describe('handleError', () => {
+    const repoData = {
+      hostname: 'github.com',
+      slug: 'nrwl/nx',
+      apiBaseUrl: 'https://api.github.com',
+    };
+
+    async function printedErrorBody(
+      client: GithubRemoteReleaseClient
+    ): Promise<string> {
+      const errorSpy = vi.spyOn(output, 'error').mockImplementation(() => {});
+      selectPromptMock.mockResolvedValue('No');
+      const originalExitCode = process.exitCode;
+      try {
+        await (client as any).handleError(
+          { response: { data: { message: 'Bad credentials' } } },
+          { url: 'https://github.com/nrwl/nx/releases/new', requestData: {} }
+        );
+      } finally {
+        process.exitCode = originalExitCode;
+      }
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const printed = errorSpy.mock.calls[0][0].bodyLines.join('\n');
+      errorSpy.mockRestore();
+      return printed;
+    }
+
+    it('should redact the token in the API error output', async () => {
+      const token = 'ghp_secret';
+      const clientWithToken = new GithubRemoteReleaseClient(repoData, false, {
+        token,
+        headerName: 'Authorization',
+      });
+
+      const printed = await printedErrorBody(clientWithToken);
+
+      expect(printed).not.toContain(token);
+      expect(printed).toContain(
+        'Token Header: Authorization: Bearer <redacted>'
+      );
+    });
+
+    it('should report when no token was configured', async () => {
+      const clientWithoutToken = new GithubRemoteReleaseClient(
+        repoData,
+        false,
+        null
+      );
+
+      const printed = await printedErrorBody(clientWithoutToken);
+
+      expect(printed).toContain('Token Header: none');
+    });
   });
 });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
@@ -346,7 +346,7 @@ export class GithubRemoteReleaseClient extends RemoteReleaseClient<GithubRemoteR
           ],
         });
       } else {
-        console.log(error);
+        console.log(this.inspectWithRedactedToken(error));
         console.error(
           `An unknown error occurred while trying to create a release on GitHub, please report this on https://github.com/nrwl/nx (NOTE: make sure to redact your GitHub token from the error message!)`
         );

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
@@ -341,7 +341,7 @@ export class GithubRemoteReleaseClient extends RemoteReleaseClient<GithubRemoteR
             `---`,
             `Request Data:`,
             `Repo: ${this.getRemoteRepoData<GithubRepoData>()?.slug}`,
-            `Token Header Data: ${this.tokenHeader}`,
+            `Token Header: ${this.getRedactedTokenHeader()}`,
             `Body: ${JSON.stringify(result.requestData)}`,
           ],
         });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
@@ -1,0 +1,71 @@
+import type { Mock } from 'vitest';
+import { output } from '../../../../utils/output';
+import { GitLabRemoteReleaseClient } from './gitlab';
+
+vi.mock('../../../../utils/prompt-helpers', () => ({
+  selectPrompt: vi.fn(),
+}));
+
+import { selectPrompt } from '../../../../utils/prompt-helpers';
+
+const selectPromptMock = selectPrompt as Mock;
+
+describe('GitLabRemoteReleaseClient', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('handleError', () => {
+    const repoData = {
+      hostname: 'gitlab.com',
+      slug: 'nrwl/nx',
+      apiBaseUrl: 'https://gitlab.com/api/v4',
+      projectId: 'nrwl%2Fnx',
+    };
+
+    async function printedErrorBody(
+      client: GitLabRemoteReleaseClient
+    ): Promise<string> {
+      const errorSpy = vi.spyOn(output, 'error').mockImplementation(() => {});
+      selectPromptMock.mockResolvedValue('No');
+      const originalExitCode = process.exitCode;
+      try {
+        await (client as any).handleError(
+          { response: { data: { message: '401 Unauthorized' } } },
+          { url: 'https://gitlab.com/nrwl/nx/-/releases/new', requestData: {} }
+        );
+      } finally {
+        process.exitCode = originalExitCode;
+      }
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const printed = errorSpy.mock.calls[0][0].bodyLines.join('\n');
+      errorSpy.mockRestore();
+      return printed;
+    }
+
+    it('should redact the token in the API error output', async () => {
+      const token = 'glpat-secret';
+      const clientWithToken = new GitLabRemoteReleaseClient(repoData, false, {
+        token,
+        headerName: 'PRIVATE-TOKEN',
+      });
+
+      const printed = await printedErrorBody(clientWithToken);
+
+      expect(printed).not.toContain(token);
+      expect(printed).toContain('Token Header: PRIVATE-TOKEN: <redacted>');
+    });
+
+    it('should report when no token was configured', async () => {
+      const clientWithoutToken = new GitLabRemoteReleaseClient(
+        repoData,
+        false,
+        null
+      );
+
+      const printed = await printedErrorBody(clientWithoutToken);
+
+      expect(printed).toContain('Token Header: none');
+    });
+  });
+});

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
@@ -139,5 +139,41 @@ describe('GitLabRemoteReleaseClient', () => {
       logSpy.mockRestore();
       consoleErrorSpy.mockRestore();
     });
+
+    it('should redact the token when it contains a line break', async () => {
+      const token = 'glpat-secret';
+      // Node strips CR/LF from outgoing header values, so the dump holds the
+      // stripped token while tokenData still carries the line break.
+      const clientWithToken = new GitLabRemoteReleaseClient(repoData, false, {
+        token: `${token.slice(0, 4)}\r\n${token.slice(4)}`,
+        headerName: 'PRIVATE-TOKEN',
+      });
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      selectPromptMock.mockResolvedValue('No');
+      const originalExitCode = process.exitCode;
+
+      try {
+        await (clientWithToken as any).handleError(
+          {
+            message: 'Network Error',
+            config: { headers: { 'PRIVATE-TOKEN': `${token}` } },
+            request: { _header: `PRIVATE-TOKEN: ${token}` },
+          },
+          { url: 'https://gitlab.com/nrwl/nx/-/releases/new', requestData: {} }
+        );
+      } finally {
+        process.exitCode = originalExitCode;
+      }
+
+      expect(typeof logSpy.mock.calls[0][0]).toBe('string');
+      const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(logged).not.toContain(token);
+      expect(logged).toContain('<redacted>');
+      logSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
   });
 });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'node:util';
 import type { Mock } from 'vitest';
 import { output } from '../../../../utils/output';
 import { GitLabRemoteReleaseClient } from './gitlab';
@@ -54,6 +55,19 @@ describe('GitLabRemoteReleaseClient', () => {
 
       expect(printed).not.toContain(token);
       expect(printed).toContain('Token Header: PRIVATE-TOKEN: <redacted>');
+    });
+
+    it('should redact a CI_JOB_TOKEN under the JOB-TOKEN header', async () => {
+      const token = 'ci-job-token-secret';
+      const clientWithToken = new GitLabRemoteReleaseClient(repoData, false, {
+        token,
+        headerName: 'JOB-TOKEN',
+      });
+
+      const printed = await printedErrorBody(clientWithToken);
+
+      expect(printed).not.toContain(token);
+      expect(printed).toContain('Token Header: JOB-TOKEN: <redacted>');
     });
 
     it('should report when no token was configured', async () => {
@@ -133,6 +147,7 @@ describe('GitLabRemoteReleaseClient', () => {
         process.exitCode = originalExitCode;
       }
 
+      expect(typeof logSpy.mock.calls[0][0]).toBe('string');
       const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
       expect(logged).not.toContain(token);
       expect(logged).toContain('<redacted>');
@@ -174,6 +189,42 @@ describe('GitLabRemoteReleaseClient', () => {
       expect(logged).toContain('<redacted>');
       logSpy.mockRestore();
       consoleErrorSpy.mockRestore();
+    });
+
+    it('should leave the dump untouched when the token is blank', async () => {
+      const clientWithToken = new GitLabRemoteReleaseClient(repoData, false, {
+        // a single space: the previous guard tested tokenData, not the token,
+        // so this split the dump on every space
+        token: ' ',
+        headerName: 'PRIVATE-TOKEN',
+      });
+
+      const inspected = (clientWithToken as any).inspectWithRedactedToken({
+        message: 'Network Error',
+      });
+
+      expect(inspected).toBe(inspect({ message: 'Network Error' }));
+      expect(inspected).not.toContain('<redacted>');
+    });
+
+    it('should redact a long token that inspect splits across lines', async () => {
+      // A wrapped paste: inspect() renders the header value as concatenated
+      // per-line chunks, which no whole-token needle spans.
+      const token = `glpat-secret_${'a'.repeat(60)}`;
+      const wrapped = `${token.slice(0, 40)}
+${token.slice(40)}`;
+      const clientWithToken = new GitLabRemoteReleaseClient(repoData, false, {
+        token: wrapped,
+        headerName: 'PRIVATE-TOKEN',
+      });
+
+      const inspected = (clientWithToken as any).inspectWithRedactedToken({
+        config: { headers: { 'PRIVATE-TOKEN': `${wrapped}` } },
+        request: { _header: `PRIVATE-TOKEN: ${wrapped}` },
+      });
+
+      expect(inspected).not.toContain(token.slice(40));
+      expect(inspected).toContain('<redacted>');
     });
   });
 });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
@@ -67,5 +67,39 @@ describe('GitLabRemoteReleaseClient', () => {
 
       expect(printed).toContain('Token Header: none');
     });
+
+    it('should redact the token in the unknown-error dump', async () => {
+      const token = 'glpat-secret';
+      const clientWithToken = new GitLabRemoteReleaseClient(repoData, false, {
+        token,
+        headerName: 'PRIVATE-TOKEN',
+      });
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      selectPromptMock.mockResolvedValue('No');
+      const originalExitCode = process.exitCode;
+
+      try {
+        await (clientWithToken as any).handleError(
+          {
+            message: 'Network Error',
+            config: { headers: { 'PRIVATE-TOKEN': token } },
+            request: { _header: `PRIVATE-TOKEN: ${token}` },
+          },
+          { url: 'https://gitlab.com/nrwl/nx/-/releases/new', requestData: {} }
+        );
+      } finally {
+        process.exitCode = originalExitCode;
+      }
+
+      const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(logged).not.toContain(token);
+      expect(logged).toContain('<redacted>');
+      expect(logged).toContain('Network Error');
+      logSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
   });
 });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.spec.ts
@@ -94,10 +94,48 @@ describe('GitLabRemoteReleaseClient', () => {
         process.exitCode = originalExitCode;
       }
 
+      // join() would stringify an object to [object Object], making the
+      // not.toContain() assertion below pass vacuously.
+      expect(typeof logSpy.mock.calls[0][0]).toBe('string');
       const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
       expect(logged).not.toContain(token);
       expect(logged).toContain('<redacted>');
       expect(logged).toContain('Network Error');
+      logSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should redact the token when it has trailing whitespace', async () => {
+      const token = 'glpat-secret';
+      // Axios trims header values, so the dump holds the trimmed token while
+      // tokenData still carries the untrimmed value read from the environment.
+      const clientWithToken = new GitLabRemoteReleaseClient(repoData, false, {
+        token: `${token}\n`,
+        headerName: 'PRIVATE-TOKEN',
+      });
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      selectPromptMock.mockResolvedValue('No');
+      const originalExitCode = process.exitCode;
+
+      try {
+        await (clientWithToken as any).handleError(
+          {
+            message: 'Network Error',
+            config: { headers: { 'PRIVATE-TOKEN': `${token}` } },
+            request: { _header: `PRIVATE-TOKEN: ${token}` },
+          },
+          { url: 'https://gitlab.com/nrwl/nx/-/releases/new', requestData: {} }
+        );
+      } finally {
+        process.exitCode = originalExitCode;
+      }
+
+      const logged = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(logged).not.toContain(token);
+      expect(logged).toContain('<redacted>');
       logSpy.mockRestore();
       consoleErrorSpy.mockRestore();
     });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.ts
@@ -234,7 +234,7 @@ export class GitLabRemoteReleaseClient extends RemoteReleaseClient<GitLabRelease
             `---`,
             `Request Data:`,
             `Repo: ${this.getRemoteRepoData<GitLabRepoData>()?.slug}`,
-            `Token Header Data: ${this.tokenHeader}`,
+            `Token Header: ${this.getRedactedTokenHeader()}`,
             `Body: ${JSON.stringify(result.requestData)}`,
           ],
         });

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.ts
@@ -239,7 +239,7 @@ export class GitLabRemoteReleaseClient extends RemoteReleaseClient<GitLabRelease
           ],
         });
       } else {
-        console.log(error);
+        console.log(this.inspectWithRedactedToken(error));
         console.error(
           `An unknown error occurred while trying to create a release on GitLab, please report this on https://github.com/nrwl/nx (NOTE: make sure to redact your GitLab token from the error message!)`
         );

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
@@ -70,9 +70,16 @@ export abstract class RemoteReleaseClient<
 
   protected inspectWithRedactedToken(error: unknown): string {
     const inspected = inspect(error);
-    return this.tokenData
-      ? inspected.split(this.tokenData.token).join('<redacted>')
-      : inspected;
+    // Axios trims header values and inspect() escapes them, so the rendered dump
+    // can hold a different string than the raw token. Redact both forms.
+    const token = this.tokenData?.token?.trim();
+    if (!token) {
+      return inspected;
+    }
+    return [token, inspect(token).slice(1, -1)].reduce(
+      (text, needle) => text.split(needle).join('<redacted>'),
+      inspected
+    );
   }
 
   protected getRedactedTokenHeader(): string {

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
@@ -83,6 +83,14 @@ export abstract class RemoteReleaseClient<
       token.replace(/[\r\n]/g, ''),
       inspect(token).slice(1, -1),
     ]);
+    // inspect() renders a long string carrying a line break as concatenated
+    // per-line chunks, which no whole-token needle spans. Redact the lines too,
+    // skipping fragments short enough to collide with ordinary dump text.
+    for (const line of token.split(/[\r\n]+/)) {
+      if (line.length >= 8) {
+        needles.add(line);
+      }
+    }
     return [...needles].reduce(
       (text, needle) => text.split(needle).join('<redacted>'),
       inspected

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'node:util';
 import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import type { PostGitTask } from '../../changelog';
@@ -65,6 +66,13 @@ export abstract class RemoteReleaseClient<
 
   getRemoteRepoData<T extends RemoteRepoData>(): T | null {
     return this.remoteRepoData as T | null;
+  }
+
+  protected inspectWithRedactedToken(error: unknown): string {
+    const inspected = inspect(error);
+    return this.tokenData
+      ? inspected.split(this.tokenData.token).join('<redacted>')
+      : inspected;
   }
 
   protected getRedactedTokenHeader(): string {

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
@@ -70,13 +70,14 @@ export abstract class RemoteReleaseClient<
 
   protected inspectWithRedactedToken(error: unknown): string {
     const inspected = inspect(error);
-    // Axios trims header values and inspect() escapes them, so the rendered dump
-    // can hold a different string than the raw token. Redact both forms.
+    // Axios trims header values, and inspect() escapes them while leaving the
+    // token bare in message/stack, so the dump can hold either rendering.
+    // Redact both; they coincide for a token with nothing to escape.
     const token = this.tokenData?.token?.trim();
     if (!token) {
       return inspected;
     }
-    return [token, inspect(token).slice(1, -1)].reduce(
+    return [...new Set([token, inspect(token).slice(1, -1)])].reduce(
       (text, needle) => text.split(needle).join('<redacted>'),
       inspected
     );

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
@@ -70,14 +70,20 @@ export abstract class RemoteReleaseClient<
 
   protected inspectWithRedactedToken(error: unknown): string {
     const inspected = inspect(error);
-    // Axios trims header values, and inspect() escapes them while leaving the
-    // token bare in message/stack, so the dump can hold either rendering.
-    // Redact both; they coincide for a token with nothing to escape.
+    // The dump can hold a different string than the raw token: axios trims
+    // header values, node strips CR/LF from them, and inspect() escapes the
+    // result while leaving the token bare in message/stack. Redact every
+    // rendering; the Set collapses them for an ordinary token.
     const token = this.tokenData?.token?.trim();
     if (!token) {
       return inspected;
     }
-    return [...new Set([token, inspect(token).slice(1, -1)])].reduce(
+    const needles = new Set([
+      token,
+      token.replace(/[\r\n]/g, ''),
+      inspect(token).slice(1, -1),
+    ]);
+    return [...needles].reduce(
       (text, needle) => text.split(needle).join('<redacted>'),
       inspected
     );

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
@@ -67,6 +67,16 @@ export abstract class RemoteReleaseClient<
     return this.remoteRepoData as T | null;
   }
 
+  protected getRedactedTokenHeader(): string {
+    if (!this.tokenData) {
+      return 'none';
+    }
+    const { headerName } = this.tokenData;
+    return headerName === 'Authorization'
+      ? `${headerName}: Bearer <redacted>`
+      : `${headerName}: <redacted>`;
+  }
+
   /**
    * Create a post git task that will be executed by nx release changelog after performing any relevant
    * git operations, if the user has opted into remote release creation.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When creating a GitHub or GitLab release fails, the error output includes `Token Header Data: [object Object]`. It doesn't leak the token today, but it reads like a formatting bug, and the obvious fix (`JSON.stringify`, like the `Body:` line next to it) would print the bearer token in CI logs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The line names the header the token was sent under, with the value redacted: `Token Header: Authorization: Bearer <redacted>`, or `Token Header: none` when no token was configured. Specs assert the token itself never appears.

The unknown-error fallback right below had the same problem: it dumped the raw axios error, which carries the token in `config.headers`. It now prints the error with the token value replaced by `<redacted>`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

NXC-4910, raised by https://socket.dev/npm/package/nx/alerts/23.1.2?alert_name=gptSecurity

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/ss-bearer-token-log-e9d15dac">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->
