### PR TITLE
fix(release): exclude AI coding agents from the changelog Thank You section

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Release/configure-changelog-format.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/configure-changelog-format.mdoc
@@ -46,6 +46,8 @@ There are a few options available to modify the default changelog renderer outpu
 
 Whether the commit authors should be added to the bottom of the changelog in a "Thank You" section. Defaults to `true`.
 
+Nx excludes bots and known AI coding agents, even when they author commits or add `Co-authored-by:` trailers.
+
 #### `applyUsernameToAuthors`
 
 If authors is enabled, controls whether or not to try to map the authors to their GitHub usernames using https://ungh.cc (from https://github.com/unjs/ungh) and the email addresses found in the commits. Defaults to `true`.

--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -243,6 +243,68 @@ describe('ChangelogRenderer', () => {
         applyUsernameSpy.mockRestore();
       });
 
+      it('should exclude AI coding agents from the Thank You section', async () => {
+        const renderer = new DefaultChangelogRenderer({
+          changes: [
+            {
+              shortHash: 'abc1234',
+              authors: [
+                { name: 'James Henry', email: 'jh@example.com' },
+                // A human whose name happens to match an agent's must still be thanked
+                { name: 'Claude Dubois', email: 'claude.dubois@example.com' },
+                // One email, many display names, because the names track model versions
+                { name: 'Claude', email: 'noreply@anthropic.com' },
+                {
+                  name: 'Claude Opus 5 (1M context)',
+                  email: 'noreply@anthropic.com',
+                },
+                { name: 'Claude Sonnet 5', email: 'noreply@anthropic.com' },
+                { name: 'Claude Code', email: 'claude@anthropic.com' },
+                { name: 'Amp', email: 'amp@ampcode.com' },
+                { name: 'Cursor Agent', email: 'cursoragent@cursor.com' },
+                { name: 'OpenHands', email: 'opendevin@all-hands.dev' },
+                // The Copilot coding agent commits under both of these spellings
+                { name: 'Copilot', email: 'Copilot@users.noreply.github.com' },
+                {
+                  name: 'copilot-swe-agent[bot]',
+                  email: '198982749+Copilot@users.noreply.github.com',
+                },
+              ],
+              body: '"\n\nM\tpackages/pkg-a/src/index.ts\n"',
+              description: 'a change co-authored by agents',
+              type: 'fix',
+              scope: 'pkg-a',
+              githubReferences: [{ value: 'abc1234', type: 'hash' }],
+              isBreaking: false,
+              revertedHashes: [],
+              affectedProjects: ['pkg-a'],
+            },
+          ],
+          remoteReleaseClient,
+          changelogEntryVersion: 'v1.1.0',
+          project: null,
+          isVersionPlans: false,
+          entryWhenNoChanges: false,
+          changelogRenderOptions: {
+            authors: true,
+          },
+          conventionalCommitsConfig: DEFAULT_CONVENTIONAL_COMMITS_CONFIG,
+        });
+        const markdown = await renderer.render();
+        expect(markdown).toMatchInlineSnapshot(`
+          "## v1.1.0
+
+          ### 🩹 Fixes
+
+          - **pkg-a:** a change co-authored by agents
+
+          ### ❤️ Thank You
+
+          - Claude Dubois
+          - James Henry"
+        `);
+      });
+
       it('should not generate a Thank You section when changelogRenderOptions.authors is false', async () => {
         const renderer = new DefaultChangelogRenderer({
           changes,

--- a/packages/nx/release/changelog-renderer/index.ts
+++ b/packages/nx/release/changelog-renderer/index.ts
@@ -11,6 +11,20 @@ export type { ChangelogChange };
 // Stripped from breaking change explanations (e.g. bot/session markers).
 const HtmlCommentRegex = /<!--[\s\S]*?-->/g;
 
+// Keyed on email: agent display names track model versions (e.g. "Claude Opus
+// 5 (1M context)"), and a human contributor can share a name with an agent.
+const AiAgentAuthorEmails = new Set([
+  'noreply@anthropic.com',
+  'claude@anthropic.com',
+  'amp@ampcode.com',
+  'cursoragent@cursor.com',
+  'openhands@all-hands.dev',
+  'opendevin@all-hands.dev',
+]);
+// The Copilot coding agent's trailer is not always [bot]-suffixed.
+const CopilotAuthorEmailRegex =
+  /^(?:\d+\+)?copilot@users\.noreply\.github\.com$/;
+
 /**
  * The ChangelogRenderOptions are specific to each ChangelogRenderer implementation, and are taken
  * from the user's nx.json configuration and passed as is into the ChangelogRenderer function.
@@ -329,7 +343,7 @@ export default class DefaultChangelogRenderer {
       }
       for (const author of change.authors) {
         const name = this.formatName(author.name);
-        if (!name || name.includes('[bot]')) {
+        if (!name || name.includes('[bot]') || this.isAiAgentAuthor(author)) {
           continue;
         }
         if (!_authors.has(name)) {
@@ -534,6 +548,13 @@ export default class DefaultChangelogRenderer {
       /^Co-authored-by:/i.test(trimmed) ||
       // Git metadata delimiter following the body
       trimmed === '"'
+    );
+  }
+
+  protected isAiAgentAuthor(author: { name: string; email: string }): boolean {
+    const email = (author.email || '').trim().toLowerCase();
+    return (
+      AiAgentAuthorEmails.has(email) || CopilotAuthorEmailRegex.test(email)
     );
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Thank You section only skips authors with `[bot]` in the name, so we thank AI agents too. 23.2.0 credits `Claude`, `Claude Opus 4.6 (1M context)`, `Claude Sonnet 5`, `Claude Fable 5`, `Amp` and `Copilot`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Only people get thanked. Agents are matched by email, since the display names track model versions.

The list covers `noreply@anthropic.com` and `claude@anthropic.com`, `amp@ampcode.com`, `cursoragent@cursor.com`, `openhands@all-hands.dev` (plus the legacy `opendevin@all-hands.dev`), and Copilot's `<id>+Copilot@users.noreply.github.com`. The cursor and openhands addresses aren't in nx history yet, but they're the real ones: cursor has ~1.2M commits on GitHub under `Cursor Agent <cursoragent@cursor.com>`, and openhands commits as `openhands@all-hands.dev` in its own repo.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
