### PR TITLE
cleanup(core): initialize the native logger once at module load

### DIFF
--- a/packages/nx/src/native/cache/expand_outputs.rs
+++ b/packages/nx/src/native/cache/expand_outputs.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, trace};
 
 use crate::native::glob::{build_glob_set, contains_glob_pattern, glob_transform::partition_glob};
-use crate::native::logger::enable_logger;
 use crate::native::utils::Normalize;
 use crate::native::walker::{nx_walker, nx_walker_sync};
 
@@ -250,7 +249,6 @@ pub fn get_files_for_outputs_batch(
     directory: String,
     entries_batch: Vec<Vec<String>>,
 ) -> anyhow::Result<Vec<Vec<String>>> {
-    enable_logger();
     let directory = Path::new(&directory);
     entries_batch
         .into_par_iter()
@@ -566,8 +564,6 @@ mod test {
         use crate::native::cache::file_ops::_copy;
         use std::os::unix::fs::symlink;
 
-        enable_logger();
-
         let workspace = TempDir::new().unwrap();
         let cache = TempDir::new().unwrap();
 
@@ -715,8 +711,6 @@ mod test {
                 .map(|n| n.get())
                 .unwrap_or(1)
         }
-
-        enable_logger();
 
         let initial_count = get_thread_count();
 

--- a/packages/nx/src/native/db/mod.rs
+++ b/packages/nx/src/native/db/mod.rs
@@ -1,7 +1,6 @@
 pub mod connection;
 pub(crate) mod initialize;
 
-use crate::native::logger::enable_logger;
 use crate::native::machine_id::get_machine_id;
 use crate::native::{db::connection::NxDbConnection, hasher::hash};
 use napi::bindgen_prelude::External;
@@ -16,7 +15,6 @@ pub fn connect_to_nx_db(
     cache_dir: String,
     db_name: Option<String>,
 ) -> anyhow::Result<External<Arc<Mutex<NxDbConnection>>>> {
-    enable_logger();
     let cache_dir_buf = PathBuf::from(cache_dir);
     let mut db_file_name = db_name.unwrap_or_else(get_machine_id);
 

--- a/packages/nx/src/native/ide/install.rs
+++ b/packages/nx/src/native/ide/install.rs
@@ -1,5 +1,4 @@
 use crate::native::ide::detection::{SupportedEditor, get_current_editor};
-use crate::native::logger::enable_logger;
 use crate::native::utils::command::create_command;
 use napi::Error;
 use tracing::{debug, trace};
@@ -127,8 +126,6 @@ fn install_extension(command: &str) -> Result<bool, Error> {
 
 #[napi]
 pub async fn can_install_nx_console() -> bool {
-    enable_logger();
-
     let current_editor = get_current_editor();
     debug!("Detected editor: {:?}", current_editor);
 
@@ -137,8 +134,6 @@ pub async fn can_install_nx_console() -> bool {
 
 #[napi]
 pub async fn can_install_nx_console_for_editor(editor: SupportedEditor) -> bool {
-    enable_logger();
-
     if let Some(command) = get_command_for_editor(&editor) {
         if let Ok(installed) = is_nx_console_installed(&command) {
             !installed // Can install if NOT installed
@@ -152,8 +147,6 @@ pub async fn can_install_nx_console_for_editor(editor: SupportedEditor) -> bool 
 
 #[napi]
 pub async fn install_nx_console() -> bool {
-    enable_logger();
-
     let current_editor = get_current_editor();
     debug!("Detected editor: {:?}", current_editor);
 
@@ -162,8 +155,6 @@ pub async fn install_nx_console() -> bool {
 
 #[napi]
 pub async fn install_nx_console_for_editor(editor: SupportedEditor) -> bool {
-    enable_logger();
-
     if let Some(command) = get_command_for_editor(&editor) {
         debug!("Attempting to install Nx Console for {:?}", editor);
         match install_extension(command) {
@@ -257,8 +248,6 @@ fn get_command_for_editor(editor: &SupportedEditor) -> Option<&'static str> {
 
 #[napi]
 pub async fn is_editor_installed(editor: SupportedEditor) -> bool {
-    enable_logger();
-
     if let Some(command) = get_command_for_editor(&editor) {
         // Just check if the command exists and is executable
         match create_command(command).arg("--version").output() {

--- a/packages/nx/src/native/logger/console.rs
+++ b/packages/nx/src/native/logger/console.rs
@@ -1,8 +1,6 @@
-use crate::native::logger::enable_logger;
 use tracing::debug;
 
 #[napi]
 pub fn log_debug(message: String) {
-    enable_logger();
     debug!(message);
 }

--- a/packages/nx/src/native/logger/mod.rs
+++ b/packages/nx/src/native/logger/mod.rs
@@ -103,14 +103,10 @@ where
 /// - `NX_NATIVE_LOGGING=[{project_name=project}]` - enable logs that contain the project in its span
 /// NX_NATIVE_FILE_LOGGING acts the same but logs to .nx/workspace-data/nx.log instead of stdout
 ///
-/// This function is idempotent - calling it multiple times is safe and won't create additional threads.
-pub(crate) fn enable_logger() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-
-    INIT.call_once(|| {
-        initialize_logger();
-    });
+/// Runs once when the native module is loaded, so nothing else has to call it.
+#[module_init]
+fn enable_logger() {
+    initialize_logger();
 }
 
 fn initialize_logger() {

--- a/packages/nx/src/native/plugins/js/ts_import_locators.rs
+++ b/packages/nx/src/native/plugins/js/ts_import_locators.rs
@@ -20,8 +20,6 @@ use swc_ecma_parser::token::Word::{Ident, Keyword};
 use swc_ecma_parser::token::{BinOpToken, Token, TokenAndSpan};
 use swc_ecma_parser::{StringInput, Syntax, Tokens, TsConfig};
 
-use crate::native::logger::enable_logger;
-
 #[napi]
 #[derive(Debug)]
 pub struct ImportResult {
@@ -757,8 +755,6 @@ fn process_file(
 fn find_imports(
     project_file_map: HashMap<String, Vec<String>>,
 ) -> anyhow::Result<Vec<ImportResult>> {
-    enable_logger();
-
     let files_to_process: Vec<(&String, &String)> = project_file_map
         .iter()
         .flat_map(|(project_name, files)| files.iter().map(move |file| (project_name, file)))

--- a/packages/nx/src/native/pseudo_terminal/mac.rs
+++ b/packages/nx/src/native/pseudo_terminal/mac.rs
@@ -4,7 +4,6 @@ use tracing::trace;
 use super::child_process::ChildProcess;
 use super::os;
 use super::pseudo_terminal::{PseudoTerminal, PseudoTerminalOptions};
-use crate::native::logger::enable_logger;
 
 #[napi]
 pub struct RustPseudoTerminal {
@@ -15,8 +14,6 @@ pub struct RustPseudoTerminal {
 impl RustPseudoTerminal {
     #[napi(constructor)]
     pub fn new() -> napi::Result<Self> {
-        enable_logger();
-
         let pseudo_terminal = PseudoTerminal::new(PseudoTerminalOptions::default())?;
 
         Ok(Self { pseudo_terminal })

--- a/packages/nx/src/native/pseudo_terminal/non_mac.rs
+++ b/packages/nx/src/native/pseudo_terminal/non_mac.rs
@@ -5,7 +5,6 @@ use tracing::trace;
 use super::child_process::ChildProcess;
 use super::os;
 use super::pseudo_terminal::{PseudoTerminal, PseudoTerminalOptions};
-use crate::native::logger::enable_logger;
 
 #[napi]
 pub struct RustPseudoTerminal {
@@ -16,8 +15,6 @@ pub struct RustPseudoTerminal {
 impl RustPseudoTerminal {
     #[napi(constructor)]
     pub fn new() -> napi::Result<Self> {
-        enable_logger();
-
         let pseudo_terminal = PseudoTerminal::new(PseudoTerminalOptions::default())?;
 
         Ok(Self { pseudo_terminal })

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -1,4 +1,3 @@
-use crate::native::logger::enable_logger;
 use crate::native::tasks::{
     dep_outputs::get_dep_output,
     types::{CwdMode, HashInstruction, HashPlans, InstructionPool, JsonFileSetInput, TaskGraph},
@@ -96,7 +95,6 @@ impl HashPlanner {
             Arc<ProjectGraph>,
         >,
     ) -> Self {
-        enable_logger();
         Self {
             nx_json,
             project_graph: Arc::clone(project_graph),

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -13,7 +13,6 @@ use napi::{Status, bindgen_prelude::Unknown};
 #[cfg(not(test))]
 use crate::native::ide::nx_console::messaging::NxConsoleMessageConnection;
 #[cfg(not(test))]
-use crate::native::logger::enable_logger;
 use crate::native::pseudo_terminal::pseudo_terminal::{MasterArc, ParserArc, WriterArc};
 use crate::native::tasks::types::{Task, TaskGraph, TaskResult};
 
@@ -463,8 +462,6 @@ impl AppLifeCycle {
         done_callback: ThreadsafeFunction<(), Unknown<'static>, (), Status, false>,
     ) -> napi::Result<()> {
         debug!("AppLifeCycle::__init called");
-
-        enable_logger();
 
         // Always start in FullScreen mode
         let initial_mode = TuiMode::FullScreen;

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -12,7 +12,6 @@ use napi::{Status, bindgen_prelude::Unknown};
 
 #[cfg(not(test))]
 use crate::native::ide::nx_console::messaging::NxConsoleMessageConnection;
-#[cfg(not(test))]
 use crate::native::pseudo_terminal::pseudo_terminal::{MasterArc, ParserArc, WriterArc};
 use crate::native::tasks::types::{Task, TaskGraph, TaskResult};
 

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use crate::native::glob::build_glob_set;
 
 #[cfg(not(target_arch = "wasm32"))]
-use crate::native::logger::enable_logger;
 use crate::native::utils::{Normalize, get_mod_time, git::parent_gitignore_files};
 use walkdir::WalkDir;
 
@@ -109,7 +108,6 @@ where
 
     use crossbeam_channel::unbounded;
     use tracing::trace;
-    enable_logger();
 
     let directory = directory.as_ref();
     let mut walker = create_walker(directory, use_ignores);

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -496,8 +496,6 @@ impl Watcher {
     }
 
     pub(crate) fn watch_inner(&mut self, callback: WatchEventCallback) -> Result<()> {
-        crate::native::logger::enable_logger();
-
         let pipeline =
             WatchPipeline::new(self.origin.clone(), &self.additional_globs, self.use_ignore)
                 .map_err(|msg| Error::new(Status::GenericFailure, msg))?;

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use crate::native::glob::glob_files::glob_files;
 use crate::native::hasher::hash;
-use crate::native::logger::enable_logger;
 use crate::native::project_graph::utils::{ProjectRootMappings, find_project_for_path};
 use crate::native::types::FileData;
 use crate::native::utils::{Normalize, NxCondvar, NxMutex, path::get_child_files};
@@ -212,8 +211,6 @@ impl FilesWorker {
 impl WorkspaceContext {
     #[napi(constructor)]
     pub fn new(workspace_root: String, cache_dir: String) -> Self {
-        enable_logger();
-
         trace!(?workspace_root);
 
         let workspace_root_path = PathBuf::from(&workspace_root);


### PR DESCRIPTION
## Current Behavior

Every napi entry point in the native module has to call `enable_logger()` by hand before it can log anything. There are 20 such calls spread across 12 files, plus their imports. It is easy to forget on a new function, and the failure is silent — the function just logs nothing.

`enable_logger()` itself guards with a `std::sync::Once`, so all but the first call are wasted work.

## Expected Behavior

The native logger initializes itself once, when the module is loaded into a process:

```rust
#[module_init]
fn enable_logger() {
    initialize_logger();
}
```

`#[module_init]` (napi-derive 3.5) expands to a `#[ctor]`, so this runs on `.node` load. All 20 hand-written call sites and their imports are removed, and the `Once` guard goes with them — a ctor is inherently one-shot.

This is also strictly broader coverage than the status quo: every process that loads the native module gets a logger, including the daemon, plugin workers and forked task runners, rather than only the functions someone remembered to annotate.

The one behavioral difference: logger setup now happens at module load rather than on the first native call. When `NX_NATIVE_FILE_LOGGING` is set, that means `.nx/workspace-data` is created slightly earlier in the process lifetime. `NX_NATIVE_LOGGING` / `NX_NATIVE_FILE_LOGGING` semantics are otherwise unchanged.

### Verification

- `cargo check -p nx` is clean (the three `ts_import_locators` warnings predate this branch).
- `nx build-native nx --configuration local` succeeds.
- With no init call anywhere in TS or Rust:
  ```
  NX_NATIVE_LOGGING=nx::native=trace node -e "require('./packages/nx/src/native/native-bindings.js').logDebug('x')"
  → DEBUG nx::native::logger::console: x
  ```
- wasm: `ctor` supports `target_family = "wasm"` via `.init_array`, and it compiles for `wasm32-wasip1-threads`.

## Related Issue(s)

N/A — internal cleanup.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Initialize-the-native-logger-once-at-module-load-e4534764">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->