### PR TITLE
fix(rspack): warn when the ignored transformers option is set

### DIFF
--- a/packages/rspack/src/executors/rspack/schema.json
+++ b/packages/rspack/src/executors/rspack/schema.json
@@ -298,7 +298,7 @@
     },
     "transformers": {
       "type": "array",
-      "description": "List of TypeScript Compiler Transfomers Plugins.",
+      "description": "List of TypeScript Compiler Transformers Plugins. Not supported by rspack, which compiles TypeScript with `builtin:swc-loader`. Setting this option has no effect and logs a warning.",
       "aliases": ["tsPlugins"],
       "items": {
         "$ref": "#/definitions/transformerPattern"

--- a/packages/rspack/src/executors/rspack/schema.json
+++ b/packages/rspack/src/executors/rspack/schema.json
@@ -298,8 +298,9 @@
     },
     "transformers": {
       "type": "array",
-      "description": "List of TypeScript Compiler Transformers Plugins. Not supported by rspack, which compiles TypeScript with `builtin:swc-loader`. Setting this option has no effect and logs a warning.",
+      "description": "List of TypeScript Compiler Transformers Plugins.",
       "aliases": ["tsPlugins"],
+      "x-deprecated": "Not supported by rspack, which compiles TypeScript with `builtin:swc-loader`. This option has no effect. Use `@nx/webpack` for projects that need a TypeScript transformer.",
       "items": {
         "$ref": "#/definitions/transformerPattern"
       }

--- a/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
@@ -274,3 +274,58 @@ describe('apply-base-config ts-checker rootDir (TS6059 prevention)', () => {
     expect(capturedPluginConfigs[0].typescript.build).toBe(true);
   });
 });
+
+describe('apply-base-config unsupported transformers warning', () => {
+  let options: NormalizedNxAppRspackPluginOptions;
+
+  beforeEach(() => {
+    jest.resetModules();
+    options = {
+      root: '/test',
+      projectRoot: 'apps/test',
+      target: 'node',
+      transformers: [{ name: 'some-transformer' }],
+    } as NormalizedNxAppRspackPluginOptions;
+    global.NX_GRAPH_CREATION = false;
+  });
+
+  afterEach(() => {
+    delete global.NX_GRAPH_CREATION;
+  });
+
+  async function runWithSpy() {
+    let warn!: jest.SpyInstance;
+    let applyBaseConfigFresh!: typeof applyBaseConfig;
+    jest.isolateModules(() => {
+      const { logger } = require('@nx/devkit');
+      warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      applyBaseConfigFresh = require('./apply-base-config').applyBaseConfig;
+    });
+    return { warn, applyBaseConfigFresh };
+  }
+
+  it('warns when the option is set', async () => {
+    const { warn, applyBaseConfigFresh } = await runWithSpy();
+
+    applyBaseConfigFresh(options, {});
+
+    expect(
+      warn.mock.calls.some((call) =>
+        String(call[0]).includes('`transformers` option is not supported')
+      )
+    ).toBe(true);
+  });
+
+  it('stays silent during graph creation', async () => {
+    global.NX_GRAPH_CREATION = true;
+    const { warn, applyBaseConfigFresh } = await runWithSpy();
+
+    applyBaseConfigFresh(options, {});
+
+    expect(
+      warn.mock.calls.some((call) =>
+        String(call[0]).includes('`transformers` option is not supported')
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
@@ -279,7 +279,6 @@ describe('apply-base-config unsupported transformers warning', () => {
   let options: NormalizedNxAppRspackPluginOptions;
 
   beforeEach(() => {
-    jest.resetModules();
     options = {
       root: '/test',
       projectRoot: 'apps/test',
@@ -293,7 +292,8 @@ describe('apply-base-config unsupported transformers warning', () => {
     delete global.NX_GRAPH_CREATION;
   });
 
-  async function runWithSpy() {
+  // Re-require so the set of already-warned projects starts empty.
+  function loadFresh() {
     let warn!: jest.SpyInstance;
     let applyBaseConfigFresh!: typeof applyBaseConfig;
     jest.isolateModules(() => {
@@ -304,28 +304,26 @@ describe('apply-base-config unsupported transformers warning', () => {
     return { warn, applyBaseConfigFresh };
   }
 
-  it('warns when the option is set', async () => {
-    const { warn, applyBaseConfigFresh } = await runWithSpy();
+  function warnedAboutTransformers(warn: jest.SpyInstance): boolean {
+    return warn.mock.calls.some((call) =>
+      String(call[0]).includes('`transformers` option is not supported')
+    );
+  }
+
+  it('warns when the option is set', () => {
+    const { warn, applyBaseConfigFresh } = loadFresh();
 
     applyBaseConfigFresh(options, {});
 
-    expect(
-      warn.mock.calls.some((call) =>
-        String(call[0]).includes('`transformers` option is not supported')
-      )
-    ).toBe(true);
+    expect(warnedAboutTransformers(warn)).toBe(true);
   });
 
-  it('stays silent during graph creation', async () => {
+  it('stays silent during graph creation', () => {
     global.NX_GRAPH_CREATION = true;
-    const { warn, applyBaseConfigFresh } = await runWithSpy();
+    const { warn, applyBaseConfigFresh } = loadFresh();
 
     applyBaseConfigFresh(options, {});
 
-    expect(
-      warn.mock.calls.some((call) =>
-        String(call[0]).includes('`transformers` option is not supported')
-      )
-    ).toBe(false);
+    expect(warnedAboutTransformers(warn)).toBe(false);
   });
 });

--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -54,7 +54,7 @@ export function applyBaseConfig(
   } = {}
 ): void {
   // Read before the default below, which would otherwise hide that the user set
-  // the option. Reported further down, once graph creation is ruled out.
+  // the option.
   const hasTransformers = !!options.transformers?.length;
 
   // Defaults that was applied from executor schema previously.
@@ -74,7 +74,7 @@ export function applyBaseConfig(
   // Some of the options only work during actual tasks, not when reading the rspack config during CreateNodes.
   if (global.NX_GRAPH_CREATION) return;
 
-  warnUnsupportedTransformers(hasTransformers);
+  warnUnsupportedTransformers(hasTransformers, options.projectRoot);
 
   applyNxDependentConfig(options, config, { useNormalizedEntry }, rspackCore);
 }

--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -22,6 +22,7 @@ import { NormalizedNxAppRspackPluginOptions } from './models';
 import { isUsingTsSolutionSetup } from '@nx/js/internal';
 import { getNonBuildableLibs } from './get-non-buildable-libs';
 import { isServeMode } from '../../utils/is-serve-mode';
+import { warnUnsupportedTransformers } from './warn-unsupported-transformers';
 
 const IGNORED_RSPACK_WARNINGS = [
   /The comment file/i,
@@ -52,6 +53,10 @@ export function applyBaseConfig(
     compiler?: Compiler;
   } = {}
 ): void {
+  // Read before the default below, which would otherwise hide that the user set
+  // the option. Reported further down, once graph creation is ruled out.
+  const hasTransformers = !!options.transformers?.length;
+
   // Defaults that was applied from executor schema previously.
   options.externalDependencies ??= 'all';
   options.fileReplacements ??= [];
@@ -68,6 +73,8 @@ export function applyBaseConfig(
 
   // Some of the options only work during actual tasks, not when reading the rspack config during CreateNodes.
   if (global.NX_GRAPH_CREATION) return;
+
+  warnUnsupportedTransformers(hasTransformers);
 
   applyNxDependentConfig(options, config, { useNormalizedEntry }, rspackCore);
 }

--- a/packages/rspack/src/plugins/utils/warn-unsupported-transformers.spec.ts
+++ b/packages/rspack/src/plugins/utils/warn-unsupported-transformers.spec.ts
@@ -13,26 +13,35 @@ describe('@nx/rspack unsupported transformers warning', () => {
   it('warns when the user sets transformers', () => {
     const { warn, mod } = setup();
 
-    mod.warnUnsupportedTransformers(true);
+    mod.warnUnsupportedTransformers(true, 'apps/demo');
 
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain('transformers');
     expect(warn.mock.calls[0][0]).toContain('builtin:swc-loader');
   });
 
-  it('warns once per process so watch rebuilds do not repeat it', () => {
+  it('warns once per project so watch rebuilds do not repeat it', () => {
     const { warn, mod } = setup();
 
-    mod.warnUnsupportedTransformers(true);
-    mod.warnUnsupportedTransformers(true);
+    mod.warnUnsupportedTransformers(true, 'apps/demo');
+    mod.warnUnsupportedTransformers(true, 'apps/demo');
 
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns for every affected project in the same process', () => {
+    const { warn, mod } = setup();
+
+    mod.warnUnsupportedTransformers(true, 'apps/one');
+    mod.warnUnsupportedTransformers(true, 'apps/two');
+
+    expect(warn).toHaveBeenCalledTimes(2);
   });
 
   it('does not warn when the user sets no transformers', () => {
     const { warn, mod } = setup();
 
-    mod.warnUnsupportedTransformers(false);
+    mod.warnUnsupportedTransformers(false, 'apps/demo');
 
     expect(warn).not.toHaveBeenCalled();
   });

--- a/packages/rspack/src/plugins/utils/warn-unsupported-transformers.spec.ts
+++ b/packages/rspack/src/plugins/utils/warn-unsupported-transformers.spec.ts
@@ -1,0 +1,39 @@
+describe('@nx/rspack unsupported transformers warning', () => {
+  function setup() {
+    let warn!: jest.SpyInstance;
+    let mod!: typeof import('./warn-unsupported-transformers');
+    jest.isolateModules(() => {
+      const { logger } = require('@nx/devkit');
+      warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      mod = require('./warn-unsupported-transformers');
+    });
+    return { warn, mod };
+  }
+
+  it('warns when the user sets transformers', () => {
+    const { warn, mod } = setup();
+
+    mod.warnUnsupportedTransformers(true);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('transformers');
+    expect(warn.mock.calls[0][0]).toContain('builtin:swc-loader');
+  });
+
+  it('warns once per process so watch rebuilds do not repeat it', () => {
+    const { warn, mod } = setup();
+
+    mod.warnUnsupportedTransformers(true);
+    mod.warnUnsupportedTransformers(true);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn when the user sets no transformers', () => {
+    const { warn, mod } = setup();
+
+    mod.warnUnsupportedTransformers(false);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/rspack/src/plugins/utils/warn-unsupported-transformers.ts
+++ b/packages/rspack/src/plugins/utils/warn-unsupported-transformers.ts
@@ -1,17 +1,20 @@
 import { logger } from '@nx/devkit';
 
-// The `transformers` option came over with the schema when the rspack executor
-// was aligned with webpack. Webpack feeds it to ts-loader's getCustomTransformers;
-// rspack compiles TypeScript with `builtin:swc-loader`, which cannot run
-// TypeScript transformer plugins, so the option has never had an effect here.
+// Webpack gives this option to ts-loader's getCustomTransformers; rspack
+// compiles TypeScript with `builtin:swc-loader`, which cannot run TypeScript
+// transformer plugins.
 export const RSPACK_TRANSFORMERS_UNSUPPORTED_MESSAGE =
   'The `transformers` option is not supported by `@nx/rspack` and has no effect. Rspack compiles TypeScript with `builtin:swc-loader`, which cannot run TypeScript transformer plugins. Remove the option, or keep using `@nx/webpack` for projects that need a TypeScript transformer such as the `@nestjs/swagger` CLI plugin.';
 
-let warned = false;
+const warnedProjects = new Set<string>();
 
-// Warn once per process so watch rebuilds don't repeat the line.
-export function warnUnsupportedTransformers(hasTransformers: boolean): void {
-  if (warned || !hasTransformers) return;
-  warned = true;
+// Keyed per project so a `run-many` still reports every affected project, while
+// watch rebuilds of one project log a single line.
+export function warnUnsupportedTransformers(
+  hasTransformers: boolean,
+  projectRoot: string
+): void {
+  if (!hasTransformers || warnedProjects.has(projectRoot)) return;
+  warnedProjects.add(projectRoot);
   logger.warn(RSPACK_TRANSFORMERS_UNSUPPORTED_MESSAGE);
 }

--- a/packages/rspack/src/plugins/utils/warn-unsupported-transformers.ts
+++ b/packages/rspack/src/plugins/utils/warn-unsupported-transformers.ts
@@ -1,0 +1,17 @@
+import { logger } from '@nx/devkit';
+
+// The `transformers` option came over with the schema when the rspack executor
+// was aligned with webpack. Webpack feeds it to ts-loader's getCustomTransformers;
+// rspack compiles TypeScript with `builtin:swc-loader`, which cannot run
+// TypeScript transformer plugins, so the option has never had an effect here.
+export const RSPACK_TRANSFORMERS_UNSUPPORTED_MESSAGE =
+  'The `transformers` option is not supported by `@nx/rspack` and has no effect. Rspack compiles TypeScript with `builtin:swc-loader`, which cannot run TypeScript transformer plugins. Remove the option, or keep using `@nx/webpack` for projects that need a TypeScript transformer such as the `@nestjs/swagger` CLI plugin.';
+
+let warned = false;
+
+// Warn once per process so watch rebuilds don't repeat the line.
+export function warnUnsupportedTransformers(hasTransformers: boolean): void {
+  if (warned || !hasTransformers) return;
+  warned = true;
+  logger.warn(RSPACK_TRANSFORMERS_UNSUPPORTED_MESSAGE);
+}


### PR DESCRIPTION
## Current Behavior

The `@nx/rspack:rspack` executor declares a `transformers` option in its schema. No code in `packages/rspack` reads that option.

A user who sets the option gets no warning and no error. The build shows `Rspack compiled successfully` and exits with code 0. The TypeScript transformer does not run.

The option arrived with the schema when two pull requests aligned the rspack executor with webpack — #28825 and #28913. Those pull requests copied the schema. They could not copy the consumer: webpack gives the option to `ts-loader` through `getCustomTransformers` (`packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts:36`), but rspack compiles TypeScript with `builtin:swc-loader` (`packages/rspack/src/plugins/utils/apply-base-config.ts:525`). SWC cannot run TypeScript transformer plugins.

An application that uses a transformer loses it without a message. The `@nestjs/swagger` CLI plugin is one example: the application loses its generated schema metadata, and the build still reports success.

## Expected Behavior

The executor tells the user that it ignores the option.

This pull request adds a warning and marks the option with `x-deprecated` in the schema. It does not add transformer support, because SWC cannot run these plugins.

Both code paths reach the warning: the `@nx/rspack:rspack` executor through `with-nx.ts`, and the inferred `@nx/rspack/plugin` through `nx-app-rspack-plugin.ts`.

Three details of the implementation:

- The code reads `options.transformers` before `applyBaseConfig` applies its defaults. The `options.transformers ??= []` line would otherwise hide that the user set the option.
- The warning comes after the `NX_GRAPH_CREATION` guard. Nx calls `applyBaseConfig` to read the config during graph creation, and a warning there would show for commands such as `nx show projects`.
- The code warns one time for each project. A `run-many` over several rspack projects reports every affected project, and watch rebuilds of one project log a single line.

The new warning:

```
The `transformers` option is not supported by `@nx/rspack` and has no effect.
Rspack compiles TypeScript with `builtin:swc-loader`, which cannot run
TypeScript transformer plugins. Remove the option, or keep using `@nx/webpack`
for projects that need a TypeScript transformer such as the `@nestjs/swagger`
CLI plugin.
```

The issue lists three possible solutions. This pull request applies solution 1, the smallest one. Solution 2 removes the option from the schema. Solution 3 supports the option through an SWC-compatible mechanism. Tell me if you prefer one of those two, and I change the pull request.

## Verification

The reproduction from the issue shows the warning with this branch:

```
The `transformers` option is not supported by `@nx/rspack` and has no effect. [...]
Rspack compiled successfully (9e54d655627f2c8e)
```

A build without the option shows no warning.

Tests: `nx test rspack` gives 182 passed in 21 suites. Five new tests cover these conditions:

- the warning itself
- the once-per-project behaviour
- a second project in the same process, which must also warn
- the silent path during graph creation
- the case with no option set

A temporary removal of the call makes `warns when the option is set` fail. This shows that the test detects the regression.

`nx run-many -t lint,build -p rspack` and `nx prepush` both pass.

## Related Issue(s)

Fixes #36875
