### PR TITLE
fix(core): report how a plugin worker was lost instead of always calling it an exit

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.spec.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.spec.ts
@@ -1,6 +1,11 @@
+import { EventEmitter } from 'events';
+import { SOCKET_REFUSED_EXIT_CODE } from '../../../utils/socket-refused-exit-code';
+import { waitForSocketConnection } from '../../../utils/wait-for-socket-connection';
 import {
+  connectToWorker,
   describeWorkerExit,
   getPluginWorkerSocketId,
+  isPluginWorkerSocketRefusal,
   IsolatedPlugin,
   LoadResultPayload,
 } from './isolated-plugin';
@@ -12,6 +17,10 @@ vi.mock('../../../daemon/socket-utils', () => ({
 
 vi.mock('../../../utils/installation-directory', () => ({
   getNxRequirePaths: vi.fn(() => ['/mock/require/path']),
+}));
+
+vi.mock('../../../utils/wait-for-socket-connection', () => ({
+  waitForSocketConnection: vi.fn(),
 }));
 
 vi.mock('../resolve-plugin', () => ({
@@ -216,6 +225,26 @@ describe('IsolatedPlugin', () => {
       expect(plugin.responseHandlers.size).toBe(2);
     });
 
+    it('unpipes the worker streams so the host stops mirroring a dead worker', () => {
+      const { plugin } = testPlugin();
+      const stdout = { unpipe: vi.fn() };
+      const stderr = { unpipe: vi.fn() };
+      plugin.worker = { stdout, stderr };
+
+      plugin.markUnusable();
+
+      expect(stdout.unpipe).toHaveBeenCalledWith(process.stdout);
+      expect(stderr.unpipe).toHaveBeenCalledWith(process.stderr);
+    });
+
+    it('survives a worker that is already gone', () => {
+      const { plugin } = testPlugin();
+      plugin.worker = null;
+
+      expect(() => plugin.markUnusable()).not.toThrow();
+      expect(plugin._alive).toBe(false);
+    });
+
     it('logs a framing failure when there are no pending requests', () => {
       const { plugin } = testPlugin(0);
       const socket = { destroy: vi.fn() };
@@ -246,6 +275,65 @@ describe('IsolatedPlugin', () => {
         'Plugin worker "test-plugin" sent a message the host could not read, so its connection was dropped. stream is out of sync',
       ]);
       expect(consoleError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reporting a worker that dies before connecting', () => {
+    afterEach(() => {
+      vi.mocked(waitForSocketConnection).mockReset();
+    });
+
+    // The worker exits while connectToWorker is still polling, which is the
+    // only window in which this message is produced.
+    function workerExitingDuringConnect(
+      code: number | null,
+      signal: NodeJS.Signals | null
+    ) {
+      const worker = new EventEmitter() as any;
+      worker.pid = 4242;
+      vi.mocked(waitForSocketConnection).mockImplementation(async () => {
+        worker.emit('exit', code, signal);
+        return null;
+      });
+      return worker;
+    }
+
+    it('names the signal rather than reporting a null exit code', async () => {
+      const worker = workerExitingDuringConnect(null, 'SIGKILL');
+
+      await expect(
+        connectToWorker(worker, '/mock/socket/path', 'test-plugin')
+      ).rejects.toThrow(
+        'Plugin worker for "test-plugin" exited (killed by SIGKILL, commonly an out-of-memory kill) before the connection was established.'
+      );
+    });
+
+    it('reports an exit code when there is no signal', async () => {
+      const worker = workerExitingDuringConnect(1, null);
+
+      await expect(
+        connectToWorker(worker, '/mock/socket/path', 'test-plugin')
+      ).rejects.toThrow(
+        'Plugin worker for "test-plugin" exited (exit code 1) before the connection was established.'
+      );
+    });
+
+    // The refusal branch keys off the code alone, so widening the handler to
+    // take a signal must not stop a refusal being recognized as one.
+    it('still recognizes a socket refusal once the signal is threaded through', async () => {
+      const worker = workerExitingDuringConnect(SOCKET_REFUSED_EXIT_CODE, null);
+
+      await expect(
+        connectToWorker(worker, '/mock/socket/path', 'test-plugin')
+      ).rejects.toSatisfy(isPluginWorkerSocketRefusal);
+    });
+
+    it('does not treat a signal kill as a socket refusal', async () => {
+      const worker = workerExitingDuringConnect(null, 'SIGKILL');
+
+      await expect(
+        connectToWorker(worker, '/mock/socket/path', 'test-plugin')
+      ).rejects.toSatisfy((error) => !isPluginWorkerSocketRefusal(error));
     });
   });
 

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.spec.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.spec.ts
@@ -172,6 +172,47 @@ describe('IsolatedPlugin', () => {
     });
   });
 
+  describe('settling pending requests when a worker is lost', () => {
+    function pluginWithTwoPendingRequests() {
+      const plugin: any = Object.create(IsolatedPlugin.prototype);
+      plugin.name = 'test-plugin';
+      plugin._alive = true;
+      plugin.responseHandlers = new Map();
+      const errors: Error[] = [];
+      for (const tx of ['1', '2']) {
+        plugin.responseHandlers.set(tx, {
+          onMessage: vi.fn(),
+          onError: (e: Error) => errors.push(e),
+        });
+      }
+      return { plugin, errors };
+    }
+
+    it('hands the caller-supplied error to every pending request', () => {
+      const { plugin, errors } = pluginWithTwoPendingRequests();
+
+      plugin.failPendingRequests(new Error('worker sent something unreadable'));
+
+      expect(errors.map((e) => e.message)).toEqual([
+        'worker sent something unreadable',
+        'worker sent something unreadable',
+      ]);
+      expect(plugin.responseHandlers.size).toBe(0);
+    });
+
+    it('takes the worker out of service without settling anything', () => {
+      const { plugin, errors } = pluginWithTwoPendingRequests();
+      plugin._connectPromise = Promise.resolve();
+
+      plugin.markUnusable();
+
+      expect(plugin._alive).toBe(false);
+      expect(plugin._connectPromise).toBeNull();
+      expect(errors).toEqual([]);
+      expect(plugin.responseHandlers.size).toBe(2);
+    });
+  });
+
   describe('lifecycle integration', () => {
     it('should shutdown after single-hook plugin completes', async () => {
       const { plugin, shutdown } = createTestPlugin(

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.spec.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.spec.ts
@@ -1,4 +1,5 @@
 import {
+  describeWorkerExit,
   getPluginWorkerSocketId,
   IsolatedPlugin,
   LoadResultPayload,
@@ -140,6 +141,36 @@ describe('IsolatedPlugin', () => {
       sendRequest,
     };
   }
+
+  describe('worker exit descriptions', () => {
+    it('reports a non-zero exit code', () => {
+      expect(describeWorkerExit(1, null)).toBe('(exit code 1)');
+    });
+
+    it('reports a zero exit code rather than dropping it as falsy', () => {
+      expect(describeWorkerExit(0, null)).toBe('(exit code 0)');
+    });
+
+    it('reports the signal when the worker was killed', () => {
+      expect(describeWorkerExit(null, 'SIGTERM')).toBe('(killed by SIGTERM)');
+    });
+
+    it('calls out SIGKILL as a likely out-of-memory kill', () => {
+      expect(describeWorkerExit(null, 'SIGKILL')).toBe(
+        '(killed by SIGKILL, commonly an out-of-memory kill)'
+      );
+    });
+
+    it('prefers the signal when both are present', () => {
+      expect(describeWorkerExit(0, 'SIGKILL')).toContain('SIGKILL');
+    });
+
+    it('says so when neither is reported', () => {
+      expect(describeWorkerExit(null, null)).toBe(
+        '(no exit code or signal reported)'
+      );
+    });
+  });
 
   describe('lifecycle integration', () => {
     it('should shutdown after single-hook plugin completes', async () => {

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.spec.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.spec.ts
@@ -173,14 +173,18 @@ describe('IsolatedPlugin', () => {
   });
 
   describe('settling pending requests when a worker is lost', () => {
-    function pluginWithTwoPendingRequests() {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function testPlugin(pendingRequests = 2) {
       const plugin: any = Object.create(IsolatedPlugin.prototype);
       plugin.name = 'test-plugin';
       plugin._alive = true;
       plugin.responseHandlers = new Map();
       const errors: Error[] = [];
-      for (const tx of ['1', '2']) {
-        plugin.responseHandlers.set(tx, {
+      for (let tx = 0; tx < pendingRequests; tx++) {
+        plugin.responseHandlers.set(String(tx), {
           onMessage: vi.fn(),
           onError: (e: Error) => errors.push(e),
         });
@@ -189,7 +193,7 @@ describe('IsolatedPlugin', () => {
     }
 
     it('hands the caller-supplied error to every pending request', () => {
-      const { plugin, errors } = pluginWithTwoPendingRequests();
+      const { plugin, errors } = testPlugin();
 
       plugin.failPendingRequests(new Error('worker sent something unreadable'));
 
@@ -201,7 +205,7 @@ describe('IsolatedPlugin', () => {
     });
 
     it('takes the worker out of service without settling anything', () => {
-      const { plugin, errors } = pluginWithTwoPendingRequests();
+      const { plugin, errors } = testPlugin();
       plugin._connectPromise = Promise.resolve();
 
       plugin.markUnusable();
@@ -210,6 +214,38 @@ describe('IsolatedPlugin', () => {
       expect(plugin._connectPromise).toBeNull();
       expect(errors).toEqual([]);
       expect(plugin.responseHandlers.size).toBe(2);
+    });
+
+    it('logs a framing failure when there are no pending requests', () => {
+      const { plugin } = testPlugin(0);
+      const socket = { destroy: vi.fn() };
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      plugin.handleFramingFailure(socket, new Error('stream is out of sync'));
+
+      expect(socket.destroy).toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith(
+        'Plugin worker "test-plugin" sent a message the host could not read, ' +
+          'so its connection was dropped. stream is out of sync'
+      );
+    });
+
+    it('routes a framing failure to pending requests without logging it twice', () => {
+      const { plugin, errors } = testPlugin();
+      const socket = { destroy: vi.fn() };
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      plugin.handleFramingFailure(socket, new Error('stream is out of sync'));
+
+      expect(errors.map((error) => error.message)).toEqual([
+        'Plugin worker "test-plugin" sent a message the host could not read, so its connection was dropped. stream is out of sync',
+        'Plugin worker "test-plugin" sent a message the host could not read, so its connection was dropped. stream is out of sync',
+      ]);
+      expect(consoleError).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
@@ -681,7 +681,7 @@ async function startPluginWorker(name: string) {
   }
 }
 
-async function connectToWorker(
+export async function connectToWorker(
   worker: ChildProcess,
   ipcPath: string,
   name: string

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
@@ -192,18 +192,10 @@ export class IsolatedPlugin implements LoadedNxPlugin {
     socket.on(
       'data',
       consumeMessagesFromSocket(this.handleSocketData, (err) => {
-        // The worker is still running here; it is the stream that failed, so
+        // The worker may still be running here; it is the stream that failed, so
         // reporting this as an exit would send whoever reads it hunting for a
-        // dead process. The framing error names the bytes it choked on, so it
-        // travels with the error rather than only reaching stderr.
-        this.markUnusable();
-        socket.destroy();
-        this.failPendingRequests(
-          new Error(
-            `Plugin worker "${this.name}" sent a message the host could not read, ` +
-              `so its connection was dropped. ${err.message}`
-          )
-        );
+        // dead process.
+        this.handleFramingFailure(socket, err);
       })
     );
 
@@ -230,6 +222,22 @@ export class IsolatedPlugin implements LoadedNxPlugin {
       onError(error);
     }
     this.responseHandlers.clear();
+  }
+
+  private handleFramingFailure(socket: Socket, error: Error): void {
+    const framingError = new Error(
+      `Plugin worker "${this.name}" sent a message the host could not read, ` +
+        `so its connection was dropped. ${error.message}`
+    );
+
+    this.markUnusable();
+    socket.destroy();
+
+    if (this.responseHandlers.size === 0) {
+      console.error(framingError.message);
+    } else {
+      this.failPendingRequests(framingError);
+    }
   }
 
   /**

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
@@ -124,7 +124,9 @@ export class IsolatedPlugin implements LoadedNxPlugin {
   private readonly shouldRegisterTSTranspiler: boolean;
 
   private lifecycle: PluginLifecycleManager;
-  private exitHandler: (() => void) | null = null;
+  private exitHandler:
+    | ((code: number | null, signal: NodeJS.Signals | null) => void)
+    | null = null;
 
   /**
    * Creates and loads an isolated plugin worker.
@@ -174,7 +176,7 @@ export class IsolatedPlugin implements LoadedNxPlugin {
 
     this.registerProcessMetrics();
 
-    this.exitHandler = () => {
+    this.exitHandler = (code: number | null, signal: NodeJS.Signals | null) => {
       this._alive = false;
       this._connectPromise = null;
       if (this.worker?.stdout) {
@@ -185,7 +187,10 @@ export class IsolatedPlugin implements LoadedNxPlugin {
       }
       // Reject all pending requests
       const error = new Error(
-        `Plugin worker "${this.name}" exited unexpectedly.`
+        `Plugin worker "${this.name}" exited unexpectedly ${describeWorkerExit(
+          code,
+          signal
+        )}.`
       );
       for (const { onError } of this.responseHandlers.values()) {
         onError(error);
@@ -199,7 +204,8 @@ export class IsolatedPlugin implements LoadedNxPlugin {
       consumeMessagesFromSocket(this.handleSocketData, (err) => {
         // Nothing else settles the pending hook promises on a framing
         // failure, so surface it the same way a dead worker would.
-        this.exitHandler?.();
+        // No process died here, so there is no code or signal to report.
+        this.exitHandler?.(null, null);
         socket.destroy();
         console.error(err.message);
       })
@@ -659,7 +665,7 @@ async function connectToWorker(
 
   // If the worker exits before we connect, abort polling immediately
   // rather than burning through attempts against a dead socket.
-  worker.once('exit', (code) => {
+  worker.once('exit', (code, signal) => {
     if (!abortController.signal.aborted) {
       // The worker sets this code only after an EPERM/EACCES on its own bind,
       // so it is proof of a refusal rather than an inference from the
@@ -669,7 +675,10 @@ async function connectToWorker(
       earlyExitError = markWorkerStartupFailure(
         new Error(
           [
-            `Plugin worker for "${name}" exited with code ${code} before the connection was established.`,
+            `Plugin worker for "${name}" exited ${describeWorkerExit(
+              code,
+              signal
+            )} before the connection was established.`,
             // The worker's own stderr may be lost with the process, so the
             // cause and the fix are repeated here.
             ...(refused || isSandbox()
@@ -723,6 +732,26 @@ export const PLUGIN_WORKER_STARTUP_FAILURE = Symbol.for(
 export const PLUGIN_WORKER_SOCKET_REFUSED = Symbol.for(
   'nx.pluginWorkerSocketRefused'
 );
+
+/**
+ * Describes how a worker died for an error message. A `null` code with a signal
+ * is an outside kill rather than anything the worker chose, and SIGKILL is what
+ * an out-of-memory kill looks like, so both are called out by name.
+ */
+export function describeWorkerExit(
+  code: number | null,
+  signal: NodeJS.Signals | null
+): string {
+  if (signal) {
+    return signal === 'SIGKILL'
+      ? `(killed by ${signal}, commonly an out-of-memory kill)`
+      : `(killed by ${signal})`;
+  }
+  if (code !== null) {
+    return `(exit code ${code})`;
+  }
+  return '(no exit code or signal reported)';
+}
 
 function markWorkerStartupFailure(error: Error, refused = false): Error {
   error[PLUGIN_WORKER_STARTUP_FAILURE] = true;

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
@@ -177,41 +177,59 @@ export class IsolatedPlugin implements LoadedNxPlugin {
     this.registerProcessMetrics();
 
     this.exitHandler = (code: number | null, signal: NodeJS.Signals | null) => {
-      this._alive = false;
-      this._connectPromise = null;
-      if (this.worker?.stdout) {
-        this.worker.stdout.unpipe(process.stdout);
-      }
-      if (this.worker?.stderr) {
-        this.worker.stderr.unpipe(process.stderr);
-      }
-      // Reject all pending requests
-      const error = new Error(
-        `Plugin worker "${this.name}" exited unexpectedly ${describeWorkerExit(
-          code,
-          signal
-        )}.`
+      this.markUnusable();
+      this.failPendingRequests(
+        new Error(
+          `Plugin worker "${this.name}" exited unexpectedly ${describeWorkerExit(
+            code,
+            signal
+          )}.`
+        )
       );
-      for (const { onError } of this.responseHandlers.values()) {
-        onError(error);
-      }
-      this.responseHandlers.clear();
     };
     worker.on('exit', this.exitHandler);
 
     socket.on(
       'data',
       consumeMessagesFromSocket(this.handleSocketData, (err) => {
-        // Nothing else settles the pending hook promises on a framing
-        // failure, so surface it the same way a dead worker would.
-        // No process died here, so there is no code or signal to report.
-        this.exitHandler?.(null, null);
+        // The worker is still running here; it is the stream that failed, so
+        // reporting this as an exit would send whoever reads it hunting for a
+        // dead process. The framing error names the bytes it choked on, so it
+        // travels with the error rather than only reaching stderr.
+        this.markUnusable();
         socket.destroy();
-        console.error(err.message);
+        this.failPendingRequests(
+          new Error(
+            `Plugin worker "${this.name}" sent a message the host could not read, ` +
+              `so its connection was dropped. ${err.message}`
+          )
+        );
       })
     );
 
     return this.sendLoadMessage();
+  }
+
+  /**
+   * Drops the worker from service without judging why. The next hook call
+   * respawns it through `ensureAlive`.
+   */
+  private markUnusable(): void {
+    this._alive = false;
+    this._connectPromise = null;
+    if (this.worker?.stdout) {
+      this.worker.stdout.unpipe(process.stdout);
+    }
+    if (this.worker?.stderr) {
+      this.worker.stderr.unpipe(process.stderr);
+    }
+  }
+
+  private failPendingRequests(error: Error): void {
+    for (const { onError } of this.responseHandlers.values()) {
+      onError(error);
+    }
+    this.responseHandlers.clear();
   }
 
   /**


### PR DESCRIPTION
Three commits, all improving diagnostics for `Plugin worker "X" exited unexpectedly.`

## Current Behavior

**The message drops the exit code and signal.** `exitHandler` takes no arguments, so the `code` and `signal` that Node's `exit` event hands it go nowhere. Every cause collapses into one string: an out-of-memory kill, the worker's own 10 second load timeout and a parse throw are indistinguishable in the output we ship. We used to print the code, and #34253 dropped it. The pre-connect message kept the code but never had the signal, so a killed worker reads there as `exited with code null`.

**The message is also emitted when no worker has exited.** `exitHandler` has a second caller: the framing-error callback added in #36838. When the host cannot parse a frame off the socket it calls that handler, so a stream failure is reported as a dead worker while the worker may still be running. Anyone reading it goes looking for a process that may not have died. Meanwhile the framing error, which names the bytes the host choked on, only reaches stderr through a bare `console.error`.

## Expected Behavior

A real exit says how it died:

```
Plugin worker "@nx/playwright/plugin" exited unexpectedly (exit code 1).
Plugin worker "@nx/playwright/plugin" exited unexpectedly (killed by SIGKILL, commonly an out-of-memory kill).
Plugin worker for "@nx/playwright/plugin" exited (killed by SIGTERM) before the connection was established.
```

A stream failure says that instead, and brings the framing detail with it:

```
Plugin worker "@nx/playwright/plugin" sent a message the host could not read, so its connection was dropped. Expected a message to begin with 'NX_MSG_' but received "{\"type\":\"createNodesResult\"". The stream is out of sync.
```

The two behaviors the handlers shared are now `markUnusable` and `failPendingRequests`, so each caller supplies its own error rather than borrowing the other's.

`describeWorkerExit` handles an exit code (including 0, which a truthiness check would drop), a signal, SIGKILL's out-of-memory case, and the case where neither is reported.

This changes only diagnostics and error routing. Framing failures with pending requests surface through the request error. Framing failures with no pending request are written to stderr, so the evidence is not dropped.

## Related Issue(s)

NXC-4932, where plugin workers are reported as exiting intermittently in CI and locally during 23.2.0, with nothing in the output to say why. This does not fix that. It makes the next occurrence diagnosable, and it separates the two failures that currently print the same sentence, which is the blocker on picking between the candidate causes.

Also unblocks NXC-3211.
