### PR TITLE
chore(repo): grant Nx's tmp roots through the Claude Code sandbox

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,17 @@
   },
   "sandbox": {
     "filesystem": {
-      "allowWrite": ["~/.nx-pr-reviews", "~/.nx-sandboxes"]
+      "allowWrite": [
+        "~/.nx-pr-reviews",
+        "~/.nx-sandboxes",
+        "/tmp/.nx",
+        "~/.nx"
+      ],
+      "allowRead": ["/tmp/.nx", "~/.nx"]
+    },
+    "network": {
+      "allowedDomains": ["www.google-analytics.com"],
+      "allowUnixSockets": ["/tmp/.nx", "~/.nx"]
     }
   },
   "extraKnownMarketplaces": {


### PR DESCRIPTION
## Current Behavior

This repo's committed `.claude/settings.json` grants the Claude Code sandbox two paths, neither of them Nx's own:

```json
"sandbox": { "filesystem": { "allowWrite": ["~/.nx-pr-reviews", "~/.nx-sandboxes"] } }
```

So an agent working in this repo under sandboxing cannot use Nx's unix sockets (daemon, plugin workers, forked tasks), cannot write the native binary cache Nx copies out of `node_modules` before loading, and — since #36514 moved the shared cache and graph DB under `~/.nx/<id>/` — EPERMs on the first cache write a task makes.

## Expected Behavior

`nx configure-ai-agents --agents claude` now emits these entries (#36514), and this commit is its output against this repo:

```json
"sandbox": {
  "filesystem": {
    "allowWrite": ["~/.nx-pr-reviews", "~/.nx-sandboxes", "/tmp/.nx", "~/.nx"],
    "allowRead": ["/tmp/.nx", "~/.nx"]
  },
  "network": {
    "allowedDomains": ["www.google-analytics.com"],
    "allowUnixSockets": ["/tmp/.nx", "~/.nx"]
  }
}
```

Both roots are spelled identically on every machine, which is what makes them worth committing: a `settings.local.json` would not exist in a fresh worktree, which is exactly where agentic migration needs it. Existing entries are preserved.

`allowUnixSockets` is scoped to the two Nx roots rather than `allowAllUnixSockets`, which would also grant connect access to every socket on the machine, including the Docker and SSH-agent sockets. What keeps users apart is not this allowlist but the 0700 per-uid directories Nx verifies on every use (`ensureOwnedPrivateDir`).

`allowedDomains` follows the workspace's analytics opt-in; the socket grant does not, since Nx needs its sockets either way.

### Two things worth a maintainer's eye

**The `~/.nx` grant is not scoped by workspace.** Now that every checkout's cache and graph DB live under that root, an agent sandboxed for this repo can read and write any other workspace's `~/.nx/<id>/cache` on the same machine. Narrowing the emitted entry to this workspace's own segment would keep the machine-independence that makes it committable while closing that. That is a change to the generator, not to this file, so it is out of scope here — raising it because landing this file is what makes the reach concrete.

**This was generated from source, not from a released nx.** `setupAiAgentsGenerator` installs nx from npm and delegates to that copy unless `NX_AI_FILES_USE_LOCAL=true`, so running the command today against a published nx produces the old output. This is what master will generate once released.

## Related Issue(s)

N/A — follow-on from #36514 (NXC-4625), applying its generator output to this repo.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/jolly-lynx-75e05567">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->