### PR TITLE
fix(core): carry minimumReleaseAge into pruned pnpm deploy output

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pruned-output.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pruned-output.spec.ts
@@ -138,6 +138,27 @@ describe('getPrunedPnpmInstallSettingsYaml', () => {
     expect(yaml).not.toContain('packages/*');
   });
 
+  it('carries minimumReleaseAge and minimumReleaseAgeExclude on pnpm 11', () => {
+    mockPnpmVersion('11.2.2');
+    writeRootWorkspaceYaml(
+      [
+        'minimumReleaseAge: 0',
+        'minimumReleaseAgeExclude:',
+        '  - esbuild',
+        '',
+      ].join('\n')
+    );
+
+    const yaml = getPrunedPnpmInstallSettingsYaml(tempDir);
+
+    const { load } = require('@zkochan/js-yaml');
+    expect(load(yaml)).toEqual({
+      packages: [],
+      minimumReleaseAge: 0,
+      minimumReleaseAgeExclude: ['esbuild'],
+    });
+  });
+
   it('carries no settings on pnpm 10 (those are read from package.json)', () => {
     mockPnpmVersion('10.5.0');
     writeRootWorkspaceYaml('allowBuilds:\n  esbuild: true\n');

--- a/packages/nx/src/plugins/js/lock-file/pruned-output.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pruned-output.spec.ts
@@ -159,6 +159,28 @@ describe('getPrunedPnpmInstallSettingsYaml', () => {
     });
   });
 
+  // pnpm 11.0.4+ turns on strict mode for an explicit minimumReleaseAge
+  // unless minimumReleaseAgeStrict: false is also declared, so dropping a
+  // declared `false` here would make the pruned output's install stricter
+  // than the source workspace's.
+  it('carries minimumReleaseAgeStrict alongside minimumReleaseAge on pnpm 11', () => {
+    mockPnpmVersion('11.2.2');
+    writeRootWorkspaceYaml(
+      ['minimumReleaseAge: 1440', 'minimumReleaseAgeStrict: false', ''].join(
+        '\n'
+      )
+    );
+
+    const yaml = getPrunedPnpmInstallSettingsYaml(tempDir);
+
+    const { load } = require('@zkochan/js-yaml');
+    expect(load(yaml)).toEqual({
+      packages: [],
+      minimumReleaseAge: 1440,
+      minimumReleaseAgeStrict: false,
+    });
+  });
+
   it('carries no settings on pnpm 10 (those are read from package.json)', () => {
     mockPnpmVersion('10.5.0');
     writeRootWorkspaceYaml('allowBuilds:\n  esbuild: true\n');

--- a/packages/nx/src/plugins/js/lock-file/pruned-output.ts
+++ b/packages/nx/src/plugins/js/lock-file/pruned-output.ts
@@ -124,16 +124,16 @@ type PrunedPnpmConfig = {
  * file is inert, verified installable with identical module resolution on
  * pnpm 9, 10 and 11.
  *
- * pnpm 11+ reads build approvals (`allowBuilds`), `supportedArchitectures`,
- * `minimumReleaseAge`/`minimumReleaseAgeExclude` and `patchedDependencies` only
- * from pnpm-workspace.yaml, so those are carried from the workspace root; pass
- * `prunedLockfileContent` to scope the approvals to the packages the pruned
- * lockfile keeps (an approval for an absent package is inert either way, this
- * only keeps the emitted file accurate). On
- * pnpm <=10, which reads them from the emitted package.json instead (see
- * `getPrunedPnpmPackageJsonBuildSettings`), or when the workspace declares
- * none, the file holds only `packages: []`. Resolution-time config stays out:
- * the pruned lockfile bakes it in (`stripPrunedLockfilePnpmConfig`).
+ * On pnpm 11+, this file carries declared `minimumReleaseAge`,
+ * `minimumReleaseAgeExclude`, `minimumReleaseAgeStrict`, build approvals,
+ * `supportedArchitectures`, and applicable `patchedDependencies` from the
+ * workspace root. Approvals and patches are scoped to the pruned lockfile.
+ *
+ * On pnpm <=10, only build approvals, `supportedArchitectures`, and
+ * `patchedDependencies` are emitted in `package.json`.
+ *
+ * Settings encoded in the pruned resolution, such as `overrides` and
+ * `packageExtensions`, are not copied (`stripPrunedLockfilePnpmConfig`).
  *
  * The major is the build machine's pnpm, which is all that is knowable at
  * build time: an output built on pnpm <=10 but deployed on pnpm 11+ will not
@@ -157,6 +157,41 @@ export function getPrunedPnpmInstallSettingsYaml(
   return dump({ packages: [], ...settings });
 }
 
+type PnpmRootWorkspaceSettings = {
+  allowBuilds?: Record<string, boolean>;
+  supportedArchitectures?: unknown;
+  minimumReleaseAge?: number;
+  minimumReleaseAgeExclude?: string[];
+  minimumReleaseAgeStrict?: boolean;
+};
+
+/**
+ * pnpm-workspace.yaml fields carried verbatim from the workspace root to the
+ * pruned output, with no interpretation beyond "declared or not" (unlike
+ * `allowBuilds`, filtered to the pruned lockfile, and `patchedDependencies`,
+ * resolved against it):
+ * - `supportedArchitectures`.
+ * - `minimumReleaseAge`/`minimumReleaseAgeExclude`: silently dropping these
+ *   falls back to pnpm's own default cutoff instead of the workspace's,
+ *   which can reject lockfile entries the workspace itself allows (or vice
+ *   versa).
+ * - `minimumReleaseAgeStrict`: starting with pnpm 11.0.0, a declared
+ *   `minimumReleaseAge` enables strict mode unless `minimumReleaseAgeStrict:
+ *   false` is also declared. Dropping an explicit `false` here would
+ *   silently re-enable strict mode in the pruned output and make its
+ *   install reject an immature exact dependency the source workspace
+ *   accepted.
+ */
+const STRAIGHT_COPY_WORKSPACE_SETTINGS: readonly Exclude<
+  keyof PnpmRootWorkspaceSettings,
+  'allowBuilds'
+>[] = [
+  'supportedArchitectures',
+  'minimumReleaseAge',
+  'minimumReleaseAgeExclude',
+  'minimumReleaseAgeStrict',
+];
+
 /**
  * The settings `getPrunedPnpmInstallSettingsYaml` emits, before serialization,
  * so a caller can tell which of them the workspace actually declares. Null when
@@ -175,12 +210,7 @@ function getPrunedPnpmWorkspaceSettings(
   if (pnpmMajor === null || pnpmMajor < 11) {
     return null;
   }
-  let rootSettings: {
-    allowBuilds?: Record<string, boolean>;
-    supportedArchitectures?: unknown;
-    minimumReleaseAge?: number;
-    minimumReleaseAgeExclude?: string[];
-  };
+  let rootSettings: PnpmRootWorkspaceSettings;
   try {
     const rootWorkspaceYaml = join(workspaceRootPath, 'pnpm-workspace.yaml');
     if (!existsSync(rootWorkspaceYaml)) {
@@ -208,19 +238,8 @@ function getPrunedPnpmWorkspaceSettings(
       settings.allowBuilds = allowBuilds;
     }
   }
-  if (rootSettings.supportedArchitectures) {
-    settings.supportedArchitectures = rootSettings.supportedArchitectures;
-  }
-  // pnpm reads `minimumReleaseAge`/`minimumReleaseAgeExclude` only from
-  // pnpm-workspace.yaml (like `allowBuilds`/`supportedArchitectures` above), so
-  // a pruned output that drops them silently falls back to pnpm's own default
-  // cutoff instead of the workspace's, which can reject lockfile entries the
-  // workspace itself allows (or vice versa).
-  if (rootSettings.minimumReleaseAge !== undefined) {
-    settings.minimumReleaseAge = rootSettings.minimumReleaseAge;
-  }
-  if (rootSettings.minimumReleaseAgeExclude) {
-    settings.minimumReleaseAgeExclude = rootSettings.minimumReleaseAgeExclude;
+  for (const field of STRAIGHT_COPY_WORKSPACE_SETTINGS) {
+    assignDefined(settings, rootSettings, field);
   }
   const patchedDependencies =
     precomputed?.patchedDependencies ??

--- a/packages/nx/src/plugins/js/lock-file/pruned-output.ts
+++ b/packages/nx/src/plugins/js/lock-file/pruned-output.ts
@@ -124,11 +124,12 @@ type PrunedPnpmConfig = {
  * file is inert, verified installable with identical module resolution on
  * pnpm 9, 10 and 11.
  *
- * pnpm 11+ reads build approvals (`allowBuilds`), `supportedArchitectures` and
- * `patchedDependencies` only from pnpm-workspace.yaml, so those are carried
- * from the workspace root; pass `prunedLockfileContent` to scope the approvals
- * to the packages the pruned lockfile keeps (an approval for an absent package
- * is inert either way, this only keeps the emitted file accurate). On
+ * pnpm 11+ reads build approvals (`allowBuilds`), `supportedArchitectures`,
+ * `minimumReleaseAge`/`minimumReleaseAgeExclude` and `patchedDependencies` only
+ * from pnpm-workspace.yaml, so those are carried from the workspace root; pass
+ * `prunedLockfileContent` to scope the approvals to the packages the pruned
+ * lockfile keeps (an approval for an absent package is inert either way, this
+ * only keeps the emitted file accurate). On
  * pnpm <=10, which reads them from the emitted package.json instead (see
  * `getPrunedPnpmPackageJsonBuildSettings`), or when the workspace declares
  * none, the file holds only `packages: []`. Resolution-time config stays out:
@@ -177,6 +178,8 @@ function getPrunedPnpmWorkspaceSettings(
   let rootSettings: {
     allowBuilds?: Record<string, boolean>;
     supportedArchitectures?: unknown;
+    minimumReleaseAge?: number;
+    minimumReleaseAgeExclude?: string[];
   };
   try {
     const rootWorkspaceYaml = join(workspaceRootPath, 'pnpm-workspace.yaml');
@@ -189,7 +192,7 @@ function getPrunedPnpmWorkspaceSettings(
   } catch {
     // Unreadable or malformed pnpm-workspace.yaml: skip rather than guess.
     logger.warn(
-      'Could not read the workspace root pnpm-workspace.yaml; the pruned output will not declare pnpm install settings (build-script approvals, supportedArchitectures, patchedDependencies).'
+      'Could not read the workspace root pnpm-workspace.yaml; the pruned output will not declare pnpm install settings (build-script approvals, supportedArchitectures, minimumReleaseAge, patchedDependencies).'
     );
     return null;
   }
@@ -207,6 +210,17 @@ function getPrunedPnpmWorkspaceSettings(
   }
   if (rootSettings.supportedArchitectures) {
     settings.supportedArchitectures = rootSettings.supportedArchitectures;
+  }
+  // pnpm reads `minimumReleaseAge`/`minimumReleaseAgeExclude` only from
+  // pnpm-workspace.yaml (like `allowBuilds`/`supportedArchitectures` above), so
+  // a pruned output that drops them silently falls back to pnpm's own default
+  // cutoff instead of the workspace's, which can reject lockfile entries the
+  // workspace itself allows (or vice versa).
+  if (rootSettings.minimumReleaseAge !== undefined) {
+    settings.minimumReleaseAge = rootSettings.minimumReleaseAge;
+  }
+  if (rootSettings.minimumReleaseAgeExclude) {
+    settings.minimumReleaseAgeExclude = rootSettings.minimumReleaseAgeExclude;
   }
   const patchedDependencies =
     precomputed?.patchedDependencies ??
@@ -261,7 +275,7 @@ function getPnpmMajorOrWarn(workspaceRootPath: string): number | null {
   const pnpmMajor = getPnpmMajor(workspaceRootPath);
   if (pnpmMajor === null) {
     logger.warn(
-      'Could not determine the pnpm version. The pruned output will not carry pnpm build-script approvals, supportedArchitectures, or patchedDependencies declarations; patch files still ship.'
+      'Could not determine the pnpm version. The pruned output will not carry pnpm build-script approvals, supportedArchitectures, minimumReleaseAge, or patchedDependencies declarations; patch files still ship.'
     );
   }
   return pnpmMajor;


### PR DESCRIPTION



<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
`getPrunedPnpmWorkspaceSettings` carries `allowBuilds`, `supportedArchitectures` and `patchedDependencies` from the workspace root's pnpm-workspace.yaml into the pruned pnpm-workspace.yaml a standalone deploy output ships, since pnpm 11+ reads those settings only from that file. It did not carry `minimumReleaseAge` or `minimumReleaseAgeExclude`, which pnpm 11+ reads the same way. A workspace that disables or tunes the release-age quarantine (e.g. `minimumReleaseAge: 0`) would silently lose that setting in the pruned output, so `pnpm install --frozen-lockfile` against it falls back to pnpm's own default cutoff and can reject lockfile entries the workspace itself allows.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Carry both settings the same way the existing ones are carried: a straight copy from the root settings onto the pruned settings object when present.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #36899
