### PR TITLE
feat(nest): let the application generator choose its bundler

### DIFF
--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -689,4 +689,44 @@ describe('application generator', () => {
       expect(readJson(tree, 'myapp-e2e/package.json').nx).toBeUndefined();
     });
   });
+  describe('--bundler', () => {
+    it('should default to webpack', async () => {
+      await applicationGenerator(tree, { directory: appDirectory });
+
+      expect(tree.exists(`${appDirectory}/webpack.config.js`)).toBe(true);
+      expect(tree.exists(`${appDirectory}/rspack.config.js`)).toBe(false);
+    });
+
+    it('should generate an rspack config when asked for rspack', async () => {
+      await applicationGenerator(tree, {
+        directory: appDirectory,
+        bundler: 'rspack',
+      });
+
+      expect(tree.exists(`${appDirectory}/rspack.config.js`)).toBe(true);
+      expect(tree.exists(`${appDirectory}/webpack.config.js`)).toBe(false);
+    });
+
+    it('should keep class and function names so Nest can resolve providers', async () => {
+      await applicationGenerator(tree, {
+        directory: appDirectory,
+        bundler: 'rspack',
+      });
+
+      const config = tree.read(`${appDirectory}/rspack.config.js`, 'utf-8');
+      expect(config).toContain('SwcJsMinimizerRspackPlugin');
+      expect(config).toContain('keep_classnames: true');
+      expect(config).toContain('keep_fnames: true');
+    });
+
+    it('should add @nx/rspack to the workspace', async () => {
+      await applicationGenerator(tree, {
+        directory: appDirectory,
+        bundler: 'rspack',
+      });
+
+      const { devDependencies } = readJson(tree, 'package.json');
+      expect(devDependencies['@nx/rspack']).toBeDefined();
+    });
+  });
 });

--- a/packages/nest/src/generators/application/lib/normalize-options.ts
+++ b/packages/nest/src/generators/application/lib/normalize-options.ts
@@ -31,6 +31,7 @@ export async function normalizeOptions(
     addPlugin,
     ...options,
     strict: options.strict ?? false,
+    bundler: options.bundler ?? 'webpack',
     appProjectName,
     appProjectRoot,
     linter: await normalizeLinterOption(tree, options.linter),
@@ -56,7 +57,7 @@ export function toNodeApplicationGeneratorOptions(
     e2eTestRunner: options.e2eTestRunner,
     enableTypedLinting: isTypedLintingEnabled(options),
     rootProject: options.rootProject,
-    bundler: 'webpack', // Some features require webpack plugins such as TS transformers
+    bundler: options.bundler,
     isNest: true,
     addPlugin: options.addPlugin,
     useProjectJson: options.useProjectJson,

--- a/packages/nest/src/generators/application/schema.d.ts
+++ b/packages/nest/src/generators/application/schema.d.ts
@@ -9,6 +9,7 @@ export interface ApplicationGeneratorOptions {
   skipFormat?: boolean;
   skipPackageJson?: boolean;
   tags?: string;
+  bundler?: 'webpack' | 'rspack';
   unitTestRunner?: 'jest' | 'vitest' | 'none';
   e2eTestRunner?: 'jest' | 'none';
   enableTypedLinting?: boolean;

--- a/packages/nest/src/generators/application/schema.json
+++ b/packages/nest/src/generators/application/schema.json
@@ -44,6 +44,13 @@
       "type": "string",
       "enum": ["none", "prettier", "oxfmt"]
     },
+    "bundler": {
+      "description": "Bundler which is used to package the application. `esbuild` is not offered because it does not emit `emitDecoratorMetadata`, which Nest needs to resolve constructor injection.",
+      "type": "string",
+      "enum": ["webpack", "rspack"],
+      "default": "webpack",
+      "x-priority": "important"
+    },
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",

--- a/packages/node/eslint.config.mjs
+++ b/packages/node/eslint.config.mjs
@@ -26,6 +26,7 @@ export default [
             // Installed on demand via `ensurePackage` when the generator is
             // asked for that bundler / unit test runner.
             '@nx/webpack',
+            '@nx/rspack',
             '@nx/vitest',
             'express',
             'koa',

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1267,6 +1267,41 @@ describe('app', () => {
     });
   });
 
+  describe('--bundler rspack', () => {
+    it('should generate an rspack config and drop the webpack one', async () => {
+      await applicationGenerator(tree, {
+        directory: 'my-rspack-app',
+        bundler: 'rspack',
+        addPlugin: true,
+      });
+
+      expect(tree.exists('my-rspack-app/rspack.config.js')).toBe(true);
+      expect(tree.exists('my-rspack-app/webpack.config.js')).toBe(false);
+    });
+
+    it('should not write an explicit build target when the plugin infers one', async () => {
+      await applicationGenerator(tree, {
+        directory: 'my-rspack-app',
+        bundler: 'rspack',
+        addPlugin: true,
+      });
+
+      const project = readProjectConfiguration(tree, 'my-rspack-app');
+      expect(project.targets.build).toBeUndefined();
+    });
+
+    it('should write an explicit build target when inference is opted out', async () => {
+      await applicationGenerator(tree, {
+        directory: 'my-rspack-app',
+        bundler: 'rspack',
+        addPlugin: false,
+      });
+
+      const project = readProjectConfiguration(tree, 'my-rspack-app');
+      expect(project.targets.build.executor).toBe('@nx/rspack:rspack');
+    });
+  });
+
   describe('--rootProject base compiler options', () => {
     it('should inline "bundler" moduleResolution into the root tsconfig.json when typescript is not declared', async () => {
       await applicationGenerator(tree, {

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1268,6 +1268,31 @@ describe('app', () => {
   });
 
   describe('--bundler rspack', () => {
+    it('should not keep class names for a framework that does not need it', async () => {
+      await applicationGenerator(tree, {
+        directory: 'my-rspack-app',
+        bundler: 'rspack',
+        addPlugin: true,
+      });
+
+      const config = tree.read('my-rspack-app/rspack.config.js', 'utf-8');
+      expect(config).not.toContain('SwcJsMinimizerRspackPlugin');
+      expect(config).not.toContain('keep_classnames');
+    });
+
+    it('should keep class names for Nest, which resolves providers by name', async () => {
+      await applicationGenerator(tree, {
+        directory: 'my-nest-app',
+        bundler: 'rspack',
+        isNest: true,
+        addPlugin: true,
+      });
+
+      const config = tree.read('my-nest-app/rspack.config.js', 'utf-8');
+      expect(config).toContain('SwcJsMinimizerRspackPlugin');
+      expect(config).toContain('keep_classnames: true');
+    });
+
     it('should generate an rspack config and drop the webpack one', async () => {
       await applicationGenerator(tree, {
         directory: 'my-rspack-app',

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -157,6 +157,18 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
         })
       );
     }
+  } else if (options.bundler === 'rspack') {
+    const { rspackInitGenerator } = ensurePackage<typeof import('@nx/rspack')>(
+      '@nx/rspack',
+      nxVersion
+    );
+    tasks.push(
+      await rspackInitGenerator(tree, {
+        addPlugin: options.addPlugin,
+        framework: options.isNest ? 'nest' : 'none',
+        rootProject: options.rootProject,
+      })
+    );
   }
 
   addAppFiles(tree, options);

--- a/packages/node/src/generators/application/files/common/rspack.config.js__tmpl__
+++ b/packages/node/src/generators/application/files/common/rspack.config.js__tmpl__
@@ -1,6 +1,8 @@
 <%_ if (rspackPluginOptions) { _%>
 const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+<%_ if (isNest) { _%>
 const rspack = require('@rspack/core');
+<%_ } _%>
 const { join } = require('path');
 
 module.exports = {
@@ -8,6 +10,7 @@ module.exports = {
     path: join(__dirname, '<%= rspackPluginOptions.outputPath %>'),
     clean: true,
   },
+<%_ if (isNest) { _%>
   optimization: {
     minimizer: [
       // Nest resolves providers by class name, so minification must not rename
@@ -20,6 +23,7 @@ module.exports = {
       }),
     ],
   },
+<%_ } _%>
   plugins: [
     new NxAppRspackPlugin({
       target: 'node',
@@ -35,7 +39,9 @@ module.exports = {
 };
 <%_ } else { _%>
 const { composePlugins, withNx } = require('@nx/rspack');
+<%_ if (isNest) { _%>
 const rspack = require('@rspack/core');
+<%_ } _%>
 
 // Nx plugins for rspack.
 module.exports = composePlugins(
@@ -45,6 +51,7 @@ module.exports = composePlugins(
   (config) => {
     config.output = { ...config.output, clean: true };
     config.devtool = 'source-map';
+<%_ if (isNest) { _%>
     // Nest resolves providers by class name, so minification must not rename
     // classes or functions.
     config.optimization = {
@@ -58,6 +65,7 @@ module.exports = composePlugins(
         }),
       ],
     };
+<%_ } _%>
     // Update the rspack config as needed here.
     // e.g. `config.plugins.push(new MyPlugin())`
     return config;

--- a/packages/node/src/generators/application/files/common/rspack.config.js__tmpl__
+++ b/packages/node/src/generators/application/files/common/rspack.config.js__tmpl__
@@ -1,0 +1,66 @@
+<%_ if (rspackPluginOptions) { _%>
+const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+const rspack = require('@rspack/core');
+const { join } = require('path');
+
+module.exports = {
+  output: {
+    path: join(__dirname, '<%= rspackPluginOptions.outputPath %>'),
+    clean: true,
+  },
+  optimization: {
+    minimizer: [
+      // Nest resolves providers by class name, so minification must not rename
+      // classes or functions.
+      new rspack.SwcJsMinimizerRspackPlugin({
+        minimizerOptions: {
+          compress: { keep_classnames: true, keep_fnames: true },
+          mangle: { keep_classnames: true, keep_fnames: true },
+        },
+      }),
+    ],
+  },
+  plugins: [
+    new NxAppRspackPlugin({
+      target: 'node',
+      main: '<%= rspackPluginOptions.main %>',
+      tsConfig: '<%= rspackPluginOptions.tsConfig %>',
+      assets: <%- JSON.stringify(rspackPluginOptions.assets) %>,
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: <%= rspackPluginOptions.generatePackageJson %>,
+      sourceMap: true,
+    })
+  ],
+};
+<%_ } else { _%>
+const { composePlugins, withNx } = require('@nx/rspack');
+const rspack = require('@rspack/core');
+
+// Nx plugins for rspack.
+module.exports = composePlugins(
+  withNx({
+    target: 'node',
+  }),
+  (config) => {
+    config.output = { ...config.output, clean: true };
+    config.devtool = 'source-map';
+    // Nest resolves providers by class name, so minification must not rename
+    // classes or functions.
+    config.optimization = {
+      ...config.optimization,
+      minimizer: [
+        new rspack.SwcJsMinimizerRspackPlugin({
+          minimizerOptions: {
+            compress: { keep_classnames: true, keep_fnames: true },
+            mangle: { keep_classnames: true, keep_fnames: true },
+          },
+        }),
+      ],
+    };
+    // Update the rspack config as needed here.
+    // e.g. `config.plugins.push(new MyPlugin())`
+    return config;
+  }
+);
+<%_ } _%>

--- a/packages/node/src/generators/application/lib/add-dependencies.ts
+++ b/packages/node/src/generators/application/lib/add-dependencies.ts
@@ -29,6 +29,10 @@ export function addProjectDependencies(
       '@nx/esbuild': nxVersion,
       esbuild: esbuildVersion,
     },
+    // The @rspack/* packages come from rspackInitGenerator.
+    rspack: {
+      '@nx/rspack': nxVersion,
+    },
   };
 
   const exprPkgVersions = expressVersions(tree);

--- a/packages/node/src/generators/application/lib/create-files.ts
+++ b/packages/node/src/generators/application/lib/create-files.ts
@@ -8,8 +8,25 @@ import {
 import { getRelativePathToRootTsConfig } from '@nx/js';
 import { join } from 'path';
 import { hasWebpackPlugin } from '../../../utils/has-webpack-plugin';
+import { hasRspackPlugin } from '../../../utils/has-rspack-plugin';
 import { addVSCodeDebugConfiguration } from '../../../utils/vscode-debug-config';
 import { NormalizedSchema } from './normalized-schema';
+
+function bundlerPluginOptions(options: NormalizedSchema) {
+  return {
+    outputPath: options.isUsingTsSolutionConfig
+      ? 'dist'
+      : joinPathFragments(
+          offsetFromRoot(options.appProjectRoot),
+          'dist',
+          options.rootProject ? options.name : options.appProjectRoot
+        ),
+    main: './src/main' + (options.js ? '.js' : '.ts'),
+    tsConfig: './tsconfig.app.json',
+    assets: ['./src/assets'],
+    generatePackageJson: !options.isUsingTsSolutionConfig,
+  };
+}
 
 export function addAppFiles(tree: Tree, options: NormalizedSchema) {
   generateFiles(
@@ -28,25 +45,22 @@ export function addAppFiles(tree: Tree, options: NormalizedSchema) {
       ),
       webpackPluginOptions:
         hasWebpackPlugin(tree) && options.addPlugin !== false
-          ? {
-              outputPath: options.isUsingTsSolutionConfig
-                ? 'dist'
-                : joinPathFragments(
-                    offsetFromRoot(options.appProjectRoot),
-                    'dist',
-                    options.rootProject ? options.name : options.appProjectRoot
-                  ),
-              main: './src/main' + (options.js ? '.js' : '.ts'),
-              tsConfig: './tsconfig.app.json',
-              assets: ['./src/assets'],
-              generatePackageJson: !options.isUsingTsSolutionConfig,
-            }
+          ? bundlerPluginOptions(options)
+          : null,
+      rspackPluginOptions:
+        hasRspackPlugin(tree) && options.addPlugin !== false
+          ? bundlerPluginOptions(options)
           : null,
     }
   );
 
-  if (options.bundler !== 'webpack') {
-    tree.delete(joinPathFragments(options.appProjectRoot, 'webpack.config.js'));
+  // files/common holds a config for every bundler; drop the ones not chosen.
+  for (const bundler of ['webpack', 'rspack']) {
+    if (options.bundler !== bundler) {
+      tree.delete(
+        joinPathFragments(options.appProjectRoot, `${bundler}.config.js`)
+      );
+    }
   }
 
   if (options.framework && options.framework !== 'none') {

--- a/packages/node/src/generators/application/lib/create-files.ts
+++ b/packages/node/src/generators/application/lib/create-files.ts
@@ -51,6 +51,9 @@ export function addAppFiles(tree: Tree, options: NormalizedSchema) {
         hasRspackPlugin(tree) && options.addPlugin !== false
           ? bundlerPluginOptions(options)
           : null,
+      // Nest resolves providers by class name, so its config keeps them
+      // through minification. Other frameworks do not need that.
+      isNest: !!options.isNest,
     }
   );
 

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -16,13 +16,44 @@ import {
   type MatchedTargetRef,
 } from '@nx/js/internal';
 import { hasWebpackPlugin } from '../../../utils/has-webpack-plugin';
+import { hasRspackPlugin } from '../../../utils/has-rspack-plugin';
 import { NormalizedSchema } from './normalized-schema';
 import {
   getEsBuildConfig,
   getServeConfig,
   getWebpackBuildConfig,
+  getRspackBuildConfig,
   getPruneTargets,
 } from './create-targets';
+
+type BundlerSpec = {
+  executor: string;
+  createTarget: (
+    tree: Tree,
+    project: ProjectConfiguration,
+    options: NormalizedSchema
+  ) => TargetConfiguration;
+  isInferred?: (tree: Tree, options: NormalizedSchema) => boolean;
+};
+
+const BUNDLERS: Record<NormalizedSchema['bundler'], BundlerSpec> = {
+  esbuild: {
+    executor: '@nx/esbuild:esbuild',
+    createTarget: getEsBuildConfig,
+  },
+  webpack: {
+    executor: '@nx/webpack:webpack',
+    createTarget: getWebpackBuildConfig,
+    isInferred: (tree, options) =>
+      hasWebpackPlugin(tree) || options.addPlugin !== false,
+  },
+  rspack: {
+    executor: '@nx/rspack:rspack',
+    createTarget: getRspackBuildConfig,
+    isInferred: (tree, options) =>
+      hasRspackPlugin(tree) || options.addPlugin !== false,
+  },
+};
 
 export function addProject(
   tree: Tree,
@@ -43,22 +74,16 @@ export function addProject(
   const pnpmDeployInputs = tree.exists('pnpm-lock.yaml')
     ? PNPM_INSTALL_SETTINGS_INPUTS
     : [];
-  if (options.bundler === 'esbuild') {
-    addBuildTargetDefaults(tree, '@nx/esbuild:esbuild', 'build', [
+  const bundler = BUNDLERS[options.bundler];
+  // Plugin-backed bundlers infer their own build target, so an explicit one is
+  // written only when inference is unavailable. esbuild has no plugin.
+  if (bundler && !bundler.isInferred?.(tree, options)) {
+    addBuildTargetDefaults(tree, bundler.executor, 'build', [
       TS_SOLUTION_SETUP_TSCONFIG_INPUT,
       ...pnpmDeployInputs,
     ]);
-    project.targets.build = getEsBuildConfig(tree, project, options);
+    project.targets.build = bundler.createTarget(tree, project, options);
     ensurePnpmDeployInputs(tree, options, project.targets.build);
-  } else if (options.bundler === 'webpack') {
-    if (!hasWebpackPlugin(tree) && options.addPlugin === false) {
-      addBuildTargetDefaults(tree, `@nx/webpack:webpack`, 'build', [
-        TS_SOLUTION_SETUP_TSCONFIG_INPUT,
-        ...pnpmDeployInputs,
-      ]);
-      project.targets.build = getWebpackBuildConfig(tree, project, options);
-      ensurePnpmDeployInputs(tree, options, project.targets.build);
-    }
   }
   project.targets = {
     ...project.targets,

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -49,6 +49,42 @@ export function getWebpackBuildConfig(
   };
 }
 
+export function getRspackBuildConfig(
+  tree: Tree,
+  project: ProjectConfiguration,
+  options: NormalizedSchema
+): TargetConfiguration {
+  const sourceRoot = getProjectSourceRoot(project, tree);
+  return {
+    executor: `@nx/rspack:rspack`,
+    outputs: ['{options.outputPath}'],
+    defaultConfiguration: 'production',
+    options: {
+      target: 'node',
+      outputPath: options.outputPath,
+      main: joinPathFragments(
+        sourceRoot,
+        'main' + (options.js ? '.js' : '.ts')
+      ),
+      tsConfig: joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
+      assets: [joinPathFragments(sourceRoot, 'assets')],
+      rspackConfig: joinPathFragments(
+        options.appProjectRoot,
+        'rspack.config.js'
+      ),
+      generatePackageJson: options.isUsingTsSolutionConfig ? undefined : true,
+    },
+    configurations: {
+      development: {
+        outputHashing: 'none',
+      },
+      production: {
+        ...(options.docker && { generateLockfile: true }),
+      },
+    },
+  };
+}
+
 export function getEsBuildConfig(
   tree: Tree,
   project: ProjectConfiguration,

--- a/packages/node/src/generators/application/schema.d.ts
+++ b/packages/node/src/generators/application/schema.d.ts
@@ -20,7 +20,7 @@ export interface Schema {
    * @deprecated Use `enableTypedLinting` instead. This option will be removed in Nx v24.
    */
   setParserOptionsProject?: boolean;
-  bundler?: 'esbuild' | 'webpack';
+  bundler?: 'esbuild' | 'webpack' | 'rspack';
   framework?: NodeJsFrameWorks;
   port?: number;
   rootProject?: boolean;

--- a/packages/node/src/generators/application/schema.json
+++ b/packages/node/src/generators/application/schema.json
@@ -99,7 +99,7 @@
     "bundler": {
       "description": "Bundler which is used to package the application",
       "type": "string",
-      "enum": ["esbuild", "webpack"],
+      "enum": ["esbuild", "webpack", "rspack"],
       "default": "esbuild",
       "x-priority": "important"
     },

--- a/packages/node/src/utils/has-rspack-plugin.ts
+++ b/packages/node/src/utils/has-rspack-plugin.ts
@@ -1,0 +1,10 @@
+import { readNxJson, Tree } from '@nx/devkit';
+
+export function hasRspackPlugin(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  return !!nxJson.plugins?.some((p) =>
+    typeof p === 'string'
+      ? p === '@nx/rspack/plugin'
+      : p.plugin === '@nx/rspack/plugin'
+  );
+}


### PR DESCRIPTION
## Current Behavior

`@nx/nest:application` hardcodes webpack and gives the user no way to change it:

```ts
// packages/nest/src/generators/application/lib/normalize-options.ts:59
bundler: 'webpack', // Some features require webpack plugins such as TS transformers
```

The option is absent from `ApplicationGeneratorOptions` and from the schema. A workspace therefore cannot follow NestJS 12, which replaces webpack with Rspack.

The comment names the wrong reason. `packages/nest` wires no TypeScript transformer at all: a search for `transformers`, `swagger` or `ReadonlyVisitor` in that package returns only the comment itself. The line arrived as a one-line guard in #14285, a pull request about React and Web.

The real reason is stronger than the comment says, and it applies to esbuild only.

## Expected Behavior

The user chooses the bundler, and every offered value produces an application that works.

This pull request adds a `bundler` option with `webpack` (still the default, so nothing changes for existing workspaces) and `rspack`. Because the Nest generator delegates its whole build setup to `@nx/node`, that package learns to build with rspack too.

**esbuild stays out of the Nest enum on purpose.** esbuild does not emit `emitDecoratorMetadata`. Nest reads `design:paramtypes` to resolve constructor injection. The schema description says so, because `@nx/node` offers esbuild one layer down.

I measured this on a generated application with a two-level provider chain (`AppController` → `AppService` → `RepoService`):

| Bundler | Starts | `GET /api` |
|---|---|---|
| webpack | yes | **200** `{"message":"from repo"}` |
| esbuild | yes | **500** Internal server error |
| rspack | yes | **200** `{"message":"from repo"}` |

An esbuild application **starts correctly** and logs `Nest application successfully started`. It fails on the first request. The default scaffold hides this, because its `AppService` has no dependency of its own.

The bundle shows why. esbuild emits no metadata:

```js
AppController = __decorateClass([Controller()], AppController);
```

rspack emits it, because SWC implements the transform:

```js
_ts_metadata("design:paramtypes", [ ... ])
```

The generated rspack config also keeps class and function names through minification, for the same reason:

```js
new rspack.SwcJsMinimizerRspackPlugin({
  minimizerOptions: {
    compress: { keep_classnames: true, keep_fnames: true },
    mangle: { keep_classnames: true, keep_fnames: true },
  },
})
```

## Implementation notes

The bundler branch in `create-project.ts` was an `if`/`else if` chain that repeated the same body. A third bundler would have repeated it once more, so it became a table:

```ts
const BUNDLERS: Record<NormalizedSchema['bundler'], BundlerSpec> = {
  esbuild: { executor: '@nx/esbuild:esbuild', createTarget: getEsBuildConfig },
  webpack: { executor: '@nx/webpack:webpack', createTarget: getWebpackBuildConfig,
             isInferred: (tree, o) => hasWebpackPlugin(tree) || o.addPlugin !== false },
  rspack:  { executor: '@nx/rspack:rspack',  createTarget: getRspackBuildConfig,
             isInferred: (tree, o) => hasRspackPlugin(tree) || o.addPlugin !== false },
};
```

The three branches become one path. The condition carries a negation, so I checked the truth table for all six input combinations.

`create-files.ts` gained a shared `bundlerPluginOptions` helper, so the webpack and rspack template variables do not duplicate it.

`@nx/rspack` goes into `ignoredDependencies` in `packages/node/eslint.config.mjs`, next to `@nx/webpack`, because both install on demand through `ensurePackage`.

## Verification

`nx test node` gives 137 passed and `nx test nest` gives 102 passed. Four new tests cover the Nest side and three cover the node side. A temporary revert of the option passthrough makes three of the four Nest tests fail. This shows they detect the regression.

End to end, with the local build in a clean workspace:

```
nx g @nx/nest:application apps/api --bundler=rspack
  -> writes rspack.config.js, no webpack.config.js
nx build api  -> Rspack compiled successfully
GET /api      -> 200 {"message":"from repo"}
```

`nx run-many -t lint,build -p node,nest` and `nx prepush` both pass.

## One limitation, already reported

`@nx/rspack` cannot build with `@rspack/core` v2 today. That condition is older than this pull request and affects every framework the package builds, React included. I reported it as #36878 with a React reproduction, and #36879 fixes it. Until that lands, a generated rspack application needs `@rspack/core` v1.

## Related Issue(s)

<!-- No issue: this addresses the hardcoded bundler found while working on NestJS 12 support. -->
