### PR TITLE
docs(misc): embed agent walkthrough video in custom workspace rules guide

### DIFF
--- a/astro-docs/src/content/docs/kb/custom-workspace-rules.mdoc
+++ b/astro-docs/src/content/docs/kb/custom-workspace-rules.mdoc
@@ -10,6 +10,8 @@ topics:
 
 Custom ESLint rules allow you to enforce team-specific conventions, project architectural patterns, and codebase-specific best practices that aren't covered by existing ESLint plugins. Nx provides two main approaches for creating and using custom ESLint rules in your workspace.
 
+{% youtube src="https://youtu.be/hUL1Gf8NFI8" title="Create custom workspace lint rules with your AI agent" /%}
+
 <!-- TODO: Add "Quick Start with the Generator" section once @nx/eslint:workspace-rule supports ESLint v9 -->
 
 ## Understanding the two approaches

--- a/astro-docs/src/content/docs/kb/custom-workspace-rules.mdoc
+++ b/astro-docs/src/content/docs/kb/custom-workspace-rules.mdoc
@@ -10,7 +10,7 @@ topics:
 
 Custom ESLint rules allow you to enforce team-specific conventions, project architectural patterns, and codebase-specific best practices that aren't covered by existing ESLint plugins. Nx provides two main approaches for creating and using custom ESLint rules in your workspace.
 
-{% youtube src="https://youtu.be/hUL1Gf8NFI8" title="Create custom workspace lint rules with your AI agent" /%}
+{% youtube src="https://youtu.be/VHCCge9NZqs" title="Create custom workspace lint rules with your AI agent" /%}
 
 <!-- TODO: Add "Quick Start with the Generator" section once @nx/eslint:workspace-rule supports ESLint v9 -->
 


### PR DESCRIPTION
## Summary

Embeds a short walkthrough video in the Custom Workspace ESLint Rules guide, showing a coding agent being pointed at `nx.dev/docs/kb/custom-workspace-rules.md` and scaffolding a `packages/workspace-tools` ESLint plugin package from it.

One file, two added lines:

```
{% youtube src="https://youtu.be/VHCCge9NZqs" title="Create custom workspace lint rules with your AI agent" /%}
```

Placed after the intro paragraph and above the existing `<!-- TODO -->` comment, which is where the other kb pages put their video (`import-project.mdoc`, `typescript-project-linking.mdoc`, `create-preset.mdoc`).

The video is currently **unlisted** on the Nx channel. It needs to be made public before this merges.

## Verification

The render was not verified locally. Attempts to serve or build astro-docs in the session clone did not work: the dev server could not bind a port under the sandbox, and the clone has no installed deps for a build or a markdoc parse. The tag syntax was confirmed textually against the working usages in `import-project.mdoc`, and it is identical in shape and spacing. CI is the real check here.

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/workspace-lint-rule-da6d7b4a">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->