### PR TITLE
fix(core): use scoped config form for pnpm 11+ publish

### DIFF
--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -1020,31 +1020,37 @@ describe('package-manager', () => {
       );
     });
 
-    it('should return pnpm publish command with scoped registry when provided for pnpm version >= 9.15.7 < 10.0.0 || >= 10.5.0', () => {
-      vi.spyOn(childProcess, 'execSync').mockImplementation((p) => {
-        switch (p) {
-          case 'pnpm --ignore-workspace --version':
-            return '9.15.7';
-        }
-      });
-      const commands = getPackageManagerCommand('pnpm');
-      expect(commands.publish(...publishCmdParam)).toEqual(
-        'pnpm publish "dist/packages/my-pkg" --json --"@org:registry=https://registry.npmjs.org/" --tag=latest --no-git-checks'
-      );
-    });
+    it.each(['9.15.7', '10.5.0', '10.99.0'])(
+      'should return pnpm publish command with scoped registry when provided for pnpm version %s',
+      (pnpmVersion) => {
+        vi.spyOn(childProcess, 'execSync').mockImplementation((p) => {
+          switch (p) {
+            case 'pnpm --ignore-workspace --version':
+              return pnpmVersion;
+          }
+        });
+        const commands = getPackageManagerCommand('pnpm');
+        expect(commands.publish(...publishCmdParam)).toEqual(
+          'pnpm publish "dist/packages/my-pkg" --json --"@org:registry=https://registry.npmjs.org/" --tag=latest --no-git-checks'
+        );
+      }
+    );
 
-    it('should return pnpm publish command without scoped registry for pnpm version >= 12.0.0', () => {
-      vi.spyOn(childProcess, 'execSync').mockImplementation((p) => {
-        switch (p) {
-          case 'pnpm --ignore-workspace --version':
-            return '12.0.0';
-        }
-      });
-      const commands = getPackageManagerCommand('pnpm');
-      expect(commands.publish(...publishCmdParam)).toEqual(
-        'pnpm publish "dist/packages/my-pkg" --json --"registry=https://registry.npmjs.org/" --tag=latest --no-git-checks'
-      );
-    });
+    it.each(['11.0.0', '12.1.0'])(
+      'should return pnpm publish command with config-scoped registry for pnpm version %s',
+      (pnpmVersion) => {
+        vi.spyOn(childProcess, 'execSync').mockImplementation((p) => {
+          switch (p) {
+            case 'pnpm --ignore-workspace --version':
+              return pnpmVersion;
+          }
+        });
+        const commands = getPackageManagerCommand('pnpm');
+        expect(commands.publish(...publishCmdParam)).toEqual(
+          'pnpm publish "dist/packages/my-pkg" --json --"config.@org:registry=https://registry.npmjs.org/" --tag=latest --no-git-checks'
+        );
+      }
+    );
 
     it('should return pnpm publish command without use scoped registry for pnpm version < 9.15.7', () => {
       vi.spyOn(childProcess, 'execSync').mockImplementation((p) => {

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -1033,6 +1033,19 @@ describe('package-manager', () => {
       );
     });
 
+    it('should return pnpm publish command without scoped registry for pnpm version >= 12.0.0', () => {
+      vi.spyOn(childProcess, 'execSync').mockImplementation((p) => {
+        switch (p) {
+          case 'pnpm --ignore-workspace --version':
+            return '12.0.0';
+        }
+      });
+      const commands = getPackageManagerCommand('pnpm');
+      expect(commands.publish(...publishCmdParam)).toEqual(
+        'pnpm publish "dist/packages/my-pkg" --json --"registry=https://registry.npmjs.org/" --tag=latest --no-git-checks'
+      );
+    });
+
     it('should return pnpm publish command without use scoped registry for pnpm version < 9.15.7', () => {
       vi.spyOn(childProcess, 'execSync').mockImplementation((p) => {
         switch (p) {

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -237,21 +237,25 @@ export function getPackageManagerCommand(
     pnpm: () => {
       let modernPnpm: boolean,
         includeDoubleDashBeforeArgs: boolean,
-        allowRegistryConfigKey: boolean;
+        configForm: boolean,
+        scopedForm: boolean;
       try {
         const pnpmVersion = getPackageManagerVersion('pnpm', root);
         modernPnpm = gte(pnpmVersion, '6.13.0');
         includeDoubleDashBeforeArgs = lt(pnpmVersion, '7.0.0');
-        // Support for --@scope:registry was added in pnpm v10.5.0 and backported to v9.15.7.
-        // Versions >=10.0.0 and <10.5.0 do NOT support this CLI option.
-        allowRegistryConfigKey = satisfies(
+        configForm = gte(pnpmVersion, '11.0.0');
+        // Support for --@scope:registry was added in pnpm v10.5.0 and
+        // backported to v9.15.7. Starting with pnpm 11, the equivalent
+        // option is --config.@scope:registry.
+        scopedForm = satisfies(
           pnpmVersion,
-          '>=9.15.7 <10.0.0 || >=10.5.0'
+          '>=9.15.7 <10.0.0 || >=10.5.0 <11.0.0'
         );
       } catch {
         modernPnpm = true;
         includeDoubleDashBeforeArgs = true;
-        allowRegistryConfigKey = false;
+        configForm = false;
+        scopedForm = false;
       }
 
       const isPnpmWorkspace = existsSync(join(root, 'pnpm-workspace.yaml'));
@@ -281,7 +285,11 @@ export function getPackageManagerCommand(
         getRegistryUrl: 'pnpm config get registry',
         publish: (packageRoot, registry, registryConfigKey, tag) =>
           `pnpm publish "${packageRoot}" --json --"${
-            allowRegistryConfigKey ? registryConfigKey : 'registry'
+            configForm
+              ? `config.${registryConfigKey}`
+              : scopedForm
+                ? registryConfigKey
+                : 'registry'
           }=${registry}" --tag=${tag} --no-git-checks`,
         ignoreScriptsFlag: '--ignore-scripts',
       };


### PR DESCRIPTION
## Current Behavior

Nx uses the direct scoped registry option for every pnpm version from 10.5.0 onward. pnpm 12 rejects that option, while falling back to the plain registry option can let a scoped registry in .npmrc win and silently publish to the wrong registry.

## Expected Behavior

Nx keeps the direct scoped option for supported pnpm 9/10 releases and uses the config-prefixed scoped option for pnpm 11 and newer, so an explicit release registry overrides workspace configuration.

## Tests

- pnpm exec vitest --config packages/nx/vitest.config.mts run packages/nx/src/utils/package-manager.spec.ts (106 tests)
- pnpm exec tsc -p packages/nx/tsconfig.lib.json --noEmit
- npx oxfmt packages/nx/src/utils/package-manager.ts packages/nx/src/utils/package-manager.spec.ts

## Related Issue(s)

Fixes #36860