### PR TITLE
chore(repo): stop enabling nx cloud verbose logging in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
       NX_ALLOW_NON_CACHEABLE_DTE: 'true'
       NX_CLOUD_EXPERIMENTAL_POLLING: 'true'
       NX_CLOUD_CONTINUOUS_ASSIGNMENT: 'true'
-      NX_CLOUD_VERBOSE_LOGGING: 'true'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

<!-- This is the behavior we have today -->

`main-linux` sets `NX_CLOUD_VERBOSE_LOGGING: 'true'`, so every CI run emits verbose cloud client logs. #34524 turned it on to debug silent agents and we've been carrying it since.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Cloud logging back to its default. Nothing else in the repo sets the var, so dropping the line is enough.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/disable-cloud-verbose-logging-226f3f94">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->