### PR TITLE
cleanup(angular): loosen the e2e es2015 bundle size assertion to a coarse ceiling

### DIFF
--- a/e2e/angular/src/projects-build-and-test.test.ts
+++ b/e2e/angular/src/projects-build-and-test.test.ts
@@ -77,13 +77,13 @@ describe('Angular Projects - Build and Test', () => {
     checkFilesExist(`dist/${esbuildApp}/browser/main.js`);
     checkFilesExist(`dist/my-dir/${standaloneApp}/main.js`);
     checkFilesExist(`dist/my-dir/${esbuildStandaloneApp}/browser/main.js`);
-    // This is a loose requirement because there are a lot of
-    // influences external from this project that affect this.
+    // Coarse ceiling: catches prod optimizations not being applied, not
+    // Angular runtime growth. Bumping it for an Angular release is a smell.
     const es2015BundleSize = getSize(tmpProjPath(`dist/${app1}/main.js`));
     console.log(
       `The current es2015 bundle size is ${es2015BundleSize / 1000} KB`
     );
-    expect(es2015BundleSize).toBeLessThanOrEqual(227000);
+    expect(es2015BundleSize).toBeLessThanOrEqual(300000);
 
     // check unit tests
     runCLI(


### PR DESCRIPTION
## Current Behavior

The `e2e-angular:projects-build-and-test` bundle size assertion fails on master and on PR branches, regardless of what the PR changes:

```
The current es2015 bundle size is 227.207 KB
expect(es2015BundleSize).toBeLessThanOrEqual(227000); // fails
```

The e2e installs Angular through the `~22.1.0` range, so every Angular patch release can move the number. Angular 22.1.4 and 22.1.5 ship about 9 KB more unminified runtime code in `@angular/core` and `@angular/router` than 22.1.3. That pushes the test app's `main.js` past the threshold set for 22.1.3.

The threshold has moved 10 times since 2018. Eight bumps followed an Angular release, and none led to a change that shrank a bundle. With under 1 KB of margin, a patch release breaks CI about once a month.

## Expected Behavior

The assertion is a coarse ceiling of 300,000 bytes. It fails when production optimizations stop applying or a template adds tens of KB. An Angular release that ships a larger runtime does not fail it.

## Related Issue(s)

NXC-4936

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4936-b9b048f3">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->