### PR TITLE
fix(linter): stop an inferred oxlint task from linting nested projects

### DIFF
--- a/astro-docs/src/content/docs/technologies/oxlint/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/oxlint/introduction.mdoc
@@ -41,6 +41,8 @@ Pass `--linter` to choose for a single project.
 
 A project gets a task when it contains files Oxlint can lint. The workspace root also needs a `package.json` and a `src` or `lib` directory, so a standalone workspace that keeps its sources elsewhere gets no root task. Documentation-only and non-JavaScript projects get no target, and giving one a config of its own does not change that: Oxlint reports `No files found to lint` where it has nothing to read.
 
+A project's task skips the roots of any projects nested inside it, so Oxlint lints each file once, under the project that owns it.
+
 View the inferred task with:
 
 ```shell

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -219,6 +219,28 @@ describe('@nx/oxlint plugin', () => {
     }
   );
 
+  // Oxlint lints every file below the directory it runs in, so without this a
+  // nested project's files are linted twice and hashed only by the inner task.
+  it('should exclude nested projects from the outer lint', async () => {
+    createFiles({
+      '.oxlintrc.json': `{"rules":{}}`,
+      'libs/a/project.json': `{"name":"a"}`,
+      'libs/a/src/index.ts': `export const a = 1;`,
+      'libs/a/nested/project.json': `{"name":"a-nested"}`,
+      'libs/a/nested/src/index.ts': `export const n = 1;`,
+    });
+
+    const results = await invokeCreateNodesOnMatchingFiles(context);
+
+    expect(results.projects['libs/a'].targets.lint.command).toBe(
+      'oxlint --ignore-pattern nested/** .'
+    );
+    // The nested project still lints its own files, through its own target.
+    expect(results.projects['libs/a/nested'].targets.lint.command).toBe(
+      'oxlint .'
+    );
+  });
+
   it('should declare local jsPlugins as file inputs but never as externalDependencies', async () => {
     createFiles({
       '.oxlintrc.json': `{"jsPlugins":["@nx/oxlint/boundaries-plugin","./tools/local-plugin.js",{"name":"acme","specifier":"@acme/oxlint-plugin"},{"name":"local","specifier":"./tools/other-plugin.js"}],"rules":{}}`,

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -280,6 +280,30 @@ describe('@nx/oxlint plugin', () => {
     );
   });
 
+  // Excluding a root already prunes everything under it, so a deeper root would
+  // be redundant — and would rehash every ancestor task when it is added.
+  it('should not emit a nested root already covered by a shallower one', async () => {
+    createFiles({
+      '.oxlintrc.json': `{"rules":{}}`,
+      'a/project.json': `{"name":"a"}`,
+      'a/index.ts': `export const a = 1;`,
+      'a/b/project.json': `{"name":"b"}`,
+      'a/b/index.ts': `export const b = 1;`,
+      'a/b/c/project.json': `{"name":"c"}`,
+      'a/b/c/index.ts': `export const c = 1;`,
+    });
+
+    const results = await invokeCreateNodesOnMatchingFiles(context);
+
+    expect(results.projects['a'].targets.lint.command).toBe(
+      'oxlint --ignore-pattern /b .'
+    );
+    expect(results.projects['a/b'].targets.lint.command).toBe(
+      'oxlint --ignore-pattern /c .'
+    );
+    expect(results.projects['a/b/c'].targets.lint.command).toBe('oxlint .');
+  });
+
   // A root reaches the shell verbatim, so a directory name is shell code unless
   // it is escaped. Escaped, not dropped: the exclusion still applies.
   (process.platform === 'win32' ? it.skip : it)(

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -262,6 +262,24 @@ describe('@nx/oxlint plugin', () => {
     );
   });
 
+  // A root-level project walks `./src` while still running from the workspace
+  // root, and a pattern anchors to the cwd rather than to the walk root.
+  it('should anchor a nested root under a standalone root project', async () => {
+    createFiles({
+      '.oxlintrc.json': `{"rules":{}}`,
+      'package.json': `{"name":"root-workspace","nx":{}}`,
+      'src/index.ts': `export const a = 1;`,
+      'src/nested/project.json': `{"name":"nested"}`,
+      'src/nested/index.ts': `export const n = 1;`,
+    });
+
+    const results = await invokeCreateNodesOnMatchingFiles(context);
+
+    expect(results.projects['.'].targets.lint.command).toBe(
+      'oxlint --ignore-pattern "/src/nested" ./src'
+    );
+  });
+
   // A root reaches the shell verbatim, so anything that is not a plain path
   // segment sequence is skipped instead of escaped.
   it('should skip a nested root that is not shell-safe', async () => {

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -245,7 +245,7 @@ describe('@nx/oxlint plugin', () => {
 
   // A pattern is anchored only when it contains a slash, so a bare single-segment
   // root would also match a same-named directory the outer project owns.
-  it('should not exclude an outer-owned directory sharing the nested root name', async () => {
+  it('should emit the nested root as an anchored pattern', async () => {
     createFiles({
       '.oxlintrc.json': `{"rules":{}}`,
       'libs/a/project.json': `{"name":"a"}`,

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -376,6 +376,44 @@ describe('@nx/oxlint plugin', () => {
     }
   );
 
+  // `--ignore-pattern` takes a gitignore pattern, not a path, so a `[` or `*` in a
+  // directory name is pattern syntax. Unescaped, `/a[b]` excludes `ab` and leaves
+  // `a[b]` walked -- a silent over-exclusion and a missed prune at once.
+  (process.platform === 'win32' ? it.skip : it)(
+    'should exclude a nested root whose name contains glob metacharacters',
+    async () => {
+      createFiles({
+        '.oxlintrc.json': `{"rules":{}}`,
+        'libs/a/project.json': `{"name":"a"}`,
+        'libs/a/index.ts': `export const a = 1;`,
+        'libs/a/n[x]/project.json': `{"name":"a-nested"}`,
+        'libs/a/n[x]/index.ts': `export const n = 1;`,
+        // Owned by `a`. An unescaped `/n[x]` is a character class matching this.
+        'libs/a/nx/keep.ts': `export const k = 1;`,
+      });
+
+      const results = await invokeCreateNodesOnMatchingFiles(context);
+      const command = results.projects['libs/a'].targets.lint.command;
+      const oxlint = join(
+        require.resolve('oxlint/package.json'),
+        '..',
+        'bin',
+        'oxlint'
+      );
+
+      const linted = execFileSync(
+        'sh',
+        ['-c', command.replace(/^oxlint /, `"${oxlint}" --debug=files `)],
+        { cwd: join(tempFs.tempDir, 'libs/a'), encoding: 'utf-8' }
+      )
+        .trim()
+        .split('\n')
+        .sort();
+
+      expect(linted).toEqual(['index.ts', 'nx/keep.ts']);
+    }
+  );
+
   it('should declare local jsPlugins as file inputs but never as externalDependencies', async () => {
     createFiles({
       '.oxlintrc.json': `{"jsPlugins":["@nx/oxlint/boundaries-plugin","./tools/local-plugin.js",{"name":"acme","specifier":"@acme/oxlint-plugin"},{"name":"local","specifier":"./tools/other-plugin.js"}],"rules":{}}`,

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -235,7 +235,7 @@ describe('@nx/oxlint plugin', () => {
     const results = await invokeCreateNodesOnMatchingFiles(context);
 
     expect(results.projects['libs/a'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern /nested .'
+      'oxlint . --ignore-pattern /nested'
     );
     // The nested project still lints its own files, through its own target.
     expect(results.projects['libs/a/nested'].targets.lint.command).toBe(
@@ -258,7 +258,7 @@ describe('@nx/oxlint plugin', () => {
     const results = await invokeCreateNodesOnMatchingFiles(context);
 
     expect(results.projects['libs/a'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern /nested .'
+      'oxlint . --ignore-pattern /nested'
     );
   });
 
@@ -276,7 +276,7 @@ describe('@nx/oxlint plugin', () => {
     const results = await invokeCreateNodesOnMatchingFiles(context);
 
     expect(results.projects['.'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern /src/nested ./src'
+      'oxlint ./src --ignore-pattern /src/nested'
     );
   });
 
@@ -296,10 +296,10 @@ describe('@nx/oxlint plugin', () => {
     const results = await invokeCreateNodesOnMatchingFiles(context);
 
     expect(results.projects['a'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern /b .'
+      'oxlint . --ignore-pattern /b'
     );
     expect(results.projects['a/b'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern /c .'
+      'oxlint . --ignore-pattern /c'
     );
     expect(results.projects['a/b/c'].targets.lint.command).toBe('oxlint .');
   });
@@ -331,9 +331,9 @@ describe('@nx/oxlint plugin', () => {
       // The name survives intact as one argument, and nothing ran.
       expect(argv).toEqual([
         'oxlint',
+        '.',
         '--ignore-pattern',
         '/n$(touch PWNED)',
-        '.',
       ]);
       expect(existsSync(join(cwd, 'PWNED'))).toBe(false);
     }

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -2,6 +2,8 @@ import { CreateDependenciesContext, CreateNodesContext } from '@nx/devkit';
 import { minimatch } from 'minimatch';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { mkdirSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
 import {
   createDependencies,
   createNodesV2,
@@ -233,13 +235,42 @@ describe('@nx/oxlint plugin', () => {
     const results = await invokeCreateNodesOnMatchingFiles(context);
 
     expect(results.projects['libs/a'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern nested/** .'
+      'oxlint --ignore-pattern "nested" .'
     );
     // The nested project still lints its own files, through its own target.
     expect(results.projects['libs/a/nested'].targets.lint.command).toBe(
       'oxlint .'
     );
   });
+
+  // `nx:run-commands` spawns the inferred command with `shell: true`, so asserting
+  // the string cannot catch an argument the shell rewrites before Oxlint sees it.
+  (process.platform === 'win32' ? it.skip : it)(
+    'should emit nested exclusions that survive the shell',
+    async () => {
+      createFiles({
+        '.oxlintrc.json': `{"rules":{}}`,
+        'libs/a/project.json': `{"name":"a"}`,
+        'libs/a/src/index.ts': `export const a = 1;`,
+        // Several visible entries: an unquoted glob would expand to all of them.
+        'libs/a/nested/project.json': `{"name":"a-nested"}`,
+        'libs/a/nested/README.md': `# nested`,
+        'libs/a/nested/src/index.ts': `export const n = 1;`,
+      });
+
+      const results = await invokeCreateNodesOnMatchingFiles(context);
+      const command = results.projects['libs/a'].targets.lint.command;
+
+      const argv = execFileSync('sh', ['-c', `printf '%s\\n' ${command}`], {
+        cwd: join(tempFs.tempDir, 'libs/a'),
+        encoding: 'utf-8',
+      })
+        .trim()
+        .split('\n');
+
+      expect(argv).toEqual(['oxlint', '--ignore-pattern', 'nested', '.']);
+    }
+  );
 
   it('should declare local jsPlugins as file inputs but never as externalDependencies', async () => {
     createFiles({

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -304,6 +304,44 @@ describe('@nx/oxlint plugin', () => {
     expect(results.projects['a/b/c'].targets.lint.command).toBe('oxlint .');
   });
 
+  // cwd and the walk root differ only for a root-level project, and a pattern
+  // anchors to the cwd. That is the one load-bearing shape the string assertions
+  // cannot see, so run it.
+  (process.platform === 'win32' ? it.skip : it)(
+    'should exclude only the nested root when a root project lints ./src',
+    async () => {
+      createFiles({
+        '.oxlintrc.json': `{"rules":{}}`,
+        'package.json': `{"name":"root-workspace","nx":{}}`,
+        'src/index.ts': `export const a = 1;`,
+        'src/nested/project.json': `{"name":"nested"}`,
+        'src/nested/index.ts': `export const n = 1;`,
+        // Owned by the root project, and shares the nested root's basename.
+        'src/deep/nested/keep.ts': `export const k = 1;`,
+      });
+
+      const results = await invokeCreateNodesOnMatchingFiles(context);
+      const command = results.projects['.'].targets.lint.command;
+      const oxlint = join(
+        require.resolve('oxlint/package.json'),
+        '..',
+        'bin',
+        'oxlint'
+      );
+
+      const linted = execFileSync(
+        'sh',
+        ['-c', command.replace(/^oxlint /, `"${oxlint}" --debug=files `)],
+        { cwd: tempFs.tempDir, encoding: 'utf-8' }
+      )
+        .trim()
+        .split('\n')
+        .sort();
+
+      expect(linted).toEqual(['src/deep/nested/keep.ts', 'src/index.ts']);
+    }
+  );
+
   // A root reaches the shell verbatim, so a directory name is shell code unless
   // it is escaped. Escaped, not dropped: the exclusion still applies.
   (process.platform === 'win32' ? it.skip : it)(
@@ -538,8 +576,10 @@ describe('@nx/oxlint plugin', () => {
     });
   });
 
-  // Without the root short-circuit, `lintPath` falls through to `.` and the root
-  // project gets `oxlint .`, re-linting every sub-project on top of its own target.
+  // Without the root short-circuit a root project with no `src` or `lib` takes `.`
+  // as its lint path and gets a task of its own. The nested-project exclusions
+  // keep that task off the sub-projects' files, but the redundant target remains,
+  // so the short-circuit is what removes it.
   it('should not give a root project a task when it has no src or lib', async () => {
     createFiles({
       '.oxlintrc.json': `{"rules":{}}`,

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -1,7 +1,7 @@
 import { CreateDependenciesContext, CreateNodesContext } from '@nx/devkit';
 import { minimatch } from 'minimatch';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
-import { mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import {
@@ -235,7 +235,7 @@ describe('@nx/oxlint plugin', () => {
     const results = await invokeCreateNodesOnMatchingFiles(context);
 
     expect(results.projects['libs/a'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern "/nested" .'
+      'oxlint --ignore-pattern /nested .'
     );
     // The nested project still lints its own files, through its own target.
     expect(results.projects['libs/a/nested'].targets.lint.command).toBe(
@@ -258,7 +258,7 @@ describe('@nx/oxlint plugin', () => {
     const results = await invokeCreateNodesOnMatchingFiles(context);
 
     expect(results.projects['libs/a'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern "/nested" .'
+      'oxlint --ignore-pattern /nested .'
     );
   });
 
@@ -276,25 +276,44 @@ describe('@nx/oxlint plugin', () => {
     const results = await invokeCreateNodesOnMatchingFiles(context);
 
     expect(results.projects['.'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern "/src/nested" ./src'
+      'oxlint --ignore-pattern /src/nested ./src'
     );
   });
 
-  // A root reaches the shell verbatim, so anything that is not a plain path
-  // segment sequence is skipped instead of escaped.
-  it('should skip a nested root that is not shell-safe', async () => {
-    createFiles({
-      '.oxlintrc.json': `{"rules":{}}`,
-      'libs/a/project.json': `{"name":"a"}`,
-      'libs/a/src/index.ts': `export const a = 1;`,
-      'libs/a/n$(touch PWNED)/project.json': `{"name":"a-evil"}`,
-      'libs/a/n$(touch PWNED)/index.ts': `export const e = 1;`,
-    });
+  // A root reaches the shell verbatim, so a directory name is shell code unless
+  // it is escaped. Escaped, not dropped: the exclusion still applies.
+  (process.platform === 'win32' ? it.skip : it)(
+    'should escape a nested root containing shell metacharacters',
+    async () => {
+      createFiles({
+        '.oxlintrc.json': `{"rules":{}}`,
+        'libs/a/project.json': `{"name":"a"}`,
+        'libs/a/src/index.ts': `export const a = 1;`,
+        'libs/a/n$(touch PWNED)/project.json': `{"name":"a-evil"}`,
+        'libs/a/n$(touch PWNED)/index.ts': `export const e = 1;`,
+      });
 
-    const results = await invokeCreateNodesOnMatchingFiles(context);
+      const results = await invokeCreateNodesOnMatchingFiles(context);
+      const command = results.projects['libs/a'].targets.lint.command;
+      const cwd = join(tempFs.tempDir, 'libs/a');
 
-    expect(results.projects['libs/a'].targets.lint.command).toBe('oxlint .');
-  });
+      const argv = execFileSync('sh', ['-c', `printf '%s\\n' ${command}`], {
+        cwd,
+        encoding: 'utf-8',
+      })
+        .trim()
+        .split('\n');
+
+      // The name survives intact as one argument, and nothing ran.
+      expect(argv).toEqual([
+        'oxlint',
+        '--ignore-pattern',
+        '/n$(touch PWNED)',
+        '.',
+      ]);
+      expect(existsSync(join(cwd, 'PWNED'))).toBe(false);
+    }
+  );
 
   // The string assertions above cannot see what a shell and Oxlint actually do
   // with the emitted argument, which is where both the anchoring and the quoting

--- a/packages/oxlint/src/plugins/plugin.spec.ts
+++ b/packages/oxlint/src/plugins/plugin.spec.ts
@@ -235,7 +235,7 @@ describe('@nx/oxlint plugin', () => {
     const results = await invokeCreateNodesOnMatchingFiles(context);
 
     expect(results.projects['libs/a'].targets.lint.command).toBe(
-      'oxlint --ignore-pattern "nested" .'
+      'oxlint --ignore-pattern "/nested" .'
     );
     // The nested project still lints its own files, through its own target.
     expect(results.projects['libs/a/nested'].targets.lint.command).toBe(
@@ -243,32 +243,75 @@ describe('@nx/oxlint plugin', () => {
     );
   });
 
-  // `nx:run-commands` spawns the inferred command with `shell: true`, so asserting
-  // the string cannot catch an argument the shell rewrites before Oxlint sees it.
+  // A pattern is anchored only when it contains a slash, so a bare single-segment
+  // root would also match a same-named directory the outer project owns.
+  it('should not exclude an outer-owned directory sharing the nested root name', async () => {
+    createFiles({
+      '.oxlintrc.json': `{"rules":{}}`,
+      'libs/a/project.json': `{"name":"a"}`,
+      'libs/a/nested/project.json': `{"name":"a-nested"}`,
+      'libs/a/nested/index.ts': `export const n = 1;`,
+      // Owned by `a`, not by the nested project, and must keep being linted.
+      'libs/a/src/nested/deep.ts': `export const d = 1;`,
+    });
+
+    const results = await invokeCreateNodesOnMatchingFiles(context);
+
+    expect(results.projects['libs/a'].targets.lint.command).toBe(
+      'oxlint --ignore-pattern "/nested" .'
+    );
+  });
+
+  // A root reaches the shell verbatim, so anything that is not a plain path
+  // segment sequence is skipped instead of escaped.
+  it('should skip a nested root that is not shell-safe', async () => {
+    createFiles({
+      '.oxlintrc.json': `{"rules":{}}`,
+      'libs/a/project.json': `{"name":"a"}`,
+      'libs/a/src/index.ts': `export const a = 1;`,
+      'libs/a/n$(touch PWNED)/project.json': `{"name":"a-evil"}`,
+      'libs/a/n$(touch PWNED)/index.ts': `export const e = 1;`,
+    });
+
+    const results = await invokeCreateNodesOnMatchingFiles(context);
+
+    expect(results.projects['libs/a'].targets.lint.command).toBe('oxlint .');
+  });
+
+  // The string assertions above cannot see what a shell and Oxlint actually do
+  // with the emitted argument, which is where both the anchoring and the quoting
+  // matter. Run the real command and check the resulting file set.
   (process.platform === 'win32' ? it.skip : it)(
-    'should emit nested exclusions that survive the shell',
+    'should exclude only the nested root when the command is executed',
     async () => {
       createFiles({
         '.oxlintrc.json': `{"rules":{}}`,
         'libs/a/project.json': `{"name":"a"}`,
-        'libs/a/src/index.ts': `export const a = 1;`,
-        // Several visible entries: an unquoted glob would expand to all of them.
+        'libs/a/index.ts': `export const a = 1;`,
         'libs/a/nested/project.json': `{"name":"a-nested"}`,
-        'libs/a/nested/README.md': `# nested`,
-        'libs/a/nested/src/index.ts': `export const n = 1;`,
+        'libs/a/nested/index.ts': `export const n = 1;`,
+        'libs/a/src/nested/deep.ts': `export const d = 1;`,
       });
 
       const results = await invokeCreateNodesOnMatchingFiles(context);
       const command = results.projects['libs/a'].targets.lint.command;
+      const oxlint = join(
+        require.resolve('oxlint/package.json'),
+        '..',
+        'bin',
+        'oxlint'
+      );
 
-      const argv = execFileSync('sh', ['-c', `printf '%s\\n' ${command}`], {
-        cwd: join(tempFs.tempDir, 'libs/a'),
-        encoding: 'utf-8',
-      })
+      const linted = execFileSync(
+        'sh',
+        ['-c', command.replace(/^oxlint /, `"${oxlint}" --debug=files `)],
+        { cwd: join(tempFs.tempDir, 'libs/a'), encoding: 'utf-8' }
+      )
         .trim()
-        .split('\n');
+        .split('\n')
+        .sort();
 
-      expect(argv).toEqual(['oxlint', '--ignore-pattern', 'nested', '.']);
+      expect(linted).toEqual(['index.ts', 'src/nested/deep.ts']);
     }
   );
 

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -81,6 +81,7 @@ const internalCreateNodes = async (
   options: OxlintPluginOptions,
   context: CreateNodesContext,
   projectRootsByOxlintRoots: Map<string, string[]>,
+  projectRoots: string[],
   getLintableFilesPerProjectRoot: () => Promise<Map<string, number>>,
   configChainsByConfig: Map<string, string[]>,
   jsPluginSpecifiersByConfig: Map<string, string[]>,
@@ -120,6 +121,7 @@ const internalCreateNodes = async (
       const project = getProjectUsingOxlintConfig(
         configFilePath,
         projectRoot,
+        projectRoots,
         options,
         context,
         pmc,
@@ -245,6 +247,7 @@ export const createNodes: CreateNodes<OxlintPluginOptions> = [
             fileOptions,
             fileContext,
             projectRootsByOxlintRoots,
+            projectRoots,
             getLintableFilesPerProjectRoot,
             configChainsByConfig,
             jsPluginSpecifiersByConfig,
@@ -783,6 +786,26 @@ function ancestorIgnorePaths(projectRoot: string): string[] {
   return result;
 }
 
+/**
+ * Project roots below `projectRoot`, relative to it and limited to `lintDir`
+ * when the lint walk starts there. Each is linted, and hashed, by its own
+ * inferred target, so the outer project must not lint them a second time.
+ */
+function nestedProjectRoots(
+  projectRoot: string,
+  projectRoots: string[],
+  lintDir: string
+): string[] {
+  const prefix = projectRoot === '.' ? '' : `${projectRoot}/`;
+  return projectRoots
+    .filter((root) => root !== projectRoot && root.startsWith(prefix))
+    .map((root) => root.slice(prefix.length))
+    .filter(
+      (rel) => !lintDir || rel === lintDir || rel.startsWith(`${lintDir}/`)
+    )
+    .sort();
+}
+
 // Only the keys are read, so the value type is left open for both callers.
 function getRootForDirectory(
   directory: string,
@@ -803,6 +826,7 @@ function getRootForDirectory(
 function getProjectUsingOxlintConfig(
   configFilePath: string,
   projectRoot: string,
+  projectRoots: string[],
   options: OxlintPluginOptions,
   context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
@@ -845,6 +869,11 @@ function getProjectUsingOxlintConfig(
   const isRootProject = projectRoot === '.';
   const lintPath =
     isRootProject && standaloneSrcPath ? `./${standaloneSrcPath}` : '.';
+  const nestedIgnoreArgs = nestedProjectRoots(
+    projectRoot,
+    projectRoots,
+    isRootProject && standaloneSrcPath ? standaloneSrcPath : ''
+  ).map((relativeRoot) => `--ignore-pattern ${relativeRoot}/**`);
 
   const jsPluginFiles = new Set(
     configInputs.flatMap((config) =>
@@ -860,7 +889,7 @@ function getProjectUsingOxlintConfig(
   );
 
   const targetConfig: TargetConfiguration = {
-    command: `oxlint ${lintPath}`,
+    command: `oxlint ${[...nestedIgnoreArgs, lintPath].join(' ')}`,
     options: { cwd: projectRoot },
     cache: true,
     inputs: [

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -804,13 +804,19 @@ function nestedProjectRoots(
   lintDir: string
 ): string[] {
   const prefix = projectRoot === '.' ? '' : `${projectRoot}/`;
-  return projectRoots
-    .filter((root) => root !== projectRoot && root.startsWith(prefix))
-    .map((root) => root.slice(prefix.length))
-    .filter(
-      (rel) => !lintDir || rel === lintDir || rel.startsWith(`${lintDir}/`)
-    )
-    .sort();
+  return (
+    projectRoots
+      .filter((root) => root !== projectRoot && root.startsWith(prefix))
+      .map((root) => root.slice(prefix.length))
+      .filter(
+        (rel) => !lintDir || rel === lintDir || rel.startsWith(`${lintDir}/`)
+      )
+      .sort()
+      // Excluding `b` already prunes `b/c`, so emitting both only lengthens the
+      // command and rehashes every ancestor task whenever a deeper project is
+      // added.
+      .filter((rel, _index, all) => !all.some((r) => rel.startsWith(`${r}/`)))
+  );
 }
 
 // Only the keys are read, so the value type is left open for both callers.

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -66,6 +66,11 @@ const LINTABLE_EXTENSIONS = [
 const LINTABLE_FILES_GLOB = `**/*.{${LINTABLE_EXTENSIONS.join(',')}}`;
 // Oxlint honours both, so both decide which files it lints.
 const IGNORE_FILENAMES = ['.eslintignore', '.gitignore'];
+// A project root reaches a shell verbatim: `run-commands` spawns the inferred
+// command with `shell: true`, and inside double quotes `$`, a backtick and `"`
+// are all still live. Roots outside a plain path-segment sequence are skipped
+// rather than escaped, which costs only the double-linting the base already did.
+const SHELL_SAFE_PROJECT_ROOT = /^[\w.@+-]+(?:\/[\w.@+-]+)*$/;
 // The one rule that looks across projects; every other rule sees one file.
 const BOUNDARIES_PLUGIN_SPECIFIER = '@nx/oxlint/boundaries-plugin';
 const PROJECT_CONFIG_FILENAMES = ['project.json', 'package.json'];
@@ -788,13 +793,14 @@ function ancestorIgnorePaths(projectRoot: string): string[] {
 
 /**
  * Project roots below `projectRoot`, relative to it and limited to `lintDir`
- * when the lint walk starts there. Each is linted, and hashed, by its own
- * inferred target, so the outer project must not lint them a second time.
+ * when the lint walk starts there. An excluded root either has its own inferred
+ * target or owns nothing lintable, so pruning it drops no lint coverage.
  *
- * Callers must emit these as the bare directory, double-quoted: `dir/**` matches
- * only entries inside `dir`, so Oxlint still descends and reads that directory's
- * ignore files, and `run-commands` spawns the command through a shell that would
- * glob-expand an unquoted pattern.
+ * Callers must emit each one anchored (`/dir`) and never as `dir/**`. A gitignore
+ * pattern is anchored only when it contains a slash, so a bare single-segment
+ * root would also match a same-named directory the outer project owns; and
+ * `dir/**` matches only entries inside `dir`, leaving Oxlint free to descend and
+ * read that directory's ignore files.
  */
 function nestedProjectRoots(
   projectRoot: string,
@@ -878,7 +884,9 @@ function getProjectUsingOxlintConfig(
     projectRoot,
     projectRoots,
     isRootProject && standaloneSrcPath ? standaloneSrcPath : ''
-  ).map((relativeRoot) => `--ignore-pattern "${relativeRoot}"`);
+  )
+    .filter((relativeRoot) => SHELL_SAFE_PROJECT_ROOT.test(relativeRoot))
+    .map((relativeRoot) => `--ignore-pattern "/${relativeRoot}"`);
 
   const jsPluginFiles = new Set(
     configInputs.flatMap((config) =>

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -956,7 +956,7 @@ function getProjectUsingOxlintConfig(
   );
 
   const targetConfig: TargetConfiguration = {
-    command: `oxlint ${[...nestedIgnoreArgs, lintPath].join(' ')}`,
+    command: `oxlint ${[lintPath, ...nestedIgnoreArgs].join(' ')}`,
     options: { cwd: projectRoot },
     cache: true,
     inputs: [

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -791,7 +791,7 @@ function ancestorIgnorePaths(projectRoot: string): string[] {
 /**
  * Escape the gitignore metacharacters in a path so `--ignore-pattern` matches it
  * literally. The value crosses two languages and `quoteShellArg` only covers the
- * shell: to Oxlint's matcher `[`, `]`, `*` and `?` are pattern syntax, and a
+ * shell: to Oxlint's matcher `\`, `[`, `]`, `*` and `?` are pattern syntax, and a
  * trailing space is stripped unless escaped — so `/a[b]` excludes `ab` while
  * leaving `a[b]` walked, which is both a miss and a silent over-exclusion.
  */
@@ -862,7 +862,7 @@ function nestedProjectRoots(
     );
 }
 
-// Only the keys are read, so the value type is left open for both callers.
+// Only the keys are read, so the value type is left open for all callers.
 function getRootForDirectory(
   directory: string,
   roots: Map<string, unknown>

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -790,6 +790,11 @@ function ancestorIgnorePaths(projectRoot: string): string[] {
  * Project roots below `projectRoot`, relative to it and limited to `lintDir`
  * when the lint walk starts there. Each is linted, and hashed, by its own
  * inferred target, so the outer project must not lint them a second time.
+ *
+ * Callers must emit these as the bare directory, double-quoted: `dir/**` matches
+ * only entries inside `dir`, so Oxlint still descends and reads that directory's
+ * ignore files, and `run-commands` spawns the command through a shell that would
+ * glob-expand an unquoted pattern.
  */
 function nestedProjectRoots(
   projectRoot: string,
@@ -873,7 +878,7 @@ function getProjectUsingOxlintConfig(
     projectRoot,
     projectRoots,
     isRootProject && standaloneSrcPath ? standaloneSrcPath : ''
-  ).map((relativeRoot) => `--ignore-pattern ${relativeRoot}/**`);
+  ).map((relativeRoot) => `--ignore-pattern "${relativeRoot}"`);
 
   const jsPluginFiles = new Set(
     configInputs.flatMap((config) =>

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -813,33 +813,21 @@ function escapeIgnorePattern(pattern: string): string {
 function nestedRootsByParentRoot(
   projectRoots: string[]
 ): Map<string, string[]> {
-  const roots = new Set(projectRoots);
+  // getRootForDirectory reads only the keys.
+  const roots = new Map(projectRoots.map((root) => [root, true]));
   const byParent = new Map<string, string[]>();
-  const claim = (parent: string, root: string) => {
+
+  for (const root of projectRoots) {
+    const parent = getRootForDirectory(dirname(root), roots);
+    // A workspace-root project is its own ancestor, so it must not claim itself.
+    if (parent === null || parent === root) {
+      continue;
+    }
     const claimed = byParent.get(parent);
     if (claimed) {
       claimed.push(root);
     } else {
       byParent.set(parent, [root]);
-    }
-  };
-
-  for (const root of projectRoots) {
-    let dir = root;
-    while (true) {
-      const parent = dirname(dir);
-      if (parent === dir) {
-        // Nothing above claimed it, so a root project takes it if there is one.
-        if (root !== '.' && roots.has('.')) {
-          claim('.', root);
-        }
-        break;
-      }
-      if (roots.has(parent)) {
-        claim(parent, root);
-        break;
-      }
-      dir = parent;
     }
   }
 
@@ -941,10 +929,18 @@ function getProjectUsingOxlintConfig(
     projectRoot,
     nestedRootsByParent,
     isRootProject && standaloneSrcPath ? standaloneSrcPath : ''
-  ).map(
-    (relativeRoot) =>
-      `--ignore-pattern ${quoteShellArg(escapeIgnorePattern(`/${relativeRoot}`))}`
-  );
+  )
+    // `quoteShellArg` documents that it cannot keep `%` literal through cmd.exe,
+    // so on Windows such a root is left unexcluded rather than excluded wrongly:
+    // it gets linted twice, which is what happened before this exclusion existed.
+    .filter(
+      (relativeRoot) =>
+        process.platform !== 'win32' || !relativeRoot.includes('%')
+    )
+    .map(
+      (relativeRoot) =>
+        `--ignore-pattern ${quoteShellArg(escapeIgnorePattern(`/${relativeRoot}`))}`
+    );
 
   const jsPluginFiles = new Set(
     configInputs.flatMap((config) =>

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -8,6 +8,7 @@ import {
   PluginCache,
   TargetProjectLocator,
   workspaceDataDirectory,
+  quoteShellArg,
 } from '@nx/devkit/internal';
 import {
   CreateDependencies,
@@ -66,11 +67,6 @@ const LINTABLE_EXTENSIONS = [
 const LINTABLE_FILES_GLOB = `**/*.{${LINTABLE_EXTENSIONS.join(',')}}`;
 // Oxlint honours both, so both decide which files it lints.
 const IGNORE_FILENAMES = ['.eslintignore', '.gitignore'];
-// A project root reaches a shell verbatim: `run-commands` spawns the inferred
-// command with `shell: true`, and inside double quotes `$`, a backtick and `"`
-// are all still live. Roots outside a plain path-segment sequence are skipped
-// rather than escaped, which costs only the double-linting the base already did.
-const SHELL_SAFE_PROJECT_ROOT = /^[\w.@+-]+(?:\/[\w.@+-]+)*$/;
 // The one rule that looks across projects; every other rule sees one file.
 const BOUNDARIES_PLUGIN_SPECIFIER = '@nx/oxlint/boundaries-plugin';
 const PROJECT_CONFIG_FILENAMES = ['project.json', 'package.json'];
@@ -884,9 +880,9 @@ function getProjectUsingOxlintConfig(
     projectRoot,
     projectRoots,
     isRootProject && standaloneSrcPath ? standaloneSrcPath : ''
-  )
-    .filter((relativeRoot) => SHELL_SAFE_PROJECT_ROOT.test(relativeRoot))
-    .map((relativeRoot) => `--ignore-pattern "/${relativeRoot}"`);
+  ).map(
+    (relativeRoot) => `--ignore-pattern ${quoteShellArg(`/${relativeRoot}`)}`
+  );
 
   const jsPluginFiles = new Set(
     configInputs.flatMap((config) =>

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -789,6 +789,19 @@ function ancestorIgnorePaths(projectRoot: string): string[] {
 }
 
 /**
+ * Escape the gitignore metacharacters in a path so `--ignore-pattern` matches it
+ * literally. The value crosses two languages and `quoteShellArg` only covers the
+ * shell: to Oxlint's matcher `[`, `]`, `*` and `?` are pattern syntax, and a
+ * trailing space is stripped unless escaped — so `/a[b]` excludes `ab` while
+ * leaving `a[b]` walked, which is both a miss and a silent over-exclusion.
+ */
+function escapeIgnorePattern(pattern: string): string {
+  return pattern
+    .replace(/([\\[\]*?])/g, '\\$1')
+    .replace(/ +$/, (spaces) => spaces.replace(/ /g, '\\ '));
+}
+
+/**
  * Direct child project roots for each project root, keyed by the parent. A root
  * belongs to its NEAREST enclosing root, so a grandchild lands under the child
  * rather than the grandparent — which is what keeps an outer project from
@@ -929,7 +942,8 @@ function getProjectUsingOxlintConfig(
     nestedRootsByParent,
     isRootProject && standaloneSrcPath ? standaloneSrcPath : ''
   ).map(
-    (relativeRoot) => `--ignore-pattern ${quoteShellArg(`/${relativeRoot}`)}`
+    (relativeRoot) =>
+      `--ignore-pattern ${quoteShellArg(escapeIgnorePattern(`/${relativeRoot}`))}`
   );
 
   const jsPluginFiles = new Set(

--- a/packages/oxlint/src/plugins/plugin.ts
+++ b/packages/oxlint/src/plugins/plugin.ts
@@ -82,7 +82,7 @@ const internalCreateNodes = async (
   options: OxlintPluginOptions,
   context: CreateNodesContext,
   projectRootsByOxlintRoots: Map<string, string[]>,
-  projectRoots: string[],
+  nestedRootsByParent: Map<string, string[]>,
   getLintableFilesPerProjectRoot: () => Promise<Map<string, number>>,
   configChainsByConfig: Map<string, string[]>,
   jsPluginSpecifiersByConfig: Map<string, string[]>,
@@ -122,7 +122,7 @@ const internalCreateNodes = async (
       const project = getProjectUsingOxlintConfig(
         configFilePath,
         projectRoot,
-        projectRoots,
+        nestedRootsByParent,
         options,
         context,
         pmc,
@@ -166,6 +166,7 @@ export const createNodes: CreateNodes<OxlintPluginOptions> = [
 
     const { oxlintConfigFiles, projectRoots, projectRootsByOxlintRoots } =
       splitConfigFiles(configFiles, context.workspaceRoot);
+    const nestedRootsByParent = nestedRootsByParentRoot(projectRoots);
 
     // The glob also matches `**/package.json`, so this callback runs in every
     // workspace, Oxlint or not. Bail before the chain walks and the hashing.
@@ -248,7 +249,7 @@ export const createNodes: CreateNodes<OxlintPluginOptions> = [
             fileOptions,
             fileContext,
             projectRootsByOxlintRoots,
-            projectRoots,
+            nestedRootsByParent,
             getLintableFilesPerProjectRoot,
             configChainsByConfig,
             jsPluginSpecifiersByConfig,
@@ -788,9 +789,58 @@ function ancestorIgnorePaths(projectRoot: string): string[] {
 }
 
 /**
- * Project roots below `projectRoot`, relative to it and limited to `lintDir`
- * when the lint walk starts there. An excluded root either has its own inferred
- * target or owns nothing lintable, so pruning it drops no lint coverage.
+ * Direct child project roots for each project root, keyed by the parent. A root
+ * belongs to its NEAREST enclosing root, so a grandchild lands under the child
+ * rather than the grandparent — which is what keeps an outer project from
+ * emitting an exclusion that a shallower one already covers.
+ *
+ * Built once per run: resolving each root's parent by walking up is linear in
+ * the workspace, where asking every project which roots sit below it is not.
+ */
+function nestedRootsByParentRoot(
+  projectRoots: string[]
+): Map<string, string[]> {
+  const roots = new Set(projectRoots);
+  const byParent = new Map<string, string[]>();
+  const claim = (parent: string, root: string) => {
+    const claimed = byParent.get(parent);
+    if (claimed) {
+      claimed.push(root);
+    } else {
+      byParent.set(parent, [root]);
+    }
+  };
+
+  for (const root of projectRoots) {
+    let dir = root;
+    while (true) {
+      const parent = dirname(dir);
+      if (parent === dir) {
+        // Nothing above claimed it, so a root project takes it if there is one.
+        if (root !== '.' && roots.has('.')) {
+          claim('.', root);
+        }
+        break;
+      }
+      if (roots.has(parent)) {
+        claim(parent, root);
+        break;
+      }
+      dir = parent;
+    }
+  }
+
+  for (const claimed of byParent.values()) {
+    claimed.sort();
+  }
+  return byParent;
+}
+
+/**
+ * The project roots nested directly below `projectRoot`, relative to it and
+ * limited to `lintDir` when the lint walk starts there. An excluded root either
+ * has its own inferred target or owns nothing lintable, so pruning it drops no
+ * lint coverage.
  *
  * Callers must emit each one anchored (`/dir`) and never as `dir/**`. A gitignore
  * pattern is anchored only when it contains a slash, so a bare single-segment
@@ -800,23 +850,15 @@ function ancestorIgnorePaths(projectRoot: string): string[] {
  */
 function nestedProjectRoots(
   projectRoot: string,
-  projectRoots: string[],
+  nestedRootsByParent: Map<string, string[]>,
   lintDir: string
 ): string[] {
   const prefix = projectRoot === '.' ? '' : `${projectRoot}/`;
-  return (
-    projectRoots
-      .filter((root) => root !== projectRoot && root.startsWith(prefix))
-      .map((root) => root.slice(prefix.length))
-      .filter(
-        (rel) => !lintDir || rel === lintDir || rel.startsWith(`${lintDir}/`)
-      )
-      .sort()
-      // Excluding `b` already prunes `b/c`, so emitting both only lengthens the
-      // command and rehashes every ancestor task whenever a deeper project is
-      // added.
-      .filter((rel, _index, all) => !all.some((r) => rel.startsWith(`${r}/`)))
-  );
+  return (nestedRootsByParent.get(projectRoot) ?? [])
+    .map((root) => root.slice(prefix.length))
+    .filter(
+      (rel) => !lintDir || rel === lintDir || rel.startsWith(`${lintDir}/`)
+    );
 }
 
 // Only the keys are read, so the value type is left open for both callers.
@@ -839,7 +881,7 @@ function getRootForDirectory(
 function getProjectUsingOxlintConfig(
   configFilePath: string,
   projectRoot: string,
-  projectRoots: string[],
+  nestedRootsByParent: Map<string, string[]>,
   options: OxlintPluginOptions,
   context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
@@ -884,7 +926,7 @@ function getProjectUsingOxlintConfig(
     isRootProject && standaloneSrcPath ? `./${standaloneSrcPath}` : '.';
   const nestedIgnoreArgs = nestedProjectRoots(
     projectRoot,
-    projectRoots,
+    nestedRootsByParent,
     isRootProject && standaloneSrcPath ? standaloneSrcPath : ''
   ).map(
     (relativeRoot) => `--ignore-pattern ${quoteShellArg(`/${relativeRoot}`)}`


### PR DESCRIPTION
## Current Behavior

Oxlint lints every file below the directory it runs in. An inferred `oxlint` task runs `oxlint .` from the project root, so a project that has another project nested inside it walks into that nested project — reading its ignore files and linting its sources.

Nx assigns each file to the **most specific** project root, so those files belong to the nested project, not the outer one. That mismatch between what the task *walks* and what it *owns* causes three problems:

**1. The outer task lints files it does not declare as inputs.** `packages/gradle/project-graph/publish-maven.ts` is linted by `gradle:oxlint`, but it is owned by `:gradle-project-graph`, so it is absent from `gradle:oxlint`'s inputs. Editing it does not invalidate that task's cache entry.

**2. The same file is linted twice** — once by `gradle:oxlint` and once by `:gradle-project-graph:oxlint` — so its diagnostics are reported twice.

**3. Undeclared ignore-file reads fail sandboxed CI.** The walk reads `packages/maven/batch-runner/.gitignore` and `packages/gradle/{batch-runner,project-graph}/.gitignore`, none of which the outer task declares. Under task sandboxing that terminates the whole distributed run:

```
error: Sandbox violation detected for task @nx/maven:oxlint: 1 unexpected read(s).
NX  Distributed Execution Terminated
```

`maven-batch-runner` and `:gradle-batch-runner` own **no lintable files at all** — the outer task descends into them, reads their ignore file, and lints nothing.

### This is a regression from the ESLint setup, not new behavior

`packages/gradle/eslint.config.mjs` already expresses the intent:

```js
ignores: ['project-graph', 'batch-runner'],
```

Oxlint does not read `eslint.config.mjs` as configuration — it reads `.oxlintrc.json`, `.eslintignore` and `.gitignore` — so that ignore stopped applying when the rules moved to Oxlint. (`eslint.config.mjs` does appear in Oxlint's file list, but as a lintable source file, not as config.)

Deriving the exclusions from the project graph also avoids the drift a hand-maintained list invites: `packages/maven/eslint.config.mjs` ignores `dist` and `**/target/**` but never listed `batch-runner`.

## Expected Behavior

An inferred `oxlint` task excludes the project roots nested below its own, emitting one `--ignore-pattern "/<relative-root>"` per nested root. `gradle:oxlint` becomes:

```
oxlint --ignore-pattern "/batch-runner" --ignore-pattern "/project-graph" .
```

Patterns are relative because the task already runs with `cwd: projectRoot`, and sorted so the command — and therefore the task hash — is stable.

Three details are load-bearing, and each was measured rather than assumed.

**Anchored (`/root`), not bare.** A gitignore pattern is anchored only when it contains a slash, so a bare single-segment root also matches a same-named directory anywhere below the outer project. The anchor is relative to the process `cwd` — which is `projectRoot`, matching what `nestedProjectRoots` returns — and not to the walk root. Those differ for a root-level project, which walks `./src` while still running from the workspace root, so it emits `/src/nested` rather than `/nested`; there is a test pinning that branch. That is not hypothetical here: `packages/dotnet` has nested roots `analyzer` and `analyzer.Tests`, and also owns `packages/dotnet/src/analyzer/`.

| command in `packages/dotnet` | files linted |
| --- | --- |
| `oxlint .` (base) | 19 |
| bare `--ignore-pattern "analyzer" "analyzer.Tests"` | 17 |
| anchored `--ignore-pattern "/analyzer" "/analyzer.Tests"` | 19 |

The two files the bare form drops — `src/analyzer/analyzer-client.ts` and its spec — are owned by `packages/dotnet` itself, and `packages/dotnet/analyzer` holds only `.cs` files, so it has no inferred target to pick them up. They would stay in the task's `{projectRoot}` inputs while nothing linted them, and the task would still exit 0.

**The directory, not `root/**`.** Gitignore-glob semantics match entries *inside* a directory but never the directory itself, so `dir/**` still lets the walker descend and read that directory's ignore files — leaving the sandbox violation in place. Traced with `strace` against an ordinary (non-FIFO) `.gitignore` in a nested project:

| pattern | `openat` | stat-family |
| --- | --- | --- |
| none | 1 | 1 |
| `dir/**` | 1 | 1 |
| `/dir` | **0** | **0** |

**Escaped, not sanitized.** `nx:run-commands` spawns the inferred command with `shell: true` (`packages/nx/src/executors/run-commands/running-tasks.ts:446`) and nothing quotes the `command` string — it only quotes the `--key=value` args it appends. A project root is a directory name, so unescaped it is shell code:

```
libs/a/n$(...)  ->  oxlint --ignore-pattern /n$(...) .   ->  runs during shell parsing,
                                                             before oxlint is resolved
```

Each pattern therefore goes through `quoteShellArg`, the helper the rest of the repo already uses for exactly this (`nx/src/utils/{safe-spawn,child-process,package-manager}.ts`, `command-line/migrate`). It keeps the POSIX and `cmd.exe` rules in one place, and it escapes rather than drops:

| root | emitted |
| --- | --- |
| `/nested` | `/nested` (no metacharacters, no quoting needed) |
| `/my nested` | `'/my nested'` |
| `/n$(touch X)` | `'/n$(touch X)'` — inert, and still excluded |

Dropping unsafe roots was the alternative and it was worse on both counts: a legitimate name — one with a space, or any non-ASCII name — silently lost its exclusion, and a hostile name was never a threat to neutralize in the first place, just an argument to pass correctly.

It is imported from `@nx/devkit/internal`, which already exposes it.

### Lint coverage

For every root that *is* excluded, nothing stops being linted: a nested project either owns lintable files — in which case it already has its own inferred target, cascading from the root Oxlint config with no per-project config required — or it owns none and there is nothing to lint.

```ts
const shouldInferTarget =
  ((await getLintableFilesPerProjectRoot()).get(projectRoot) ?? 0) > 0;
```

That count is assigned by most-specific root. Confirmed in this repo: `:gradle-project-graph` (1 lintable file) has an `oxlint` target despite having no Oxlint config of its own; `maven-batch-runner` (0 lintable files) has none.

The one thing that argument does **not** cover is a directory that merely shares a nested root's last path segment. That is handled by anchoring rather than by this reasoning: it is not a project root, so it is never excluded and stays linted by its owner.

### The exclusion list

Only *direct* child roots are emitted. Each project root is resolved to its nearest enclosing root once per run and the result keyed by parent, so a grandchild lands under the child rather than the grandparent:

```
a      ->  oxlint --ignore-pattern /b .
a/b    ->  oxlint --ignore-pattern /c .
a/b/c  ->  oxlint .
```

`a` does not also emit `/b/c`: excluding `/b` already prunes it. That matters beyond tidiness, because the command string feeds the task hash — emitting descendants would rewrite the command of every ancestor whenever a deeper project was added, missing their caches even though what each one lints is unchanged. It also keeps the argument list clear of `cmd.exe`'s command-line limit.

Resolving by parent rather than by scanning every root for each project is also what keeps this off the graph's critical path: the scan was O(n²), measured at 1.6s for 11k project roots against 2.7ms for the same output.

Narrowing the walk this way also makes the existing `{projectRoot}` input filesets *true* rather than something to compensate for, so no input widening or dependency hashing is needed and the "no dependency hashing without the boundaries bridge" invariant is untouched.

### Tests

- The emitted command for a project with a nested project, and that the nested project still lints its own files through its own target.
- An outer-owned directory sharing the nested root's name is **not** excluded — the anchoring case.
- A nested root whose name contains shell metacharacters is still excluded, reaches Oxlint as one intact argument, and executes nothing.
- A root-level project, where the walk root (`./src`) and the cwd differ.
- Three levels of nesting, asserting the outer project emits only its direct child.
- The generated command executed through `sh` with the real Oxlint binary, asserting the resulting file set — string equality cannot see what a shell and Oxlint actually do with the argument, which is where the anchoring and the quoting both live.

## Related Issue(s)

Follow-up to #36869 and #36828, which narrowed the inferred task's inputs. The nested-project case was not covered by either.

N/A — no linked issue.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Migrate-repos-to-nx-23.2.0-rc.1-5fb69437">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->