### PR TITLE
fix(linter): fall back to `tsconfig.json` in ast-utils barrel lookup

### DIFF
--- a/packages/eslint-plugin/src/utils/ast-utils.spec.ts
+++ b/packages/eslint-plugin/src/utils/ast-utils.spec.ts
@@ -1,7 +1,10 @@
 import '@nx/devkit/internal-testing-utils/mock-fs';
 
 import { vol } from 'memfs';
-import { getRelativeImportPath } from './ast-utils';
+import {
+  getBarrelEntryPointByImportScope,
+  getRelativeImportPath,
+} from './ast-utils';
 
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual<any>('@nx/devkit'),
@@ -50,6 +53,32 @@ describe('ast-utils', () => {
         '/root/libs/mylib/src/index.ts'
       );
       expect(result).toBe('/root/libs/mylib/src/index.ts');
+    });
+  });
+
+  describe('getBarrelEntryPointByImportScope', () => {
+    it('should read paths from a root tsconfig.json when tsconfig.base.json does not exist', () => {
+      vol.fromJSON(
+        {
+          './libs/mylib/src/index.ts': 'export class MyClass {}',
+          './tsconfig.json': JSON.stringify({
+            compilerOptions: {
+              paths: {
+                '@acme/mylib': ['libs/mylib/src/index.ts'],
+              },
+            },
+          }),
+        },
+        '/root'
+      );
+
+      const result = getBarrelEntryPointByImportScope('@acme/mylib');
+      expect(result).toEqual(['libs/mylib/src/index.ts']);
+    });
+
+    it('should return an empty array when neither tsconfig file exists', () => {
+      const result = getBarrelEntryPointByImportScope('@acme/mylib');
+      expect(result).toEqual([]);
     });
   });
 });

--- a/packages/eslint-plugin/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin/src/utils/ast-utils.ts
@@ -1,10 +1,5 @@
-import {
-  logger,
-  ProjectGraphProjectNode,
-  readJsonFile,
-  workspaceRoot,
-} from '@nx/devkit';
-import { findNodes } from '@nx/js';
+import { logger, ProjectGraphProjectNode, readJsonFile } from '@nx/devkit';
+import { findNodes, getRootTsConfigPath } from '@nx/js';
 import { getProjectSourceRoot } from '@nx/js/internal';
 import { getModifiers } from '@typescript-eslint/type-utils';
 import { existsSync, lstatSync, readdirSync, readFileSync } from 'fs';
@@ -12,10 +7,16 @@ import { dirname, join } from 'path';
 import ts = require('typescript');
 
 function tryReadBaseJson() {
+  // Root tsconfig can be named either `tsconfig.base.json` or `tsconfig.json`;
+  // getRootTsConfigPath() checks both instead of hardcoding the former.
+  const tsConfigPath = getRootTsConfigPath();
+  if (!tsConfigPath) {
+    return null;
+  }
   try {
-    return readJsonFile(join(workspaceRoot, 'tsconfig.base.json'));
+    return readJsonFile(tsConfigPath);
   } catch (e) {
-    logger.warn(`Error reading "tsconfig.base.json": \n${JSON.stringify(e)}`);
+    logger.warn(`Error reading "${tsConfigPath}": \n${JSON.stringify(e)}`);
     return null;
   }
 }


### PR DESCRIPTION
## Current Behavior

`@nx/oxlint/boundaries-plugin` (and `@nx/eslint-plugin`'s `enforce-module-boundaries`, which it
bridges to) prints:

```
Error reading "tsconfig.base.json":
{"errno":-2,"code":"ENOENT","syscall":"open","path":"/home/kuba/project/tsconfig.base.json"}
```

whenever the workspace's root TypeScript config is named `tsconfig.json` instead of
`tsconfig.base.json`. Lint results are otherwise correct, since barrel-import resolution
(the only consumer of this helper) just silently gets `null`/`[]` back.

The cause is `tryReadBaseJson()` in `packages/eslint-plugin/src/utils/ast-utils.ts`, which reads
the root tsconfig by a hardcoded filename:

```ts
return readJsonFile(join(workspaceRoot, 'tsconfig.base.json'));
```

`@nx/js` already exports `getRootTsConfigPath()`, which checks `tsconfig.base.json` first and
falls back to `tsconfig.json`, and this file already imports other helpers from `@nx/js`.

## Fix

Swap the hardcoded path for `getRootTsConfigPath()`. This removes the bogus ENOENT warning and,
as a side effect, fixes barrel-import path resolution for workspaces whose `paths` mapping lives
in a root `tsconfig.json` with no `tsconfig.base.json` — previously that case silently resolved
to nothing.

Added regression coverage for both the `tsconfig.json`-only case and the neither-file-exists case
using the existing memfs-based test setup in `ast-utils.spec.ts`.

Closes #36773
