### PR TITLE
fix(core): pass release publish commands as argv instead of shell strings

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
@@ -3,14 +3,17 @@ import {
   readJsonFile,
   detectPackageManager,
 } from '@nx/devkit';
-import { execSync } from 'child_process';
+import { safeExecFileSync } from '@nx/devkit/internal';
 import { PublishExecutorSchema } from './schema';
 import runExecutor from './release-publish.impl';
 import * as npmConfigModule from '../../utils/npm-config';
 import * as npmRunPath from 'npm-run-path';
 import * as extractModule from './extract-npm-publish-json-data';
 
-jest.mock('child_process');
+jest.mock('@nx/devkit/internal', () => ({
+  ...jest.requireActual('@nx/devkit/internal'),
+  safeExecFileSync: jest.fn(),
+}));
 jest.mock('npm-run-path', () => ({
   env: jest.fn(() => ({})),
 }));
@@ -26,7 +29,9 @@ jest.mock('./log-tar');
 describe('release-publish executor', () => {
   let context: ExecutorContext;
   let options: PublishExecutorSchema;
-  const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+  const mockExec = safeExecFileSync as jest.MockedFunction<
+    typeof safeExecFileSync
+  >;
   const mockDetectPackageManager = detectPackageManager as jest.MockedFunction<
     typeof detectPackageManager
   >;
@@ -83,8 +88,8 @@ describe('release-publish executor', () => {
       registryConfigKey: 'registry',
     });
 
-    // Default mock for npm --version check (first execSync call in the executor)
-    mockExecSync.mockReturnValueOnce('11.5.1' as any);
+    // Default mock for npm --version check (first safeExecFileSync call in the executor)
+    mockExec.mockReturnValueOnce('11.5.1');
   });
 
   afterEach(() => {
@@ -93,17 +98,15 @@ describe('release-publish executor', () => {
 
   describe('already published error handling', () => {
     function mockNpmViewNotFound() {
-      mockExecSync.mockImplementationOnce(() => {
+      mockExec.mockImplementationOnce(() => {
         const error: any = new Error('npm view failed');
-        error.stdout = Buffer.from(
-          JSON.stringify({
-            error: {
-              code: 'E404',
-              summary: 'Not found',
-            },
-          })
-        );
-        error.stderr = Buffer.from('npm ERR! 404 Not Found');
+        error.stdout = JSON.stringify({
+          error: {
+            code: 'E404',
+            summary: 'Not found',
+          },
+        });
+        error.stderr = 'npm ERR! 404 Not Found';
         throw error;
       });
     }
@@ -111,18 +114,16 @@ describe('release-publish executor', () => {
     it('should skip publishing when pnpm reports that the version was previously published', async () => {
       mockDetectPackageManager.mockReturnValue('pnpm');
       mockNpmViewNotFound();
-      mockExecSync.mockImplementationOnce(() => {
+      mockExec.mockImplementationOnce(() => {
         const error: any = new Error('pnpm publish failed');
-        error.stdout = Buffer.from(
-          JSON.stringify({
-            error: {
-              code: 'E403',
-              message:
-                'You cannot publish over the previously published versions: 1.0.0.',
-            },
-          })
-        );
-        error.stderr = Buffer.from('');
+        error.stdout = JSON.stringify({
+          error: {
+            code: 'E403',
+            message:
+              'You cannot publish over the previously published versions: 1.0.0.',
+          },
+        });
+        error.stderr = '';
         throw error;
       });
 
@@ -138,12 +139,11 @@ describe('release-publish executor', () => {
     it('should skip publishing when raw publish output says the version was previously published', async () => {
       mockDetectPackageManager.mockReturnValue('pnpm');
       mockNpmViewNotFound();
-      mockExecSync.mockImplementationOnce(() => {
+      mockExec.mockImplementationOnce(() => {
         const error: any = new Error('pnpm publish failed');
-        error.stdout = Buffer.from('not json');
-        error.stderr = Buffer.from(
-          'ERR_PNPM_PUBLISH_CONFLICT 403 Forbidden - You cannot publish over the previously published versions: 1.0.0.'
-        );
+        error.stdout = 'not json';
+        error.stderr =
+          'ERR_PNPM_PUBLISH_CONFLICT 403 Forbidden - You cannot publish over the previously published versions: 1.0.0.';
         throw error;
       });
 
@@ -159,17 +159,15 @@ describe('release-publish executor', () => {
     it('should fail when pnpm publish returns a generic 403 error', async () => {
       mockDetectPackageManager.mockReturnValue('pnpm');
       mockNpmViewNotFound();
-      mockExecSync.mockImplementationOnce(() => {
+      mockExec.mockImplementationOnce(() => {
         const error: any = new Error('pnpm publish failed');
-        error.stdout = Buffer.from(
-          JSON.stringify({
-            error: {
-              code: 'E403',
-              message: '403 Forbidden - You do not have permission to publish',
-            },
-          })
-        );
-        error.stderr = Buffer.from('');
+        error.stdout = JSON.stringify({
+          error: {
+            code: 'E403',
+            message: '403 Forbidden - You do not have permission to publish',
+          },
+        });
+        error.stderr = '';
         throw error;
       });
 
@@ -206,20 +204,18 @@ describe('release-publish executor', () => {
         expect.stringContaining('no new version was resolved')
       );
       // Should only have called npm --version, not npm view or npm publish
-      expect(mockExecSync).toHaveBeenCalledTimes(1);
+      expect(mockExec).toHaveBeenCalledTimes(1);
     });
 
     it('should proceed with publishing when nxReleaseVersionData indicates a new version', async () => {
-      mockExecSync
+      mockExec
         .mockReturnValueOnce(
-          Buffer.from(
-            JSON.stringify({
-              versions: ['0.9.0'],
-              'dist-tags': { latest: '0.9.0' },
-            })
-          )
+          JSON.stringify({
+            versions: ['0.9.0'],
+            'dist-tags': { latest: '0.9.0' },
+          })
         ) // npm view
-        .mockReturnValueOnce(Buffer.from('{}') as any); // npm publish
+        .mockReturnValueOnce('{}'); // npm publish
 
       jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
         beforeJsonData: '',
@@ -254,20 +250,18 @@ describe('release-publish executor', () => {
 
       expect(result.success).toBe(true);
       // Should have proceeded with npm --version, npm view, and publish
-      expect(mockExecSync).toHaveBeenCalledTimes(3);
+      expect(mockExec).toHaveBeenCalledTimes(3);
     });
 
     it('should proceed with publishing when nxReleaseVersionData is not provided', async () => {
-      mockExecSync
+      mockExec
         .mockReturnValueOnce(
-          Buffer.from(
-            JSON.stringify({
-              versions: ['0.9.0'],
-              'dist-tags': { latest: '0.9.0' },
-            })
-          )
+          JSON.stringify({
+            versions: ['0.9.0'],
+            'dist-tags': { latest: '0.9.0' },
+          })
         ) // npm view
-        .mockReturnValueOnce(Buffer.from('{}') as any); // npm publish
+        .mockReturnValueOnce('{}'); // npm publish
 
       jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
         beforeJsonData: '',
@@ -291,25 +285,23 @@ describe('release-publish executor', () => {
 
       expect(result.success).toBe(true);
       // Should have proceeded with npm --version, npm view, and publish
-      expect(mockExecSync).toHaveBeenCalledTimes(3);
+      expect(mockExec).toHaveBeenCalledTimes(3);
     });
   });
 
   describe('npm dist-tag error handling', () => {
     it('returns failure and logs only the dist-tag add error when add fails with empty stdout', async () => {
-      mockExecSync
+      mockExec
         .mockReturnValueOnce(
-          Buffer.from(
-            JSON.stringify({
-              versions: ['1.0.0'],
-              'dist-tags': { latest: '0.9.0' },
-            })
-          )
+          JSON.stringify({
+            versions: ['1.0.0'],
+            'dist-tags': { latest: '0.9.0' },
+          })
         )
         .mockImplementationOnce(() => {
           const error: any = new Error('npm dist-tag add failed');
-          error.stdout = Buffer.from('');
-          error.stderr = Buffer.from('npm ERR! permission denied');
+          error.stdout = '';
+          error.stderr = 'npm ERR! permission denied';
           error.code = 1;
           throw error;
         });
@@ -328,24 +320,22 @@ describe('release-publish executor', () => {
   describe('npm availability check', () => {
     it('should continue without error when pm is bun and npm is not installed', async () => {
       mockDetectPackageManager.mockReturnValue('bun');
-      mockExecSync.mockReset();
+      mockExec.mockReset();
 
       // npm --version throws (npm not installed)
-      mockExecSync
+      mockExec
         .mockImplementationOnce(() => {
           throw new Error('Command not found: npm');
         })
         // bun info call for view command
         .mockReturnValueOnce(
-          Buffer.from(
-            JSON.stringify({
-              versions: ['0.9.0'],
-              'dist-tags': { latest: '0.9.0' },
-            })
-          )
+          JSON.stringify({
+            versions: ['0.9.0'],
+            'dist-tags': { latest: '0.9.0' },
+          })
         )
         // bun publish call
-        .mockReturnValueOnce(Buffer.from('bun publish output'));
+        .mockReturnValueOnce('bun publish output');
 
       jest
         .spyOn(extractModule, 'extractNpmPublishJsonData')
@@ -355,44 +345,42 @@ describe('release-publish executor', () => {
 
       expect(result.success).toBe(true);
       // Verify the view command used bun info (not npm view)
-      expect(mockExecSync).toHaveBeenCalledWith(
-        expect.stringContaining('bun info'),
+      expect(mockExec).toHaveBeenCalledWith(
+        'bun',
+        expect.arrayContaining(['info']),
         expect.anything()
       );
       // Verify npm dist-tag add was NOT called (npm not installed)
-      expect(mockExecSync).not.toHaveBeenCalledWith(
-        expect.stringContaining('npm dist-tag add'),
+      expect(mockExec).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['dist-tag', 'add']),
         expect.anything()
       );
     });
 
     it('should fall back to npm publish when bun publish fails with an authentication error and npm is installed', async () => {
       mockDetectPackageManager.mockReturnValue('bun');
-      mockExecSync.mockReset();
+      mockExec.mockReset();
 
-      mockExecSync
+      mockExec
         // npm --version succeeds (npm is installed)
-        .mockReturnValueOnce('11.5.1' as any)
+        .mockReturnValueOnce('11.5.1')
         // bun info (view) call
         .mockReturnValueOnce(
-          Buffer.from(
-            JSON.stringify({
-              versions: ['0.9.0'],
-              'dist-tags': { latest: '0.9.0' },
-            })
-          )
+          JSON.stringify({
+            versions: ['0.9.0'],
+            'dist-tags': { latest: '0.9.0' },
+          })
         )
         // bun publish fails with missing authentication
         .mockImplementationOnce(() => {
           const error: any = new Error('bun publish failed');
-          error.stdout = Buffer.from('');
-          error.stderr = Buffer.from(
-            'error: missing authentication (run `bunx npm login`)'
-          );
+          error.stdout = '';
+          error.stderr = 'error: missing authentication (run `bunx npm login`)';
           throw error;
         })
         // npm publish (fallback) succeeds
-        .mockReturnValueOnce(Buffer.from('{}') as any);
+        .mockReturnValueOnce('{}');
 
       jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
         beforeJsonData: '',
@@ -416,13 +404,15 @@ describe('release-publish executor', () => {
 
       expect(result.success).toBe(true);
       // bun publish was tried first
-      expect(mockExecSync).toHaveBeenCalledWith(
-        expect.stringContaining('bun publish'),
+      expect(mockExec).toHaveBeenCalledWith(
+        'bun',
+        expect.arrayContaining(['publish']),
         expect.anything()
       );
       // npm publish was tried after bun failed
-      expect(mockExecSync).toHaveBeenCalledWith(
-        expect.stringContaining('npm publish'),
+      expect(mockExec).toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish']),
         expect.anything()
       );
       // the user-facing fallback warning was logged
@@ -433,27 +423,23 @@ describe('release-publish executor', () => {
 
     it('should not fall back to npm publish when bun publish fails with a non-auth error', async () => {
       mockDetectPackageManager.mockReturnValue('bun');
-      mockExecSync.mockReset();
+      mockExec.mockReset();
 
-      mockExecSync
+      mockExec
         // npm --version succeeds (npm is installed)
-        .mockReturnValueOnce('11.5.1' as any)
+        .mockReturnValueOnce('11.5.1')
         // bun info (view) call
         .mockReturnValueOnce(
-          Buffer.from(
-            JSON.stringify({
-              versions: ['0.9.0'],
-              'dist-tags': { latest: '0.9.0' },
-            })
-          )
+          JSON.stringify({
+            versions: ['0.9.0'],
+            'dist-tags': { latest: '0.9.0' },
+          })
         )
         // bun publish fails with a non-auth error (e.g., version conflict)
         .mockImplementationOnce(() => {
           const error: any = new Error('bun publish failed');
-          error.stdout = Buffer.from('');
-          error.stderr = Buffer.from(
-            'error: version 1.0.0 already exists in the registry'
-          );
+          error.stdout = '';
+          error.stderr = 'error: version 1.0.0 already exists in the registry';
           throw error;
         });
 
@@ -462,8 +448,9 @@ describe('release-publish executor', () => {
       expect(result.success).toBe(false);
       expect(console.error).toHaveBeenCalledWith('bun publish error:');
       // npm publish must NOT be attempted for non-auth bun errors
-      expect(mockExecSync).not.toHaveBeenCalledWith(
-        expect.stringContaining('npm publish'),
+      expect(mockExec).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish']),
         expect.anything()
       );
       // the fallback warning must NOT have been logged
@@ -474,29 +461,25 @@ describe('release-publish executor', () => {
 
     it('should not fall back to npm publish when bun publish fails with an authentication error but npm is not installed', async () => {
       mockDetectPackageManager.mockReturnValue('bun');
-      mockExecSync.mockReset();
+      mockExec.mockReset();
 
-      mockExecSync
+      mockExec
         // npm --version throws (npm not installed)
         .mockImplementationOnce(() => {
           throw new Error('Command not found: npm');
         })
         // bun info (view) call
         .mockReturnValueOnce(
-          Buffer.from(
-            JSON.stringify({
-              versions: ['0.9.0'],
-              'dist-tags': { latest: '0.9.0' },
-            })
-          )
+          JSON.stringify({
+            versions: ['0.9.0'],
+            'dist-tags': { latest: '0.9.0' },
+          })
         )
         // bun publish fails with an auth error — but npm is unavailable, so no fallback
         .mockImplementationOnce(() => {
           const error: any = new Error('bun publish failed');
-          error.stdout = Buffer.from('');
-          error.stderr = Buffer.from(
-            'error: missing authentication (run `bunx npm login`)'
-          );
+          error.stdout = '';
+          error.stderr = 'error: missing authentication (run `bunx npm login`)';
           throw error;
         });
 
@@ -505,18 +488,19 @@ describe('release-publish executor', () => {
       expect(result.success).toBe(false);
       expect(console.error).toHaveBeenCalledWith('bun publish error:');
       // npm publish must NOT be attempted when npm is unavailable
-      expect(mockExecSync).not.toHaveBeenCalledWith(
-        expect.stringContaining('npm publish'),
+      expect(mockExec).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish']),
         expect.anything()
       );
     });
 
     it('should return failure when pm is not bun and npm is not installed', async () => {
       mockDetectPackageManager.mockReturnValue('pnpm');
-      mockExecSync.mockReset();
+      mockExec.mockReset();
 
       // npm --version throws (npm not installed)
-      mockExecSync.mockImplementationOnce(() => {
+      mockExec.mockImplementationOnce(() => {
         throw new Error('Command not found: npm');
       });
 
@@ -529,6 +513,81 @@ describe('release-publish executor', () => {
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('"pnpm"')
       );
+    });
+  });
+
+  describe('untrusted values reaching the child process', () => {
+    // `tag` and `registry` come back from `npm config get`, i.e. verbatim from
+    // a workspace .npmrc an install script can write.
+    const TAG_PAYLOAD = 'latest; touch NX_PWNED';
+    const REGISTRY_PAYLOAD = 'https://r.example.com/"; touch NX_PWNED; "';
+
+    function argvFor(binary: string, subcommand: string): string[] | undefined {
+      return mockExec.mock.calls.find(
+        ([command, args]) => command === binary && args?.[0] === subcommand
+      )?.[1] as string[] | undefined;
+    }
+
+    it('should pass an injected tag and registry to publish as single argv elements', async () => {
+      mockParseRegistryOptions.mockResolvedValue({
+        registry: REGISTRY_PAYLOAD,
+        tag: TAG_PAYLOAD,
+        registryConfigKey: 'registry',
+      });
+      mockExec
+        .mockReturnValueOnce(
+          JSON.stringify({ versions: ['0.9.0'], 'dist-tags': {} })
+        ) // npm view
+        .mockReturnValueOnce('{}'); // npm publish
+      jest
+        .spyOn(extractModule, 'extractNpmPublishJsonData')
+        .mockReturnValue(null);
+
+      await runExecutor(options, context);
+
+      const publishArgs = argvFor('npm', 'publish');
+      expect(publishArgs).toContain(`--tag=${TAG_PAYLOAD}`);
+      expect(publishArgs).toContain(`--registry=${REGISTRY_PAYLOAD}`);
+    });
+
+    it('should pass an injected tag to npm dist-tag add as a single argv element', async () => {
+      mockParseRegistryOptions.mockResolvedValue({
+        registry: REGISTRY_PAYLOAD,
+        tag: TAG_PAYLOAD,
+        registryConfigKey: 'registry',
+      });
+      mockExec
+        .mockReturnValueOnce(
+          JSON.stringify({ versions: ['1.0.0'], 'dist-tags': {} })
+        ) // npm view: the version already exists, so the dist-tag path runs
+        .mockReturnValueOnce(''); // npm dist-tag add
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      const distTagArgs = argvFor('npm', 'dist-tag');
+      expect(distTagArgs).toContain(TAG_PAYLOAD);
+      expect(distTagArgs).toContain(`--registry=${REGISTRY_PAYLOAD}`);
+    });
+
+    it('should pass otp and access through as single argv elements', async () => {
+      mockExec
+        .mockReturnValueOnce(
+          JSON.stringify({ versions: ['0.9.0'], 'dist-tags': {} })
+        ) // npm view
+        .mockReturnValueOnce('{}'); // npm publish
+      jest
+        .spyOn(extractModule, 'extractNpmPublishJsonData')
+        .mockReturnValue(null);
+
+      await runExecutor(
+        { ...options, otp: '123456; touch NX_PWNED', access: 'public evil' },
+        context
+      );
+
+      const publishArgs = argvFor('npm', 'publish');
+      expect(publishArgs).toContain('--otp=123456; touch NX_PWNED');
+      expect(publishArgs).toContain('--access=public evil');
     });
   });
 });

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -4,7 +4,7 @@ import {
   ExecutorContext,
   readJsonFile,
 } from '@nx/devkit';
-import { execSync } from 'child_process';
+import { safeExecFileSync } from '@nx/devkit/internal';
 import { statSync } from 'fs';
 import { env as appendLocalEnv } from 'npm-run-path';
 import { join } from 'path';
@@ -66,9 +66,7 @@ export default async function runExecutor(
   let isNpmInstalled = false;
   try {
     isNpmInstalled =
-      execSync('npm --version', {
-        encoding: 'utf-8',
-        windowsHide: true,
+      safeExecFileSync('npm', ['--version'], {
         stdio: ['ignore', 'pipe', 'ignore'],
       }).trim() !== '';
   } catch {
@@ -196,15 +194,38 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
 
   // Use bun info when bun is the package manager, otherwise use npm view
   // (npm view works across npm/pnpm/yarn environments and is the established default)
-  const npmViewCommandSegments =
+  const npmViewCommand =
     pm === 'bun'
-      ? ['bun info', packageName, `--json --"${registryConfigKey}=${registry}"`]
-      : [
-          `npm view ${packageName} versions dist-tags --json --"${registryConfigKey}=${registry}"`,
-        ];
-  const npmDistTagAddCommandSegments = [
-    `npm dist-tag add ${packageName}@${packageJson.version} ${tag} --"${registryConfigKey}=${registry}"`,
-  ];
+      ? {
+          command: 'bun',
+          args: [
+            'info',
+            packageName,
+            '--json',
+            `--${registryConfigKey}=${registry}`,
+          ],
+        }
+      : {
+          command: 'npm',
+          args: [
+            'view',
+            packageName,
+            'versions',
+            'dist-tags',
+            '--json',
+            `--${registryConfigKey}=${registry}`,
+          ],
+        };
+  const npmDistTagAddCommand = {
+    command: 'npm',
+    args: [
+      'dist-tag',
+      'add',
+      `${packageName}@${packageJson.version}`,
+      tag,
+      `--${registryConfigKey}=${registry}`,
+    ],
+  };
 
   /**
    * In a dry-run scenario, it is most likely that all commands are being run with dry-run, therefore
@@ -217,14 +238,17 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
   if (!isDryRun && !options.firstRelease) {
     const currentVersion = packageJson.version;
     try {
-      const result = execSync(npmViewCommandSegments.join(' '), {
-        env: processEnv(true),
-        cwd: context.root,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        windowsHide: true,
-      });
+      const result = safeExecFileSync(
+        npmViewCommand.command,
+        npmViewCommand.args,
+        {
+          env: processEnv(true),
+          cwd: context.root,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }
+      );
 
-      const resultJson = JSON.parse(result.toString());
+      const resultJson = JSON.parse(result);
       const distTags = resultJson['dist-tags'] || {};
       if (distTags[tag] === currentVersion) {
         console.warn(
@@ -244,12 +268,15 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
         if (versions.includes(currentVersion)) {
           try {
             if (!isDryRun) {
-              execSync(npmDistTagAddCommandSegments.join(' '), {
-                env: processEnv(true),
-                cwd: context.root,
-                stdio: 'ignore',
-                windowsHide: true,
-              });
+              safeExecFileSync(
+                npmDistTagAddCommand.command,
+                npmDistTagAddCommand.args,
+                {
+                  env: processEnv(true),
+                  cwd: context.root,
+                  stdio: 'ignore',
+                }
+              );
               console.log(
                 `Added the dist-tag ${tag} to v${currentVersion} for registry ${registry}.\n`
               );
@@ -420,29 +447,31 @@ function runPublish(ctx: RunPublishContext): { success: boolean } {
     packageTxt,
   } = ctx;
   const pmCommand = getPackageManagerCommand(pm);
-  const publishCommandSegments = [
-    pmCommand.publish(packageRoot, registry, registryConfigKey, tag),
-  ];
+  const { command: publishCommand, args: publishArgs } = pmCommand.publishArgv(
+    packageRoot,
+    registry,
+    registryConfigKey,
+    tag
+  );
 
   if (options.otp) {
-    publishCommandSegments.push(`--otp=${options.otp}`);
+    publishArgs.push(`--otp=${options.otp}`);
   }
 
   if (options.access) {
-    publishCommandSegments.push(`--access=${options.access}`);
+    publishArgs.push(`--access=${options.access}`);
   }
 
   if (isDryRun) {
-    publishCommandSegments.push(`--dry-run`);
+    publishArgs.push(`--dry-run`);
   }
 
   try {
-    const output = execSync(publishCommandSegments.join(' '), {
+    const output = safeExecFileSync(publishCommand, publishArgs, {
       maxBuffer: LARGE_BUFFER,
       env: processEnv(true),
       cwd: context.root,
       stdio: ['ignore', 'pipe', 'pipe'],
-      windowsHide: true,
     });
     // If in dry-run mode, the version on disk will not represent the version that would be published, so we scrub it from the output to avoid confusion.
     const dryRunVersionPlaceholder = 'X.X.X-dry-run';
@@ -455,7 +484,7 @@ function runPublish(ctx: RunPublishContext): { success: boolean } {
 
     // bun publish does not support outputting JSON, so we need to modify and print the output string directly
     if (pm === 'bun') {
-      let outputStr = output.toString();
+      let outputStr = output;
       if (isDryRun) {
         outputStr = outputStr.replace(
           new RegExp(`${packageJson.name}@${packageJson.version}`, 'g'),
@@ -474,7 +503,7 @@ function runPublish(ctx: RunPublishContext): { success: boolean } {
      * Additionally, we want to capture and show the lifecycle script outputs as beforeJsonData and afterJsonData and print them accordingly below.
      */
     const { beforeJsonData, jsonData, afterJsonData } =
-      extractNpmPublishJsonData(output.toString());
+      extractNpmPublishJsonData(output);
     if (!jsonData) {
       console.error(
         `The ${pm} publish output data could not be extracted. Please report this issue on https://github.com/nrwl/nx`

--- a/packages/js/src/release/version-actions.spec.ts
+++ b/packages/js/src/release/version-actions.spec.ts
@@ -1,11 +1,70 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { readJson, writeJson, type Tree } from '@nx/devkit';
+import { safeSpawn } from '@nx/devkit/internal';
 import JsVersionActions from './version-actions';
+import * as npmConfigModule from '../utils/npm-config';
 
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual('@nx/devkit'),
   detectPackageManager: jest.fn(() => 'pnpm'),
 }));
+jest.mock('@nx/devkit/internal', () => ({
+  ...jest.requireActual('@nx/devkit/internal'),
+  safeSpawn: jest.fn(),
+}));
+
+describe('readCurrentVersionFromRegistry', () => {
+  // registry and tag come back from `npm config get`, i.e. verbatim from a
+  // workspace .npmrc an install script can write.
+  const TAG_PAYLOAD = 'latest; touch NX_PWNED';
+  const REGISTRY_PAYLOAD = 'https://r.example.com/"; touch NX_PWNED; "';
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('passes an injected registry and tag to npm as single argv elements', async () => {
+    jest.spyOn(npmConfigModule, 'parseRegistryOptions').mockResolvedValue({
+      registry: REGISTRY_PAYLOAD,
+      tag: TAG_PAYLOAD,
+      registryConfigKey: 'registry',
+    });
+    (safeSpawn as jest.Mock).mockImplementation(() => {
+      const { EventEmitter } = require('events');
+      const { PassThrough } = require('stream');
+      const child: any = new EventEmitter();
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      process.nextTick(() => {
+        child.stdout.end('1.2.3\n');
+        child.stderr.end('');
+        setImmediate(() => child.emit('close', 0));
+      });
+      return child;
+    });
+
+    const tree = createTreeWithEmptyWorkspace();
+    writeJson(tree, 'packages/my-lib/package.json', {
+      name: 'my-lib',
+      version: '1.0.0',
+    });
+    const versionActions = await createVersionActions(tree);
+
+    const { currentVersion } =
+      await versionActions.readCurrentVersionFromRegistry(tree, {} as any);
+
+    expect(currentVersion).toBe('1.2.3');
+    expect(safeSpawn).toHaveBeenCalledWith(
+      'npm',
+      [
+        'view',
+        'my-lib',
+        'version',
+        `--registry=${REGISTRY_PAYLOAD}`,
+        `--tag=${TAG_PAYLOAD}`,
+      ],
+      expect.anything()
+    );
+  });
+});
 
 describe('JsVersionActions', () => {
   it('preserves package.json formatting when updating versions and dependencies', async () => {

--- a/packages/js/src/release/version-actions.ts
+++ b/packages/js/src/release/version-actions.ts
@@ -1,4 +1,4 @@
-import { getCatalogManager } from '@nx/devkit/internal';
+import { getCatalogManager, safeSpawn } from '@nx/devkit/internal';
 import {
   detectPackageManager,
   PackageManager,
@@ -8,7 +8,6 @@ import {
   Tree,
   workspaceRoot,
 } from '@nx/devkit';
-import { exec } from 'node:child_process';
 import { join } from 'node:path';
 import { applyEdits, FormattingOptions, modify } from 'jsonc-parser';
 import { validRange } from 'semver';
@@ -120,29 +119,47 @@ export default class JsVersionActions extends VersionActions {
     try {
       // Must be non-blocking async to allow spinner to render
       currentVersion = await new Promise<string>((resolve, reject) => {
-        exec(
-          `npm view ${packageName} version --"${registryConfigKey}=${registry}" --tag=${tag}`,
-          {
-            windowsHide: true,
-          },
-          (error, stdout, stderr) => {
-            if (error) {
-              return reject(error);
-            }
-            // Only reject on stderr if it contains actual errors, not just npm warnings
-            // npm 11+ writes "npm warn" messages to stderr even on successful commands
-            if (
-              stderr &&
-              !stderr
-                .trim()
-                .split('\n')
-                .every((line) => line.startsWith('npm warn'))
-            ) {
-              return reject(stderr);
-            }
-            return resolve(stdout.trim());
-          }
+        // registry and tag come from the workspace .npmrc, so they reach npm as
+        // arguments rather than through a shell.
+        const child = safeSpawn(
+          'npm',
+          [
+            'view',
+            packageName,
+            'version',
+            `--${registryConfigKey}=${registry}`,
+            `--tag=${tag}`,
+          ],
+          { stdio: ['ignore', 'pipe', 'pipe'] }
         );
+        let stdout = '';
+        let stderr = '';
+        child.stdout
+          .setEncoding('utf-8')
+          .on('data', (chunk) => (stdout += chunk));
+        child.stderr
+          .setEncoding('utf-8')
+          .on('data', (chunk) => (stderr += chunk));
+        child.on('error', reject);
+        child.on('close', (code) => {
+          if (code !== 0) {
+            return reject(
+              new Error(`npm view ${packageName} exited with code ${code}`)
+            );
+          }
+          // Only reject on stderr if it contains actual errors, not just npm warnings
+          // npm 11+ writes "npm warn" messages to stderr even on successful commands
+          if (
+            stderr &&
+            !stderr
+              .trim()
+              .split('\n')
+              .every((line) => line.startsWith('npm warn'))
+          ) {
+            return reject(stderr);
+          }
+          return resolve(stdout.trim());
+        });
       });
     } catch {}
 

--- a/packages/js/src/utils/npm-config.spec.ts
+++ b/packages/js/src/utils/npm-config.spec.ts
@@ -1,47 +1,39 @@
-import { ExecException } from 'child_process';
 import { join } from 'path';
 import { getNpmRegistry, getNpmTag, parseRegistryOptions } from './npm-config';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
-import { PackageJson } from '@nx/devkit/internal';
+import { PackageJson, safeSpawn } from '@nx/devkit/internal';
 
-jest.mock('child_process', () => {
-  const original = jest.requireActual('child_process');
+jest.mock('@nx/devkit/internal', () => {
+  const { EventEmitter } = require('events');
+  const { PassThrough } = require('stream');
+  const CONFIG_VALUES: Record<string, string> = {
+    '@scope:registry': 'https://scoped-registry.com',
+    '@missing:registry': 'undefined',
+    registry: 'https://custom-registry.com',
+    tag: 'next',
+  };
+
   return {
-    ...original,
-    exec: jest
-      .fn()
-      .mockImplementation(
-        (
-          command: string,
-          _: unknown,
-          callback: (
-            error: ExecException,
-            stdout: string,
-            stderr: string
-          ) => void
-        ) => {
-          switch (command) {
-            case 'npm config get @scope:registry':
-              callback(null, 'https://scoped-registry.com', null);
-              break;
-            case 'npm config get @missing:registry':
-              callback(null, 'undefined', null);
-              break;
-            case 'npm config get registry':
-              callback(null, 'https://custom-registry.com', null);
-              break;
-            case 'npm config get tag':
-              callback(null, 'next', null);
-              break;
-            default:
-              callback(
-                new Error(`unexpected command: ${command}`),
-                null,
-                'ERROR'
-              );
-          }
-        }
-      ),
+    ...jest.requireActual('@nx/devkit/internal'),
+    safeSpawn: jest.fn((binary: string, args: string[]) => {
+      const child: any = new EventEmitter();
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+
+      const [subcommand, action, key] = args;
+      const value =
+        binary === 'npm' && subcommand === 'config' && action === 'get'
+          ? CONFIG_VALUES[key]
+          : undefined;
+
+      process.nextTick(() => {
+        child.stdout.end(value === undefined ? '' : `${value}\n`);
+        child.stderr.end(value === undefined ? 'ERROR' : '');
+        setImmediate(() => child.emit('close', value === undefined ? 1 : 0));
+      });
+
+      return child;
+    }),
   };
 });
 
@@ -66,6 +58,19 @@ describe('npm-config', () => {
     it('should return registry if package is not scoped', async () => {
       const registry = await getNpmRegistry(tempFs.tempDir);
       expect(registry).toEqual('https://custom-registry.com');
+    });
+
+    it('should pass a scope carrying shell syntax to npm as a single argv element', async () => {
+      // the scope comes from the package's own manifest name
+      const scope = '@evil$(touch NX_PWNED)';
+
+      await getNpmRegistry(tempFs.tempDir, scope);
+
+      expect(safeSpawn).toHaveBeenCalledWith(
+        'npm',
+        ['config', 'get', `${scope}:registry`],
+        expect.anything()
+      );
     });
   });
 

--- a/packages/js/src/utils/npm-config.ts
+++ b/packages/js/src/utils/npm-config.ts
@@ -1,7 +1,6 @@
-import { exec } from 'child_process';
 import { existsSync } from 'fs';
 import { join, relative } from 'path';
-import { PackageJson } from '@nx/devkit/internal';
+import { PackageJson, safeSpawn } from '@nx/devkit/internal';
 
 export async function parseRegistryOptions(
   cwd: string,
@@ -98,19 +97,33 @@ export async function getNpmTag(cwd: string): Promise<string> {
 
 async function getNpmConfigValue(key: string, cwd: string): Promise<string> {
   try {
-    const result = await execAsync(`npm config get ${key}`, cwd);
+    const result = await npmConfigGet(key, cwd);
     return result === 'undefined' ? undefined : result;
   } catch (e) {
     return Promise.resolve(undefined);
   }
 }
 
-async function execAsync(command: string, cwd: string): Promise<string> {
+// `key` carries the package's own scope, so it goes to npm as an argument
+// rather than through a shell.
+async function npmConfigGet(key: string, cwd: string): Promise<string> {
   // Must be non-blocking async to allow spinner to render
   return new Promise<string>((resolve, reject) => {
-    exec(command, { cwd, windowsHide: true }, (error, stdout, stderr) => {
-      if (error) {
-        return reject((stderr ? `${stderr}\n` : '') + error);
+    const child = safeSpawn('npm', ['config', 'get', key], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf-8').on('data', (chunk) => (stdout += chunk));
+    child.stderr.setEncoding('utf-8').on('data', (chunk) => (stderr += chunk));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) {
+        return reject(
+          (stderr ? `${stderr}\n` : '') +
+            `npm config get ${key} exited with code ${code}`
+        );
       }
       return resolve(stdout.trim());
     });

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -1009,14 +1009,14 @@ describe('package-manager', () => {
     it('should return npm publish command', () => {
       const commands = getPackageManagerCommand('npm');
       expect(commands.publish(...publishCmdParam)).toEqual(
-        'npm publish "dist/packages/my-pkg" --json --"@org:registry=https://registry.npmjs.org/" --tag=latest'
+        'npm publish dist/packages/my-pkg --json --@org:registry=https://registry.npmjs.org/ --tag=latest'
       );
     });
 
     it('should return yarn publish command using npm publish', () => {
       const commands = getPackageManagerCommand('yarn');
       expect(commands.publish(...publishCmdParam)).toEqual(
-        'npm publish "dist/packages/my-pkg" --json --"@org:registry=https://registry.npmjs.org/" --tag=latest'
+        'npm publish dist/packages/my-pkg --json --@org:registry=https://registry.npmjs.org/ --tag=latest'
       );
     });
 
@@ -1031,7 +1031,7 @@ describe('package-manager', () => {
         });
         const commands = getPackageManagerCommand('pnpm');
         expect(commands.publish(...publishCmdParam)).toEqual(
-          'pnpm publish "dist/packages/my-pkg" --json --"@org:registry=https://registry.npmjs.org/" --tag=latest --no-git-checks'
+          'pnpm publish dist/packages/my-pkg --json --@org:registry=https://registry.npmjs.org/ --tag=latest --no-git-checks'
         );
       }
     );
@@ -1047,7 +1047,7 @@ describe('package-manager', () => {
         });
         const commands = getPackageManagerCommand('pnpm');
         expect(commands.publish(...publishCmdParam)).toEqual(
-          'pnpm publish "dist/packages/my-pkg" --json --"config.@org:registry=https://registry.npmjs.org/" --tag=latest --no-git-checks'
+          'pnpm publish dist/packages/my-pkg --json --config.@org:registry=https://registry.npmjs.org/ --tag=latest --no-git-checks'
         );
       }
     );
@@ -1064,14 +1064,136 @@ describe('package-manager', () => {
       vi.spyOn(fileUtils, 'readJsonFile').mockReturnValueOnce({});
       const commands = getPackageManagerCommand('pnpm');
       expect(commands.publish(...publishCmdParam)).toEqual(
-        'pnpm publish "dist/packages/my-pkg" --json --"registry=https://registry.npmjs.org/" --tag=latest --no-git-checks'
+        'pnpm publish dist/packages/my-pkg --json --registry=https://registry.npmjs.org/ --tag=latest --no-git-checks'
       );
     });
 
     it('should return bun publish command with registry and tag', () => {
       const commands = getPackageManagerCommand('bun');
       expect(commands.publish(...publishCmdParam)).toEqual(
-        'bun publish --cwd="dist/packages/my-pkg" --json --registry="https://registry.npmjs.org/" --tag=latest'
+        'bun publish --cwd=dist/packages/my-pkg --json --registry=https://registry.npmjs.org/ --tag=latest'
+      );
+    });
+
+    describe('untrusted .npmrc values', () => {
+      // `tag` and `registry` come from `npm config get`, i.e. verbatim from a
+      // workspace .npmrc an install script can write.
+      const TAG_PAYLOAD = 'latest; touch NX_PWNED';
+      // an .npmrc `tag = "latest\ncalc"` yields an interior newline, which
+      // getNpmConfigValue's stdout.trim() does not remove
+      const NEWLINE_TAG_PAYLOAD = 'latest\ntouch NX_PWNED';
+      const REGISTRY_PAYLOAD = 'https://r.example.com/"; touch NX_PWNED; "';
+
+      it.each(['npm', 'yarn', 'pnpm', 'bun'] as const)(
+        'should keep a %s tag carrying shell syntax in one argv element',
+        (packageManager) => {
+          const { args } = getPackageManagerCommand(packageManager).publishArgv(
+            'dist/packages/my-pkg',
+            'https://registry.npmjs.org/',
+            '@org:registry',
+            TAG_PAYLOAD
+          );
+          expect(args).toContain(`--tag=${TAG_PAYLOAD}`);
+        }
+      );
+
+      it.each(['npm', 'yarn', 'pnpm', 'bun'] as const)(
+        'should keep a %s registry carrying quotes in one argv element',
+        (packageManager) => {
+          const { args } = getPackageManagerCommand(packageManager).publishArgv(
+            'dist/packages/my-pkg',
+            REGISTRY_PAYLOAD,
+            '@org:registry',
+            'latest'
+          );
+          expect(args.some((arg) => arg.endsWith(`=${REGISTRY_PAYLOAD}`))).toBe(
+            true
+          );
+        }
+      );
+
+      it.each(['npm', 'yarn', 'pnpm', 'bun'] as const)(
+        'should keep a %s tag carrying a line break in one argv element',
+        (packageManager) => {
+          const { args } = getPackageManagerCommand(packageManager).publishArgv(
+            'dist/packages/my-pkg',
+            'https://registry.npmjs.org/',
+            '@org:registry',
+            NEWLINE_TAG_PAYLOAD
+          );
+          expect(args).toContain(`--tag=${NEWLINE_TAG_PAYLOAD}`);
+        }
+      );
+
+      it('should refuse a line break on Windows rather than emitting it', () => {
+        const original = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: 'win32' });
+        try {
+          expect(() =>
+            getPackageManagerCommand('npm').publish(
+              'dist/packages/my-pkg',
+              'https://registry.npmjs.org/',
+              '@org:registry',
+              NEWLINE_TAG_PAYLOAD
+            )
+          ).toThrow('a line break inside it');
+        } finally {
+          Object.defineProperty(process, 'platform', original);
+        }
+      });
+
+      it.runIf(process.platform !== 'win32')(
+        'should quote both fields in the string form',
+        () => {
+          expect(
+            getPackageManagerCommand('npm').publish(
+              'dist/packages/my-pkg',
+              REGISTRY_PAYLOAD,
+              '@org:registry',
+              TAG_PAYLOAD
+            )
+          ).toEqual(
+            `npm publish dist/packages/my-pkg --json ` +
+              `'--@org:registry=https://r.example.com/"; touch NX_PWNED; "' ` +
+              `'--tag=latest; touch NX_PWNED'`
+          );
+        }
+      );
+
+      it.runIf(process.platform !== 'win32')(
+        'should tokenize the string form back into exactly the argv, executing nothing',
+        async () => {
+          const { execSync: realExecSync } =
+            await vi.importActual<typeof import('child_process')>(
+              'child_process'
+            );
+          const realFs = await vi.importActual<typeof import('fs')>('fs');
+          const cwd = realFs.mkdtempSync(join(tmpdir(), 'nx-publish-quoting-'));
+
+          const commands = getPackageManagerCommand('npm');
+          const publishArgs = [
+            'dist/packages/my-pkg',
+            REGISTRY_PAYLOAD,
+            '@org:registry',
+            TAG_PAYLOAD,
+          ] as const;
+          const { command, args } = commands.publishArgv(...publishArgs);
+
+          // `$@` hands back exactly what the shell parsed the emitted string
+          // into, so the payload forking into extra tokens shows up here. NUL
+          // delimits, because a newline payload would forge a boundary.
+          const tokens = realExecSync(
+            `sh -c 'printf "%s\\0" "$@"' _ ${commands.publish(...publishArgs)}`,
+            { cwd, encoding: 'utf-8' }
+          );
+
+          try {
+            expect(tokens.split('\0').slice(0, -1)).toEqual([command, ...args]);
+            expect(realFs.existsSync(join(cwd, 'NX_PWNED'))).toBe(false);
+          } finally {
+            realFs.rmSync(cwd, { recursive: true, force: true });
+          }
+        }
       );
     });
 

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -98,12 +98,22 @@ export interface PackageManagerCommands {
   run: (script: string, args?: string) => string;
   // Make this required once bun adds programatically support for reading config https://github.com/oven-sh/bun/issues/7140
   getRegistryUrl?: string;
+  /**
+   * @deprecated Use `publishArgv` instead, which needs no shell off Windows.
+   * This will be removed in Nx 24.
+   */
   publish: (
     packageRoot: string,
     registry: string,
     registryConfigKey: string,
     tag: string
   ) => string;
+  publishArgv: (
+    packageRoot: string,
+    registry: string,
+    registryConfigKey: string,
+    tag: string
+  ) => { command: string; args: string[] };
   // yarn berry doesn't support ignoring scripts via flag
   ignoreScriptsFlag?: string;
 }
@@ -179,6 +189,17 @@ export function isWorkspacesEnabled(
 }
 
 /**
+ * The registry and tag reach `publish` from `.npmrc`, which an install script
+ * can write, so every token is quoted before it becomes shell syntax.
+ */
+function publishCommandFromArgv({
+  command,
+  args,
+}: ReturnType<PackageManagerCommands['publishArgv']>): string {
+  return [command, ...args].map(quoteShellArg).join(' ');
+}
+
+/**
  * Returns commands for the package manager used in the workspace.
  * By default, the package manager is derived based on the lock file,
  * but it can also be passed in explicitly.
@@ -207,6 +228,22 @@ export function getPackageManagerCommand(
         useBerry = true;
       }
 
+      const publishArgv: PackageManagerCommands['publishArgv'] = (
+        packageRoot,
+        registry,
+        registryConfigKey,
+        tag
+      ) => ({
+        command: 'npm',
+        args: [
+          'publish',
+          packageRoot,
+          '--json',
+          `--${registryConfigKey}=${registry}`,
+          `--tag=${tag}`,
+        ],
+      });
+
       // new versions of yarn only support ignoring scripts via .yarnrc.yml
       return {
         preInstall: `yarn set version ${yarnVersion}`,
@@ -229,8 +266,8 @@ export function getPackageManagerCommand(
         getRegistryUrl: useBerry
           ? 'yarn config get npmRegistryServer'
           : 'yarn config get registry',
-        publish: (packageRoot, registry, registryConfigKey, tag) =>
-          `npm publish "${packageRoot}" --json --"${registryConfigKey}=${registry}" --tag=${tag}`,
+        publish: (...args) => publishCommandFromArgv(publishArgv(...args)),
+        publishArgv,
         ignoreScriptsFlag: useBerry ? undefined : `--ignore-scripts`,
       };
     },
@@ -259,6 +296,30 @@ export function getPackageManagerCommand(
       }
 
       const isPnpmWorkspace = existsSync(join(root, 'pnpm-workspace.yaml'));
+
+      const publishArgv: PackageManagerCommands['publishArgv'] = (
+        packageRoot,
+        registry,
+        registryConfigKey,
+        tag
+      ) => ({
+        command: 'pnpm',
+        args: [
+          'publish',
+          packageRoot,
+          '--json',
+          `--${
+            configForm
+              ? `config.${registryConfigKey}`
+              : scopedForm
+                ? registryConfigKey
+                : 'registry'
+          }=${registry}`,
+          `--tag=${tag}`,
+          '--no-git-checks',
+        ],
+      });
+
       return {
         install: 'pnpm install --no-frozen-lockfile', // explicitly disable in case of CI
         ciInstall: 'pnpm install --frozen-lockfile',
@@ -283,18 +344,28 @@ export function getPackageManagerCommand(
         list: 'pnpm ls --depth 100',
         why: 'pnpm why',
         getRegistryUrl: 'pnpm config get registry',
-        publish: (packageRoot, registry, registryConfigKey, tag) =>
-          `pnpm publish "${packageRoot}" --json --"${
-            configForm
-              ? `config.${registryConfigKey}`
-              : scopedForm
-                ? registryConfigKey
-                : 'registry'
-          }=${registry}" --tag=${tag} --no-git-checks`,
+        publish: (...args) => publishCommandFromArgv(publishArgv(...args)),
+        publishArgv,
         ignoreScriptsFlag: '--ignore-scripts',
       };
     },
     npm: () => {
+      const publishArgv: PackageManagerCommands['publishArgv'] = (
+        packageRoot,
+        registry,
+        registryConfigKey,
+        tag
+      ) => ({
+        command: 'npm',
+        args: [
+          'publish',
+          packageRoot,
+          '--json',
+          `--${registryConfigKey}=${registry}`,
+          `--tag=${tag}`,
+        ],
+      });
+
       return {
         install: 'npm install',
         ciInstall: 'npm ci',
@@ -309,12 +380,28 @@ export function getPackageManagerCommand(
         list: 'npm ls',
         why: 'npm explain',
         getRegistryUrl: 'npm config get registry',
-        publish: (packageRoot, registry, registryConfigKey, tag) =>
-          `npm publish "${packageRoot}" --json --"${registryConfigKey}=${registry}" --tag=${tag}`,
+        publish: (...args) => publishCommandFromArgv(publishArgv(...args)),
+        publishArgv,
         ignoreScriptsFlag: '--ignore-scripts',
       };
     },
     bun: () => {
+      const publishArgv: PackageManagerCommands['publishArgv'] = (
+        packageRoot,
+        registry,
+        _registryConfigKey,
+        tag
+      ) => ({
+        command: 'bun',
+        args: [
+          'publish',
+          `--cwd=${packageRoot}`,
+          '--json',
+          `--registry=${registry}`,
+          `--tag=${tag}`,
+        ],
+      });
+
       // bun doesn't current support programmatically reading config https://github.com/oven-sh/bun/issues/7140
       return {
         install: 'bun install',
@@ -329,8 +416,8 @@ export function getPackageManagerCommand(
         list: 'bun pm ls',
         why: 'bun why',
         // Unlike npm, bun publish does not support a custom registryConfigKey option
-        publish: (packageRoot, registry, registryConfigKey, tag) =>
-          `bun publish --cwd="${packageRoot}" --json --registry="${registry}" --tag=${tag}`,
+        publish: (...args) => publishCommandFromArgv(publishArgv(...args)),
+        publishArgv,
         ignoreScriptsFlag: '--ignore-scripts',
       };
     },

--- a/packages/nx/src/utils/safe-spawn.ts
+++ b/packages/nx/src/utils/safe-spawn.ts
@@ -6,7 +6,7 @@ import {
   SpawnOptions,
 } from 'child_process';
 import { win32 } from 'path';
-import { quoteShellArg } from './shell-quoting';
+import { LINE_BREAK, quoteShellArg } from './shell-quoting';
 
 // Node refuses to launch a Windows `.cmd`/`.bat` shim without a shell
 // (CVE-2024-27980). A bare name takes the shell for the same reason, one step
@@ -29,9 +29,6 @@ function needsShell(binary: string): boolean {
   return ext === '' || ext === '.cmd' || ext === '.bat';
 }
 
-// A line break ends the command line whatever the quoting, so nothing can carry
-// one.
-//
 // `%` is deliberately NOT refused, and this is a known gap rather than a safe
 // case. cmd.exe expands `%VAR%` whether or not the value is quoted — see
 // `quoteShellArg`'s own docstring in ./shell-quoting, which says so and pins it
@@ -46,7 +43,6 @@ function needsShell(binary: string): boolean {
 // is bounded by the argument that bounds this whole class: a repo that can reach
 // here already has `mvnw` / `pom.xml` executing on its behalf. Closing it
 // properly is tracked as NXC-4798.
-const LINE_BREAK = /[\r\n]/;
 
 /**
  * Spawn a binary that may be a Windows `.cmd`/`.bat` shim, without letting its

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -108,9 +108,25 @@ describe('quoteShellArg', () => {
       );
     });
 
+    it.each([
+      ['a line feed', 'latest\nwhoami'],
+      ['a carriage return', 'latest\rwhoami'],
+    ])('refuses %s: %j', (_, value) => {
+      expect(() => quoteShellArg(value)).toThrow(
+        'would end the command line and leave the rest of the argument to be read as commands'
+      );
+    });
+
     it('leaves a percent sign unquoted, since quoting cannot stop %VAR%', () => {
       expect(quoteShellArg('%USERNAME%')).toBe('%USERNAME%');
     });
+  });
+
+  // The refusal above is Windows-only because a single-quoted run does hold a
+  // line break, so POSIX needs no equivalent.
+  it('contains a line break on POSIX, where single quotes hold it', () => {
+    setPlatform('linux');
+    expect(quoteShellArg('latest\nwhoami')).toBe(`'latest\nwhoami'`);
   });
 
   it('treats a caret as ordinary text on POSIX, where it has no meaning', () => {

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -21,6 +21,13 @@
 const SHELL_META_CHARS = /[|&;<>()$`\\!"'*?[\]{}~#\s]/;
 
 /**
+ * A line break ends a cmd.exe command line whatever the quoting, so no quoted
+ * run can carry one. POSIX single quotes hold a newline fine, which is why the
+ * refusal in `quoteShellArg` is Windows-only.
+ */
+export const LINE_BREAK = /[\r\n]/;
+
+/**
  * Check if a string contains shell metacharacters that require quoting.
  * These characters have special meaning in shell and would be interpreted
  * incorrectly if not quoted (e.g., | for pipe, & for background, etc.)
@@ -52,10 +59,16 @@ export function isAlreadyQuoted(str: string): boolean {
  * @throws on Windows when the argument contains a double quote, which ends that
  * run, since cmd.exe recognizes no backslash escape. Carrying one means
  * caret-escaping every metacharacter instead, doubled for a `.cmd` shim, which
- * this path does not implement.
+ * this path does not implement. Also throws on a line break, which ends the
+ * command line itself and so survives no quoting at all.
  */
 export function quoteShellArg(arg: string): string {
   const isWindows = process.platform === 'win32';
+  if (isWindows && LINE_BREAK.test(arg)) {
+    throw new Error(
+      `Cannot safely pass ${arg} to cmd.exe as a single argument: a line break inside it would end the command line and leave the rest of the argument to be read as commands. Remove the line break and run the command again.`
+    );
+  }
   if (isWindows && arg.includes('"')) {
     throw new Error(
       `Cannot safely pass ${arg} to cmd.exe as a single argument: a double quote inside it would end the quoting and leave the rest of the argument to be read as commands. Remove the double quote and run the command again.`


### PR DESCRIPTION
## Current Behavior

`nx release` builds its npm invocations as shell strings and runs them through `execSync` / `exec`,
interpolating the registry and tag directly into the command. Both values default to
`npm config get registry` / `npm config get tag`, which return the workspace `.npmrc` value
verbatim, and the tag was interpolated with no quoting at all.

That makes `.npmrc` an execution vector rather than configuration. It matters because `.npmrc` is
writable by a dependency's install lifecycle script, and these commands run in CI with publish
credentials present.

The same pair reaches a shell from more than the one place:

| Path | Command |
| --- | --- |
| `nx release publish` | `<pm> publish`, `npm view` / `bun info`, `npm dist-tag add` |
| `nx release version` | `npm view … version`, when `currentVersionResolver` is `registry` |
| both | `npm config get <scope>:registry`, where the scope comes from the package manifest |

`--otp` and `--access` were interpolated unquoted too.

## Expected Behavior

Every one of those commands is passed as **argv**, so shell syntax in any of the values is data
rather than syntax. Off Windows no shell is involved at all.

- `PackageManagerCommands` gains `publishArgv`, returning `{ command, args }`, for all four package
  managers. The existing `publish` is kept for external callers, but is now *derived* from
  `publishArgv` through `quoteShellArg` — so the two renderings cannot drift — and is deprecated for
  Nx 24.
- The publish executor, `parseRegistryOptions` and `readCurrentVersionFromRegistry` all move onto
  the existing `safeExecFileSync` / `safeSpawn` helpers.
- `quoteShellArg` now refuses a line break on Windows, matching the guard `safeSpawn` already
  applied. A line break ends a cmd.exe command line whatever quoting surrounds it, so this is the
  one input quoting cannot make safe. POSIX is unaffected, since a single-quoted run holds a newline
  fine.

### Coverage

Regression tests assert the untrusted values arrive as **single argv elements** rather than
asserting an emitted string, so they fail if the escaping is removed rather than merely changing.
The string form additionally round-trips through a real shell and asserts the tokens come back equal
to the argv, with NUL delimiting so a newline cannot forge a token boundary. Each new guard was
mutation-tested — removing it fails the corresponding test.

`readCurrentVersionFromRegistry` had no test at all before this; it has one now.

### Not closed by this PR

On Windows `npm` is a bare name, so `safeExecFileSync` still goes through cmd.exe, which expands
`%VAR%` inside quotes. That is the pre-existing, documented gap tracked as **NXC-4798**, and it now
has `.npmrc` as one of its inputs. Worth knowing before treating this as a complete fix on Windows.

## Notes

Rebased onto master now that #36867 has merged, so this is just the four `NXC-4918` commits. The
`pnpm` 11+ `--config.@scope:registry` form from that PR is carried through into the argv builder.

## Related Issue(s)

Internal ticket: **NXC-4918**. No public issue is linked, so there is nothing for this to auto-close.
