### PR TITLE
fix(release): stage deleted version plans on Windows

### DIFF
--- a/packages/nx/src/command-line/release/utils/git-add.spec.ts
+++ b/packages/nx/src/command-line/release/utils/git-add.spec.ts
@@ -1,0 +1,88 @@
+import { gitAdd } from './git';
+
+const mockExecCommand = vi.fn();
+vi.mock('./exec-command', () => ({
+  execCommand: (...args: unknown[]) => mockExecCommand(...args),
+}));
+
+vi.mock('../../../utils/workspace-root', () => ({
+  workspaceRoot: '/workspace',
+}));
+
+describe('gitAdd', () => {
+  beforeEach(() => {
+    mockExecCommand.mockReset();
+  });
+
+  it('should normalize backslash paths in deletedFiles to match git status output', async () => {
+    // git status --porcelain returns forward-slash paths
+    mockExecCommand.mockImplementation(
+      (cmd: string, args: string[], _opts?: unknown) => {
+        if (cmd === 'git' && args[0] === 'status') {
+          return Promise.resolve(
+            ' D .nx/version-plans/version-plan-123.md\n'
+          );
+        }
+        if (cmd === 'git' && args[0] === 'check-ignore') {
+          return Promise.reject(new Error('not ignored'));
+        }
+        if (cmd === 'git' && args[0] === 'add') {
+          return Promise.resolve('');
+        }
+        return Promise.resolve('');
+      }
+    );
+
+    // On Windows, path.join produces backslash-separated paths
+    await gitAdd({
+      deletedFiles: ['.nx\\version-plans\\version-plan-123.md'],
+      cwd: '/workspace',
+    });
+
+    const addCall = mockExecCommand.mock.calls.find(
+      (c: unknown[]) =>
+        c[0] === 'git' &&
+        Array.isArray(c[1]) &&
+        (c[1] as string[])[0] === 'add'
+    );
+    expect(addCall).toBeDefined();
+    expect((addCall![1] as string[])[1]).toBe(
+      '.nx/version-plans/version-plan-123.md'
+    );
+  });
+
+  it('should stage deleted files with forward-slash paths unchanged', async () => {
+    mockExecCommand.mockImplementation(
+      (cmd: string, args: string[], _opts?: unknown) => {
+        if (cmd === 'git' && args[0] === 'status') {
+          return Promise.resolve(
+            ' D .nx/version-plans/version-plan-456.md\n'
+          );
+        }
+        if (cmd === 'git' && args[0] === 'check-ignore') {
+          return Promise.reject(new Error('not ignored'));
+        }
+        if (cmd === 'git' && args[0] === 'add') {
+          return Promise.resolve('');
+        }
+        return Promise.resolve('');
+      }
+    );
+
+    await gitAdd({
+      deletedFiles: ['.nx/version-plans/version-plan-456.md'],
+      cwd: '/workspace',
+    });
+
+    const addCall = mockExecCommand.mock.calls.find(
+      (c: unknown[]) =>
+        c[0] === 'git' &&
+        Array.isArray(c[1]) &&
+        (c[1] as string[])[0] === 'add'
+    );
+    expect(addCall).toBeDefined();
+    expect((addCall![1] as string[])[1]).toBe(
+      '.nx/version-plans/version-plan-456.md'
+    );
+  });
+});

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -348,12 +348,13 @@ export async function gitAdd({
   if (deletedFiles?.length > 0) {
     const changedTrackedFiles = await getChangedTrackedFiles(cwd);
     for (const f of deletedFiles ?? []) {
-      const isFileIgnored = await isIgnored(f, cwd);
+      const normalized = f.replace(/\\/g, '/');
+      const isFileIgnored = await isIgnored(normalized, cwd);
       if (isFileIgnored) {
-        ignoredFiles.push(f);
+        ignoredFiles.push(normalized);
         // git add will fail if trying to add an untracked file that doesn't exist
-      } else if (changedTrackedFiles.has(f) || dryRun) {
-        filesToAdd.push(f);
+      } else if (changedTrackedFiles.has(normalized) || dryRun) {
+        filesToAdd.push(normalized);
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #36792 — `nx release changelog` deletes applied version plans but does not stage the deletion on Windows, leaving the removed files as uncommitted changes.

**Root cause:** `plan.relativePath` is built with Node's `path.join`, which produces backslash-separated paths on Windows (`.nx\version-plans\file.md`). The `gitAdd` function compares deleted file paths against `git status --porcelain` output, which always uses forward slashes (`.nx/version-plans/file.md`). The `Set.has()` lookup fails because the separators don't match, so the deleted file is never added to the staging list.

**Fix:** Normalize backslash separators to forward slashes in the `deletedFiles` loop inside `gitAdd`, before the `isIgnored` check and the `changedTrackedFiles.has()` lookup. Forward-slash paths are passed to `git add`, which accepts them on all platforms.

## Changed files

- `packages/nx/src/command-line/release/utils/git.ts` — normalize `\` to `/` in `deletedFiles` paths before comparison and staging
- `packages/nx/src/command-line/release/utils/git-add.spec.ts` — regression test: backslash-separated deleted file path is normalized and staged

## Test plan

- [x] `tsc --noEmit` on changed files — no errors
- [ ] Unit test passes (requires native module build; verified test compiles and logic is correct)
- The backslash path issue only manifests on Windows; forward-slash paths on Unix are unaffected by the normalization