### PR TITLE
fix(core): file lock check keeps a held lock and waits can time out

### DIFF
--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -72,9 +72,58 @@ export declare class FileLock {
   locked: boolean
   constructor(lockFilePath: string)
   unlock(): void
+  /**
+   * Whether anybody holds the lock, the caller itself included.
+   *
+   * The caller's own lock is never disturbed by asking. A lock that is
+   * *free* is briefly taken and released on a file description of the
+   * probe's own, and that hold is real: two processes asking at the same
+   * instant can each be told the lock is held, and a concurrent
+   * `lockTimeout(0)` can fail against nobody. flock has no query operation,
+   * so a take-and-release is the only way to ask.
+   */
   check(): boolean
   wait(): Promise<void>
+  /**
+   * Resolves `true` as soon as nobody holds the lock exclusively, `false`
+   * once the timeout has passed with it still held. Nothing is held on
+   * return either way, and `locked` is left as it was: a caller that wants
+   * the current answer asks `check()`, as the graph wait loop does.
+   *
+   * The probe uses its own file description, so a handle that itself holds
+   * the lock waits on nobody but itself and gets `false` at the deadline.
+   *
+   * `timeoutMs` is a count of milliseconds: `Infinity` means `wait()`, with
+   * no deadline at all, and a negative or NaN value is refused. The refusal
+   * is thrown synchronously, before the promise exists, so it cannot be
+   * reached with `.catch()`.
+   */
+  waitTimeout(timeoutMs: number): Promise<boolean>
   lock(): void
+  /**
+   * `lock()` that gives up: `true` and the lock is held, `false` once the
+   * timeout has passed without acquiring it. Blocks the calling thread for
+   * at most that long, as `lock()` blocks it indefinitely.
+   *
+   * `timeoutMs` is a count of milliseconds: `0` is a single attempt,
+   * `Infinity` is `lock()` itself, and a negative or NaN value is refused.
+   *
+   * After a `false`, `locked` still reads `true`. The field says whether
+   * anybody holds the lock, not whether this handle does - `false` is
+   * precisely the answer that somebody else does - so `unlock()` after one
+   * would be releasing a lock this handle never took.
+   *
+   * On Windows the lock is `LockFileEx` over the whole range, and an
+   * overlapping request conflicts with a lock the same handle already holds
+   * rather than being granted as flock grants it. So a handle asking for a
+   * lock it already holds gets `true` at once on Unix, while on Windows a
+   * finite budget would poll to the deadline and answer `false` and
+   * `Infinity` - which is `lock()`, the blocking form with no
+   * `LOCKFILE_FAIL_IMMEDIATELY` - would wait on itself. Read out of the
+   * `fs4` source and the Win32 contract, not run there; neither in-tree
+   * caller asks.
+   */
+  lockTimeout(timeoutMs: number): boolean
 }
 
 export declare class HashPlanInspector {

--- a/packages/nx/src/native/utils/file_lock.rs
+++ b/packages/nx/src/native/utils/file_lock.rs
@@ -2,12 +2,21 @@
 use napi::bindgen_prelude::*;
 use std::fs;
 #[cfg(not(target_arch = "wasm32"))]
-use std::{fs::OpenOptions, path::Path};
+use std::{
+    fs::OpenOptions,
+    path::Path,
+    time::{Duration, Instant},
+};
 #[cfg(not(target_arch = "wasm32"))]
 use tracing::trace;
 
 #[cfg(not(target_arch = "wasm32"))]
 use fs4::fs_std::FileExt;
+
+/// How often a bounded wait re-probes the lock. flock(2) has no timed variant,
+/// so a bounded wait is a non-blocking probe repeated until the deadline.
+#[cfg(not(target_arch = "wasm32"))]
+const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[napi]
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
@@ -28,6 +37,12 @@ pub struct FileLock {
 ///  writeToCache()
 ///  lock.unlock()
 /// }
+///
+/// Both blocking calls have a bounded form that reports whether it succeeded
+/// instead of waiting on a wedged holder forever:
+///
+/// if (!(await lock.waitTimeout(30_000))) { ... give up ... }
+/// if (!lock.lockTimeout(30_000)) { ... give up ... }
 
 #[napi]
 #[cfg(not(target_arch = "wasm32"))]
@@ -38,11 +53,7 @@ impl FileLock {
         fs::create_dir_all(Path::new(&lock_file_path).parent().unwrap())?;
 
         // Opens the lock file
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(&lock_file_path)?;
+        let file = open_lock_file(&lock_file_path)?;
 
         trace!("Locking file {}", lock_file_path);
 
@@ -68,17 +79,29 @@ impl FileLock {
         Ok(())
     }
 
+    /// Whether anybody holds the lock, the caller itself included.
+    ///
+    /// The caller's own lock is never disturbed by asking. A lock that is
+    /// *free* is briefly taken and released on a file description of the
+    /// probe's own, and that hold is real: two processes asking at the same
+    /// instant can each be told the lock is held, and a concurrent
+    /// `lockTimeout(0)` can fail against nobody. flock has no query operation,
+    /// so a take-and-release is the only way to ask.
     #[napi]
     pub fn check(&mut self) -> Result<bool> {
-        // Check if the file is locked
-        let file_lock: std::result::Result<(), std::io::Error> = self.file.try_lock_exclusive();
+        // The probe needs a description of its own: flock re-locks a
+        // description that already holds the lock without complaint, so probing
+        // on `self.file` would answer "free" on the holder and release the
+        // caller's lock on the way out.
+        let probe = open_lock_file(&self.lock_file_path)?;
+        let probed = probe.try_lock_exclusive();
 
-        if file_lock.is_ok() {
-            // Checking if the file is locked, locks it, so unlock it.
-            fs4::fs_std::FileExt::unlock(&self.file)?;
+        if probed.is_ok() {
+            // Probing took the lock on the probe's own description; drop it.
+            fs4::fs_std::FileExt::unlock(&probe)?;
         }
 
-        self.locked = file_lock.is_err();
+        self.locked = probed.is_err();
         Ok(self.locked)
     }
 
@@ -88,11 +111,7 @@ impl FileLock {
             let lock_file_path = self.lock_file_path.clone();
             self.locked = false;
             let promise = env.spawn_future(async move {
-                let file = OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .create(true)
-                    .open(&lock_file_path)?;
+                let file = open_lock_file(&lock_file_path)?;
                 fs4::fs_std::FileExt::lock_shared(&file)?;
                 fs4::fs_std::FileExt::unlock(&file)?;
                 Ok(())
@@ -106,12 +125,173 @@ impl FileLock {
         }
     }
 
+    /// Resolves `true` as soon as nobody holds the lock exclusively, `false`
+    /// once the timeout has passed with it still held. Nothing is held on
+    /// return either way, and `locked` is left as it was: a caller that wants
+    /// the current answer asks `check()`, as the graph wait loop does.
+    ///
+    /// The probe uses its own file description, so a handle that itself holds
+    /// the lock waits on nobody but itself and gets `false` at the deadline.
+    ///
+    /// `timeoutMs` is a count of milliseconds: `Infinity` means `wait()`, with
+    /// no deadline at all, and a negative or NaN value is refused. The refusal
+    /// is thrown synchronously, before the promise exists, so it cannot be
+    /// reached with `.catch()`.
+    #[napi(ts_return_type = "Promise<boolean>")]
+    pub fn wait_timeout(
+        &mut self,
+        env: Env,
+        timeout_ms: f64,
+    ) -> napi::Result<PromiseRaw<'static, bool>> {
+        let timeout = timeout_from_ms(timeout_ms)?;
+        let lock_file_path = self.lock_file_path.clone();
+        let promise = env.spawn_future(async move {
+            // The poll sleeps the thread it runs on; keep that off the async
+            // workers so a long wait cannot starve other native futures.
+            tokio::task::spawn_blocking(move || -> napi::Result<bool> {
+                let file = open_lock_file(&lock_file_path)?;
+                Ok(wait_until_free(&file, timeout)?)
+            })
+            .await
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?
+        })?;
+        // SAFETY: PromiseRaw's inner napi_value is GC-managed by V8
+        // and remains valid beyond this stack frame.
+        Ok(unsafe {
+            std::mem::transmute::<PromiseRaw<'_, bool>, PromiseRaw<'static, bool>>(promise)
+        })
+    }
+
     #[napi]
     pub fn lock(&mut self) -> napi::Result<()> {
         self.file.lock_exclusive()?;
         self.locked = true;
         Ok(())
     }
+
+    /// `lock()` that gives up: `true` and the lock is held, `false` once the
+    /// timeout has passed without acquiring it. Blocks the calling thread for
+    /// at most that long, as `lock()` blocks it indefinitely.
+    ///
+    /// `timeoutMs` is a count of milliseconds: `0` is a single attempt,
+    /// `Infinity` is `lock()` itself, and a negative or NaN value is refused.
+    ///
+    /// After a `false`, `locked` still reads `true`. The field says whether
+    /// anybody holds the lock, not whether this handle does - `false` is
+    /// precisely the answer that somebody else does - so `unlock()` after one
+    /// would be releasing a lock this handle never took.
+    ///
+    /// On Windows the lock is `LockFileEx` over the whole range, and an
+    /// overlapping request conflicts with a lock the same handle already holds
+    /// rather than being granted as flock grants it. So a handle asking for a
+    /// lock it already holds gets `true` at once on Unix, while on Windows a
+    /// finite budget would poll to the deadline and answer `false` and
+    /// `Infinity` - which is `lock()`, the blocking form with no
+    /// `LOCKFILE_FAIL_IMMEDIATELY` - would wait on itself. Read out of the
+    /// `fs4` source and the Win32 contract, not run there; neither in-tree
+    /// caller asks.
+    #[napi]
+    pub fn lock_timeout(&mut self, timeout_ms: f64) -> napi::Result<bool> {
+        let Some(timeout) = timeout_from_ms(timeout_ms)? else {
+            // No deadline is what lock() already is, and it blocks in the
+            // kernel rather than waking 100 times a second to ask again.
+            self.lock()?;
+            return Ok(true);
+        };
+        let acquired = poll_until(timeout, || {
+            fs4::fs_std::FileExt::try_lock_exclusive(&self.file)
+        })?;
+        if acquired {
+            self.locked = true;
+        }
+        Ok(acquired)
+    }
+}
+
+/// Milliseconds as they arrive from JS, or `None` for "no deadline".
+///
+/// The parameter is an `f64` rather than a `u32` because napi converts a `u32`
+/// through JS `ToUint32`: `Infinity` arrives as 0 and `-1` as 4294967295, so
+/// the two spellings a caller reaches for to mean "no limit" and "one below
+/// zero" turn into "give up now" and "give up in 49.7 days" - silently, and
+/// each the opposite of what was written.
+#[cfg(not(target_arch = "wasm32"))]
+fn timeout_from_ms(timeout_ms: f64) -> napi::Result<Option<Duration>> {
+    if timeout_ms.is_nan() || timeout_ms < 0.0 {
+        return Err(napi::Error::new(
+            napi::Status::InvalidArg,
+            format!("timeoutMs must be a non-negative number of milliseconds, got {timeout_ms}"),
+        ));
+    }
+    if timeout_ms.is_infinite() {
+        return Ok(None);
+    }
+    // Float-to-int casts saturate, so an absurd finite value becomes an absurd
+    // Duration rather than wrapping to a small one; poll_until then treats a
+    // deadline the monotonic clock cannot hold as no deadline.
+    Ok(Some(Duration::from_millis(timeout_ms as u64)))
+}
+
+/// Opens the file a lock lives on, creating it if needed and never truncating
+/// it: the file carries no content, only the flock state of its descriptions.
+#[cfg(not(target_arch = "wasm32"))]
+fn open_lock_file(path: &str) -> std::io::Result<fs::File> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+}
+
+/// Repeats a non-blocking lock attempt until it succeeds or `timeout` passes.
+/// Contention is the only error that is retried; anything else propagates.
+#[cfg(not(target_arch = "wasm32"))]
+fn poll_until<F>(timeout: Duration, mut attempt: F) -> std::io::Result<bool>
+where
+    F: FnMut() -> std::io::Result<()>,
+{
+    // A timeout large enough to overflow the monotonic clock leaves no
+    // deadline to compare against, and at that scale there is nothing to
+    // distinguish it from an unbounded wait anyway.
+    let deadline = Instant::now().checked_add(timeout);
+    let contended = fs4::lock_contended_error().raw_os_error();
+    loop {
+        match attempt() {
+            Ok(()) => return Ok(true),
+            Err(e) if e.raw_os_error() == contended => {}
+            Err(e) => return Err(e),
+        }
+        let now = Instant::now();
+        match deadline {
+            Some(deadline) if now >= deadline => return Ok(false),
+            Some(deadline) => std::thread::sleep(LOCK_POLL_INTERVAL.min(deadline - now)),
+            None => std::thread::sleep(LOCK_POLL_INTERVAL),
+        }
+    }
+}
+
+/// The blocking half of `wait_timeout`: a shared probe on `file`, released at
+/// once when it succeeds. A deadline makes it a non-blocking probe retried
+/// until that deadline; `None` blocks in the kernel, which is what `wait()`
+/// does and is cheaper than waking to ask.
+///
+/// `file` must be a description of its own, not the handle's. On Unix a shared
+/// probe on a description that already holds the exclusive lock is granted at
+/// once - flock downgrades it - and on Windows `LockFileEx` would refuse or
+/// block instead. Neither answers the question that was asked.
+#[cfg(not(target_arch = "wasm32"))]
+fn wait_until_free(file: &fs::File, timeout: Option<Duration>) -> std::io::Result<bool> {
+    let Some(timeout) = timeout else {
+        fs4::fs_std::FileExt::lock_shared(file)?;
+        fs4::fs_std::FileExt::unlock(file)?;
+        return Ok(true);
+    };
+    let free = poll_until(timeout, || fs4::fs_std::FileExt::try_lock_shared(file))?;
+    if free {
+        fs4::fs_std::FileExt::unlock(file)?;
+    }
+    Ok(free)
 }
 
 #[napi]
@@ -123,7 +303,6 @@ impl FileLock {
     }
 }
 
-// TODO: Fix the tests
 #[cfg(test)]
 mod test {
     use super::*;
@@ -131,13 +310,21 @@ mod test {
     use assert_fs::TempDir;
     use assert_fs::prelude::*;
 
+    fn lock_path(tmp_dir: &TempDir) -> String {
+        tmp_dir
+            .child("test_lock_file")
+            .path()
+            .to_path_buf()
+            .into_os_string()
+            .into_string()
+            .unwrap()
+    }
+
     #[test]
     fn test_new_lock() {
         let tmp_dir = TempDir::new().unwrap();
         let lock_file = tmp_dir.child("test_lock_file");
-        let lock_file_path = lock_file.path().to_path_buf();
-        let lock_file_path_str = lock_file_path.into_os_string().into_string().unwrap();
-        let mut file_lock = FileLock::new(lock_file_path_str).unwrap();
+        let mut file_lock = FileLock::new(lock_path(&tmp_dir)).unwrap();
         assert_eq!(file_lock.locked, false);
         let _ = file_lock.lock();
         assert_eq!(file_lock.locked, true);
@@ -149,14 +336,302 @@ mod test {
     #[test]
     fn test_drop() {
         let tmp_dir = TempDir::new().unwrap();
-        let lock_file = tmp_dir.child("test_lock_file");
-        let lock_file_path = lock_file.path().to_path_buf();
-        let lock_file_path_str = lock_file_path.into_os_string().into_string().unwrap();
+        let path = lock_path(&tmp_dir);
         {
-            let mut file_lock = FileLock::new(lock_file_path_str.clone()).unwrap();
+            let mut file_lock = FileLock::new(path.clone()).unwrap();
             let _ = file_lock.lock();
         }
-        let file_lock = FileLock::new(lock_file_path_str.clone());
-        assert_eq!(file_lock.unwrap().locked, false);
+        assert_eq!(FileLock::new(path).unwrap().locked, false);
+    }
+
+    // flock is per open file description, so a second handle in this process
+    // is excluded exactly like another process would be. That is what lets
+    // every test here run without a subprocess.
+    #[test]
+    fn a_second_handle_is_excluded_while_the_first_holds() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        a.lock().unwrap();
+
+        let mut b = FileLock::new(path.clone()).unwrap();
+        assert!(b.locked, "constructor probe must see a's lock");
+        assert!(
+            b.check().unwrap(),
+            "check from a non-holder must see a's lock"
+        );
+
+        a.unlock().unwrap();
+        assert!(!b.check().unwrap(), "a's unlock must free the file for b");
+    }
+
+    #[test]
+    fn check_on_the_holder_reports_locked_and_keeps_the_lock() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        a.lock().unwrap();
+
+        assert!(
+            a.check().unwrap(),
+            "the holder must be told the file is locked"
+        );
+        assert!(a.locked);
+
+        // The lock must survive the question: a fresh description is still
+        // excluded, which it would not be if check() had probed on a's own
+        // description and unlocked it.
+        let mut b = FileLock::new(path.clone()).unwrap();
+        assert!(b.locked, "check() on the holder must not release the lock");
+        assert!(!b.lock_timeout(50.0).unwrap());
+
+        a.unlock().unwrap();
+        assert!(!b.check().unwrap());
+    }
+
+    #[test]
+    fn check_follows_whoever_holds_the_lock() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        let mut b = FileLock::new(path.clone()).unwrap();
+
+        a.lock().unwrap();
+        a.unlock().unwrap();
+
+        // a no longer holds it, so a's check() must report what others do.
+        assert!(!a.check().unwrap());
+        b.lock().unwrap();
+        assert!(a.check().unwrap());
+        b.unlock().unwrap();
+        assert!(!a.check().unwrap());
+    }
+
+    #[test]
+    fn lock_timeout_acquires_a_free_lock_and_holds_it() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        assert!(a.lock_timeout(1_000.0).unwrap());
+        assert!(a.locked);
+
+        let b = FileLock::new(path.clone()).unwrap();
+        assert!(b.locked, "lock_timeout must actually take the lock");
+
+        a.unlock().unwrap();
+        assert!(!FileLock::new(path).unwrap().locked);
+    }
+
+    #[test]
+    fn lock_timeout_gives_up_after_the_budget_while_held() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        a.lock().unwrap();
+        let mut b = FileLock::new(path.clone()).unwrap();
+
+        let start = Instant::now();
+        assert!(!b.lock_timeout(100.0).unwrap());
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "gave up after {elapsed:?}, before the 100ms budget"
+        );
+        assert!(elapsed < Duration::from_secs(5), "waited {elapsed:?}");
+
+        a.unlock().unwrap();
+        assert!(b.lock_timeout(1_000.0).unwrap());
+        b.unlock().unwrap();
+    }
+
+    #[test]
+    fn lock_timeout_acquires_once_the_holder_releases_mid_wait() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        a.lock().unwrap();
+        let mut b = FileLock::new(path.clone()).unwrap();
+
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            a.unlock().unwrap();
+        });
+
+        let start = Instant::now();
+        assert!(b.lock_timeout(5_000.0).unwrap());
+        let elapsed = start.elapsed();
+        release.join().unwrap();
+        assert!(
+            elapsed >= Duration::from_millis(50),
+            "acquired after {elapsed:?}, while a still held the lock"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "took the whole budget ({elapsed:?}) although the lock was released early"
+        );
+        assert!(b.locked);
+        b.unlock().unwrap();
+    }
+
+    #[test]
+    fn check_refreshes_the_cached_locked_flag() {
+        // wait() branches on the field rather than on a fresh probe, so an
+        // answer check() does not write back is an answer nothing acts on.
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        a.lock().unwrap();
+
+        let mut b = FileLock::new(path.clone()).unwrap();
+        assert!(b.locked, "constructor probe must see a's lock");
+
+        a.unlock().unwrap();
+        assert!(!b.check().unwrap());
+        assert!(!b.locked, "check() must write back the answer it gave");
+
+        a.lock().unwrap();
+        assert!(b.check().unwrap());
+        assert!(b.locked, "check() must write back the answer it gave");
+    }
+
+    #[test]
+    fn lock_timeout_with_a_zero_budget_still_attempts_once() {
+        // Zero is the only try-lock this API offers: one attempt, no waiting.
+        // Testing the deadline before the first attempt would make it a call
+        // that can never succeed, and every other case here has a budget large
+        // enough to hide that.
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        assert!(
+            a.lock_timeout(0.0).unwrap(),
+            "a zero budget must still make one attempt"
+        );
+        assert!(a.locked);
+
+        let mut b = FileLock::new(path).unwrap();
+        assert!(
+            !b.lock_timeout(0.0).unwrap(),
+            "and must report failure rather than wait when it is held"
+        );
+    }
+
+    #[test]
+    fn a_timeout_that_is_not_a_count_of_milliseconds_is_refused() {
+        // A u32 parameter would arrive through JS ToUint32, turning -1 into
+        // 4294967295 - a 49.7-day block - and NaN into 0. Refusing here is
+        // what keeps either from looking like a deliberate budget.
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+        let mut a = FileLock::new(path).unwrap();
+
+        assert!(a.lock_timeout(-1.0).is_err());
+        assert!(a.lock_timeout(f64::NAN).is_err());
+        assert!(!a.locked, "a refused call must not have taken the lock");
+    }
+
+    #[test]
+    fn an_infinite_timeout_waits_rather_than_giving_up_at_once() {
+        // The other half of the same trap: ToUint32 turns Infinity into 0, so
+        // `lockTimeout(opts.timeout ?? Infinity)` would fail instantly. The
+        // lock has to be held for that to be visible - against a free one a
+        // zero budget succeeds too.
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        a.lock().unwrap();
+        let mut b = FileLock::new(path.clone()).unwrap();
+
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            a.unlock().unwrap();
+        });
+
+        let start = Instant::now();
+        assert!(b.lock_timeout(f64::INFINITY).unwrap());
+        let elapsed = start.elapsed();
+        release.join().unwrap();
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "gave up after {elapsed:?} instead of waiting out the holder"
+        );
+        assert!(b.locked);
+    }
+
+    #[test]
+    fn wait_until_free_without_a_deadline_returns_once_the_holder_releases() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        a.lock().unwrap();
+
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            a.unlock().unwrap();
+        });
+
+        let probe = open_lock_file(&path).unwrap();
+        let start = Instant::now();
+        assert!(wait_until_free(&probe, None).unwrap());
+        let elapsed = start.elapsed();
+        release.join().unwrap();
+        assert!(
+            elapsed >= Duration::from_millis(50),
+            "returned after {elapsed:?}, while a still held the lock"
+        );
+
+        // The successful probe must leave nothing held behind, deadline or not.
+        assert!(!FileLock::new(path).unwrap().locked);
+    }
+
+    #[test]
+    fn poll_until_propagates_errors_other_than_contention() {
+        let start = Instant::now();
+        let result = poll_until(Duration::from_millis(200), || {
+            Err(std::io::Error::other("not a lock conflict"))
+        });
+        assert!(
+            result.is_err(),
+            "a non-contention error must not be retried"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(200),
+            "the error was retried until the deadline instead of propagated"
+        );
+    }
+
+    #[test]
+    fn wait_until_free_gives_up_while_held_and_returns_once_released() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = lock_path(&tmp_dir);
+
+        let mut a = FileLock::new(path.clone()).unwrap();
+        a.lock().unwrap();
+
+        let probe = open_lock_file(&path).unwrap();
+        let start = Instant::now();
+        assert!(!wait_until_free(&probe, Some(Duration::from_millis(100))).unwrap());
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "gave up after {elapsed:?}, before the 100ms budget"
+        );
+        assert!(elapsed < Duration::from_secs(5), "waited {elapsed:?}");
+
+        a.unlock().unwrap();
+        assert!(wait_until_free(&probe, Some(Duration::from_secs(1))).unwrap());
+
+        // The successful probe must leave nothing held behind.
+        assert!(!FileLock::new(path).unwrap().locked);
     }
 }


### PR DESCRIPTION
## Current Behavior

`FileLock.check()` probes with `try_lock_exclusive()` followed by `unlock()` on the handle's **own** file. `fs4` resolves to `flock(2)` here, and flock re-locks a description that already holds the lock without complaint, so on the holder the probe succeeds, the unlock releases what the caller holds, and `check()` answers `false`. The holder is told nobody holds the lock, and from then on nobody does:

```js
const holder = new FileLock(path);
holder.lock();
holder.check();              // false, expected true
new FileLock(path).locked;   // false, expected true
```

This is Unix-only. On Windows `fs4` is `LockFileEx`, which refuses a second exclusive lock from the same handle, so the old probe already answered the holder correctly there.

Separately, `lock()` and `wait()` have no bound, so a wedged holder blocks every future waiter indefinitely.

Neither is reachable from the in-tree callers today: `project-graph.ts` uses `tryLock()` and `wait()`, `acquire_files` calls `check()` only on a handle that does not hold the lock, and `migrate/run/state-lock.ts` never calls it. It is the API that is wrong: a caller that wants to hold the lock across a check has no way to ask.

## Expected Behavior

- `check()` probes on a file description of its own, so it answers `true` on the holder and releases nothing. A non-holder gets the same answer as before.
- `lockTimeout(ms): boolean` and `waitTimeout(ms): Promise<boolean>` report whether they succeeded instead of blocking forever. `lockTimeout` repeats `tryLock()` until the deadline; `waitTimeout` polls the way `wait_blocking` does, on the blocking pool so it cannot starve other native futures.
- The timeout is an `f64`, not a `u32`. napi converts a `u32` through `ToUint32`, so `Infinity` would arrive as `0` and `-1` as `4294967295`: `lockTimeout(opts.timeout ?? Infinity)` would give up at once, and a deadline one below zero would block for 49.7 days. `Infinity` means `lock()` / `wait()` with no deadline; `NaN` and negatives are refused with `InvalidArg`, synchronously in `waitTimeout`.
- `wait_blocking`'s loop moves into a function shared with `waitTimeout`, and the four copies of the lock file `OpenOptions` become one helper.

`check()` still takes and releases a *free* lock to answer, briefly, and that hold is observable: flock has no query operation. `wait()`, `lock()` and `tryLock()` keep their meaning.

## Related Issue(s)

Fixes #36907

Builds on `tryLock` and `wait_blocking` from #36999 and #36980.

## Scope

The `check()` fix and the timed API are independent, and the timed API has no in-tree caller yet (`lockTimeout(0)` is `tryLock()` under another name; the difference starts above zero). The bounded waits are groundwork for #36903, which needs an async bounded acquire on top of this; they are not that primitive. If you would rather take the `check()` fix on its own and see `lockTimeout` / `waitTimeout` land with the change that consumes them, say so and I will split it.

## Tests

`cargo test -p nx file_lock` is 21 passed and the crate is 755 passed, 2 ignored. Twenty further runs of the test binary were clean; the same loop on master shows the wall-clock `dep_outputs::test_performance_large_graph` failing now and then. One earlier full run failed `file_lock::test::test_drop`, which relies on the close releasing the lock; it did not recur in 22 later runs or in 40 on master, and I have no explanation for it.

`cargo fmt --all --check` and `oxfmt` are clean; `cargo clippy -p nx --tests` gives the same 176 warnings as master. A debug `napi build` regenerates `index.d.ts` byte for byte, and against master it adds 16 lines, all in `FileLock`. `file_lock.spec.ts` is 9 passed against that build. Its four new cases cover `check()` on the holder, giving up on a held lock, `waitTimeout(Infinity)` and the refusal of `-1` / `NaN`; the last two are what a `u32` parameter would break at the TS boundary.

Mutation-checked, each row failing the test written for it:

| mutation | failing test |
|---|---|
| `check()` probes on a dup of the handle's own description (the original bug) | `check_on_the_holder_reports_locked_and_keeps_the_lock` |
| `check()` returns the answer without writing it back | `check_refreshes_the_cached_locked_flag` |
| `lockTimeout` takes the lock without recording it | `lock_timeout_acquires_a_free_lock_and_holds_it`, `lock_timeout_that_gives_up_leaves_locked_reading_true` |
| `lockTimeout` tests the deadline before the first attempt | `lock_timeout_with_a_zero_budget_still_attempts_once` |
| `Infinity` becomes a zero budget | `an_infinite_timeout_waits_rather_than_giving_up_at_once` |
| negatives and NaN are accepted | `a_timeout_that_is_not_a_count_of_milliseconds_is_refused` |
| the bounded wait answers without probing | `wait_for_release_gives_up_while_held_and_returns_once_released`, `wait_for_release_on_the_holders_own_lock_waits_on_nobody_but_itself` |
| the bounded wait never retries on contention | `wait_for_release_gives_up_while_held_and_returns_once_released`, `wait_blocking_returns_true_once_the_holder_releases` |
| the unbounded wait returns without probing | `wait_for_release_without_a_deadline_returns_once_the_holder_releases` |
| the deadline is multiplied by 100 | `lock_timeout_gives_up_after_the_budget_while_held` |
| `deadline_after` adds instead of `checked_add` | `a_budget_no_clock_can_hold_has_no_deadline` |
| `u32` timeouts and `check()` probing on the holder's description, in one addon | the three spec cases written for those |

On the built addon: `check()` on the holder is `true` and a fresh handle still finds the lock held. `lockTimeout(100)` against a held lock is `false` in 104 ms, `waitTimeout(150)` is `false` in 151 ms, and `lockTimeout(0)` is `true` in 0 ms on a free lock. `lockTimeout(-1)`, `lockTimeout(NaN)` and `waitTimeout(-1)` are refused with `timeoutMs must be a non-negative number of milliseconds`, the last synchronously. Against a holder in another process, `lockTimeout(Infinity)` returns `true` at 600 ms for a release at 600 ms and `waitTimeout(Infinity)` resolves `true` 101 ms after a release at 100 ms; the event loop keeps running during `waitTimeout` (10 ticks of a 10 ms interval in 117 ms).

## Not verified

Windows and wasm32, neither built nor run. On Windows a finite budget in `lockTimeout` on a handle that already holds the lock would poll to the deadline (`LockFileEx` conflicts with the same handle) and `Infinity` would wait on itself, where Unix returns `true` at once; that is read out of the `fs4` source and the Win32 contract, and neither in-tree caller asks. `nx prepush` and the affected targets were not run, only the checks above, and the TS spec ran with another checkout's `node_modules` linked in.
