### PR TITLE
fix(release): correct declared type of `parallel` in `PublishOptions`

### DIFF
--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -88,11 +88,18 @@ export type ChangelogOptions = NxReleaseArgs &
   };
 
 export type PublishOptions = NxReleaseArgs &
-  Partial<RunManyOptions> & { outputStyle?: OutputStyle } & FirstReleaseArgs & {
+  Omit<Partial<RunManyOptions>, 'parallel'> & { outputStyle?: OutputStyle } & FirstReleaseArgs & {
     registry?: string;
     tag?: string;
     access?: string;
     otp?: number;
+    /**
+     * Unlike the CLI path, which normalizes the raw yargs string via
+     * readParallelFromArgsAndEnv() before it reaches this type, programmatic
+     * API callers must pass the already-resolved number directly — it flows
+     * straight into getThreadPoolSize() in task-orchestrator.ts.
+     */
+    parallel?: number;
     // This will only be set if using the `nx release` top level command, or orchestrating via the programmatic API
     versionData?: VersionData;
     // This will only be set if using the `nx release` top level command, or orchestrating via the programmatic API


### PR DESCRIPTION
## Current Behavior

`PublishOptions.parallel` is typed as `string` (inherited from `RunOptions.parallel` in
[shared-options.ts](https://github.com/nrwl/nx/blob/7e5b452eb771d66097a1aae4192b31d9a2158789/packages/nx/src/command-line/yargs-utils/shared-options.ts#L30),
via `PublishOptions = NxReleaseArgs & Partial<RunManyOptions> & {...}` in
[command-object.ts](https://github.com/nrwl/nx/blob/7e5b452eb771d66097a1aae4192b31d9a2158789/packages/nx/src/command-line/release/command-object.ts#L90-L100)).

That type reflects the raw CLI/yargs value *before* normalization. On the CLI path, the raw string
is always passed through `readParallelFromArgsAndEnv()`
([shared-options.ts](https://github.com/nrwl/nx/blob/7e5b452eb771d66097a1aae4192b31d9a2158789/packages/nx/src/command-line/yargs-utils/shared-options.ts#L436-L455)),
which coerces it to a real `number` before it reaches the task orchestrator.

However, callers using the *programmatic* API — e.g. the `releasePublish` function returned by
`createAPI(...)` in
[publish.ts](https://github.com/nrwl/nx/blob/7e5b452eb771d66097a1aae4192b31d9a2158789/packages/nx/src/command-line/release/publish.ts#L58-L68),
used directly instead of going through `yargsReleaseCommand` — never go through that normalization
step. If such a caller passes `parallel` as a numeric string (matching the declared TS type), it
flows straight into `getThreadPoolSize()`
([task-orchestrator.ts](https://github.com/nrwl/nx/blob/7e5b452eb771d66097a1aae4192b31d9a2158789/packages/nx/src/tasks-runner/task-orchestrator.ts#L2139-L2166)):

```ts
const discrete = options['parallel'];
const continuous = continuousCount;
const total = discrete + continuous; // string concatenation, not addition, if parallel is a string
```

`getThreadPoolSize` only coerces the sentinel values `'true'`/`'false'`/`''`/`undefined` — any other
string (including a plain numeric string like `"3"`) passes through unchanged. `total` then reaches:

```ts
process.stdout.setMaxListeners(total + defaultMaxListeners);
process.stderr.setMaxListeners(total + defaultMaxListeners);
process.setMaxListeners(total + defaultMaxListeners);
```

`setMaxListeners(n)` requires `n` to be a `number` and throws `ERR_INVALID_ARG_TYPE` when given a
string, so a type-correct programmatic caller crashes at runtime.

## Expected Behavior

The declared type of `parallel` should match whatever a caller of the programmatic API is actually
required to provide — a real `number`, not a `string`.

## Fix

`PublishOptions.parallel` is now typed as `number`, using `Omit<Partial<RunManyOptions>, 'parallel'>`
to override the inherited CLI-string type (a plain intersection would otherwise collapse to `never`).
This is a type-only change — no runtime behavior is modified.

## Repro

```ts
const publish = createAPI(overrideReleaseConfig, ignoreNxJsonConfig);
await publish({ groups: [...], dryRun: false, parallel: '3' /* matches the old declared type */ });
// throws inside task-orchestrator.ts because "3" + continuousCount is string concatenation,
// and the resulting string is passed to process.stdout.setMaxListeners(...)
```

Passing `parallel` as an actual `number` (contradicting the old declared type) avoided the crash,
confirming the type declaration didn't match the runtime contract for this code path.

Closes #36777
