### PR TITLE
fix(linter): declare .gitignore as an input for inferred oxlint tasks

### DIFF
--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -159,7 +159,7 @@ describe('@nx/oxlint plugin', () => {
     expect(inputs).toContainEqual({ fileset: LINTABLE_FILES });
     expect(inputs).toContainEqual({
       fileset:
-        '{projectRoot}/**/{.oxlintrc.json,.oxlintrc.jsonc,oxlint.config.ts,oxlint.config.mts,.eslintignore,tsconfig*.json}',
+        '{projectRoot}/**/{.oxlintrc.json,.oxlintrc.jsonc,oxlint.config.ts,oxlint.config.mts,.eslintignore,.gitignore,tsconfig*.json}',
     });
   });
 
@@ -198,23 +198,26 @@ describe('@nx/oxlint plugin', () => {
     });
   });
 
-  // Oxlint layers .eslintignore files from every ancestor of a linted file,
-  // which changes which files are linted.
-  it('should declare ancestor .eslintignore files as inputs', async () => {
-    createFiles({
-      '.oxlintrc.json': `{"rules":{}}`,
-      'libs/a/project.json': `{"name":"a"}`,
-      'libs/a/src/index.ts': `export const a = 1;`,
-    });
+  // Oxlint layers ignore files from every ancestor of a linted file, which
+  // changes which files are linted.
+  it.each(['.eslintignore', '.gitignore'])(
+    'should declare ancestor %s files as inputs',
+    async (filename) => {
+      createFiles({
+        '.oxlintrc.json': `{"rules":{}}`,
+        'libs/a/project.json': `{"name":"a"}`,
+        'libs/a/src/index.ts': `export const a = 1;`,
+      });
 
-    const results = await invokeCreateNodesOnMatchingFiles(context);
-    const inputs = results.projects['libs/a'].targets.lint.inputs;
+      const results = await invokeCreateNodesOnMatchingFiles(context);
+      const inputs = results.projects['libs/a'].targets.lint.inputs;
 
-    expect(inputs).toContain('{workspaceRoot}/.eslintignore');
-    expect(inputs).toContain('{workspaceRoot}/libs/.eslintignore');
-    // The project's own directory is covered by its own fileset.
-    expect(inputs).not.toContain('{workspaceRoot}/libs/a/.eslintignore');
-  });
+      expect(inputs).toContain(`{workspaceRoot}/${filename}`);
+      expect(inputs).toContain(`{workspaceRoot}/libs/${filename}`);
+      // The project's own directory is covered by its own fileset.
+      expect(inputs).not.toContain(`{workspaceRoot}/libs/a/${filename}`);
+    }
+  );
 
   it('should declare local jsPlugins as file inputs but never as externalDependencies', async () => {
     createFiles({

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -64,6 +64,8 @@ const LINTABLE_EXTENSIONS = [
   'astro',
 ];
 const LINTABLE_FILES_GLOB = `**/*.{${LINTABLE_EXTENSIONS.join(',')}}`;
+// Oxlint honours both, so both decide which files it lints.
+const IGNORE_FILENAMES = ['.eslintignore', '.gitignore'];
 // The one rule that looks across projects; every other rule sees one file.
 const BOUNDARIES_PLUGIN_SPECIFIER = '@nx/oxlint/boundaries-plugin';
 const PROJECT_CONFIG_FILENAMES = ['project.json', 'package.json'];
@@ -224,7 +226,7 @@ export const createNodes: CreateNodes<OxlintPluginOptions> = [
             ),
             // Change which files Oxlint considers lintable, and therefore
             // whether a target is inferred at all.
-            ...ancestorEslintignorePaths(root),
+            ...ancestorIgnorePaths(root),
             lockFilePattern,
             ...(tsconfigChainsByProjectRoot.get(root) ?? []),
           ]),
@@ -761,16 +763,18 @@ async function collectLintableFilesByProjectRoot(
 }
 
 /**
- * `.eslintignore` candidates in every ancestor directory of the project root,
+ * Ignore-file candidates in every ancestor directory of the project root,
  * workspace root included. The project's own directory is excluded — files
- * there are covered by the `default` input — except at the workspace root,
- * which is its own ancestor and so keeps its `.eslintignore`.
+ * there are covered by the in-project ignore-file input — except at the
+ * workspace root, which is its own ancestor and so keeps its ignore files.
  */
-function ancestorEslintignorePaths(projectRoot: string): string[] {
+function ancestorIgnorePaths(projectRoot: string): string[] {
   const result: string[] = [];
   let dir = projectRoot === '.' ? '.' : dirname(projectRoot);
   while (true) {
-    result.push(dir === '.' ? '.eslintignore' : `${dir}/.eslintignore`);
+    for (const filename of IGNORE_FILENAMES) {
+      result.push(dir === '.' ? filename : `${dir}/${filename}`);
+    }
     if (dir === '.') {
       break;
     }
@@ -875,13 +879,13 @@ function getProjectUsingOxlintConfig(
         : []),
       // Configs, ignore files and tsconfigs inside the project.
       {
-        fileset: `{projectRoot}/**/{${[...OXLINT_CONFIG_FILENAMES, '.eslintignore', 'tsconfig*.json'].join(',')}}`,
+        fileset: `{projectRoot}/**/{${[...OXLINT_CONFIG_FILENAMES, ...IGNORE_FILENAMES, 'tsconfig*.json'].join(',')}}`,
       },
       ...configInputs.map((config) => `{workspaceRoot}/${config}`),
       ...[...jsPluginFiles].map((file) => `{workspaceRoot}/${file}`),
-      // Oxlint layers .eslintignore files from every ancestor of a linted
-      // file. Declared even when absent, like the extends chain.
-      ...ancestorEslintignorePaths(projectRoot).map(
+      // Oxlint layers ignore files from every ancestor of a linted file.
+      // Declared even when absent, like the extends chain.
+      ...ancestorIgnorePaths(projectRoot).map(
         (file) => `{workspaceRoot}/${file}`
       ),
       ...tsconfigChainOutsideProjectRoot.map(


### PR DESCRIPTION
## Current Behavior

#36828 replaced the inferred `oxlint` task's `default` / `^default` inputs with an explicit, narrower set: lintable files, Oxlint configs, `.eslintignore` and `tsconfig*.json`. `.gitignore` was left out.

Oxlint honours `.gitignore` when deciding which files to lint — the plugin's own doc comment says so:

> `Oxlint honours `ignorePatterns`, `.eslintignore` and `.gitignore`, including from nested project configs [...]`

So `.gitignore` decides what gets linted, but was not declared as an input. Two consequences:

1. **Stale cache (the real bug).** Editing a `.gitignore` changes which files Oxlint lints, but does not invalidate the task — you get a cache hit for the wrong file set.
2. **Sandbox violations.** The undeclared read trips Nx Cloud's sandbox check. On this repo it fails four tasks, and because one violation terminates the distributed execution, every other task in the run fails with it:

```
Sandbox violation detected for task @nx/maven:oxlint: 1 unexpected read(s).
  → packages/maven/batch-runner/.gitignore
astro-docs:oxlint  → astro-docs/.gitignore
gradle:oxlint      → packages/gradle/{batch-runner,project-graph}/.gitignore
nx-dev:oxlint      → nx-dev/nx-dev/.gitignore
```

This surfaces on any workspace with a `.gitignore` nested under a project.

## Expected Behavior

`.gitignore` is declared as an input everywhere `.eslintignore` already is. The two filenames are now a single `IGNORE_FILENAMES` constant, so all three call sites stay in step:

- the in-project ignore-file fileset,
- the ancestor-layering paths (`ancestorEslintignorePaths` → `ancestorIgnorePaths`), since Oxlint layers ignore files from every ancestor directory,
- the plugin's own invalidation hash, which decides whether a target is inferred at all.

Also corrects a comment that #36828 left stale — it still credited the removed `default` input for covering the project's own directory.

Tests: the ancestor-inputs case is now parametrized over both filenames. 35/35 pass in `@nx/oxlint`.

## Related Issue(s)

Follow-up to #36828. Unblocks #36868, where the version bump to `23.2.0-rc.0` is what first pulls in the #36828 behavior — `master` is still on `23.2.0-beta.12`, which predates it, so CI there is unaffected.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Migrate-repos-to-nx-23.2.0-rc.0-14647f12">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->