### PR TITLE
fix(core): validate the migrations path before extracting package migrations

### DIFF
--- a/packages/nx/src/command-line/migrate/prompt-files.ts
+++ b/packages/nx/src/command-line/migrate/prompt-files.ts
@@ -1,11 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { dirname, isAbsolute, join, posix, relative, sep } from 'path';
+import { dirname, join, posix } from 'path';
 import {
   MigrationsJson,
   MigrationsJsonEntry,
 } from '../../config/misc-interfaces';
 import { extractFileFromTarball } from '../../utils/tar';
-import { joinPathFragments } from '../../utils/path';
+import { isContainedRelativePath, joinPathFragments } from '../../utils/path';
 
 export const AI_MIGRATIONS_DIR = joinPathFragments('tools', 'ai-migrations');
 
@@ -70,26 +70,13 @@ async function resolvePromptFiles(
     : undefined;
 }
 
-function isPromptPathWithinMigrationsDir(
-  migrationsDir: string,
-  promptRelPath: string
-): boolean {
-  const rel = relative(migrationsDir, join(migrationsDir, promptRelPath));
-  return !(
-    isAbsolute(promptRelPath) ||
-    rel === '..' ||
-    rel.startsWith(`..${sep}`) ||
-    rel.startsWith(`..${posix.sep}`)
-  );
-}
-
 function assertPromptPathWithinMigrationsDir(
   migrationsDir: string,
   promptRelPath: string,
   packageName: string,
   packageVersion: string
 ): void {
-  if (!isPromptPathWithinMigrationsDir(migrationsDir, promptRelPath)) {
+  if (!isContainedRelativePath(promptRelPath)) {
     throw new Error(
       `Invalid prompt path "${promptRelPath}" in package "${packageName}@${packageVersion}": prompt paths must be relative and resolve within the package's migrations directory.`
     );
@@ -125,7 +112,7 @@ export function resolvePrompt(
   promptPath: string,
   migrationsDir: string
 ): string {
-  if (!isPromptPathWithinMigrationsDir(migrationsDir, promptPath)) {
+  if (!isContainedRelativePath(promptPath)) {
     throw new PromptResolutionError(promptPath, migrationsDir);
   }
   const resolvedPath = join(migrationsDir, promptPath);

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -968,6 +968,30 @@ catalogs:
 });
 
 describe('readNxMigrateConfig', () => {
+  it.each([
+    '../../../../etc/profile',
+    '/etc/profile',
+    'migrations/../../../escape.json',
+  ])('should reject the escaping migrations path %s', (migrations) => {
+    expect(() =>
+      readNxMigrateConfig({
+        name: 'hostile',
+        version: '1.0.0',
+        'nx-migrations': { migrations },
+      })
+    ).toThrow(/Invalid migrations path .* in package "hostile@1.0.0"/);
+  });
+
+  it('should reject an escaping migrations path given in the string shorthand', () => {
+    expect(() =>
+      readNxMigrateConfig({
+        name: 'hostile',
+        version: '1.0.0',
+        'nx-migrations': '../../../../etc/profile',
+      } as any)
+    ).toThrow(/Invalid migrations path/);
+  });
+
   it('should carry supportsOptionalMigrations from the nx-migrations config', () => {
     const config = readNxMigrateConfig({
       'nx-migrations': {

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -153,14 +153,14 @@ export function normalizePackageGroup(
 export function readNxMigrateConfig(
   json: Partial<PackageJson>
 ): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup } {
-  // The migrations file is extracted to a path built from this value, so a `..`
-  // or absolute value would escape the directory it is extracted into.
+  // Registry fetching uses this value to build a temporary extraction path.
+  // Reject unsupported absolute paths and escaping parent traversal before extraction.
   const assertContained = (migrations: string): string => {
     if (!isContainedRelativePath(migrations)) {
       throw new Error(
         `Invalid migrations path "${migrations}" in package "${json.name ?? 'unknown'}@${
           json.version ?? 'unknown'
-        }": migrations paths must be relative and resolve within the package.`
+        }": migration paths must not be absolute or escape their base directory through parent traversal.`
       );
     }
     return migrations;

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -18,6 +18,7 @@ import { mergeTargetConfigurations } from '../project-graph/utils/project-config
 import { getCatalogManager } from './catalog';
 import { readJsonFile } from './fileutils';
 import { hasNxJsPlugin } from './has-nx-js-plugin';
+import { isContainedRelativePath } from './path';
 import { getNxRequirePaths } from './installation-directory';
 import {
   createTempNpmDirectory,
@@ -152,6 +153,19 @@ export function normalizePackageGroup(
 export function readNxMigrateConfig(
   json: Partial<PackageJson>
 ): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup } {
+  // The migrations file is extracted to a path built from this value, so a `..`
+  // or absolute value would escape the directory it is extracted into.
+  const assertContained = (migrations: string): string => {
+    if (!isContainedRelativePath(migrations)) {
+      throw new Error(
+        `Invalid migrations path "${migrations}" in package "${json.name ?? 'unknown'}@${
+          json.version ?? 'unknown'
+        }": migrations paths must be relative and resolve within the package.`
+      );
+    }
+    return migrations;
+  };
+
   const parseNxMigrationsConfig = (
     fromJson?: string | NxMigrationsConfiguration
   ): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup } => {
@@ -159,11 +173,13 @@ export function readNxMigrateConfig(
       return {};
     }
     if (typeof fromJson === 'string') {
-      return { migrations: fromJson, packageGroup: [] };
+      return { migrations: assertContained(fromJson), packageGroup: [] };
     }
 
     return {
-      ...(fromJson.migrations ? { migrations: fromJson.migrations } : {}),
+      ...(fromJson.migrations
+        ? { migrations: assertContained(fromJson.migrations) }
+        : {}),
       ...(fromJson.packageGroup
         ? { packageGroup: normalizePackageGroup(fromJson.packageGroup) }
         : {}),

--- a/packages/nx/src/utils/path.spec.ts
+++ b/packages/nx/src/utils/path.spec.ts
@@ -1,4 +1,8 @@
-import { joinPathFragments, normalizePath } from './path';
+import {
+  isContainedRelativePath,
+  joinPathFragments,
+  normalizePath,
+} from './path';
 
 describe('normalizePath', () => {
   it('should remove drive letters', () => {
@@ -20,5 +24,25 @@ describe('joinPathFragments', () => {
     expect(joinPathFragments('C://some/path', '../other-path')).toEqual(
       '/some/other-path'
     );
+  });
+});
+
+describe('isContainedRelativePath', () => {
+  it.each(['migrations.json', './migrations.json', 'a/b/../migrations.json'])(
+    'should accept the contained path %s',
+    (path) => {
+      expect(isContainedRelativePath(path)).toBe(true);
+    }
+  );
+
+  it.each(['../migrations.json', '..', 'a/../../migrations.json'])(
+    'should reject the escaping path %s',
+    (path) => {
+      expect(isContainedRelativePath(path)).toBe(false);
+    }
+  );
+
+  it('should reject absolute paths, which path.join would treat as relative', () => {
+    expect(isContainedRelativePath('/etc/profile')).toBe(false);
   });
 });

--- a/packages/nx/src/utils/path.ts
+++ b/packages/nx/src/utils/path.ts
@@ -22,6 +22,23 @@ export function joinPathFragments(...fragments: string[]): string {
 }
 
 /**
+ * True when `relativePath` stays inside the directory it is resolved against.
+ * Absolute paths are rejected because `path.join` silently treats them as
+ * relative, so they would otherwise slip past a `..` check.
+ */
+export function isContainedRelativePath(relativePath: string): boolean {
+  if (path.isAbsolute(relativePath)) {
+    return false;
+  }
+  const normalized = path.normalize(relativePath);
+  return !(
+    normalized === '..' ||
+    normalized.startsWith(`..${path.sep}`) ||
+    normalized.startsWith(`..${path.posix.sep}`)
+  );
+}
+
+/**
  * When running a script with the package manager (e.g. `npm run`), the package manager will
  * traverse the directory tree upwards until it finds a `package.json` and will set `process.cwd()`
  * to the folder where it found it. The actual working directory is stored in the INIT_CWD


### PR DESCRIPTION
## Current Behavior

`readNxMigrateConfig` returned the `nx-migrations.migrations` value from a package manifest without validating it. Consumers joined that value onto a directory and used the result as a write destination, so the field was trusted to be package-relative without anything enforcing it.

The same containment rule was already implemented locally in `prompt-files.ts` for the sibling `prompt` field, so there were two copies of the idea and only one of them was applied.

## Expected Behavior

The value is validated where it is read. A `migrations` path must be relative and must resolve within its own package; anything else fails closed with an error naming the offending package and version. Both the object form and the string shorthand are covered, so every consumer of the field is gated at the point the value is parsed rather than at each use.

The containment check now lives in `utils/path.ts` as `isContainedRelativePath` and replaces the duplicate local helper in `prompt-files.ts`, leaving one rule for the whole migrate path.

## Related Issue(s)

Security report supplied privately.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-migrate-migrations-path-validation-a7e3ec5d">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->