### PR TITLE
fix(core): skip the migrate formatter command when the configured formatter is not installed

### DIFF
--- a/packages/nx/src/command-line/format/format.spec.ts
+++ b/packages/nx/src/command-line/format/format.spec.ts
@@ -5,7 +5,13 @@ import { format } from './format';
 // whether CI passes - fail-open, configured-but-not-installed, and the
 // write/check dispatch - have no fast test. These mock the seams around it.
 
-vi.mock('../../utils/formatters', () => ({ detectFormatter: vi.fn() }));
+vi.mock('../../utils/formatters', async () => ({
+  detectFormatter: vi.fn(),
+  resolveFormatterBin: {
+    oxfmt: (await import('../../utils/formatters/oxfmt')).getOxfmtBinPath,
+    prettier: (await import('../../utils/formatters/prettier')).getPrettierPath,
+  },
+}));
 vi.mock('../../utils/formatters/oxfmt', () => ({
   getOxfmtBinPath: vi.fn(),
   writeWithOxfmt: vi.fn(),

--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -17,16 +17,15 @@ import {
   splitArgsIntoNxArgsAndOverrides,
 } from '../../utils/command-line-utils';
 import { fileExists, readJsonFile, writeJsonFile } from '../../utils/fileutils';
-import { detectFormatter, type FormatterType } from '../../utils/formatters';
 import {
-  checkWithOxfmt,
-  getOxfmtBinPath,
-  writeWithOxfmt,
-} from '../../utils/formatters/oxfmt';
+  detectFormatter,
+  type FormatterType,
+  resolveFormatterBin,
+} from '../../utils/formatters';
+import { checkWithOxfmt, writeWithOxfmt } from '../../utils/formatters/oxfmt';
 import {
   checkWithPrettier,
   filterToPrettierSupportedFiles,
-  getPrettierPath,
   quoteForShell,
   writeWithPrettier,
 } from '../../utils/formatters/prettier';
@@ -34,16 +33,6 @@ import { getIgnoreObject } from '../../utils/ignore';
 import { sortObjectByKeys } from '../../utils/object-sort';
 import { output } from '../../utils/output';
 import { workspaceRoot } from '../../utils/workspace-root';
-
-/**
- * A table, not a `switch`: this lookup sits inside a `try` whose `catch`
- * reports "configured but not installed", and a `never` arm would throw into
- * that catch and be misreported. A missing member is a compile error here.
- */
-const resolveFormatterBin = {
-  oxfmt: getOxfmtBinPath,
-  prettier: getPrettierPath,
-} satisfies Record<FormatterType, () => string>;
 
 export async function format(
   command: 'check' | 'write',

--- a/packages/nx/src/command-line/migrate/agentic/format-command.spec.ts
+++ b/packages/nx/src/command-line/migrate/agentic/format-command.spec.ts
@@ -1,8 +1,25 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import type { Mock } from 'vitest';
 import { resetFormatterWarningsForTesting } from '../../../utils/formatters';
 import { resolveFormatCommand } from './format-command';
+
+// Detection reads the temp workspace; the bin lookup is mocked because it
+// resolves against the nx repo, where both formatters are installed.
+vi.mock('../../../utils/formatters/oxfmt', async () => ({
+  ...(await vi.importActual('../../../utils/formatters/oxfmt')),
+  getOxfmtBinPath: vi.fn(),
+}));
+vi.mock('../../../utils/formatters/prettier', async () => ({
+  ...(await vi.importActual('../../../utils/formatters/prettier')),
+  getPrettierPath: vi.fn(),
+}));
+
+const { getOxfmtBinPath } =
+  (await import('../../../utils/formatters/oxfmt')) as Record<string, Mock>;
+const { getPrettierPath } =
+  (await import('../../../utils/formatters/prettier')) as Record<string, Mock>;
 
 describe('resolveFormatCommand', () => {
   let root: string;
@@ -11,6 +28,8 @@ describe('resolveFormatCommand', () => {
     root = mkdtempSync(join(tmpdir(), 'nx-format-command-'));
     // The both-configured warning is warn-once module state.
     resetFormatterWarningsForTesting();
+    getOxfmtBinPath.mockReset().mockReturnValue('/bin/oxfmt');
+    getPrettierPath.mockReset().mockReturnValue('/bin/prettier');
   });
 
   afterEach(() => {
@@ -47,4 +66,20 @@ describe('resolveFormatCommand', () => {
       'npx prettier --write --ignore-unknown <paths>'
     );
   });
+
+  // Under npm the command would make `npx` download and run the formatter.
+  it.each([
+    ['prettier', '.prettierrc', () => getPrettierPath],
+    ['oxfmt', '.oxfmtrc.json', () => getOxfmtBinPath],
+  ])(
+    'returns null when %s is configured but not installed',
+    (_formatter, configFile, bin) => {
+      writeFileSync(join(root, configFile), '{}');
+      bin().mockImplementation(() => {
+        throw new Error('MODULE_NOT_FOUND');
+      });
+
+      expect(resolveFormatCommand(root, 'npx')).toBeNull();
+    }
+  );
 });

--- a/packages/nx/src/command-line/migrate/agentic/format-command.ts
+++ b/packages/nx/src/command-line/migrate/agentic/format-command.ts
@@ -1,4 +1,8 @@
-import { detectFormatter, FormatterType } from '../../../utils/formatters';
+import {
+  detectFormatter,
+  FormatterType,
+  resolveFormatterBin,
+} from '../../../utils/formatters';
 
 /**
  * The command the agent runs over the files it changed, with a `<paths>`
@@ -27,12 +31,22 @@ export function formatCommandFor(
  * Resolved against the workspace as it is now, so it goes stale once a
  * migration changes the formatter; callers re-resolve per dispense, and the
  * scope rules name the replacement commands for the step that made the change.
- * `null` when no formatter is configured.
+ * `null` when no formatter is configured, or the configured one is not
+ * installed: under npm the command would otherwise make `npx` download and run
+ * it, where `nx format` refuses.
  */
 export function resolveFormatCommand(
   root: string,
   pmExec: string
 ): string | null {
   const formatter = detectFormatter(root);
-  return formatter === null ? null : formatCommandFor(formatter, pmExec);
+  if (formatter === null) {
+    return null;
+  }
+  try {
+    resolveFormatterBin[formatter]();
+  } catch {
+    return null;
+  }
+  return formatCommandFor(formatter, pmExec);
 }

--- a/packages/nx/src/command-line/migrate/agentic/prompts/fragments.ts
+++ b/packages/nx/src/command-line/migrate/agentic/prompts/fragments.ts
@@ -60,11 +60,11 @@ function renderFormatRule(pmExec: string, format: FormatInstruction): string {
   const replacement = `If this migration itself added or replaced the workspace formatter, run the new one ${FORMAT_SCOPE} instead: \`${formatCommandFor(
     'prettier',
     pmExec
-  )}\` for Prettier, \`${formatCommandFor('oxfmt', pmExec)}\` for oxfmt. ${NO_FILES}`;
+  )}\` for Prettier, \`${formatCommandFor('oxfmt', pmExec)}\` for oxfmt, but only if it is installed under node_modules; if it is not, do not install or run it. ${NO_FILES}`;
   switch (format.source) {
     case 'command':
       return format.command === null
-        ? `- This workspace has no formatter configured; do not run one over your changes. ${replacement}`
+        ? `- No configured formatter is installed in this workspace; do not install or run one over your changes. ${replacement}`
         : `- After applying your changes and before writing the handoff, run \`${format.command}\` ${FORMAT_SCOPE} (the flag keeps the command from failing when some or all of those paths are files the formatter does not handle). ${replacement} ${NO_NX_FORMAT}`;
     case 'dispensed-step':
       return `- After applying your changes and before writing the handoff, run the command on the dispensed step's \`Format command:\` line ${FORMAT_SCOPE}; when that line says none, do not run a formatter. ${replacement} ${NO_NX_FORMAT}`;

--- a/packages/nx/src/command-line/migrate/agentic/prompts/system-prompt.spec.ts
+++ b/packages/nx/src/command-line/migrate/agentic/prompts/system-prompt.spec.ts
@@ -174,7 +174,7 @@ describe('buildSystemPrompt', () => {
     it('tells the agent not to run a formatter when the workspace has none', () => {
       const prompt = buildSystemPrompt({ ...ctx, formatCommand: null });
       expect(prompt).toContain(
-        'This workspace has no formatter configured; do not run one over your changes.'
+        'No configured formatter is installed in this workspace; do not install or run one over your changes.'
       );
       expect(prompt).not.toContain(
         'After applying your changes and before writing the handoff, run'
@@ -195,7 +195,7 @@ describe('buildSystemPrompt', () => {
         // The command was resolved before the step ran, so only the agent
         // knows the formatter changed; the flags must not be left to it.
         expect(prompt).toContain(
-          'If this migration itself added or replaced the workspace formatter, run the new one over exactly the files you created or modified instead: `pnpm exec prettier --write --ignore-unknown <paths>` for Prettier, `pnpm exec oxfmt --no-error-on-unmatched-pattern <paths>` for oxfmt. If you created or modified no files, do not run it.'
+          'If this migration itself added or replaced the workspace formatter, run the new one over exactly the files you created or modified instead: `pnpm exec prettier --write --ignore-unknown <paths>` for Prettier, `pnpm exec oxfmt --no-error-on-unmatched-pattern <paths>` for oxfmt, but only if it is installed under node_modules; if it is not, do not install or run it. If you created or modified no files, do not run it.'
         );
       }
     );

--- a/packages/nx/src/command-line/migrate/migrate-commits.ts
+++ b/packages/nx/src/command-line/migrate/migrate-commits.ts
@@ -254,7 +254,6 @@ function defaultBranchToCompare(
   return remote ? baseRef.slice(remote.length + 1) : baseRef;
 }
 
-/** The current branch when it is the workspace's default branch, else null. */
 export function currentBranchIfDefault(root: string): string | null {
   const currentBranch = getGitCurrentBranch(root);
   if (!currentBranch) {

--- a/packages/nx/src/command-line/migrate/run/orchestrator.spec.ts
+++ b/packages/nx/src/command-line/migrate/run/orchestrator.spec.ts
@@ -2230,7 +2230,7 @@ describe('orchestrator', () => {
         });
         await runOrchestratorReconcile({ root, runId: 'run-1' });
         expect(lastBlock().payload.instructions).toContain(
-          'Format command: none (no formatter is configured)'
+          'Format command: none (no configured formatter is installed)'
         );
 
         writeFileSync(join(root, '.prettierrc'), '{}');

--- a/packages/nx/src/command-line/migrate/run/orchestrator.ts
+++ b/packages/nx/src/command-line/migrate/run/orchestrator.ts
@@ -1980,7 +1980,7 @@ function emitAwaitPrompt(
         // since the runbook was written.
         `Format command: ${
           resolveFormatCommand(root, pmExecPrefix(root)) ??
-          'none (no formatter is configured)'
+          'none (no configured formatter is installed)'
         }`,
       ];
   lines.push(

--- a/packages/nx/src/command-line/migrate/run/runbook.spec.ts
+++ b/packages/nx/src/command-line/migrate/run/runbook.spec.ts
@@ -96,7 +96,7 @@ describe('renderRunbook', () => {
       "run the command on the dispensed step's `Format command:` line over exactly the files you created or modified; when that line says none, do not run a formatter."
     );
     expect(runbook).toContain(
-      'If this migration itself added or replaced the workspace formatter, run the new one over exactly the files you created or modified instead: `pnpm exec prettier --write --ignore-unknown <paths>` for Prettier, `pnpm exec oxfmt --no-error-on-unmatched-pattern <paths>` for oxfmt. If you created or modified no files, do not run it.'
+      'If this migration itself added or replaced the workspace formatter, run the new one over exactly the files you created or modified instead: `pnpm exec prettier --write --ignore-unknown <paths>` for Prettier, `pnpm exec oxfmt --no-error-on-unmatched-pattern <paths>` for oxfmt, but only if it is installed under node_modules; if it is not, do not install or run it. If you created or modified no files, do not run it.'
     );
   });
 

--- a/packages/nx/src/utils/formatters/index.ts
+++ b/packages/nx/src/utils/formatters/index.ts
@@ -3,8 +3,12 @@ import { join } from 'node:path';
 import type { Tree } from '../../generators/tree';
 import { readJson } from '../../generators/utils/json';
 import { readJsonFile } from '../fileutils';
-import { isUsingOxfmt, isUsingOxfmtInTree } from './oxfmt';
-import { isUsingPrettier, isUsingPrettierInTree } from './prettier';
+import { getOxfmtBinPath, isUsingOxfmt, isUsingOxfmtInTree } from './oxfmt';
+import {
+  getPrettierPath,
+  isUsingPrettier,
+  isUsingPrettierInTree,
+} from './prettier';
 import { logger } from '../logger';
 
 /**
@@ -15,6 +19,16 @@ import { logger } from '../logger';
  * its emitted declarations, so those only fail once it has been rebuilt.
  */
 export type FormatterType = 'prettier' | 'oxfmt';
+
+/**
+ * A table, not a `switch`: callers run this inside a `try` whose `catch`
+ * means "configured but not installed", and a `never` arm would throw into
+ * that catch and be misreported. A missing member is a compile error here.
+ */
+export const resolveFormatterBin = {
+  oxfmt: getOxfmtBinPath,
+  prettier: getPrettierPath,
+} satisfies Record<FormatterType, () => string>;
 
 // Once per process: detection runs on every one of 200+ `formatFiles` call sites.
 let warnedBothConfigured = false;


### PR DESCRIPTION
## Current Behavior

Stacked on #36766.

The agentic migrate prompts tell the agent to format its changed files with the formatter nx resolves from the workspace. That resolution reads configuration only. A workspace can carry a `.prettierrc` without prettier installed: a fresh clone, an `--omit=dev` install, a pruned tree. The prompt still emits the npm command, and npx downloads the package and runs it. Without a TTY, npm assumes `--yes`, and an agent on a TTY answers the prompt itself. Before #36766 the prompt pointed at `nx format:write`, which refuses that state:

```
NX   prettier is configured for this workspace but is not installed.
```

The guidance for a migration that adds or replaces the formatter has the same gap. It names the direct commands without asking whether the new formatter is installed.

## Expected Behavior

When the configured formatter is not installed, the dispensed step says `Format command: none (no configured formatter is installed)`. The per-step prompt tells the agent not to install or run one. A migration that adds a formatter is told to run it only if it is installed under `node_modules`.

## Related Issue(s)

NXC-4627

## Implementation Notes

- The formatter binary is resolved through the table `nx format` already uses, moved to `utils/formatters` so both callers share it. A missing binary maps to the same `null` as no formatter, so neither the prompt nor the orchestrator grows a third state.
- The added-formatter case stays prose. The command is resolved before the step runs, so only the agent can check the install after the migration.
- The JSDoc on `currentBranchIfDefault` restated its signature and is removed.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4627-9cb5f956">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->