### PR TITLE
fix(rspack): write the normalized cache option in NxAppRspackPlugin

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
@@ -1,6 +1,7 @@
 import { applyBaseConfig } from './apply-base-config';
 import { NormalizedNxAppRspackPluginOptions } from './models';
 import type { Configuration } from '@rspack/core';
+import * as path from 'path';
 
 describe('apply-base-config libraryTarget handling', () => {
   let options: NormalizedNxAppRspackPluginOptions;
@@ -272,5 +273,107 @@ describe('apply-base-config ts-checker rootDir (TS6059 prevention)', () => {
     expect(capturedPluginConfigs).toHaveLength(1);
     expect(capturedPluginConfigs[0].typescript.configOverwrite).toBeUndefined();
     expect(capturedPluginConfigs[0].typescript.build).toBe(true);
+  });
+});
+
+describe('apply-base-config cache option', () => {
+  const baseOptions = {
+    root: '/test',
+    projectRoot: 'apps/test',
+    target: 'web',
+  } as NormalizedNxAppRspackPluginOptions;
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.NX_GRAPH_CREATION = false;
+  });
+
+  afterEach(() => {
+    delete global.NX_GRAPH_CREATION;
+    jest.dontMock('@rspack/core');
+    jest.resetModules();
+  });
+
+  it('writes the public cache value as-is in executor mode', async () => {
+    const { applyBaseConfig } = await import('./apply-base-config');
+
+    const defaults: Partial<Configuration> = {};
+    applyBaseConfig({ ...baseOptions }, defaults);
+    expect(defaults.cache).toBe(true);
+
+    const disabled: Partial<Configuration> = {};
+    applyBaseConfig({ ...baseOptions, cache: false }, disabled);
+    expect(disabled.cache).toBe(false);
+  });
+
+  it('writes the shape produced by the rspack normalizer into compiler.options in plugin mode', async () => {
+    // Stub the normalizer so the expected shape does not depend on the
+    // installed @rspack/core version.
+    const normalize = (cache: unknown) =>
+      cache === true
+        ? { type: 'memory', snapshot: {} }
+        : { ...(cache as object), snapshot: {} };
+    const getNormalizedRspackOptions = jest.fn(({ cache }) => ({
+      cache: normalize(cache),
+    }));
+    jest.doMock('@rspack/core', () => {
+      const actual = jest.requireActual('@rspack/core');
+      return new Proxy(actual, {
+        get(target, prop) {
+          if (prop === 'config') {
+            return { ...(target as any).config, getNormalizedRspackOptions };
+          }
+          return (target as any)[prop];
+        },
+      });
+    });
+    const { applyBaseConfig } = await import('./apply-base-config');
+
+    const defaults: Partial<Configuration> = {};
+    applyBaseConfig({ ...baseOptions }, defaults, { useNormalizedEntry: true });
+    expect(getNormalizedRspackOptions).toHaveBeenCalledWith({
+      context: path.join('/test', 'apps/test'),
+      cache: true,
+    });
+    expect(defaults.cache).toEqual({ type: 'memory', snapshot: {} });
+
+    const persistent: Partial<Configuration> = {};
+    applyBaseConfig(
+      { ...baseOptions, cache: { type: 'persistent' } as any },
+      persistent,
+      { useNormalizedEntry: true }
+    );
+    expect(persistent.cache).toEqual({ type: 'persistent', snapshot: {} });
+  });
+
+  it('passes an explicit cache option through the installed normalizer in plugin mode', async () => {
+    const { applyBaseConfig } = await import('./apply-base-config');
+    const rspackCore: typeof import('@rspack/core') =
+      jest.requireActual('@rspack/core');
+    const normalizedCache = (cache: Configuration['cache']) =>
+      rspackCore.config.getNormalizedRspackOptions({
+        context: path.join('/test', 'apps/test'),
+        cache,
+      }).cache;
+
+    const enabled: Partial<Configuration> = {};
+    applyBaseConfig({ ...baseOptions, cache: true }, enabled, {
+      useNormalizedEntry: true,
+    });
+    expect(enabled.cache).toEqual(normalizedCache(true));
+
+    const disabled: Partial<Configuration> = {};
+    applyBaseConfig({ ...baseOptions, cache: false }, disabled, {
+      useNormalizedEntry: true,
+    });
+    expect(disabled.cache).toBe(false);
+
+    const persistent: Partial<Configuration> = {};
+    applyBaseConfig(
+      { ...baseOptions, cache: { type: 'persistent' } as any },
+      persistent,
+      { useNormalizedEntry: true }
+    );
+    expect(persistent.cache).toEqual(normalizedCache({ type: 'persistent' }));
   });
 });

--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -491,7 +491,15 @@ function applyNxDependentConfig(
   config.externals = externals;
 
   // Enabled for performance
-  config.cache = 'cache' in options ? options.cache : true;
+  const cache = 'cache' in options ? options.cache : true;
+  // compiler.options is already normalized when NxAppRspackPlugin runs, and
+  // @rspack/core >= 2.1 rejects the public `cache` shape after normalization.
+  config.cache = useNormalizedEntry
+    ? rspackCore.config.getNormalizedRspackOptions({
+        context: config.context,
+        cache,
+      }).cache
+    : cache;
   config.module = {
     ...config.module,
     rules: [


### PR DESCRIPTION
## Current Behavior

`NxAppRspackPlugin.apply()` runs `applyBaseConfig` against `compiler.options`, which Rspack has already normalized, but writes the public shape of the `cache` option (`config.cache = 'cache' in options ? options.cache : true`). Since `@rspack/core` 2.1 the normalized shape of `true` is `{ type: 'memory' }`, and since 2.2.2 (web-infra-dev/rspack#15374) it also carries a `snapshot` object, so the raw boolean breaks the next steps:

- 2.1.0 to 2.2.1: `compiler.run()` (and `compiler.watch()`) throws ``Invalid Rspack configuration: "cache.maxAge" must be a positive integer (1..4294967295) or Infinity, get `undefined`.``
- 2.2.2: `createCompiler` throws `TypeError: Cannot read properties of undefined (reading 'immutablePaths')` in `applyCacheDefaults`.

With `@rspack/core` >= 2.1 installed, every config that uses `NxAppRspackPlugin` with the default or with `cache: true` (the generated config sets no `cache` option) fails on both `build` and `serve`; `cache: false` is unaffected. Freshly generated workspaces pin `@rspack/core` 2.0.4 and still build; workspaces that upgraded `@rspack/core` (or resolved a caret range) hit it.

## Expected Behavior

In plugin mode (`useNormalizedEntry`, i.e. the config is `compiler.options`) the `cache` value, whether the explicit option or the `true` default, is passed through `config.getNormalizedRspackOptions` of the `@rspack/core` the compiler was created with (`compiler.rspack`), so `compiler.options.cache` always has the shape that version expects: `true` on 1.x and 2.0, `{ type: 'memory' }` from 2.1.0 to 2.2.1, `{ type: 'memory', snapshot: {} }` since 2.2.2. The `nx:rspack` executor path (`withNx` called on a fresh, not-yet-normalized config object) keeps writing the public value.

The `true` default is kept on purpose: Nx sets `mode: 'none'` for Node targets, which turns Rspack's own default memory cache off. The `cache` option docs in `models.ts` and the executor `schema.json` describe the Node-and-watch-only default of `applyNxIndependentConfig`, which `applyNxDependentConfig` has always overwritten with `true`; that pre-existing mismatch is unchanged here.

Not covered: `useLegacyNxPlugin`, which runs the composed `withNx` chain against `compiler.options` in `beforeCompile`, still writes the public shape; on 2.2.2 the value cannot be fixed by normalizing alone because `applyRspackOptionsDefaults` has already run at that point, so it needs its own change.

Verified with a standalone `rspack()` + `compiler.run()` script (a plugin that writes `compiler.options.cache`, no Nx) against `@rspack/core` 1.6.8, 2.0.8, 2.1.0, 2.1.9, 2.1.10, 2.2.0, 2.2.1 and 2.2.2: `true` fails from 2.1.0 on with the two errors above, a plain `{ type: 'memory' }` fails on 2.2.2, and the value returned by the normalizer builds on all eight. The Nx code path is covered by unit tests (executor mode, plugin mode without the option, `cache: true`, `cache: false`, a persistent object) against the workspace's `@rspack/core` plus a stubbed normalizer.

## Related Issue(s)

Fixes #36878

Related: #36879 takes a different route (a hardcoded `{ type: 'memory' }` behind a major-version check). That value builds on 2.1.0 to 2.2.1 but still crashes `createCompiler` on 2.2.2 (npm `latest`) with the `immutablePaths` error, because the normalized shape now needs `snapshot`; it also leaves an explicit `cache: true` option untouched. Asking the running Rspack for its own normalized value avoids tracking that shape in Nx.
