### PR TITLE
fix(core): start one daemon per workspace start window

### DIFF
--- a/packages/nx/src/daemon/cache.ts
+++ b/packages/nx/src/daemon/cache.ts
@@ -18,22 +18,19 @@ export const serverProcessJsonPath = join(
 );
 
 export function readDaemonProcessJsonCache(): DaemonProcessJson | null {
-  try {
-    const daemonJson = readJsonFile(serverProcessJsonPath);
-    // If the daemon version doesn't match the client version, throw error
-    if (daemonJson.nxVersion !== nxVersion) {
-      clientLogger.log(
-        `[Cache] Version mismatch: daemon=${daemonJson.nxVersion}, client=${nxVersion}`
-      );
-      throw new VersionMismatchError();
-    }
-    return daemonJson;
-  } catch (e) {
-    if (e instanceof VersionMismatchError) {
-      throw e; // Let version mismatch bubble up
-    }
+  const daemonJson = readDaemonRegistrationSync();
+  if (!daemonJson) {
     return null;
   }
+  // A daemon on another version cannot serve this client, and the caller has to
+  // hear about it rather than read it as "no daemon registered".
+  if (daemonJson.nxVersion !== nxVersion) {
+    clientLogger.log(
+      `[Cache] Version mismatch: daemon=${daemonJson.nxVersion}, client=${nxVersion}`
+    );
+    throw new VersionMismatchError();
+  }
+  return daemonJson;
 }
 
 export function deleteDaemonJsonProcessCache(): void {
@@ -52,15 +49,25 @@ export async function writeDaemonJsonProcessCache(
   });
 }
 
-// Must be sync for the help output use case
-export function getDaemonProcessIdSync(): number | null {
+/**
+ * The registration exactly as written, with no version check and no throw.
+ *
+ * readDaemonProcessJsonCache() cannot serve a caller that only wants to know
+ * who is registered: it raises VersionMismatchError, and the daemon start path
+ * deciding whether to stand down must not take a throw.
+ */
+export function readDaemonRegistrationSync(): DaemonProcessJson | null {
   if (!existsSync(serverProcessJsonPath)) {
     return null;
   }
   try {
-    const daemonProcessJson = readJsonFile(serverProcessJsonPath);
-    return daemonProcessJson.processId;
+    return readJsonFile(serverProcessJsonPath);
   } catch {
     return null;
   }
+}
+
+// Must be sync for the help output use case
+export function getDaemonProcessIdSync(): number | null {
+  return readDaemonRegistrationSync()?.processId ?? null;
 }

--- a/packages/nx/src/daemon/client/client.spec.ts
+++ b/packages/nx/src/daemon/client/client.spec.ts
@@ -58,7 +58,7 @@ vi.mock('../cache', async () => ({
 
 import { waitForSocketConnection } from '../../utils/wait-for-socket-connection';
 import { clientLogger } from '../logger';
-import { readDaemonProcessJsonCache } from '../cache';
+import { getDaemonProcessIdSync, readDaemonProcessJsonCache } from '../cache';
 import { DAEMON_OUTPUT_LOG_FILE as logFile } from '../tmp-dir';
 import { SOCKET_REFUSED_EXIT_CODE } from '../../utils/socket-refused-exit-code';
 import {
@@ -455,5 +455,20 @@ describe('startInBackground', () => {
 
     expect((error as any).daemonPermissionError).toBeUndefined();
     expect((error as any).internalDaemonError).toBe(true);
+  });
+
+  // The starter this spawns stands down when a healthy daemon already owns the
+  // workspace, so by the time the socket answers its pid names a process that
+  // has exited. That pid is what gets logged as "Daemon server started", handed
+  // to the metrics service and printed as the ID of `nx daemon --start`. The
+  // registration is written before the daemon listens, so whoever answers is
+  // the pid to report. 4242 is the spawn mock's; 9001 is the registration's.
+  it('should report the registered daemon pid, not the pid of the process it spawned', async () => {
+    (waitForSocketConnection as Mock).mockResolvedValue({
+      destroy: vi.fn(),
+    });
+    (getDaemonProcessIdSync as Mock).mockReturnValue(9001);
+
+    expect(await daemonClient.startInBackground()).toBe(9001);
   });
 });

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1551,10 +1551,15 @@ export class DaemonClient {
     const { available, refusal: polled } =
       await this.waitForServerToBeAvailable({ ignoreVersionMismatch: true });
     if (available) {
-      clientLogger.log(
-        `[Client] Daemon server started, pid=${backgroundProcess.pid}`
-      );
-      return backgroundProcess.pid;
+      // The process spawned above is not necessarily the daemon. It stands down
+      // when it finds a healthy owner already serving this workspace, and its
+      // pid is then a process that has exited - which would be what this logs,
+      // hands to the metrics service and prints as the ID of `nx daemon
+      // --start`. Whoever answers the socket is the one in the registration,
+      // written before the daemon listens.
+      const daemonPid = getDaemonProcessIdSync() ?? backgroundProcess.pid;
+      clientLogger.log(`[Client] Daemon server started, pid=${daemonPid}`);
+      return daemonPid;
     } else {
       // A permission refusal from either source wins, then the poll's errno,
       // then the probe's. Recency alone would report a daemon's ENOENT over the

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -17,6 +17,11 @@ import { nxVersion } from '../../utils/versions';
 import { setupWorkspaceContext } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { getDaemonProcessIdSync, writeDaemonJsonProcessCache } from '../cache';
+import {
+  acquireDaemonStartLock,
+  findHealthyDaemonOwner,
+  releaseDaemonStartLock,
+} from './start-lock';
 import { isNxVersionMismatch } from '../is-nx-version-mismatch';
 import { getInstalledNxVersion } from '../../utils/installed-nx-version';
 import { serverLogger } from '../logger';
@@ -672,21 +677,28 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
 };
 
 export async function startServer(): Promise<Server> {
-  // Watch before scan: a file written during boot must be visible to the
-  // watcher or the scan below. Scan-first left a blind window where such
-  // files stayed invisible to both until an unrelated change arrived.
-  if (!getWatcherInstance()) {
-    storeWatcherInstance(await watchWorkspace(server, handleWorkspaceChanges));
-    serverLogger.watcherLog(
-      `Subscribed to changes within: ${workspaceRoot} (native)`
+  // Claim the workspace before doing anything expensive. A starter that loses
+  // the race exits, and everything it set up first - the watcher below, the
+  // workspace context, the project graph - is work thrown away. The claim is
+  // held until this process is listening, not just until it has registered:
+  // the gap between the two contains the whole workspace scan, and a starter
+  // arriving inside it must wait rather than read a silent socket as a vacant
+  // workspace. See start-lock.ts.
+  const startLock = await acquireDaemonStartLock();
+  const ownerPid = await findHealthyDaemonOwner(startLock);
+  if (ownerPid !== null) {
+    // process.exit skips finally blocks, so the lock is released explicitly.
+    releaseDaemonStartLock(startLock);
+    serverLogger.log(
+      `Another daemon already owns this workspace (pid ${ownerPid}); standing down`
     );
+    process.exit(0);
   }
 
-  setupWorkspaceContext(workspaceRoot);
-
-  // Initialize analytics for daemon process
-  await startAnalytics();
-
+  // Resolved after the stand-down rather than before it: the socket directory
+  // name hashes this pid, so asking for the path creates a directory that only
+  // this process could ever have used. A starter that stands down should leave
+  // nothing behind.
   const socketPath = getFullOsSocketPath();
 
   // Log daemon startup information for debugging
@@ -703,6 +715,21 @@ export async function startServer(): Promise<Server> {
     socketPath,
     nxVersion,
   });
+
+  // Watch before scan: a file written during boot must be visible to the
+  // watcher or the scan below. Scan-first left a blind window where such
+  // files stayed invisible to both until an unrelated change arrived.
+  if (!getWatcherInstance()) {
+    storeWatcherInstance(await watchWorkspace(server, handleWorkspaceChanges));
+    serverLogger.watcherLog(
+      `Subscribed to changes within: ${workspaceRoot} (native)`
+    );
+  }
+
+  setupWorkspaceContext(workspaceRoot);
+
+  // Initialize analytics for daemon process
+  await startAnalytics();
 
   // See notes in socket-command-line-utils.ts on OS differences regarding clean up of existings connections.
   if (!isWindows) {
@@ -750,6 +777,7 @@ export async function startServer(): Promise<Server> {
     // The exit code is what carries the errno to the client, which otherwise
     // sees only a missing socket and cannot tell a refusal from a cold start.
     server.on('error', (error: NodeJS.ErrnoException) => {
+      releaseDaemonStartLock(startLock);
       serverLogger.log(`Failed to listen on: ${socketPath} (${error.message})`);
       process.exit(isPermissionDenied(error) ? SOCKET_REFUSED_EXIT_CODE : 1);
     });
@@ -758,6 +786,10 @@ export async function startServer(): Promise<Server> {
       server.listen(socketPath, async () => {
         try {
           serverLogger.log(`Started listening on: ${socketPath}`);
+
+          // Only now is the claim redundant: a starter that takes the lock
+          // after this point probes a socket that answers.
+          releaseDaemonStartLock(startLock);
 
           // Linux gates connect() on write permission to the socket file; macOS/BSD gate
           // on the directory, which is already 0700. Done after listen because

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -11,6 +11,7 @@ import {
 import { cleanupPlugins } from '../../project-graph/plugins/get-plugins';
 import { writeMessage } from '../../utils/consume-messages-from-socket';
 import { cleanupLatestNx } from './latest-nx';
+import { releaseDaemonStartLock } from './start-lock';
 import { flushAnalytics } from '../../analytics';
 import { spawn } from 'child_process';
 import { join } from 'path';
@@ -151,6 +152,14 @@ async function performShutdown(
 
     serverLogger.log(`Server stopped because: "${reason}"`);
   } finally {
+    // In the finally rather than beside deleteDaemonJsonProcessCache(): every
+    // await above can reject, and a rejection lands here and exits. The lock
+    // file outlives the process and is judged by the liveness of the pid in it,
+    // so one left behind by a daemon that stopped mid-boot goes stale the
+    // moment that pid is reused - after a reboot, certainly. Releasing it is
+    // safe from any process: releaseDaemonStartLock removes the file only when
+    // it names this pid.
+    releaseDaemonStartLock(true);
     process.exit(0);
   }
 }

--- a/packages/nx/src/daemon/server/start-lock.spec.ts
+++ b/packages/nx/src/daemon/server/start-lock.spec.ts
@@ -1,0 +1,360 @@
+import { spawnSync } from 'child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'fs';
+import { createServer, Server } from 'net';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const h = vi.hoisted(() => {
+  const { mkdtempSync } = require('fs');
+  const { tmpdir } = require('os');
+  const { join } = require('path');
+  return {
+    daemonDir: mkdtempSync(join(tmpdir(), 'nx-start-lock-daemon-dir-')),
+    registration: {
+      value: null as {
+        processId?: number;
+        socketPath?: string;
+        nxVersion?: string;
+      } | null,
+    },
+  };
+});
+
+vi.mock('../cache', () => ({
+  readDaemonRegistrationSync: () => h.registration.value,
+}));
+vi.mock('../tmp-dir', () => ({
+  DAEMON_DIR_FOR_CURRENT_WORKSPACE: h.daemonDir,
+}));
+
+import {
+  acquireDaemonStartLock,
+  daemonSocketAccepts,
+  findHealthyDaemonOwner,
+  isProcessAlive,
+  releaseDaemonStartLock,
+} from './start-lock';
+import { nxVersion } from '../../utils/versions';
+
+/**
+ * A pid that is genuinely gone, rather than one assumed to be free: spawn a
+ * process that does nothing and wait for it to exit.
+ */
+function deadPid(): number {
+  const { pid } = spawnSync(process.execPath, ['-e', '']);
+  return pid;
+}
+
+function age(path: string, msAgo: number): void {
+  const when = new Date(Date.now() - msAgo);
+  utimesSync(path, when, when);
+}
+
+describe('daemon start lock', () => {
+  let dir: string;
+  let lockFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'nx-start-lock-'));
+    lockFile = join(dir, 'daemon-start.lock');
+    h.registration.value = null;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates the lock and writes the holder pid', async () => {
+    expect(await acquireDaemonStartLock(lockFile)).toBe(true);
+    expect(readFileSync(lockFile, 'utf8')).toEqual(String(process.pid));
+  });
+
+  // Both tests below arrange their failure by taking write permission off a
+  // directory. Windows does not honour the mode bits that way, and root ignores
+  // them outright, so on either the arrangement quietly succeeds instead.
+  const asUser = it.skipIf(
+    process.platform === 'win32' || process.getuid?.() === 0
+  );
+
+  asUser(
+    'gives up at once when the lock cannot be created at all',
+    async () => {
+      // EEXIST is the only error waiting can resolve. Anything else - here a
+      // directory this process may not write - must come back as a refusal
+      // rather than a throw, and must not spend the deadline first.
+      chmodSync(dir, 0o500);
+      try {
+        const startedAt = Date.now();
+        expect(await acquireDaemonStartLock(lockFile, 5_000)).toBe(false);
+        expect(Date.now() - startedAt).toBeLessThan(1_000);
+        expect(existsSync(lockFile)).toBe(false);
+      } finally {
+        chmodSync(dir, 0o700);
+      }
+    }
+  );
+
+  asUser(
+    'gives up at the deadline when an abandoned lock cannot be removed, without spinning',
+    async () => {
+      // A takeover that keeps failing is the one path through the loop with no
+      // held lock to wait on, so nothing yields except the loop's own sleep.
+      // Wall time cannot see whether it does: the deadline bounds it either
+      // way. CPU can - a sleeping loop spends single-digit milliseconds of it
+      // over this budget, a spinning one spends the budget.
+      writeFileSync(lockFile, '');
+      age(lockFile, 10 * 60_000);
+      chmodSync(dir, 0o500);
+      try {
+        const startedAt = Date.now();
+        const cpuBefore = process.cpuUsage();
+        expect(await acquireDaemonStartLock(lockFile, 200, 60_000)).toBe(false);
+        const cpu = process.cpuUsage(cpuBefore);
+        expect(Date.now() - startedAt).toBeLessThan(3_000);
+        expect((cpu.user + cpu.system) / 1_000).toBeLessThan(100);
+      } finally {
+        chmodSync(dir, 0o700);
+      }
+    }
+  );
+
+  it('refuses to take a lock held by a live process, and gives up at the deadline', async () => {
+    writeFileSync(lockFile, String(process.pid));
+
+    const startedAt = Date.now();
+    expect(await acquireDaemonStartLock(lockFile, 200)).toBe(false);
+    // It waited rather than failing on the first EEXIST.
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(100);
+    // And left the holder's lock alone.
+    expect(existsSync(lockFile)).toBe(true);
+  });
+
+  it('does not take an old lock away from a live holder', async () => {
+    // The lock now spans a whole boot, so age alone must not evict a holder
+    // that is simply slow: a large workspace legitimately takes minutes.
+    writeFileSync(lockFile, String(process.pid));
+    age(lockFile, 10 * 60_000);
+
+    expect(await acquireDaemonStartLock(lockFile, 200, 60_000)).toBe(false);
+    expect(readFileSync(lockFile, 'utf8')).toEqual(String(process.pid));
+  });
+
+  it('takes over a lock a live holder has held far past any real boot', async () => {
+    // Liveness cannot separate the original holder from a process that
+    // inherited its pid, and the lock file lives long enough for that to
+    // happen: it survives a reboot, after which pids restart from 1. Without
+    // an upper bound such a file is never removed, and every later start pays
+    // the full acquire budget before booting unserialised.
+    writeFileSync(lockFile, String(process.ppid));
+    age(lockFile, 40 * 60_000);
+
+    expect(await acquireDaemonStartLock(lockFile, 200, 60_000)).toBe(true);
+    expect(readFileSync(lockFile, 'utf8')).toEqual(String(process.pid));
+  });
+
+  it('takes over a lock whose holder is gone', async () => {
+    writeFileSync(lockFile, String(deadPid()));
+
+    expect(await acquireDaemonStartLock(lockFile, 200)).toBe(true);
+    expect(readFileSync(lockFile, 'utf8')).toEqual(String(process.pid));
+  });
+
+  it('takes over an old lock whose holder cannot be identified', async () => {
+    // openSync publishes the file before writeSync fills it, so an empty lock
+    // file is a real state; there is no pid to ask about, only age.
+    writeFileSync(lockFile, '');
+    age(lockFile, 10 * 60_000);
+
+    expect(await acquireDaemonStartLock(lockFile, 200, 60_000)).toBe(true);
+    expect(readFileSync(lockFile, 'utf8')).toEqual(String(process.pid));
+  });
+
+  it('waits on an unidentified lock that is still young', async () => {
+    writeFileSync(lockFile, '');
+
+    expect(await acquireDaemonStartLock(lockFile, 200, 60_000)).toBe(false);
+    expect(readFileSync(lockFile, 'utf8')).toEqual('');
+  });
+
+  it('releases only a lock this process holds', () => {
+    writeFileSync(lockFile, String(deadPid()));
+    releaseDaemonStartLock(true, lockFile);
+    expect(existsSync(lockFile)).toBe(true);
+
+    writeFileSync(lockFile, String(process.pid));
+    releaseDaemonStartLock(true, lockFile);
+    expect(existsSync(lockFile)).toBe(false);
+  });
+
+  it('does not release a lock it never took', () => {
+    writeFileSync(lockFile, String(process.pid));
+    releaseDaemonStartLock(false, lockFile);
+    expect(existsSync(lockFile)).toBe(true);
+  });
+});
+
+describe('isProcessAlive', () => {
+  it('is true for this process and false for one that has exited', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+    expect(isProcessAlive(deadPid())).toBe(false);
+  });
+});
+
+describe('findHealthyDaemonOwner', () => {
+  let dir: string;
+  let socketPath: string;
+  let server: Server | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'nx-owner-'));
+    socketPath = join(dir, 's');
+    h.registration.value = null;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((res) => server!.close(() => res()));
+      server = undefined;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const listen = () =>
+    new Promise<void>((res) => {
+      server = createServer();
+      server.listen(socketPath, () => res());
+    });
+
+  /**
+   * A registration for a daemon of this same nx version - the ordinary case.
+   * Spelled out rather than left undefined so the mismatch tests below have a
+   * matching case to differ from: with the field absent, every test here would
+   * silently take the mismatch branch and none could catch a regression on the
+   * other one.
+   */
+  const registered = (over: {
+    processId?: number;
+    socketPath?: string;
+    nxVersion?: string;
+  }) => ({ nxVersion, ...over });
+
+  it('reports no owner when nothing is registered', async () => {
+    expect(await findHealthyDaemonOwner(true)).toBeNull();
+  });
+
+  it('reports no owner when the registered pid is gone', async () => {
+    h.registration.value = registered({ processId: deadPid(), socketPath });
+    expect(await findHealthyDaemonOwner(true)).toBeNull();
+  });
+
+  it('reports no owner when the registration names this process', async () => {
+    h.registration.value = registered({ processId: process.pid, socketPath });
+    expect(await findHealthyDaemonOwner(true)).toBeNull();
+  });
+
+  it('stands down for a registration whose own socket answers', async () => {
+    await listen();
+    h.registration.value = registered({ processId: process.ppid, socketPath });
+    expect(await findHealthyDaemonOwner(true)).toEqual(process.ppid);
+  });
+
+  it('claims the workspace when the registered daemon does not answer', async () => {
+    h.registration.value = registered({ processId: process.ppid, socketPath });
+    expect(await findHealthyDaemonOwner(true)).toBeNull();
+  });
+
+  it('probes the socket named by the registration, not one derived here', async () => {
+    // The daemon's socket directory hashes the pid of whichever process created
+    // it, so a path derived in this process names a socket nobody ever listened
+    // on. Registering the live socket under a DIFFERENT path is what separates
+    // reading the registration from deriving a path.
+    await listen();
+    h.registration.value = registered({
+      processId: process.ppid,
+      socketPath: join(dir, 'not-the-live-one'),
+    });
+    expect(await findHealthyDaemonOwner(true)).toBeNull();
+
+    h.registration.value = registered({ processId: process.ppid, socketPath });
+    expect(await findHealthyDaemonOwner(true)).toEqual(process.ppid);
+  });
+
+  it('reports no owner when the registration carries no socket path', async () => {
+    h.registration.value = registered({ processId: process.ppid });
+    expect(await findHealthyDaemonOwner(true)).toBeNull();
+  });
+
+  it('stands down for a live registration without probing when the lock was not taken', async () => {
+    // Nothing is listening, so a probe would report the owner unhealthy. Not
+    // holding the lock means somebody else is mid-claim: a live registered pid
+    // is a daemon still booting, and taking over would recreate the herd.
+    h.registration.value = registered({ processId: process.ppid, socketPath });
+    expect(await findHealthyDaemonOwner(false)).toEqual(process.ppid);
+  });
+
+  it('claims the workspace when the lock was not taken and the registration is dead', async () => {
+    h.registration.value = registered({ processId: deadPid(), socketPath });
+    expect(await findHealthyDaemonOwner(false)).toBeNull();
+  });
+
+  it('claims the workspace from a live answering daemon on another nx version', async () => {
+    // The client spawns a starter on a version mismatch and never kills the
+    // incumbent, so treating a responsive old daemon as the owner strands the
+    // client: its poll resolves the socket through the version check and gets
+    // nothing, every attempt, until the budget runs out.
+    await listen();
+    h.registration.value = registered({
+      processId: process.ppid,
+      socketPath,
+      nxVersion: `${nxVersion}-not`,
+    });
+    expect(await findHealthyDaemonOwner(true)).toBeNull();
+  });
+
+  it('claims the workspace from another nx version even without the lock', async () => {
+    // The mid-boot courtesy the lockless branch extends to a live registration
+    // does not apply: waiting for a daemon of the wrong version to finish
+    // booting waits for something that can never serve this client.
+    h.registration.value = registered({
+      processId: process.ppid,
+      socketPath,
+      nxVersion: `${nxVersion}-not`,
+    });
+    expect(await findHealthyDaemonOwner(false)).toBeNull();
+  });
+});
+
+describe('daemonSocketAccepts', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'nx-sock-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('is false when nothing is listening', async () => {
+    expect(await daemonSocketAccepts(join(dir, 's'), 200)).toBe(false);
+  });
+
+  it('is true when a server answers', async () => {
+    const socketPath = join(dir, 's');
+    const server = createServer();
+    await new Promise<void>((res) => server.listen(socketPath, () => res()));
+    try {
+      expect(await daemonSocketAccepts(socketPath, 200)).toBe(true);
+    } finally {
+      await new Promise<void>((res) => server.close(() => res()));
+    }
+  });
+});

--- a/packages/nx/src/daemon/server/start-lock.ts
+++ b/packages/nx/src/daemon/server/start-lock.ts
@@ -1,0 +1,247 @@
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeSync,
+} from 'fs';
+import { connect } from 'net';
+import { dirname, join } from 'path';
+import { readDaemonRegistrationSync } from '../cache';
+import { DAEMON_DIR_FOR_CURRENT_WORKSPACE } from '../tmp-dir';
+import { nxVersion } from '../../utils/versions';
+
+/**
+ * Serialises the "claim this workspace" step of daemon startup.
+ *
+ * Writing the daemon registration is a read-then-write over a file that every
+ * starter races for. Unserialised, every daemon spawned inside one start window
+ * passes the check and writes the registration; the outdated-check interval
+ * then kills all but one - after each has already subscribed a recursive
+ * watcher over the workspace and set up its workspace context.
+ *
+ * The lock is held for the whole boot rather than just the write, so that "the
+ * start lock is held" means "a daemon is booting or serving". A starter that
+ * arrives mid-boot then waits and finds a daemon that answers, instead of
+ * reading an as-yet-silent socket as a vacant workspace.
+ */
+
+export const DAEMON_START_LOCK_FILE = join(
+  DAEMON_DIR_FOR_CURRENT_WORKSPACE,
+  'daemon-start.lock'
+);
+
+// The lock spans the whole boot - claim to server.listen() - so this budget has
+// to outlast a cold start on a large workspace, not just the few syscalls the
+// claim itself costs. A starter that gives up here still stands down for a live
+// registration (see findHealthyDaemonOwner); it only loses the socket probe.
+export const DAEMON_START_LOCK_TIMEOUT_MS = 60_000;
+// Backstop for a lock file whose holder cannot be identified at all. A readable
+// pid is settled by liveness first; without one there is nothing else to go on.
+export const DAEMON_START_LOCK_MAX_AGE_MS = 5 * 60_000;
+// Upper bound for a lock whose holder pid is readable AND alive. Liveness on
+// its own cannot tell the original holder from an unrelated process that
+// inherited its pid, and the lock file lives in the workspace data directory:
+// it survives a reboot, after which pids restart from 1. Without this bound a
+// reused pid pins the lock permanently and every later start burns the whole
+// acquire budget before booting unserialised. Far above any real boot, because
+// it is not deciding how long to wait for a slow holder - the acquire timeout
+// already does that - only whether the file is ever cleaned up at all.
+export const DAEMON_START_LOCK_MAX_HOLD_MS = 30 * 60_000;
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM: the process exists, it just belongs to another user.
+    return (err as NodeJS.ErrnoException)?.code === 'EPERM';
+  }
+}
+
+export function daemonSocketAccepts(
+  socketPath: string,
+  timeoutMs = 1_000
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    // finish() is reachable more than once - a connect and the timeout can both
+    // fire - and both calls it makes are idempotent: resolve() is first-call-
+    // wins, and destroy() on an already-destroyed socket is a documented no-op.
+    const finish = (accepted: boolean) => {
+      socket.destroy();
+      resolve(accepted);
+    };
+    const socket = connect(socketPath);
+    socket.once('connect', () => finish(true));
+    socket.once('error', () => finish(false));
+    setTimeout(() => finish(false), timeoutMs).unref();
+  });
+}
+
+/**
+ * The pid of a daemon that already owns this workspace, or null if this process
+ * should become the daemon.
+ *
+ * How much the registration is worth depends on whether this process holds the
+ * start lock. Holding it means nobody else is mid-claim, so a registered daemon
+ * that does not answer on its socket is broken and this process should take
+ * over. Without it the wait lapsed, somebody is claiming right now, and a live
+ * registered pid is far likelier to be a daemon still booting than a dead one -
+ * standing down keeps a slow boot from producing the very herd this exists to
+ * prevent.
+ */
+export async function findHealthyDaemonOwner(
+  lockHeld: boolean
+): Promise<number | null> {
+  const registration = readDaemonRegistrationSync();
+  const ownerPid = registration?.processId;
+  if (!ownerPid || ownerPid === process.pid || !isProcessAlive(ownerPid)) {
+    return null;
+  }
+
+  // A daemon on another nx version is never an owner, however alive and
+  // responsive it is. An incumbent that is merely outdated retires itself: its
+  // own 20ms outdated-check interval reaches getInstalledNxVersion(), which
+  // re-reads the workspace's nx/package.json on every call, so it notices the
+  // upgrade within a tick and shuts down without restarting. What reaches this
+  // branch is the incumbent that cannot - one wedged mid-boot or mid-tick, or
+  // caught inside that 20ms window. Standing down for it would leave the
+  // client polling a socket path it is never allowed to read:
+  // readDaemonProcessJsonCache() raises VersionMismatchError on every attempt,
+  // which the poll swallows, until the whole budget is spent. Displacing the
+  // incumbent is the only outcome that lets the client make progress.
+  if (registration.nxVersion !== nxVersion) {
+    return null;
+  }
+
+  if (!lockHeld) {
+    return ownerPid;
+  }
+
+  // The socket path has to come from the owner's own registration: it cannot be
+  // derived here, because the socket directory name hashes the pid of whichever
+  // process created it (see daemon/tmp-dir.ts). Deriving it would probe a path
+  // belonging to this process, on which nothing has ever listened.
+  if (!registration.socketPath) {
+    return null;
+  }
+  return (await daemonSocketAccepts(registration.socketPath)) ? ownerPid : null;
+}
+
+/**
+ * Age of the lock file, or Infinity when it cannot be stat'd - a lock nothing
+ * can be learned about is treated as expired, exactly like an old one.
+ */
+function lockFileAgeMs(lockFile: string): number {
+  try {
+    return Date.now() - statSync(lockFile).mtimeMs;
+  } catch {
+    return Infinity;
+  }
+}
+
+export async function acquireDaemonStartLock(
+  lockFile: string = DAEMON_START_LOCK_FILE,
+  timeoutMs: number = DAEMON_START_LOCK_TIMEOUT_MS,
+  maxAgeMs: number = DAEMON_START_LOCK_MAX_AGE_MS
+): Promise<boolean> {
+  mkdirSync(dirname(lockFile), { recursive: true });
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    let fd: number | undefined;
+    try {
+      fd = openSync(lockFile, 'wx');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'EEXIST') {
+        // Anything other than "somebody holds it" - a read-only directory,
+        // say - is not something waiting will fix.
+        return false;
+      }
+    }
+    // Only the create belongs in that try. A write that fails after it leaves
+    // a lock file nobody can be read out of, and an unidentified holder is the
+    // one case with no liveness to settle it: every later starter would wait
+    // out the full age backstop for a lock this process never took.
+    if (fd !== undefined) {
+      try {
+        writeSync(fd, String(process.pid));
+        return true;
+      } catch {
+        try {
+          unlinkSync(lockFile);
+        } catch {}
+        return false;
+      } finally {
+        closeSync(fd);
+      }
+    }
+
+    let holderPid: number | null = null;
+    try {
+      // openSync publishes the file before writeSync fills it, so a reader can
+      // legitimately find it empty. Number('') is 0, and signal 0 sent to pid 0
+      // targets this process group and succeeds - hence the explicit `> 0`,
+      // without which an empty lock file reads as held by a live process.
+      const pid = Number(readFileSync(lockFile, 'utf8').trim());
+      if (Number.isInteger(pid) && pid > 0) {
+        holderPid = pid;
+      }
+    } catch {}
+
+    const abandoned =
+      holderPid !== null
+        ? !isProcessAlive(holderPid) ||
+          lockFileAgeMs(lockFile) > DAEMON_START_LOCK_MAX_HOLD_MS
+        : lockFileAgeMs(lockFile) > maxAgeMs;
+
+    let removed = false;
+    if (abandoned) {
+      // Two starters can both judge the same lock abandoned, and the slower one
+      // can then remove a lock the faster one has already created in its place.
+      // The lock is addressed by path throughout, so this window cannot be
+      // closed here. What bounds it is that both then reach the ownership check
+      // together and, with no registration to find, both boot: two daemons
+      // racing the outdated-check interval is the worst it degrades to, and it
+      // takes a daemon dying mid-claim to get there.
+      try {
+        unlinkSync(lockFile);
+        removed = true;
+      } catch (err) {
+        // ENOENT is somebody else having removed it first - the file is gone
+        // either way, which is all this branch wanted.
+        removed = (err as NodeJS.ErrnoException)?.code === 'ENOENT';
+      }
+    }
+
+    // Checked before the sleep so a lapsed deadline is not paid for twice.
+    if (Date.now() > deadline) {
+      return false;
+    }
+    // Every iteration that left the lock file in place yields, the takeover
+    // branch included - so the gate is the removal, not the verdict that
+    // preceded it. Gated on `abandoned` alone, a removal that keeps failing (an
+    // unwritable directory) retries openSync/readFileSync/statSync/unlinkSync
+    // with nothing awaited until the deadline: a full core for the whole
+    // budget, 60s of it in production.
+    if (!removed) {
+      await new Promise((res) => setTimeout(res, 25));
+    }
+  }
+}
+
+export function releaseDaemonStartLock(
+  held: boolean,
+  lockFile: string = DAEMON_START_LOCK_FILE
+): void {
+  if (!held) {
+    return;
+  }
+  try {
+    if (Number(readFileSync(lockFile, 'utf8').trim()) === process.pid) {
+      unlinkSync(lockFile);
+    }
+  } catch {}
+}

--- a/packages/nx/src/daemon/server/start.ts
+++ b/packages/nx/src/daemon/server/start.ts
@@ -2,12 +2,19 @@
 import '../../utils/enable-compile-cache';
 import { output } from '../../utils/output';
 import { startServer } from './server';
+import { releaseDaemonStartLock } from './start-lock';
 import * as process from 'process';
 
 (async () => {
   try {
     await startServer();
   } catch (err) {
+    // startServer holds the start lock from its first line until the server is
+    // listening, and this exit is the one way out of that span that the server
+    // module cannot clean up after. Left behind, the file is settled by the
+    // liveness of the pid written in it, so it goes stale on pid reuse and
+    // stalls every later start for the whole acquire budget.
+    releaseDaemonStartLock(true);
     output.error({
       title:
         err?.message ||


### PR DESCRIPTION
## Current Behavior

`startServer()` writes the daemon registration unconditionally, so daemon start
is not idempotent: every process starting inside one window registers itself,
and the 20 ms outdated-check interval kills all but the last writer. Two ways
into that window:

- **Cold start.** N clients find no registration and each spawn `start.js`.
- **Lock-file restart.** The restart path deletes the registration, spawns a
  replacement fire-and-forget and only then shuts down. Everything arriving in
  that gap starts its own daemon.

The socket cannot arbitrate either: `killSocketOrPath()` unlinks the socket path
unconditionally on non-Windows, so a later starter simply takes it.

### What the losers cost

On `master` the workspace context, which owns the daemon's watch since #37025,
is set up at the very top of `startServer()`, ahead of the registration write,
so each displaced starter scans the whole workspace and sets up a recursive
native watcher before it can discover it has been displaced.

The numbers below are from 22.7.5, where the watcher still comes after
`listen()`, so they measure the *cheaper* shape. A ~475-project workspace,
8 vCPU / 15.7 GB RAM / 3.2 GB swap partition, Linux. N concurrent cold-start
`nx show projects` clients against an isolated `NX_WORKSPACE_DATA_DIRECTORY`,
sampled at 1 Hz; registrations counted from that workspace's own `daemon.log`.
Each cell is `before -> after`:

| clients | daemon registrations | peak swap used | MemAvailable floor | peak load1 | wall |
|---|---|---|---|---|---|
| 8, warm control | 1 -> 1 | 0 -> 100 MB | 11501 -> 12665 MB | 3.3 -> 13.9 | 24 -> 29 s |
| 4 | 4 -> 1 | 0 -> 98 MB | 9959 -> 13583 MB | 9.2 -> 9.3 | 29 -> 22 s |
| 8 | 8 -> 1 | 0 -> 98 MB | 6462 -> 13319 MB | 22.4 -> 7.6 | 46 -> 23 s |
| 14 | 11 -> 1 | 3 -> 98 MB | 1949 -> 11335 MB | 38.0 -> 6.2 | 72 -> 25 s |
| 20 | 20 -> 1 | **3280 -> 98 MB** | **48 -> 9644 MB** | 73.5 -> 6.9 | **111 -> 26 s** |

At 20 concurrent clients the unpatched box consumes the entire swap partition
and is left with 48 MB of available memory at load 73. No client failed on
either side (54 ok / 0 failed each). The qualifiers - the flat 98 MB is residue
from the preceding phase, and the change stops registrations rather than spawns
- are spelled out in #36891.

## Expected Behavior

`packages/nx/src/daemon/server/start-lock.ts` claims the workspace under an
exclusive lock file (`openSync(..., 'wx')`) and stands down when a healthy
daemon already owns it. Three properties are worth stating explicitly, because
each of them is a case where the obvious version is wrong:

**The claim is held until `listen()` succeeds, not just until the registration
is written.** The gap between those two contains the workspace context (which
starts the watch and scans) and analytics - on a large workspace, tens of
seconds. A starter arriving inside that gap must wait for the incumbent rather
than read an as-yet-silent socket as a vacant workspace. So "the start lock is
held" means "a daemon is booting or serving", which is a fact rather than a
guess about timestamps.

**The registration is written before the workspace context starts.** A starter
whose wait for the lock lapses in the middle of that scan then finds the booting
daemon registered and stands down. With the registration written after the scan
it would find nothing and start a second daemon, which is the herd this exists
to prevent.

**The socket to probe comes from the owner's own registration.** It cannot be
derived by the prober: `socketDirName()` hashes `process.pid`, so a path derived
in the probing process names a socket that only that process would ever have
created. Probing a derived path reports every live daemon as dead. This is why
`cache.ts` grows `readDaemonRegistrationSync()` - `readDaemonProcessJsonCache()`
raises `VersionMismatchError`, and a daemon deciding whether to stand down must
not take a throw on that path.

`readDaemonProcessJsonCache()` is then rebased onto that reader rather than left
reading the file its own way, so one file has one reader instead of two to keep
in step - I would otherwise be the one who created the second. Its observable
behaviour is unchanged: absent, unreadable and malformed all still return
`null`, and a version mismatch still logs and throws. One difference worth
naming rather than leaving for someone to find: the old body wrapped everything
in one `catch`, so a `clientLogger.log()` that threw would have been swallowed
into a `null`. That was never intended - a logger failure reported as "no daemon
registered" is worse than the throw - and it now propagates.

**How much the registration is worth depends on holding the lock.** Holding it
means nobody else is mid-claim, so a registered daemon that does not answer is
broken and this process takes over. Without it - the wait lapsed - somebody is
claiming right now, and a live registered pid is far likelier to be a daemon
still booting than a dead one, so stand down rather than add to the herd. That
asymmetry is what lets the lock have a deadline at all: a starter that gives up
waiting still behaves safely.

**Staleness is decided by the holder's liveness, with an age bound above it.**
A readable pid is settled by `process.kill(pid, 0)`, which is exact about the
process - but not about the *file*. The lock sits in the workspace data
directory, so it outlives a reboot, after which pids restart from 1 and an
unrelated live process can own the pid written in it. Liveness alone would read
such a lock as held forever, and every later start would pay the whole acquire
budget before booting unserialised - strictly worse than `master`, whose
on-disk state self-heals. So an identified live holder gets an upper bound of
30 minutes as well. That is far above any real boot on purpose: it is not
deciding how long to wait for a slow holder, the 60 s acquire timeout already
does that, only whether the file is ever removed at all. A lock whose holder
pid cannot be read at all keeps the shorter 5-minute rule, since there is
nothing else to go on.

**The lock is released on every path out of the daemon.** `process.exit` skips
`finally`, so each exit releases explicitly: the three inside `startServer()`
(standing down, `server.on('error')`, and `listen()` succeeding), plus
`performShutdown()` - the exit taken by SIGINT, SIGTERM, SIGHUP, the
outdated-check interval and `nx daemon --stop` - and `start.ts`'s own failure
exit. In `performShutdown()` the call sits in the `finally`, because every
await above it can reject and land straight there. Asking to release is safe
from any process: the file is removed only when it names this pid.

**A daemon on another nx version is never an owner, however alive and
responsive it is.** An incumbent that is merely outdated retires itself: its
own 20 ms outdated-check interval reaches `getInstalledNxVersion()`, which
re-reads the workspace's `nx/package.json` on every call, so it notices an
upgrade within a tick and shuts down without restarting. What reaches this
branch is the incumbent that *cannot* - one wedged mid-boot or mid-tick, or
caught inside that 20 ms window. Standing down for it would strand the client -
its poll resolves the socket path through that same version check, swallows the
throw and retries until the whole budget is spent, and no second starter is
ever spawned. Displacing it is what the unserialised path did, and it stays
right here.

**`startInBackground()` now returns the registered daemon's pid, not the pid of
the process it spawned.** This follows from stand-down rather than being an
unrelated fix: a starter that finds a healthy owner exits, so by the time the
poll sees an answering socket its pid names a process that is gone. That value
is logged as `Daemon server started`, handed to the metrics service, and printed
to the user as the `ID:` of `nx daemon --start`. It was a race before this
change and would be the designed path after it. The registration is written
before `listen()`, so once the socket answers it names whoever is answering.

## Related Issue(s)

Fixes #36891

## What this does not do

It stops the registrations, not the spawns. The client still calls `spawn()`
fire-and-forget after `probeServer()` reports nothing available, so `ps` still
sees several starter processes; they now take the lock, find a healthy owner and
exit before setting anything up. Taking the claim in the **client**, before
`spawn()`, would remove those processes too - a larger change to
`startDaemonIfNecessary()` that I deliberately kept out of this PR. Happy to go
that way instead if you would rather have it there.

It also leaves one duplication in place knowingly: `isProcessAlive` here is
line-for-line `isPidAlive` in `command-line/migrate/run/util.ts`, whose own
first line says it is internal to `run/` and deliberately not re-exported.
Importing it would drag `execute-migration`, `utils/package-manager` and
`run/state-lock` onto the daemon boot path. The shared home would be `utils/`,
which this PR does not otherwise touch - flagging it as known rather than
missed, and happy to move it if you would rather have that here.

## An alternative I did not take: the native `FileLock`

`packages/nx/src/native/utils/file_lock.rs` already ships an `fs4`/flock lock,
used by `project-graph.ts` and `migrate/run/state-lock.ts`. Using it here would
delete the stale-lock handling outright, since the kernel releases a dead
holder's lock. I measured it rather than assuming, and did not adopt it, for
three reasons:

- **It has no timeout.** The escape hatch above - give up waiting, stand down
  for a live registration, never block a start forever - depends on a bounded
  wait. `lock()` blocks and `wait()` resolves only when the holder lets go, so a
  wedged holder would block every future starter indefinitely; `wait_blocking`
  on master is bounded but Rust-only. That matters more now that the lock spans
  a whole boot.
- **`check()` answers the holder wrongly, and destroys the lock while
  answering.** It runs `try_lock_exclusive` then `unlock` on the handle's own
  file, and flock succeeds for a description that already holds the lock - so
  on a handle that holds it, `check()` returns `false` and leaves the file
  unlocked. Measured through the shipped binding: with handle `a` holding,
  `a.check()` is `false`, and a handle constructed afterwards finds the file
  free. The constructor has the same take-and-release shape.
- Both defects above are real, and #36906 (rebased on master's `tryLock` and
  `wait_blocking`) fixes `check()` and adds a bounded `lockTimeout`/`waitTimeout`.
  That still does not make the native lock a drop-in here, and the reason is a
  specific gap rather than a preference: `lockTimeout` is **synchronous**, so a
  booting daemon would block its own event loop for up to the whole 60 s budget,
  and `waitTimeout` is async but does not acquire. The missing primitive is an
  *async bounded acquire*, and I measured whether it is reachable rather than
  guessing: a lock taken on a `try_clone()` of the handle's file excludes a
  fresh description, **survives that clone being closed** (flock releases only
  once every descriptor for the description is gone), and is released through
  the original handle's `unlock()`. So the async form is a `spawn_blocking` poll
  on a clone - roughly 30 lines on top of #36906, with the same "`locked` is
  left as it was, ask `check()`" contract `waitTimeout` already documents. Say
  the word and I will add it. Two honest limits: that was measured on macOS
  only, and on Windows `fs4` is an emulation I have not run.

  Worth stating plainly rather than leaving for review to find: under such a
  primitive most of the staleness machinery in `start-lock.ts` - the pid write,
  the liveness test, both age backstops, the unlink-and-retake with its
  unclosable window, the five release paths that exist because `process.exit`
  skips `finally` - would simply be deleted, because the kernel releases a dead
  holder's lock. That is roughly half the file and a third of the spec. I would
  rather land this and follow up than couple the two PRs; say the word if you
  would prefer it the other way round.

Measured behaviour, for the record: `fs4` 0.12.0 resolves to flock(2) here, so
locks are per open file description. Exclusion is correct in both directions -
across processes, and between two handles inside one process - and unlocking or
closing one handle leaves another handle's lock alone. `locked` and `check()`
both report `true` while a live holder has it and `false` once that holder is
`SIGKILL`ed, confirming the kernel-release property. The one case that misreports
is the holder asking about its own lock, above.

## Tests

`packages/nx/src/daemon/server/start-lock.spec.ts`, 25 cases: lock creation,
refusal against a live holder with a deadline, refusal to evict a live holder by
the short backstop, takeover of a lock a live holder has held past the long age
bound, takeover when the holder is gone, takeover of an unidentifiable lock by
age, two refusals that must not spend the deadline or spin, release only by the
holder, and the owner-health decision against a real listening unix socket in
both the lock-held and lock-not-held branches - including one case that
registers a live socket under a *different* path than the one a prober would
derive, and two that register a live, answering daemon on another nx version.

Mutation-checked on the rebased head - each of these makes the named case fail:

| mutation | failing case |
|---|---|
| `'wx'` -> `'w'` | refuses to take a lock held by a live process |
| drop the socket probe | claims the workspace when the registered daemon does not answer |
| probe a path derived locally instead of the registration's | probes the socket named by the registration, not one derived here |
| drop the lock-not-held branch | stands down for a live registration without probing when the lock was not taken |
| let the short backstop evict an identified live holder | does not take an old lock away from a live holder |
| drop the long age bound above an identified live holder | takes over a lock a live holder has held far past any real boot |
| release without the holder-pid check | releases only a lock this process holds |
| drop the nx-version rule | both "claims the workspace from another nx version" cases |
| fixtures stop carrying a matching version | three cases that depend on the daemon being an owner |
| let a non-EEXIST open error fall through to waiting | gives up at once when the lock cannot be created at all |
| gate the sleep on the takeover verdict instead of on the removal | gives up at the deadline when an abandoned lock cannot be removed, without spinning |
| return the spawned process's pid instead of the registration's | should report the registered daemon pid, not the pid of the process it spawned |

Two of those rows are worth spelling out, because the failure they guard is
invisible to every ordinary assertion. The takeover branch removes an abandoned
lock and retries at once, so it is the one path through the loop with nothing to
wait on and no `await` of its own. Let it skip the deadline check and a removal
that keeps failing - an unwritable directory under an unidentifiable lock -
never leaves the loop at all: that mutation does not make the spec fail, it
**hangs**, at 99% CPU, with even the test timeout unable to fire because nothing
yields. Bounding it there is not sufficient on its own. Gate the sleep on the
takeover *verdict* rather than on whether the removal succeeded, and the same
failing unlink re-enters `openSync`/`readFileSync`/`statSync`/`unlinkSync` with
nothing awaited until the deadline - a full core for the whole budget, 60 s of
it in production. Wall time cannot see that, because the deadline bounds the
call either way; CPU can. So the gate is the removal, and the spec asserts CPU
with a 100 ms ceiling on a 200 ms budget: restoring the verdict gate puts it at
219 ms of CPU against 204 ms of wall.

One caveat on that CPU assertion, so a red run is read correctly: `cpuUsage()`
is process-wide, so anything else busy in the same vitest worker during those
200 ms counts against the ceiling. The margin is roughly 20x on an idle machine.
If it ever flakes, the fix is a ratio against wall time, not a higher absolute
ceiling - a raise would put the spin back inside the assertion.

The two permission-based cases are skipped on Windows and as root, where taking
write permission off a directory does not arrange the failure they need.

`vitest run src/daemon/server/start-lock.spec.ts` - 25 passed.
`tsc -p packages/nx/tsconfig.lib.json --noEmit` - clean.
`oxfmt --check` on every changed file - clean.

`vitest run src/daemon` is 298 passed. Two specs in that directory were
timing-sensitive and went red on a loaded machine on the previous base -
`client.spec.ts > should surface socket guidance when the daemon exits having
been refused its bind` and `project-graph-incremental-recomputation.watcher.spec.ts
> returns a fresh graph reflecting an in-flight project add`. Both reproduced on
the parent commit with these changes removed, and both passed in this run.

**What the tests do not cover:** the end-to-end claim - two `startServer()`
entries leaving one registration - is not exercised by a spec. The unit tests
cover the helpers and the decision; the end-to-end evidence is the 22.7.5
measurement above. The order inside `startServer()` (claim, registration, then
the workspace context) is not covered either, for the same reason: no spec can
run it twice in one process.

Neither are the two new release call sites. `performShutdown()` and `start.ts`'s
failure path both end in `process.exit`, so there is nothing a spec in the same
process can assert about them. What is pinned is the property they rely on -
`releases only a lock this process holds` - and the wiring itself was read
rather than executed.

Also uncovered, and I checked rather than assumed: `readDaemonProcessJsonCache()`
itself. Inverting its version comparison changes nothing in `vitest run
src/daemon` - `client.spec.ts` mocks the whole `../cache` module, so the real
function never runs in any spec in the package. Its rebase above rests on
reading both forms, not on a test.

**Untested: Windows.** `openSync(..., 'wx')`, `process.kill(pid, 0)` and
`net.connect` against the `\\.\pipe\nx\...` socket form should all behave, but
none of it was run there.



