### PR TITLE
fix(core): combine Windows watcher recursive root and rescan recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,15 +1041,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
  "bitflags 2.13.0",
  "inotify-sys",
@@ -1653,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -1955,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1965,11 +1956,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -2331,20 +2322,22 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.2.0"
+version = "9.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+checksum = "7768eb7201a1964d8eb10224e850df046ab584ee3c3d26e340a993d81f748148"
 dependencies = [
  "bitflags 2.13.0",
- "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
  "mio",
  "notify-types",
+ "objc2-core-foundation",
+ "objc2-core-services",
  "walkdir",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -2549,6 +2542,16 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,11 @@
+disallowed-methods = [
+  # On Windows, std::fs::canonicalize returns an extended-length verbatim path
+  # that does not compare equal to the normal paths the rest of the code uses
+  # (and which notify reports). Use dunce::canonicalize, which strips the prefix.
+  { path = "std::fs::canonicalize", reason = "Use dunce::canonicalize; std returns a Windows extended-length verbatim path that mismatches normal paths" },
+  { path = "std::path::Path::canonicalize", reason = "Use dunce::canonicalize; std returns a Windows extended-length verbatim path that mismatches normal paths" },
+]
+
 disallowed-types = [
   # We need to ensure adjustments for light and dark themes are applied appropriately
   { path = "ratatui::style::Color", reason = "Use our utils from crate::native::tui::colors instead to ensure appropriate light/dark theme support" },

--- a/packages/maven/assets.json
+++ b/packages/maven/assets.json
@@ -6,18 +6,18 @@
     { "glob": "migrations/**/*.md", "input": "packages/maven/src" },
     { "glob": "@(generators|executors).json" },
     {
-      "glob": "**/*.jar",
+      "glob": "**/batch-runner.jar",
       "input": "packages/maven/batch-runner/target",
       "includeIgnoredFiles": true
     },
     {
-      "glob": "**/*.jar",
+      "glob": "**/maven3-adapter.jar",
       "input": "packages/maven/batch-runner-adapters/maven3/target",
       "output": "/nx-maven-adapters",
       "includeIgnoredFiles": true
     },
     {
-      "glob": "**/*.jar",
+      "glob": "**/maven4-adapter.jar",
       "input": "packages/maven/batch-runner-adapters/maven4/target",
       "output": "/nx-maven-adapters",
       "includeIgnoredFiles": true

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -124,7 +124,7 @@ reqwest = { version = "0.12.22", default-features = false, features = [
   "hickory-dns",
 ] }
 rusqlite = { version = "0.32.1", features = ["bundled", "array", "vtab"] }
-notify = "8"
+notify = "=9.0.0-rc.5"
 machine-uid = "0.5.2"
 interprocess = { version = "=2.2.3", features = ["tokio"] }
 jsonrpsee = { version = "0.25.1", features = [

--- a/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
@@ -5,6 +5,7 @@ vi.mock('../logger', () => ({
   serverLogger: { watcherLog: vi.fn() },
 }));
 vi.mock('./outputs-tracking', () => ({
+  clearRecordedOutputsHashes: vi.fn(),
   disableOutputsTracking: vi.fn(),
   processFileChangesInOutputs: vi.fn(),
 }));
@@ -26,6 +27,7 @@ describe('handleOutputsChanges', () => {
   let handleOutputsChanges: typeof import('./handle-outputs-changes').handleOutputsChanges;
   let getOutputsWatcherTerminalError: typeof import('./handle-outputs-changes').getOutputsWatcherTerminalError;
   let outputsTracking: {
+    clearRecordedOutputsHashes: Mock;
     disableOutputsTracking: Mock;
     processFileChangesInOutputs: Mock;
   };
@@ -58,6 +60,18 @@ describe('handleOutputsChanges', () => {
 
   afterEach(() => {
     consoleError.mockRestore();
+  });
+
+  it('starts the tracker over and invalidates the graph on a rescan, without processing per-path events', async () => {
+    await handleOutputsChanges(null, [{ path: '', type: EventType.rescan }]);
+
+    expect(outputsTracking.clearRecordedOutputsHashes).toHaveBeenCalled();
+    expect(recomputation.invalidateGraphCache).toHaveBeenCalled();
+    expect(outputsTracking.processFileChangesInOutputs).not.toHaveBeenCalled();
+    expect(dotenvChanges.classifyDotEnvChanges).not.toHaveBeenCalled();
+    // A rescan is recoverable: the watch stream is still alive.
+    expect(getOutputsWatcherTerminalError()).toBeUndefined();
+    expect(outputsTracking.disableOutputsTracking).not.toHaveBeenCalled();
   });
 
   it('records a native watcher error as terminal, preserving its message, and disables outputs tracking', async () => {

--- a/packages/nx/src/daemon/server/handle-outputs-changes.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.ts
@@ -4,6 +4,7 @@ import {
   queuePendingDotEnvEvents,
 } from './dotenv-graph-changes';
 import {
+  clearRecordedOutputsHashes,
   disableOutputsTracking,
   processFileChangesInOutputs,
 } from './outputs-tracking';
@@ -73,6 +74,18 @@ export const handleOutputsChanges: FileWatcherCallback = async (
     // here cannot trip the outputs-tracking kill switch below, which belongs
     // to an unrelated subsystem, and it fails safe by invalidating: a stale
     // graph on a dotenv edit is the bug this prevents.
+    if (changeEvents.some((event) => event.type === 'rescan')) {
+      // Dropped events cannot be classified: any recorded output hash and any
+      // gitignored dotenv file may have changed unseen. Start the tracker
+      // over and invalidate the graph rather than trust either.
+      serverLogger.watcherLog(
+        'The outputs watcher reported dropped events; clearing recorded output hashes and invalidating the graph cache.'
+      );
+      clearRecordedOutputsHashes();
+      invalidateGraphCache();
+      return;
+    }
+
     try {
       const { invalidating, unclassified } = classifyDotEnvChanges(
         changeEvents,

--- a/packages/nx/src/daemon/server/handle-outputs-changes.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.ts
@@ -57,6 +57,18 @@ export const handleOutputsChanges: FileWatcherCallback = async (
       return;
     }
 
+    if (changeEvents.some((event) => event.type === 'rescan')) {
+      // Dropped events cannot be classified: any recorded output hash and any
+      // gitignored dotenv file may have changed unseen. Start the tracker
+      // over and invalidate the graph rather than trust either.
+      serverLogger.watcherLog(
+        'The outputs watcher reported dropped events; clearing recorded output hashes and invalidating the graph cache.'
+      );
+      clearRecordedOutputsHashes();
+      invalidateGraphCache();
+      return;
+    }
+
     // A dotenv change that a task chain loads must refresh the graph so
     // createNodes re-resolves config reading process.env. This runs above the
     // outputsWatcherError guard: the two concerns are independent, and a
@@ -74,18 +86,6 @@ export const handleOutputsChanges: FileWatcherCallback = async (
     // here cannot trip the outputs-tracking kill switch below, which belongs
     // to an unrelated subsystem, and it fails safe by invalidating: a stale
     // graph on a dotenv edit is the bug this prevents.
-    if (changeEvents.some((event) => event.type === 'rescan')) {
-      // Dropped events cannot be classified: any recorded output hash and any
-      // gitignored dotenv file may have changed unseen. Start the tracker
-      // over and invalidate the graph rather than trust either.
-      serverLogger.watcherLog(
-        'The outputs watcher reported dropped events; clearing recorded output hashes and invalidating the graph cache.'
-      );
-      clearRecordedOutputsHashes();
-      invalidateGraphCache();
-      return;
-    }
-
     try {
       const { invalidating, unclassified } = classifyDotEnvChanges(
         changeEvents,

--- a/packages/nx/src/daemon/server/outputs-tracking.ts
+++ b/packages/nx/src/daemon/server/outputs-tracking.ts
@@ -130,6 +130,24 @@ export function recordOutputsHashBatch(
   }
 }
 
+/**
+ * One-shot reset for a watcher rescan: recorded hashes may describe outputs
+ * whose change events were dropped, so none can be trusted. Unlike
+ * `disableOutputsTracking` the tracker keeps running; it just starts over.
+ */
+export function clearRecordedOutputsHashes() {
+  for (const store of [
+    dirsContainingOutputs,
+    recordedHashes,
+    timestamps,
+    numberOfExpandedOutputs,
+  ]) {
+    for (const key of Object.keys(store)) {
+      delete store[key];
+    }
+  }
+}
+
 export function disableOutputsTracking() {
   disabled = true;
 }

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
 import { TempFs } from '../../internal-testing-utils/temp-fs';
@@ -1947,5 +1953,124 @@ describe('pending dotenv replay before serving a graph', () => {
     const fourth = await getCachedSerializedProjectGraphPromise();
     expect(fourth.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
     expect(retrieveCallCount).toBe(2);
+  });
+});
+
+describe('handleWatcherRescan', () => {
+  let fs: TempFs;
+
+  beforeEach(() => {
+    fs = new TempFs('pgir-rescan');
+  });
+
+  afterEach(() => {
+    fs.cleanup();
+    delete (global as any).NX_DAEMON;
+  });
+
+  it('recovers file changes the watcher never delivered', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/src/index.ts': 'original',
+      'libs/foo/src/stale.ts': '',
+    });
+
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    // handleWatcherRescan runs on the daemon, where the context wrappers
+    // take their direct path.
+    (global as any).NX_DAEMON = true;
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+
+    const {
+      getCachedSerializedProjectGraphPromise,
+      handleWatcherRescan,
+      isKnownWorkspaceFile,
+    } = await import('./project-graph-incremental-recomputation');
+
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.error).toBeNull();
+    expect(first.projectGraph.nodes.foo).toBeDefined();
+    expect(isKnownWorkspaceFile('libs/bar/project.json')).toBe(false);
+
+    // Dropped events: the workspace moves on with no watcher batch at all.
+    writeFileSync(join(fs.tempDir, 'libs/foo/src/index.ts'), 'changed');
+    mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
+    writeFileSync(
+      join(fs.tempDir, 'libs/bar/project.json'),
+      JSON.stringify({ name: 'bar', root: 'libs/bar' })
+    );
+    rmSync(join(fs.tempDir, 'libs/foo/src/stale.ts'));
+
+    await handleWatcherRescan();
+
+    const second = await getCachedSerializedProjectGraphPromise();
+    expect(second.error).toBeNull();
+    expect(second.projectGraph.nodes.bar).toBeDefined();
+    expect(isKnownWorkspaceFile('libs/bar/project.json')).toBe(true);
+    expect(isKnownWorkspaceFile('libs/foo/src/stale.ts')).toBe(false);
+  });
+
+  it('keeps the cached graph when the re-walk finds no differences', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+
+    vi.resetModules();
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    (global as any).NX_DAEMON = true;
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+
+    const { getCachedSerializedProjectGraphPromise, handleWatcherRescan } =
+      await import('./project-graph-incremental-recomputation');
+
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.error).toBeNull();
+
+    await handleWatcherRescan();
+
+    // Same result object: no invalidation happened, the cached compute
+    // survived the rescan.
+    const second = await getCachedSerializedProjectGraphPromise();
+    expect(second).toBe(first);
+  });
+});
+
+describe('diffFileData', () => {
+  it('classifies created, updated, unchanged and deleted files', async () => {
+    const { diffFileData } =
+      await import('./project-graph-incremental-recomputation');
+
+    const diff = diffFileData(
+      [
+        { file: 'a.ts', hash: '1' },
+        { file: 'b.ts', hash: '2' },
+        { file: 'c.ts', hash: '3' },
+      ],
+      [
+        { file: 'b.ts', hash: '2' },
+        { file: 'c.ts', hash: 'changed' },
+        { file: 'd.ts', hash: '4' },
+      ]
+    );
+
+    expect(diff.createdFiles).toEqual(['d.ts']);
+    // Created files carry their hash too: the collector needs one for every
+    // file it records, created or updated.
+    expect(diff.updatedFiles).toEqual([
+      { file: 'c.ts', hash: 'changed' },
+      { file: 'd.ts', hash: '4' },
+    ]);
+    expect(diff.deletedFiles).toEqual(['a.ts']);
   });
 });

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -2045,32 +2045,3 @@ describe('handleWatcherRescan', () => {
     expect(second).toBe(first);
   });
 });
-
-describe('diffFileData', () => {
-  it('classifies created, updated, unchanged and deleted files', async () => {
-    const { diffFileData } =
-      await import('./project-graph-incremental-recomputation');
-
-    const diff = diffFileData(
-      [
-        { file: 'a.ts', hash: '1' },
-        { file: 'b.ts', hash: '2' },
-        { file: 'c.ts', hash: '3' },
-      ],
-      [
-        { file: 'b.ts', hash: '2' },
-        { file: 'c.ts', hash: 'changed' },
-        { file: 'd.ts', hash: '4' },
-      ]
-    );
-
-    expect(diff.createdFiles).toEqual(['d.ts']);
-    // Created files carry their hash too: the collector needs one for every
-    // file it records, created or updated.
-    expect(diff.updatedFiles).toEqual([
-      { file: 'c.ts', hash: 'changed' },
-      { file: 'd.ts', hash: '4' },
-    ]);
-    expect(diff.deletedFiles).toEqual(['a.ts']);
-  });
-});

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -38,9 +38,8 @@ import {
 } from '../../project-graph/utils/retrieve-workspace-files';
 import { fileExists } from '../../utils/fileutils';
 import {
-  getAllFileDataInContext,
+  rescanAndDiffInContext,
   resetWorkspaceContext,
-  setupWorkspaceContext,
   updateFilesInContext,
 } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -397,51 +396,22 @@ export function scheduleProjectGraphRecomputation(
   }
 }
 
-export interface FileDataDiff {
-  createdFiles: string[];
-  updatedFiles: Array<{ file: string; hash: string }>;
-  deletedFiles: string[];
-}
-
-export function diffFileData(
-  before: FileData[],
-  after: FileData[]
-): FileDataDiff {
-  const beforeHashes = new Map(before.map((f) => [f.file, f.hash]));
-  const createdFiles: string[] = [];
-  const updatedFiles: Array<{ file: string; hash: string }> = [];
-  for (const f of after) {
-    const previousHash = beforeHashes.get(f.file);
-    if (previousHash === undefined) {
-      createdFiles.push(f.file);
-      updatedFiles.push({ file: f.file, hash: f.hash });
-    } else {
-      if (previousHash !== f.hash) {
-        updatedFiles.push({ file: f.file, hash: f.hash });
-      }
-      beforeHashes.delete(f.file);
-    }
-  }
-  return {
-    createdFiles,
-    updatedFiles,
-    deletedFiles: [...beforeHashes.keys()],
-  };
-}
-
 /**
  * The watcher reported dropped events (a kernel event-queue overflow), so the
  * per-path stream cannot be trusted complete. Recover by re-walking the
  * workspace and diffing it against the context's known files, then feed the
  * synthesized changes through the same collection and notification path a
  * normal watcher batch takes.
+ *
+ * The walk and the diff both happen in the workspace context: it already owns
+ * the file map, so diffing there keeps the whole workspace from crossing the
+ * napi boundary twice per recovery, and lets the context re-gather in place
+ * instead of being torn down and rebuilt.
  */
 export async function handleWatcherRescan(): Promise<void> {
   performance.mark('watcher-rescan-start');
-  const before = await getAllFileDataInContext(workspaceRoot);
-  resetWorkspaceContext();
-  setupWorkspaceContext(workspaceRoot);
-  const after = await getAllFileDataInContext(workspaceRoot);
+  const { createdFiles, updatedFiles, deletedFiles } =
+    rescanAndDiffInContext(workspaceRoot);
   performance.mark('watcher-rescan-end');
   performance.measure(
     're-walk workspace after watcher rescan',
@@ -449,43 +419,39 @@ export async function handleWatcherRescan(): Promise<void> {
     'watcher-rescan-end'
   );
 
-  const { createdFiles, updatedFiles, deletedFiles } = diffFileData(
-    before,
-    after
-  );
-  if (updatedFiles.length === 0 && deletedFiles.length === 0) {
+  if (
+    createdFiles.length === 0 &&
+    updatedFiles.length === 0 &&
+    deletedFiles.length === 0
+  ) {
     serverLogger.watcherLog(
       'Rescan re-walk found no differences; keeping the cached graph.'
     );
     return;
   }
   serverLogger.watcherLog(
-    `Rescan re-walk recovered ${createdFiles.length} created, ${
-      updatedFiles.length - createdFiles.length
-    } updated and ${deletedFiles.length} deleted file(s).`
+    `Rescan re-walk recovered ${createdFiles.length} created, ` +
+      `${updatedFiles.length} updated and ${deletedFiles.length} deleted file(s).`
   );
 
   ++fileChangeCounter;
-  const createdFileSet = new Set(createdFiles);
-  const updatedFileNames: string[] = [];
-  for (const { file, hash } of updatedFiles) {
+  for (const { file, hash } of [...createdFiles, ...updatedFiles]) {
     collectedDeletedFiles.delete(file);
     collectedUpdatedFiles.set(file, { version: fileChangeCounter, hash });
-    if (!createdFileSet.has(file)) {
-      updatedFileNames.push(file);
-    }
   }
   for (const file of deletedFiles) {
     collectedUpdatedFiles.delete(file);
     collectedDeletedFiles.set(file, fileChangeCounter);
   }
 
+  const createdFileNames = createdFiles.map(({ file }) => file);
+  const updatedFileNames = updatedFiles.map(({ file }) => file);
   notifyFileChangeListeners({
-    createdFiles,
+    createdFiles: createdFileNames,
     updatedFiles: updatedFileNames,
     deletedFiles,
   });
-  notifyFileWatcherSockets(createdFiles, updatedFileNames, deletedFiles);
+  notifyFileWatcherSockets(createdFileNames, updatedFileNames, deletedFiles);
   ++recomputationGeneration;
   kickOffRecompute();
 }

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -38,7 +38,9 @@ import {
 } from '../../project-graph/utils/retrieve-workspace-files';
 import { fileExists } from '../../utils/fileutils';
 import {
+  getAllFileDataInContext,
   resetWorkspaceContext,
+  setupWorkspaceContext,
   updateFilesInContext,
 } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -393,6 +395,99 @@ export function scheduleProjectGraphRecomputation(
       kickOffRecompute();
     }
   }
+}
+
+export interface FileDataDiff {
+  createdFiles: string[];
+  updatedFiles: Array<{ file: string; hash: string }>;
+  deletedFiles: string[];
+}
+
+export function diffFileData(
+  before: FileData[],
+  after: FileData[]
+): FileDataDiff {
+  const beforeHashes = new Map(before.map((f) => [f.file, f.hash]));
+  const createdFiles: string[] = [];
+  const updatedFiles: Array<{ file: string; hash: string }> = [];
+  for (const f of after) {
+    const previousHash = beforeHashes.get(f.file);
+    if (previousHash === undefined) {
+      createdFiles.push(f.file);
+      updatedFiles.push({ file: f.file, hash: f.hash });
+    } else {
+      if (previousHash !== f.hash) {
+        updatedFiles.push({ file: f.file, hash: f.hash });
+      }
+      beforeHashes.delete(f.file);
+    }
+  }
+  return {
+    createdFiles,
+    updatedFiles,
+    deletedFiles: [...beforeHashes.keys()],
+  };
+}
+
+/**
+ * The watcher reported dropped events (a kernel event-queue overflow), so the
+ * per-path stream cannot be trusted complete. Recover by re-walking the
+ * workspace and diffing it against the context's known files, then feed the
+ * synthesized changes through the same collection and notification path a
+ * normal watcher batch takes.
+ */
+export async function handleWatcherRescan(): Promise<void> {
+  performance.mark('watcher-rescan-start');
+  const before = await getAllFileDataInContext(workspaceRoot);
+  resetWorkspaceContext();
+  setupWorkspaceContext(workspaceRoot);
+  const after = await getAllFileDataInContext(workspaceRoot);
+  performance.mark('watcher-rescan-end');
+  performance.measure(
+    're-walk workspace after watcher rescan',
+    'watcher-rescan-start',
+    'watcher-rescan-end'
+  );
+
+  const { createdFiles, updatedFiles, deletedFiles } = diffFileData(
+    before,
+    after
+  );
+  if (updatedFiles.length === 0 && deletedFiles.length === 0) {
+    serverLogger.watcherLog(
+      'Rescan re-walk found no differences; keeping the cached graph.'
+    );
+    return;
+  }
+  serverLogger.watcherLog(
+    `Rescan re-walk recovered ${createdFiles.length} created, ${
+      updatedFiles.length - createdFiles.length
+    } updated and ${deletedFiles.length} deleted file(s).`
+  );
+
+  ++fileChangeCounter;
+  const createdFileSet = new Set(createdFiles);
+  const updatedFileNames: string[] = [];
+  for (const { file, hash } of updatedFiles) {
+    collectedDeletedFiles.delete(file);
+    collectedUpdatedFiles.set(file, { version: fileChangeCounter, hash });
+    if (!createdFileSet.has(file)) {
+      updatedFileNames.push(file);
+    }
+  }
+  for (const file of deletedFiles) {
+    collectedUpdatedFiles.delete(file);
+    collectedDeletedFiles.set(file, fileChangeCounter);
+  }
+
+  notifyFileChangeListeners({
+    createdFiles,
+    updatedFiles: updatedFileNames,
+    deletedFiles,
+  });
+  notifyFileWatcherSockets(createdFiles, updatedFileNames, deletedFiles);
+  ++recomputationGeneration;
+  kickOffRecompute();
 }
 
 export function registerProjectGraphRecomputationListener(

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -57,7 +57,10 @@ import {
 import { notifyFileChangeListeners } from './file-watching/file-change-events';
 import { notifyFileWatcherSockets } from './file-watching/file-watcher-sockets';
 import { notifyProjectGraphListenerSockets } from './project-graph-listener-sockets';
-import { flushPendingWorkspaceChanges } from './watcher';
+import {
+  flushPendingWorkspaceChanges,
+  restartDaemonIfIgnoreFilesChanged,
+} from './watcher';
 import { serverLogger } from '../logger';
 
 interface SerializedProjectGraph {
@@ -418,6 +421,23 @@ export async function handleWatcherRescan(): Promise<void> {
     'watcher-rescan-start',
     'watcher-rescan-end'
   );
+
+  // An overflow can drop an ignore-file edit outright, so dispatchWorkspaceChanges
+  // never sees it and the native filterer keeps stale ignore rules. The re-walk
+  // is where it resurfaces, so restart here too — the fresh daemon rebuilds the
+  // filterer from the current ignore files.
+  if (
+    restartDaemonIfIgnoreFilesChanged([
+      ...createdFiles.map(({ file }) => file),
+      ...updatedFiles.map(({ file }) => file),
+      ...deletedFiles,
+    ])
+  ) {
+    serverLogger.watcherLog(
+      'Rescan recovered an ignore-file change; restarting the daemon to reload ignore rules.'
+    );
+    return;
+  }
 
   if (
     createdFiles.length === 0 &&

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -146,6 +146,7 @@ import {
   handleOutputsChanges,
 } from './handle-outputs-changes';
 import {
+  handleWatcherRescan,
   scheduleProjectGraphRecomputation,
   registerProjectGraphRecomputationListener,
 } from './project-graph-incremental-recomputation';
@@ -658,6 +659,14 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
       console.error(error);
       workspaceWatcherError = error;
       notifyFileWatcherSocketsOfError(error);
+      return;
+    }
+
+    if (changeEvents.some((event) => event.type === 'rescan')) {
+      serverLogger.watcherLog(
+        'The watcher reported dropped events; re-walking the workspace to recover the missed changes.'
+      );
+      await handleWatcherRescan();
       return;
     }
 

--- a/packages/nx/src/daemon/server/watcher.spec.ts
+++ b/packages/nx/src/daemon/server/watcher.spec.ts
@@ -1,0 +1,33 @@
+// Loading ./watcher pulls in the daemon server and the shutdown path. Stub both
+// so a restart decision can be observed without starting either. vi.hoisted
+// runs before the hoisted vi.mock factories, which is the only way the spy can
+// be shared with them.
+const { terminate } = vi.hoisted(() => ({ terminate: vi.fn() }));
+vi.mock('./shutdown-utils', () => ({
+  handleServerProcessTermination: terminate,
+  getWatcherInstance: vi.fn(),
+}));
+vi.mock('./server', () => ({ openSockets: new Set() }));
+
+import { restartDaemonIfIgnoreFilesChanged } from './watcher';
+
+describe('restartDaemonIfIgnoreFilesChanged', () => {
+  beforeEach(() => {
+    terminate.mockClear();
+  });
+
+  it.each(['.gitignore', '.nxignore'])(
+    'restarts the daemon when %s changes',
+    (name) => {
+      expect(restartDaemonIfIgnoreFilesChanged([`pkg/${name}`])).toBe(true);
+      expect(terminate).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  // .ignore is a ripgrep convention neither create_walker nor the watch
+  // filterer reads, so editing one changes no rule and must not cost a restart.
+  it('leaves the daemon running when a .ignore changes', () => {
+    expect(restartDaemonIfIgnoreFilesChanged(['pkg/.ignore'])).toBe(false);
+    expect(terminate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -37,7 +37,7 @@ function dispatchWorkspaceChanges(
 // are never watched — only take effect on the next daemon start: .git/info/exclude
 // (under the hardcoded-ignored .git), the global core.excludesFile (outside the
 // tree), and parent .gitignore files above the workspace root.
-const IGNORE_FILE_NAMES = ['.gitignore', '.ignore', '.nxignore'];
+const IGNORE_FILE_NAMES = ['.gitignore', '.nxignore'];
 
 /**
  * The native filterer's ignore rules are fixed when the watcher starts, so an

--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -26,18 +26,30 @@ let workspaceChangesCallback!: FileWatcherCallback;
 function dispatchWorkspaceChanges(
   events: WatchEvent[]
 ): Promise<void> | undefined {
-  for (const event of events) {
-    if (event.path.endsWith('.gitignore') || event.path === '.nxignore') {
-      // If the ignore files themselves have changed we need to dynamically
-      // update our cached ignoreGlobs
+  if (restartDaemonIfIgnoreFilesChanged(events.map((event) => event.path))) {
+    return;
+  }
+  return workspaceChangesCallback(null, events);
+}
+
+/**
+ * The native filterer's ignore rules are fixed when the watcher starts, so an
+ * ignore-file edit needs a daemon restart to take effect. Exposed so the rescan
+ * recovery can restart too: an overflow can drop the ignore-file event that
+ * dispatchWorkspaceChanges would have caught, and only the re-walk finds it.
+ */
+export function restartDaemonIfIgnoreFilesChanged(paths: string[]): boolean {
+  for (const path of paths) {
+    if (path.endsWith('.gitignore') || path === '.nxignore') {
       handleServerProcessTermination({
         server: activeServer,
         reason: 'Stopping the daemon the set of ignored files changed (native)',
         sockets: openSockets,
       });
+      return true;
     }
   }
-  return workspaceChangesCallback(null, events);
+  return false;
 }
 
 export async function watchWorkspace(server: Server, cb: FileWatcherCallback) {

--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -32,6 +32,13 @@ function dispatchWorkspaceChanges(
   return workspaceChangesCallback(null, events);
 }
 
+// Mirrors the per-directory ignore files create_filter reads (watch_filterer.rs).
+// The other two sources it honours cannot trigger a restart from here:
+// .git/info/exclude lives under the hardcoded-ignored .git (never watched) and
+// the global core.excludesFile is outside the tree — a change to either only
+// takes effect on the next daemon start.
+const IGNORE_FILE_NAMES = ['.gitignore', '.ignore', '.nxignore'];
+
 /**
  * The native filterer's ignore rules are fixed when the watcher starts, so an
  * ignore-file edit needs a daemon restart to take effect. Exposed so the rescan
@@ -40,7 +47,8 @@ function dispatchWorkspaceChanges(
  */
 export function restartDaemonIfIgnoreFilesChanged(paths: string[]): boolean {
   for (const path of paths) {
-    if (path.endsWith('.gitignore') || path === '.nxignore') {
+    const basename = path.slice(path.lastIndexOf('/') + 1);
+    if (IGNORE_FILE_NAMES.includes(basename)) {
       handleServerProcessTermination({
         server: activeServer,
         reason: 'Stopping the daemon the set of ignored files changed (native)',

--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -33,10 +33,10 @@ function dispatchWorkspaceChanges(
 }
 
 // Mirrors the per-directory ignore files create_filter reads (watch_filterer.rs).
-// The other two sources it honours cannot trigger a restart from here:
-// .git/info/exclude lives under the hardcoded-ignored .git (never watched) and
-// the global core.excludesFile is outside the tree — a change to either only
-// takes effect on the next daemon start.
+// The sources it honours that cannot trigger a restart from here — because they
+// are never watched — only take effect on the next daemon start: .git/info/exclude
+// (under the hardcoded-ignored .git), the global core.excludesFile (outside the
+// tree), and parent .gitignore files above the workspace root.
 const IGNORE_FILE_NAMES = ['.gitignore', '.ignore', '.nxignore'];
 
 /**

--- a/packages/nx/src/lib.rs
+++ b/packages/nx/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::disallowed_types)]
+#![deny(clippy::disallowed_methods)]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 // add all the napi macros globally
 #[macro_use]

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -376,7 +376,12 @@ export interface EventDimensions {
 export declare const enum EventType {
   delete = 'delete',
   update = 'update',
-  create = 'create'
+  create = 'create',
+  /**
+   * The kernel dropped events (e.g. an inotify queue overflow); per-path
+   * events cannot be trusted complete and consumers must re-walk.
+   */
+  rescan = 'rescan'
 }
 
 export declare function expandOutputs(directory: string, entries: Array<string>): Array<string>

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -283,6 +283,13 @@ export declare class WorkspaceContext {
   incrementalUpdate(updatedFiles: Array<string>, deletedFiles: Array<string>): Record<string, string>
   updateProjectFiles(projectRootMappings: Record<string, string>, projectFiles: ExternalObject<Record<string, Array<FileData>>>, globalFiles: ExternalObject<Array<FileData>>, updatedFiles: Record<string, string>, deletedFiles: Array<string>): UpdatedWorkspaceFiles
   allFileData(): Array<FileData>
+  /**
+   * Recover from dropped watch events: re-walk, and report what changed
+   * against the map this context was holding. The fresh map is adopted, so
+   * the caller only has to feed the returned changes through its normal
+   * recomputation path.
+   */
+  rescanAndDiff(): RescanDiff
   getFilesInDirectory(directory: string): Array<string>
 }
 
@@ -705,6 +712,13 @@ export interface ProjectGraph {
 }
 
 export declare function remove(src: string): void
+
+/** What a rescan re-walk found had changed while the watcher was not being told. */
+export interface RescanDiff {
+  createdFiles: Array<FileData>
+  updatedFiles: Array<FileData>
+  deletedFiles: Array<string>
+}
 
 export declare function restoreTerminal(): void
 

--- a/packages/nx/src/native/utils/get_mod_time.rs
+++ b/packages/nx/src/native/utils/get_mod_time.rs
@@ -26,3 +26,27 @@ pub fn get_mod_time(metadata: &Metadata) -> i64 {
         .map(|t| t.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() as i64)
         .unwrap_or(0)
 }
+
+/// "Now", in the same units and resolution `get_mod_time` reports on this
+/// platform. Stamped into the files archive so a later selective hash can tell
+/// which entries were read while the workspace could still be changing under it.
+///
+/// Windows returns `i64::MAX`: `last_write_time` is a 100ns FILETIME tick, so a
+/// rewrite can never land on the same value as the read that preceded it, and
+/// every archived entry stays reusable.
+#[cfg(target_os = "windows")]
+pub fn gather_stamp() -> i64 {
+    i64::MAX
+}
+
+/// Whole seconds, matching `st_mtime`/`mtime()`. Falls back to 0 — which makes
+/// every archived entry ambiguous, costing a full re-hash rather than trusting
+/// a stale one — if the clock is unreadable.
+#[cfg(not(target_os = "windows"))]
+pub fn gather_stamp() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/packages/nx/src/native/utils/get_mod_time.rs
+++ b/packages/nx/src/native/utils/get_mod_time.rs
@@ -31,12 +31,21 @@ pub fn get_mod_time(metadata: &Metadata) -> i64 {
 /// platform. Stamped into the files archive so a later selective hash can tell
 /// which entries were read while the workspace could still be changing under it.
 ///
-/// Windows returns `i64::MAX`: `last_write_time` is a 100ns FILETIME tick, so a
-/// rewrite can never land on the same value as the read that preceded it, and
-/// every archived entry stays reusable.
+/// FILETIME ticks, matching `last_write_time`. 100ns is FILETIME's
+/// representation, not its resolution: Windows stamps last-write from the
+/// system clock, whose granularity is the timer interval (~15.6ms, 1ms if a
+/// process raised it), and exFAT/SMB volumes are coarser still at 2s. Two
+/// writes inside one tick therefore do share a timestamp, so the guard is
+/// needed here exactly as it is elsewhere.
 #[cfg(target_os = "windows")]
 pub fn gather_stamp() -> i64 {
-    i64::MAX
+    use std::time::{SystemTime, UNIX_EPOCH};
+    /// 100ns ticks between the FILETIME epoch (1601-01-01) and the Unix epoch.
+    const FILETIME_TICKS_AT_UNIX_EPOCH: i64 = 116_444_736_000_000_000;
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| (d.as_nanos() / 100) as i64 + FILETIME_TICKS_AT_UNIX_EPOCH)
+        .unwrap_or(0)
 }
 
 /// Whole seconds, matching `st_mtime`/`mtime()`. Falls back to 0 — which makes

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -206,6 +206,11 @@ where
     walker.require_git(false);
     walker.hidden(false);
 
+    // `.ignore` is a ripgrep convention the ignore crate enables by default.
+    // Nx never chose it, and the watcher does not read it, so honouring it here
+    // would drop files the watcher still admits.
+    walker.ignore(false);
+
     if use_ignores {
         // Handle parent .gitignore files based on git repository boundaries
         if let Some(gitignore_paths) = parent_gitignore_files(&directory) {
@@ -510,6 +515,56 @@ nested/child-two/
         assert!(
             !files.iter().any(|f| f == "a-unix-socket"),
             "unix socket should be skipped, got: {:?}",
+            files
+        );
+    }
+
+    // `.ignore` is a ripgrep convention the ignore crate turns on by default.
+    // Nx never chose it and the watch filterer does not read it, so the walk
+    // must not either.
+    #[test]
+    fn does_not_honour_dot_ignore() {
+        let temp_dir = setup_fs();
+        temp_dir.child(".ignore").write_str("foo.txt\n").unwrap();
+
+        let files: Vec<_> = nx_walker(temp_dir.path(), true)
+            .map(|f| f.normalized_path)
+            .collect();
+
+        assert!(
+            files.iter().any(|f| f == "foo.txt"),
+            "a .ignore entry should not exclude foo.txt, got: {:?}",
+            files
+        );
+    }
+
+    // The reference semantics the watch filterer's rank-before-depth sort
+    // mirrors: the ignore crate keeps the deepest match per class and then
+    // prefers the higher class, so a .nxignore wins over a .gitignore that
+    // sits deeper.
+    #[test]
+    fn nxignore_outranks_a_deeper_gitignore_negation() {
+        let temp_dir = setup_fs();
+        temp_dir
+            .child("pkg/.nxignore")
+            .write_str("keep.tmp\n")
+            .unwrap();
+        temp_dir
+            .child("pkg/deep/.gitignore")
+            .write_str("!keep.tmp\n")
+            .unwrap();
+        temp_dir
+            .child("pkg/deep/keep.tmp")
+            .write_str("data")
+            .unwrap();
+
+        let files: Vec<_> = nx_walker(temp_dir.path(), true)
+            .map(|f| f.normalized_path)
+            .collect();
+
+        assert!(
+            !files.iter().any(|f| f == "pkg/deep/keep.tmp"),
+            "the shallower .nxignore should outrank the deeper .gitignore negation, got: {:?}",
             files
         );
     }

--- a/packages/nx/src/native/watch/git_utils.rs
+++ b/packages/nx/src/native/watch/git_utils.rs
@@ -12,8 +12,9 @@ fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<PathBuf> {
 /// (node_modules pruned), returning absolute paths. `create_walker` honours
 /// `.ignore` and nested `.nxignore` in addition to `.gitignore`; the watch
 /// filterer discovers the same set so it no longer misses a directory the walk
-/// excludes. (Exact cross-source precedence at one directory is approximated,
-/// not identical to the ignore crate — see WatchFilterer::git_ignores.)
+/// excludes. (Within one directory the sources rank exactly like the ignore
+/// crate; cross-DIRECTORY precedence is depth-first where the crate is
+/// class-first — a tracked follow-up, see WatchFilterer::git_ignores.)
 pub(in crate::native) fn collect_workspace_ignore_files<P: AsRef<Path>>(
     root: P,
     names: &[&str],

--- a/packages/nx/src/native/watch/git_utils.rs
+++ b/packages/nx/src/native/watch/git_utils.rs
@@ -10,11 +10,8 @@ fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<PathBuf> {
 
 /// Collect ignore files with any of `names` anywhere in the workspace
 /// (node_modules pruned), returning absolute paths. `create_walker` honours
-/// `.ignore` and nested `.nxignore` in addition to `.gitignore`; the watch
-/// filterer discovers the same set so it no longer misses a directory the walk
-/// excludes. (Within one directory the sources rank exactly like the ignore
-/// crate; cross-DIRECTORY precedence is depth-first where the crate is
-/// class-first — a tracked follow-up, see WatchFilterer::git_ignores.)
+/// nested `.nxignore` in addition to `.gitignore`; the watch filterer discovers
+/// the same set so it no longer misses a directory the walk excludes.
 pub(in crate::native) fn collect_workspace_ignore_files<P: AsRef<Path>>(
     root: P,
     names: &[&str],

--- a/packages/nx/src/native/watch/git_utils.rs
+++ b/packages/nx/src/native/watch/git_utils.rs
@@ -11,7 +11,9 @@ fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<PathBuf> {
 /// Collect ignore files with any of `names` anywhere in the workspace
 /// (node_modules pruned), returning absolute paths. `create_walker` honours
 /// `.ignore` and nested `.nxignore` in addition to `.gitignore`; the watch
-/// filterer discovers them the same way so the two agree on what is ignored.
+/// filterer discovers the same set so it no longer misses a directory the walk
+/// excludes. (Exact cross-source precedence at one directory is approximated,
+/// not identical to the ignore crate — see WatchFilterer::git_ignores.)
 pub(in crate::native) fn collect_workspace_ignore_files<P: AsRef<Path>>(
     root: P,
     names: &[&str],

--- a/packages/nx/src/native/watch/git_utils.rs
+++ b/packages/nx/src/native/watch/git_utils.rs
@@ -5,21 +5,28 @@ use crate::native::utils::git::parent_gitignore_files;
 
 /// Collect .gitignore files using a simple approach that reuses walker logic
 fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<PathBuf> {
+    collect_workspace_ignore_files(root, &[".gitignore"])
+}
+
+/// Collect ignore files with any of `names` anywhere in the workspace
+/// (node_modules pruned), returning absolute paths. `create_walker` honours
+/// `.ignore` and nested `.nxignore` in addition to `.gitignore`; the watch
+/// filterer discovers them the same way so the two agree on what is ignored.
+pub(in crate::native) fn collect_workspace_ignore_files<P: AsRef<Path>>(
+    root: P,
+    names: &[&str],
+) -> Vec<PathBuf> {
     use crate::native::walker::nx_walker_sync;
 
-    // Use our own walker to find .gitignore files, filtering out node_modules
-    let gitignore_filters = vec!["node_modules".to_string()];
-
+    let filters = vec!["node_modules".to_string()];
     let root_path = root.as_ref();
 
-    nx_walker_sync(&root, Some(&gitignore_filters))
+    nx_walker_sync(&root, Some(&filters))
         .filter_map(|relative_path| {
-            // Only process .gitignore files
-            if relative_path.file_name()?.to_str()? == ".gitignore" {
-                Some(root_path.join(&relative_path))
-            } else {
-                None
-            }
+            let name = relative_path.file_name()?.to_str()?;
+            names
+                .contains(&name)
+                .then(|| root_path.join(&relative_path))
         })
         .collect()
 }

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -1,39 +1,61 @@
+use std::cell::OnceCell;
 use std::fs::{self, Metadata};
 use std::io;
 use std::path::{Path, PathBuf};
 
-use notify::event::{CreateKind, ModifyKind, RenameMode};
+use notify::event::{CreateKind, ModifyKind, RemoveKind, RenameMode};
 use notify::{Event, EventKind};
 use tracing::trace;
 
 use crate::native::watch::utils::canonicalize_event_paths;
 
-/// A notify event enriched with a per-path metadata stat. The metadata is
-/// computed once when the event arrives and reused everywhere downstream
-/// (filter, new-directory detection, transform) instead of re-statting.
+/// A notify event with a per-path stat computed on demand. A stat is a
+/// syscall (on Windows a `CreateFileW` + `GetFileInformationByHandle`), and
+/// most events never need it: the event kind already says file-vs-directory,
+/// and filtered events are discarded before any consumer looks. So the stat
+/// is deferred to first access and skipped whenever the kind answers first.
 pub(super) struct RawWatchEvent {
     pub event: Event,
-    /// Parallel to `event.paths` — one stat result per path.
-    pub metadata: Vec<io::Result<Metadata>>,
+    /// Parallel to `event.paths` — a lazily-populated stat per path.
+    metadata: Vec<OnceCell<io::Result<Metadata>>>,
 }
 
 impl RawWatchEvent {
     pub fn new(event: Event) -> Self {
         let event = canonicalize_event_paths(&event);
-        let metadata = event.paths.iter().map(fs::metadata).collect();
+        let metadata = event.paths.iter().map(|_| OnceCell::new()).collect();
         Self { event, metadata }
     }
 
-    pub fn paths(&self) -> impl Iterator<Item = (&Path, &io::Result<Metadata>)> {
-        self.event
-            .paths
-            .iter()
-            .zip(self.metadata.iter())
-            .map(|(p, m)| (p.as_path(), m))
+    fn metadata_at(&self, index: usize) -> &io::Result<Metadata> {
+        self.metadata[index].get_or_init(|| fs::metadata(&self.event.paths[index]))
     }
 
-    pub fn first(&self) -> Option<(&Path, &io::Result<Metadata>)> {
-        self.paths().next()
+    /// Whether the path at `index` is a directory, answered from the event
+    /// kind when notify reports it definitively and only otherwise by a stat.
+    pub(super) fn is_dir_at(&self, index: usize) -> bool {
+        match is_dir_from_kind(&self.event.kind) {
+            Some(is_dir) => is_dir,
+            None => meta_is_dir(self.metadata_at(index)),
+        }
+    }
+
+    /// Whether the path at `index` exists. Always a stat — the kind cannot
+    /// confirm a removal against the atomic-rename race, which is its one use.
+    pub(super) fn exists_at(&self, index: usize) -> bool {
+        meta_exists(self.metadata_at(index))
+    }
+
+    /// Iterate `(path, stat)`, forcing the lazy stat for each path. Used by
+    /// consumers that genuinely need metadata (macOS classification, the
+    /// trace log). Kind-answerable questions should use `is_dir_at` instead.
+    pub fn paths(&self) -> impl Iterator<Item = (&Path, &io::Result<Metadata>)> + '_ {
+        (0..self.event.paths.len())
+            .map(move |i| (self.event.paths[i].as_path(), self.metadata_at(i)))
+    }
+
+    pub fn first_path(&self) -> Option<&Path> {
+        self.event.paths.first().map(PathBuf::as_path)
     }
 
     pub fn kind(&self) -> &EventKind {
@@ -47,6 +69,21 @@ pub(super) fn meta_is_dir(metadata: &io::Result<Metadata>) -> bool {
 
 pub(super) fn meta_exists(metadata: &io::Result<Metadata>) -> bool {
     metadata.is_ok()
+}
+
+/// `Some` only when notify states file-vs-directory definitively. `None` for
+/// ambiguous kinds (`Any`, renames), which must fall back to a stat — a wrong
+/// guess would send a directory path to JS or skip a real file.
+pub(super) fn is_dir_from_kind(kind: &EventKind) -> Option<bool> {
+    match kind {
+        EventKind::Create(CreateKind::File) => Some(false),
+        EventKind::Create(CreateKind::Folder) => Some(true),
+        EventKind::Remove(RemoveKind::File) => Some(false),
+        EventKind::Remove(RemoveKind::Folder) => Some(true),
+        // Directories carry no data stream, so a data change is always a file.
+        EventKind::Modify(ModifyKind::Data(_)) => Some(false),
+        _ => None,
+    }
 }
 
 #[napi(string_enum)]
@@ -97,7 +134,7 @@ pub(super) fn transform_event_to_watch_events(
     value: &RawWatchEvent,
     origin: &str,
 ) -> anyhow::Result<Vec<WatchEventInternal>> {
-    let Some((path_ref, metadata)) = value.first() else {
+    let Some(path_ref) = value.first_path() else {
         let error_msg = "unable to get path from the event";
         trace!(event = ?value.event, error_msg);
         anyhow::bail!(error_msg)
@@ -111,9 +148,9 @@ pub(super) fn transform_event_to_watch_events(
     // otherwise misclassify a Modify/Create event as Delete — which then
     // makes updateFilesInContext remove the still-existing file from the
     // workspace context, silently dropping projects from the project
-    // graph. For non-Remove kinds, fall through to the platform-specific
-    // handling which derives the type from event_kind without re-statting.
-    if !meta_exists(metadata) && matches!(event_kind, EventKind::Remove(_)) {
+    // graph. The kind check is first so the confirming stat runs only on
+    // Remove events, never on a create/write storm.
+    if matches!(event_kind, EventKind::Remove(_)) && !value.exists_at(0) {
         return Ok(vec![WatchEventInternal {
             path: relative_to_origin(path_ref, origin),
             r#type: EventType::delete,
@@ -123,6 +160,10 @@ pub(super) fn transform_event_to_watch_events(
     #[cfg(target_os = "macos")]
     {
         use std::time::Duration;
+
+        // FSEvents kinds are unreliable, so macOS classifies from the stat:
+        // this is the one branch that genuinely needs metadata per event.
+        let metadata = value.metadata_at(0);
 
         // Skip directory events
         if meta_is_dir(metadata) {
@@ -169,8 +210,9 @@ pub(super) fn transform_event_to_watch_events(
 
     #[cfg(target_os = "windows")]
     {
-        // Skip directory events
-        if meta_is_dir(metadata) {
+        // Skip directory events. is_dir_at answers from the kind first, so a
+        // precise Create(File)/Modify(Data) never stats here.
+        if value.is_dir_at(0) {
             return Ok(vec![]);
         }
         Ok(create_watch_event_internal(origin, event_kind, path_ref))

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -58,6 +58,10 @@ pub enum EventType {
     update,
     #[allow(non_camel_case_types)]
     create,
+    /// The kernel dropped events (e.g. an inotify queue overflow); per-path
+    /// events cannot be trusted complete and consumers must re-walk.
+    #[allow(non_camel_case_types)]
+    rescan,
 }
 
 #[derive(Debug, Clone)]

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -210,8 +210,11 @@ pub(super) fn transform_event_to_watch_events(
 
     #[cfg(target_os = "windows")]
     {
-        // Skip directory events. is_dir_at answers from the kind first, so a
-        // precise Create(File)/Modify(Data) never stats here.
+        // Skip directory events. is_dir_at reads the kind first, so a
+        // definitive Create(File) skips the stat; the ambiguous Modify(Any)
+        // that Windows delivers for a write still stats. notify's Windows
+        // backend already stat'd to classify the create, so the saved stat
+        // is a de-dup here — the clean elimination lands on Linux.
         if value.is_dir_at(0) {
             return Ok(vec![]);
         }

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -80,7 +80,9 @@ pub(super) fn is_dir_from_kind(kind: &EventKind) -> Option<bool> {
         EventKind::Create(CreateKind::Folder) => Some(true),
         EventKind::Remove(RemoveKind::File) => Some(false),
         EventKind::Remove(RemoveKind::Folder) => Some(true),
-        // Directories carry no data stream, so a data change is always a file.
+        // inotify and ReadDirectoryChangesW raise Data only for files. FSEvents
+        // does not distinguish, so macOS classifies from the stat instead.
+        #[cfg(not(target_os = "macos"))]
         EventKind::Modify(ModifyKind::Data(_)) => Some(false),
         _ => None,
     }

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -1,4 +1,3 @@
-use std::fs::canonicalize;
 use std::path::{Path, PathBuf};
 
 use notify::Event;
@@ -20,7 +19,7 @@ pub(super) fn canonicalize_event_paths(event: &Event) -> Event {
         let mut event = event.clone();
         for path in &mut event.paths {
             trace!("canonicalizing {:?}", path);
-            if let Ok(real_path) = canonicalize(&path) {
+            if let Ok(real_path) = dunce::canonicalize(&path) {
                 trace!("real path {:?}", real_path);
                 *path = real_path;
             }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use tracing::trace;
 
 use crate::native::watch::git_utils::get_gitignore_files;
-use crate::native::watch::types::{RawWatchEvent, meta_is_dir};
+use crate::native::watch::types::RawWatchEvent;
 use crate::native::watch::utils::get_nx_ignore;
 
 #[derive(Debug)]
@@ -98,15 +98,17 @@ impl WatchFilterer {
             }
         }
 
-        // Check each path against ignore rules.
-        for (path, metadata) in event.paths() {
+        // Check each path against ignore rules. is_dir_at answers from the
+        // event kind when it can, so a filtered event with a precise kind is
+        // rejected without ever statting it.
+        for (index, path) in event.event.paths.iter().enumerate() {
             // Reject paths ending with ~ (editor backup files)
             if path.display().to_string().ends_with('~') {
                 trace!(?path, "path ends with ~ - rejected");
                 return false;
             }
 
-            if !self.filter_path(path, meta_is_dir(metadata)) {
+            if !self.filter_path(path, event.is_dir_at(index)) {
                 return false;
             }
         }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -13,12 +13,13 @@ use crate::native::watch::utils::get_nx_ignore;
 #[derive(Debug)]
 pub struct WatchFilterer {
     origin: PathBuf,
-    nx_ignore: Option<Gitignore>,
     /// Per-directory ignore matchers, consulted first-match-wins. Each entry is
     /// (directory the matcher applies in, class rank, compiled matcher), sorted
-    /// deepest-first then by rank so within a directory a more specific source
-    /// wins: nested .nxignore > .ignore > .gitignore > .git-exclude/global. Full
-    /// class-above-depth parity with the ignore crate is a tracked follow-up.
+    /// by rank then depth so the higher class wins at any depth and the deepest
+    /// file wins within a class: .nxignore > .gitignore > .git-exclude/global.
+    /// That is how the ignore crate resolves a path, so the watcher and
+    /// `create_walker` agree. The root `.nxignore` is an ordinary entry at the
+    /// .nxignore rank, so a nested one beats it.
     git_ignores: Vec<(PathBuf, u8, Gitignore)>,
     /// node_modules/.git/.nx/cache/.nx/workspace-data/.yarn/cache. A hard veto
     /// that no user .gitignore or .nxignore negation can beat, mirroring
@@ -73,31 +74,10 @@ impl WatchFilterer {
     }
 
     fn brought_in_allows(&self, path: &std::path::Path, is_dir: bool) -> bool {
-        // .nxignore takes precedence over .gitignore. Only consult it for
-        // paths under the origin — gitignore-style matchers are scoped to
-        // the directory the ignore file lives in, so external symlink
-        // targets shouldn't be matched against workspace rules.
-        let nx_match = if let Some(ig) = &self.nx_ignore
-            && path.starts_with(&self.origin)
-        {
-            ig.matched_path_or_any_parents(path, is_dir)
-        } else {
-            Match::None
-        };
-
-        match nx_match {
-            Match::Whitelist(_) => {
-                trace!(?path, "nxignore whitelist match, ignoring gitignore");
-                return true;
-            }
-            Match::Ignore(_) => {
-                trace!(?path, "nxignore ignore match, ignoring gitignore");
-                return false;
-            }
-            Match::None => {}
-        }
-
-        // Check gitignores deepest-first; first non-None match wins.
+        // Ranked highest class first, deepest file first within a class; the
+        // first non-None match wins. Each matcher is only consulted for paths
+        // under its own directory — gitignore-style matchers are scoped to
+        // where the ignore file lives.
         let git_match = self
             .git_ignores
             .iter()
@@ -107,11 +87,11 @@ impl WatchFilterer {
 
         match git_match {
             Some(Match::Ignore(_)) => {
-                trace!(?path, "gitignore match - blocked");
+                trace!(?path, "ignore file match - blocked");
                 false
             }
             Some(Match::Whitelist(_)) => {
-                trace!(?path, "gitignore whitelist match - allowed");
+                trace!(?path, "ignore file whitelist match - allowed");
                 true
             }
             _ => true,
@@ -182,7 +162,6 @@ pub(super) fn create_filter(
     // clippy lint keeps lib code on dunce, but `lint-native` runs clippy without
     // --all-targets, so cfg(test) is unlinted — tests must hold this by hand.
     let ignore_files = use_ignore.then(|| get_gitignore_files(origin));
-    let nx_ignore_path = get_nx_ignore(origin);
 
     trace!(
         ?use_ignore,
@@ -212,14 +191,14 @@ pub(super) fn create_filter(
         }
     }
 
-    // `.ignore` and nested `.nxignore` — create_walker honours both, so a
-    // directory they exclude must not reach the watcher (it would be inserted
-    // into the file map and then reported deleted on the next rescan, since the
-    // rescan walk drops it). The root `.nxignore` keeps its dedicated
-    // highest-precedence slot below, so it is skipped here.
+    // Nested `.nxignore` — create_walker honours it, so a directory it excludes
+    // must not reach the watcher (it would be inserted into the file map and
+    // then reported deleted on the next rescan, since the rescan walk drops it).
+    // The root `.nxignore` is added below, outside the `use_ignore` gate, so it
+    // is skipped here rather than added twice.
     if use_ignore {
         let root_nxignore = PathBuf::from(origin).join(".nxignore");
-        for path in collect_workspace_ignore_files(origin, &[".ignore", ".nxignore"]) {
+        for path in collect_workspace_ignore_files(origin, &[".nxignore"]) {
             if path == root_nxignore {
                 continue;
             }
@@ -232,20 +211,15 @@ pub(super) fn create_filter(
                 );
             }
             let dir = path.parent().unwrap_or(&path).to_path_buf();
-            let rank = if path.file_name().and_then(|n| n.to_str()) == Some(".nxignore") {
-                3
-            } else {
-                2
-            };
-            git_ignores.push((dir, rank, gitignore));
+            git_ignores.push((dir, 2, gitignore));
         }
 
         // `.git/info/exclude` and the global core.excludesFile: the canonical
         // homes for local, uncommittable exclusions (scratch, secrets). Both
         // are gitignore-format and apply workspace-wide, so they are rooted at
         // origin (not at their own parent dir, which would break the prefix
-        // strip in matched_path_or_any_parents) and sit at the shallowest
-        // depth, below any per-directory rule.
+        // strip in matched_path_or_any_parents) and take the lowest rank, below
+        // any per-directory rule.
         let mut workspace_wide = GitignoreBuilder::new(origin);
         let git_exclude = PathBuf::from(origin)
             .join(".git")
@@ -279,15 +253,11 @@ pub(super) fn create_filter(
         Some(builder.build()?)
     };
 
-    // Sort deepest-first (most path components first) so deeper gitignores take priority
-    git_ignores.sort_by(|(a, ra, _), (b, rb, _)| {
-        let a_depth = a.components().count();
-        let b_depth = b.components().count();
-        b_depth.cmp(&a_depth).then(rb.cmp(ra))
-    });
-
-    // Build .nxignore
-    let nx_ignore = if let Some(nxignore_path) = nx_ignore_path {
+    // The root `.nxignore` applies whether or not `use_ignore` is set — it is
+    // nx's own opt-out, not a git source. It joins git_ignores at the .nxignore
+    // rank rather than above everything, so a nested .nxignore beats it the way
+    // it does in the walk.
+    if let Some(nxignore_path) = get_nx_ignore(origin) {
         let (gitignore, err) = Gitignore::new(&nxignore_path);
         if let Some(err) = err {
             trace!(
@@ -296,10 +266,18 @@ pub(super) fn create_filter(
                 "error parsing nxignore, using partial result"
             );
         }
-        Some(gitignore)
-    } else {
-        None
-    };
+        git_ignores.push((PathBuf::from(origin), 2, gitignore));
+    }
+
+    // Rank before depth, matching how the ignore crate combines classes: it
+    // keeps the deepest match per class and then prefers the higher class, so a
+    // nested .nxignore beats a .gitignore at ANY depth. Sorting depth first
+    // would let a deeper .gitignore negation un-ignore it.
+    git_ignores.sort_by(|(a, ra, _), (b, rb, _)| {
+        let a_depth = a.components().count();
+        let b_depth = b.components().count();
+        rb.cmp(ra).then(b_depth.cmp(&a_depth))
+    });
 
     // The hardcoded ignores are enforced unconditionally, independent of
     // `use_ignore` and of the brought-in files, exactly as `create_walker`
@@ -313,7 +291,6 @@ pub(super) fn create_filter(
     Ok(WatchFilterer {
         origin: PathBuf::from(origin),
         git_ignores,
-        nx_ignore,
         hardcoded,
         additional_globs,
     })

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -154,12 +154,13 @@ pub(super) fn create_filter(
     additional_globs: &[String],
     use_ignore: bool,
 ) -> anyhow::Result<WatchFilterer> {
-    // `origin` must already be canonical: filter_path rejects any path not under
-    // it, and event paths arrive realpath'd (canonicalize_event_paths on Linux,
-    // FSEvents on macOS). WatchPipeline::new canonicalizes once and hands the
-    // same string here and to origin_path, so the prefix check and the
-    // transform's relative_to_origin agree. Tests call this directly and pass a
-    // canonicalized temp path for the same reason.
+    // `origin` is expected canonical and in dunce form (no Windows `\\?\`
+    // verbatim prefix): WatchPipeline::new canonicalizes it with
+    // dunce::canonicalize and hands the same string here and to origin_path.
+    // filter_path rejects any path not under origin and dunce::simplifies event
+    // paths, so a `\\?\` origin would reject every event. The disallowed_methods
+    // clippy lint bans std::fs::canonicalize so every caller — tests included —
+    // stays on dunce and this precondition holds.
     let ignore_files = use_ignore.then(|| get_gitignore_files(origin));
     let nx_ignore_path = get_nx_ignore(origin);
 

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -154,15 +154,12 @@ pub(super) fn create_filter(
     additional_globs: &[String],
     use_ignore: bool,
 ) -> anyhow::Result<WatchFilterer> {
-    // Match the canonical form the event paths take: filter_path rejects any
-    // path not under origin, and canonicalize_event_paths realpaths every event
-    // on Linux. A symlinked NX_WORKSPACE_ROOT_PATH left un-canonicalized here
-    // would then fail that prefix check for every event and drop them all.
-    let origin = dunce::canonicalize(origin)
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| origin.to_string());
-    let origin = origin.as_str();
-
+    // `origin` must already be canonical: filter_path rejects any path not under
+    // it, and event paths arrive realpath'd (canonicalize_event_paths on Linux,
+    // FSEvents on macOS). WatchPipeline::new canonicalizes once and hands the
+    // same string here and to origin_path, so the prefix check and the
+    // transform's relative_to_origin agree. Tests call this directly and pass a
+    // canonicalized temp path for the same reason.
     let ignore_files = use_ignore.then(|| get_gitignore_files(origin));
     let nx_ignore_path = get_nx_ignore(origin);
 

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -14,9 +14,12 @@ use crate::native::watch::utils::get_nx_ignore;
 pub struct WatchFilterer {
     origin: PathBuf,
     nx_ignore: Option<Gitignore>,
-    /// Per-directory gitignore instances, sorted deepest-first (most path components first).
-    /// Each entry is (directory the .gitignore applies in, compiled Gitignore).
-    git_ignores: Vec<(PathBuf, Gitignore)>,
+    /// Per-directory ignore matchers, consulted first-match-wins. Each entry is
+    /// (directory the matcher applies in, class rank, compiled matcher), sorted
+    /// deepest-first then by rank so within a directory a more specific source
+    /// wins: nested .nxignore > .ignore > .gitignore > .git-exclude/global. Full
+    /// class-above-depth parity with the ignore crate is a tracked follow-up.
+    git_ignores: Vec<(PathBuf, u8, Gitignore)>,
     /// node_modules/.git/.nx/cache/.yarn/cache. A hard veto that no .gitignore
     /// or .nxignore negation can beat, mirroring `create_walker`'s filter_entry
     /// so the watcher and the walk agree on what is ignored.
@@ -33,11 +36,17 @@ impl WatchFilterer {
         // them. `create_walker` enforces the same set as an unbeatable
         // filter_entry; if the two disagreed, files the walker excludes but
         // the watcher admits would be reported deleted on every rescan.
+        //
+        // The origin guard matches the .nxignore/gitignore sites: the matcher
+        // is rooted at origin and matched_path_or_any_parents panics on a path
+        // outside its root, which a symlink resolved out of the workspace can
+        // produce on Linux.
         self.brought_in_allows(path, is_dir)
-            && !matches!(
-                self.hardcoded.matched_path_or_any_parents(path, is_dir),
-                Match::Ignore(_)
-            )
+            && !(path.starts_with(&self.origin)
+                && matches!(
+                    self.hardcoded.matched_path_or_any_parents(path, is_dir),
+                    Match::Ignore(_)
+                ))
     }
 
     fn brought_in_allows(&self, path: &std::path::Path, is_dir: bool) -> bool {
@@ -69,8 +78,8 @@ impl WatchFilterer {
         let git_match = self
             .git_ignores
             .iter()
-            .filter(|(dir, _)| path.starts_with(dir))
-            .map(|(_, ig)| ig.matched_path_or_any_parents(path, is_dir))
+            .filter(|(dir, _, _)| path.starts_with(dir))
+            .map(|(_, _, ig)| ig.matched_path_or_any_parents(path, is_dir))
             .find(|m| !matches!(m, Match::None));
 
         match git_match {
@@ -152,7 +161,7 @@ pub(super) fn create_filter(
         "Using these ignore files for the watcher"
     );
 
-    let mut git_ignores: Vec<(PathBuf, Gitignore)> = Vec::new();
+    let mut git_ignores: Vec<(PathBuf, u8, Gitignore)> = Vec::new();
 
     // Build per-directory Gitignore instances from .gitignore files
     if let Some(paths) = ignore_files {
@@ -169,7 +178,7 @@ pub(super) fn create_filter(
                 .parent()
                 .unwrap_or(&gitignore_path)
                 .to_path_buf();
-            git_ignores.push((dir, gitignore));
+            git_ignores.push((dir, 1, gitignore));
         }
     }
 
@@ -193,7 +202,12 @@ pub(super) fn create_filter(
                 );
             }
             let dir = path.parent().unwrap_or(&path).to_path_buf();
-            git_ignores.push((dir, gitignore));
+            let rank = if path.file_name().and_then(|n| n.to_str()) == Some(".nxignore") {
+                3
+            } else {
+                2
+            };
+            git_ignores.push((dir, rank, gitignore));
         }
 
         // `.git/info/exclude` and the global core.excludesFile: the canonical
@@ -218,7 +232,7 @@ pub(super) fn create_filter(
         {
             trace!(?err, ?global_excludes, "error parsing global gitignore");
         }
-        git_ignores.push((PathBuf::from(origin), workspace_wide.build()?));
+        git_ignores.push((PathBuf::from(origin), 0, workspace_wide.build()?));
     }
 
     // Build additional globs as a synthetic gitignore rooted at origin
@@ -228,14 +242,14 @@ pub(super) fn create_filter(
             builder.add_line(None, glob)?;
         }
         let gitignore = builder.build()?;
-        git_ignores.push((PathBuf::from(origin), gitignore));
+        git_ignores.push((PathBuf::from(origin), 0, gitignore));
     }
 
     // Sort deepest-first (most path components first) so deeper gitignores take priority
-    git_ignores.sort_by(|(a, _), (b, _)| {
+    git_ignores.sort_by(|(a, ra, _), (b, rb, _)| {
         let a_depth = a.components().count();
         let b_depth = b.components().count();
-        b_depth.cmp(&a_depth)
+        b_depth.cmp(&a_depth).then(rb.cmp(ra))
     });
 
     // Build .nxignore

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -5,6 +5,7 @@ use notify::event::{CreateKind, ModifyKind, RemoveKind};
 use std::path::PathBuf;
 use tracing::trace;
 
+use crate::native::walker::HARDCODED_IGNORE_PATTERNS;
 use crate::native::watch::git_utils::get_gitignore_files;
 use crate::native::watch::types::RawWatchEvent;
 use crate::native::watch::utils::get_nx_ignore;
@@ -16,12 +17,30 @@ pub struct WatchFilterer {
     /// Per-directory gitignore instances, sorted deepest-first (most path components first).
     /// Each entry is (directory the .gitignore applies in, compiled Gitignore).
     git_ignores: Vec<(PathBuf, Gitignore)>,
+    /// node_modules/.git/.nx/cache/.yarn/cache. A hard veto that no .gitignore
+    /// or .nxignore negation can beat, mirroring `create_walker`'s filter_entry
+    /// so the watcher and the walk agree on what is ignored.
+    hardcoded: Gitignore,
 }
 
 impl WatchFilterer {
     fn filter_path(&self, path: &std::path::Path, is_dir: bool) -> bool {
         let path = dunce::simplified(path);
 
+        // The brought-in ignore files decide keep/drop, then the hardcoded
+        // patterns veto unconditionally — applied last so a .gitignore
+        // whitelist (e.g. a zero-install `!.yarn/cache`) cannot un-ignore
+        // them. `create_walker` enforces the same set as an unbeatable
+        // filter_entry; if the two disagreed, files the walker excludes but
+        // the watcher admits would be reported deleted on every rescan.
+        self.brought_in_allows(path, is_dir)
+            && !matches!(
+                self.hardcoded.matched_path_or_any_parents(path, is_dir),
+                Match::Ignore(_)
+            )
+    }
+
+    fn brought_in_allows(&self, path: &std::path::Path, is_dir: bool) -> bool {
         // .nxignore takes precedence over .gitignore. Only consult it for
         // paths under the origin — gitignore-style matchers are scoped to
         // the directory the ignore file lives in, so external symlink
@@ -186,9 +205,19 @@ pub(super) fn create_filter(
         None
     };
 
+    // The hardcoded ignores are enforced unconditionally, independent of
+    // `use_ignore` and of the brought-in files, exactly as `create_walker`
+    // applies them.
+    let mut hardcoded_builder = GitignoreBuilder::new(origin);
+    for pattern in HARDCODED_IGNORE_PATTERNS {
+        hardcoded_builder.add_line(None, pattern)?;
+    }
+    let hardcoded = hardcoded_builder.build()?;
+
     Ok(WatchFilterer {
         origin: PathBuf::from(origin),
         git_ignores,
         nx_ignore,
+        hardcoded,
     })
 }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -20,9 +20,9 @@ pub struct WatchFilterer {
     /// wins: nested .nxignore > .ignore > .gitignore > .git-exclude/global. Full
     /// class-above-depth parity with the ignore crate is a tracked follow-up.
     git_ignores: Vec<(PathBuf, u8, Gitignore)>,
-    /// node_modules/.git/.nx/cache/.yarn/cache. A hard veto that no user
-    /// .gitignore or .nxignore negation can beat, mirroring `create_walker`'s
-    /// filter_entry so the watcher and the walk agree on what is ignored.
+    /// node_modules/.git/.nx/cache/.nx/workspace-data/.yarn/cache. A hard veto
+    /// that no user .gitignore or .nxignore negation can beat, mirroring
+    /// `create_walker`'s filter_entry so the watcher and the walk agree.
     hardcoded: Gitignore,
     /// nx's own watch-scoping globs (create_filter's `additional_globs`, e.g. the
     /// outputs watcher's `!.nx/workspace-data/.../server-process.json`). An
@@ -51,7 +51,7 @@ impl WatchFilterer {
         // `!.nx/workspace-data/.../server-process.json` must punch through the
         // .nx/workspace-data veto, or that event is dropped and a superseded
         // daemon never sees it to self-terminate. The veto is only there to stop
-        // USER ignore files un-ignoring hardcoded paths, which these never carry.
+        // USER ignore files un-ignoring hardcoded paths.
         if let Some(globs) = &self.additional_globs {
             match globs.matched_path_or_any_parents(path, is_dir) {
                 Match::Whitelist(_) => return true,

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -1,12 +1,12 @@
 use ignore::Match;
-use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use ignore::gitignore::{Gitignore, GitignoreBuilder, gitconfig_excludes_path};
 use notify::EventKind;
 use notify::event::{CreateKind, ModifyKind, RemoveKind};
 use std::path::PathBuf;
 use tracing::trace;
 
 use crate::native::walker::HARDCODED_IGNORE_PATTERNS;
-use crate::native::watch::git_utils::get_gitignore_files;
+use crate::native::watch::git_utils::{collect_workspace_ignore_files, get_gitignore_files};
 use crate::native::watch::types::RawWatchEvent;
 use crate::native::watch::utils::get_nx_ignore;
 
@@ -171,6 +171,54 @@ pub(super) fn create_filter(
                 .to_path_buf();
             git_ignores.push((dir, gitignore));
         }
+    }
+
+    // `.ignore` and nested `.nxignore` — create_walker honours both, so a
+    // directory they exclude must not reach the watcher (it would be inserted
+    // into the file map and then reported deleted on the next rescan, since the
+    // rescan walk drops it). The root `.nxignore` keeps its dedicated
+    // highest-precedence slot below, so it is skipped here.
+    if use_ignore {
+        let root_nxignore = PathBuf::from(origin).join(".nxignore");
+        for path in collect_workspace_ignore_files(origin, &[".ignore", ".nxignore"]) {
+            if path == root_nxignore {
+                continue;
+            }
+            let (gitignore, err) = Gitignore::new(&path);
+            if let Some(err) = err {
+                trace!(
+                    ?err,
+                    ?path,
+                    "error parsing ignore file, using partial result"
+                );
+            }
+            let dir = path.parent().unwrap_or(&path).to_path_buf();
+            git_ignores.push((dir, gitignore));
+        }
+
+        // `.git/info/exclude` and the global core.excludesFile: the canonical
+        // homes for local, uncommittable exclusions (scratch, secrets). Both
+        // are gitignore-format and apply workspace-wide, so they are rooted at
+        // origin (not at their own parent dir, which would break the prefix
+        // strip in matched_path_or_any_parents) and sit at the shallowest
+        // depth, below any per-directory rule.
+        let mut workspace_wide = GitignoreBuilder::new(origin);
+        let git_exclude = PathBuf::from(origin)
+            .join(".git")
+            .join("info")
+            .join("exclude");
+        if git_exclude.is_file()
+            && let Some(err) = workspace_wide.add(&git_exclude)
+        {
+            trace!(?err, ?git_exclude, "error parsing .git/info/exclude");
+        }
+        if let Some(global_excludes) = gitconfig_excludes_path()
+            && global_excludes.is_file()
+            && let Some(err) = workspace_wide.add(&global_excludes)
+        {
+            trace!(?err, ?global_excludes, "error parsing global gitignore");
+        }
+        git_ignores.push((PathBuf::from(origin), workspace_wide.build()?));
     }
 
     // Build additional globs as a synthetic gitignore rooted at origin

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -49,9 +49,10 @@ impl WatchFilterer {
         // nx's own watch globs are an internal opt-in and take precedence over
         // everything, the hardcoded veto included: the outputs watcher's
         // `!.nx/workspace-data/.../server-process.json` must punch through the
-        // .nx/workspace-data veto, or that event is dropped and a superseded
-        // daemon never sees it to self-terminate. The veto is only there to stop
-        // USER ignore files un-ignoring hardcoded paths.
+        // .nx/workspace-data veto, or the outputs watcher loses its prompt
+        // shutdown signal (server.ts's 20ms poll still terminates the daemon).
+        // The veto is only there to stop USER ignore files un-ignoring
+        // hardcoded paths.
         if let Some(globs) = &self.additional_globs {
             match globs.matched_path_or_any_parents(path, is_dir) {
                 Match::Whitelist(_) => return true,
@@ -178,8 +179,8 @@ pub(super) fn create_filter(
     // dunce::canonicalize and hands the same string here and to origin_path.
     // filter_path rejects any path not under origin and dunce::simplifies event
     // paths, so a `\\?\` origin would reject every event. The disallowed_methods
-    // clippy lint bans std::fs::canonicalize so every caller — tests included —
-    // stays on dunce and this precondition holds.
+    // clippy lint keeps lib code on dunce, but `lint-native` runs clippy without
+    // --all-targets, so cfg(test) is unlinted — tests must hold this by hand.
     let ignore_files = use_ignore.then(|| get_gitignore_files(origin));
     let nx_ignore_path = get_nx_ignore(origin);
 
@@ -267,7 +268,7 @@ pub(super) fn create_filter(
     // nx's own watch-scoping globs, kept OUT of git_ignores and the hardcoded
     // veto: they are an internal opt-in that must win. The outputs watcher passes
     // `!.nx/workspace-data/.../server-process.json` to punch through the
-    // .nx/workspace-data hardcoded ignore so a superseded daemon self-terminates.
+    // .nx/workspace-data hardcoded ignore so it keeps its prompt shutdown signal.
     let additional_globs = if additional_globs.is_empty() {
         None
     } else {

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -20,10 +20,15 @@ pub struct WatchFilterer {
     /// wins: nested .nxignore > .ignore > .gitignore > .git-exclude/global. Full
     /// class-above-depth parity with the ignore crate is a tracked follow-up.
     git_ignores: Vec<(PathBuf, u8, Gitignore)>,
-    /// node_modules/.git/.nx/cache/.yarn/cache. A hard veto that no .gitignore
-    /// or .nxignore negation can beat, mirroring `create_walker`'s filter_entry
-    /// so the watcher and the walk agree on what is ignored.
+    /// node_modules/.git/.nx/cache/.yarn/cache. A hard veto that no user
+    /// .gitignore or .nxignore negation can beat, mirroring `create_walker`'s
+    /// filter_entry so the watcher and the walk agree on what is ignored.
     hardcoded: Gitignore,
+    /// nx's own watch-scoping globs (create_filter's `additional_globs`, e.g. the
+    /// outputs watcher's `!.nx/workspace-data/.../server-process.json`). An
+    /// internal opt-in, so it outranks even the hardcoded veto — the veto only
+    /// stops USER ignore files un-ignoring hardcoded paths, not nx's own scoping.
+    additional_globs: Option<Gitignore>,
 }
 
 impl WatchFilterer {
@@ -41,10 +46,24 @@ impl WatchFilterer {
             return false;
         }
 
-        // The brought-in ignore files decide keep/drop, then the hardcoded
-        // patterns veto unconditionally — applied last so a .gitignore
-        // whitelist (a zero-install `!.yarn/cache`) cannot un-ignore them,
-        // matching create_walker's filter_entry.
+        // nx's own watch globs are an internal opt-in and take precedence over
+        // everything, the hardcoded veto included: the outputs watcher's
+        // `!.nx/workspace-data/.../server-process.json` must punch through the
+        // .nx/workspace-data veto, or that event is dropped and a superseded
+        // daemon never sees it to self-terminate. The veto is only there to stop
+        // USER ignore files un-ignoring hardcoded paths, which these never carry.
+        if let Some(globs) = &self.additional_globs {
+            match globs.matched_path_or_any_parents(path, is_dir) {
+                Match::Whitelist(_) => return true,
+                Match::Ignore(_) => return false,
+                Match::None => {}
+            }
+        }
+
+        // The brought-in USER ignore files decide keep/drop, then the hardcoded
+        // patterns veto unconditionally — applied last so a .gitignore whitelist
+        // (a zero-install `!.yarn/cache`) cannot un-ignore them, matching
+        // create_walker's filter_entry.
         self.brought_in_allows(path, is_dir)
             && !matches!(
                 self.hardcoded.matched_path_or_any_parents(path, is_dir),
@@ -245,15 +264,19 @@ pub(super) fn create_filter(
         git_ignores.push((PathBuf::from(origin), 0, workspace_wide.build()?));
     }
 
-    // Build additional globs as a synthetic gitignore rooted at origin
-    if !additional_globs.is_empty() {
+    // nx's own watch-scoping globs, kept OUT of git_ignores and the hardcoded
+    // veto: they are an internal opt-in that must win. The outputs watcher passes
+    // `!.nx/workspace-data/.../server-process.json` to punch through the
+    // .nx/workspace-data hardcoded ignore so a superseded daemon self-terminates.
+    let additional_globs = if additional_globs.is_empty() {
+        None
+    } else {
         let mut builder = GitignoreBuilder::new(origin);
         for glob in additional_globs {
             builder.add_line(None, glob)?;
         }
-        let gitignore = builder.build()?;
-        git_ignores.push((PathBuf::from(origin), 0, gitignore));
-    }
+        Some(builder.build()?)
+    };
 
     // Sort deepest-first (most path components first) so deeper gitignores take priority
     git_ignores.sort_by(|(a, ra, _), (b, rb, _)| {
@@ -291,5 +314,6 @@ pub(super) fn create_filter(
         git_ignores,
         nx_ignore,
         hardcoded,
+        additional_globs,
     })
 }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -30,23 +30,26 @@ impl WatchFilterer {
     fn filter_path(&self, path: &std::path::Path, is_dir: bool) -> bool {
         let path = dunce::simplified(path);
 
+        // A path outside the workspace is not subject to its ignore rules, and
+        // the origin-rooted matchers panic on one (matched_path_or_any_parents
+        // asserts the path is under the root). canonicalize_event_paths can
+        // produce one on Linux by resolving a watched symlink out of the tree.
+        // Reject it rather than admit it — admitting emits an out-of-workspace
+        // path into the file map and nx watch, and still panics the transform's
+        // Create branch when a root .nxignore is present.
+        if !path.starts_with(&self.origin) {
+            return false;
+        }
+
         // The brought-in ignore files decide keep/drop, then the hardcoded
         // patterns veto unconditionally — applied last so a .gitignore
-        // whitelist (e.g. a zero-install `!.yarn/cache`) cannot un-ignore
-        // them. `create_walker` enforces the same set as an unbeatable
-        // filter_entry; if the two disagreed, files the walker excludes but
-        // the watcher admits would be reported deleted on every rescan.
-        //
-        // The origin guard matches the .nxignore/gitignore sites: the matcher
-        // is rooted at origin and matched_path_or_any_parents panics on a path
-        // outside its root, which a symlink resolved out of the workspace can
-        // produce on Linux.
+        // whitelist (a zero-install `!.yarn/cache`) cannot un-ignore them,
+        // matching create_walker's filter_entry.
         self.brought_in_allows(path, is_dir)
-            && !(path.starts_with(&self.origin)
-                && matches!(
-                    self.hardcoded.matched_path_or_any_parents(path, is_dir),
-                    Match::Ignore(_)
-                ))
+            && !matches!(
+                self.hardcoded.matched_path_or_any_parents(path, is_dir),
+                Match::Ignore(_)
+            )
     }
 
     fn brought_in_allows(&self, path: &std::path::Path, is_dir: bool) -> bool {
@@ -151,6 +154,15 @@ pub(super) fn create_filter(
     additional_globs: &[String],
     use_ignore: bool,
 ) -> anyhow::Result<WatchFilterer> {
+    // Match the canonical form the event paths take: filter_path rejects any
+    // path not under origin, and canonicalize_event_paths realpaths every event
+    // on Linux. A symlinked NX_WORKSPACE_ROOT_PATH left un-canonicalized here
+    // would then fail that prefix check for every event and drop them all.
+    let origin = dunce::canonicalize(origin)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| origin.to_string());
+    let origin = origin.as_str();
+
     let ignore_files = use_ignore.then(|| get_gitignore_files(origin));
     let nx_ignore_path = get_nx_ignore(origin);
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -313,14 +313,17 @@ impl WatchPipeline {
         // Trace only events that survive the filter — Access reads and
         // other floods are dropped above, so we don't pollute the log
         // with their misleading age_ms (mtime there is the prior write,
-        // not the event).
-        for (path, metadata) in raw.paths() {
-            trace!(
-                ?path,
-                kind = ?raw.kind(),
-                age_ms = event_age_ms(metadata),
-                "ingest"
-            );
+        // not the event). Guarded so the age_ms stat is never paid when
+        // trace logging is off, which is the normal case.
+        if tracing::enabled!(tracing::Level::TRACE) {
+            for (path, metadata) in raw.paths() {
+                trace!(
+                    ?path,
+                    kind = ?raw.kind(),
+                    age_ms = event_age_ms(metadata),
+                    "ingest"
+                );
+            }
         }
 
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -684,6 +687,44 @@ mod tests {
 
         pipeline.reset_burst();
         assert!(!pipeline.has_pending());
+    }
+
+    #[test]
+    fn is_dir_from_kind_only_answers_definitive_kinds() {
+        use crate::native::watch::types::is_dir_from_kind;
+        use notify::EventKind;
+        use notify::event::{CreateKind, DataChange, ModifyKind, RemoveKind, RenameMode};
+
+        // Definitive kinds are answered without a stat.
+        assert_eq!(
+            is_dir_from_kind(&EventKind::Create(CreateKind::File)),
+            Some(false)
+        );
+        assert_eq!(
+            is_dir_from_kind(&EventKind::Create(CreateKind::Folder)),
+            Some(true)
+        );
+        assert_eq!(
+            is_dir_from_kind(&EventKind::Remove(RemoveKind::File)),
+            Some(false)
+        );
+        assert_eq!(
+            is_dir_from_kind(&EventKind::Remove(RemoveKind::Folder)),
+            Some(true)
+        );
+        assert_eq!(
+            is_dir_from_kind(&EventKind::Modify(ModifyKind::Data(DataChange::Any))),
+            Some(false)
+        );
+
+        // Ambiguous kinds must fall back to a stat, never guess.
+        assert_eq!(is_dir_from_kind(&EventKind::Create(CreateKind::Any)), None);
+        assert_eq!(is_dir_from_kind(&EventKind::Remove(RemoveKind::Any)), None);
+        assert_eq!(is_dir_from_kind(&EventKind::Modify(ModifyKind::Any)), None);
+        assert_eq!(
+            is_dir_from_kind(&EventKind::Modify(ModifyKind::Name(RenameMode::To))),
+            None
+        );
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -728,6 +728,46 @@ mod tests {
     }
 
     #[test]
+    fn filter_uses_kind_derived_is_dir_not_the_stat() {
+        // A directory-only ignore pattern (`ignored_dir/`) matches only when
+        // the filterer is told the path is a directory. This exercises the
+        // is_dir_at wiring end to end through check_event: the on-disk path is
+        // a real directory, so a stat would call BOTH events directories, but
+        // the event kind must decide. A Create(Folder) is filtered; a
+        // Create(File) for the same path passes, because the trailing-slash
+        // pattern is dir-only. If is_dir_at ignored the kind (or the helper
+        // returned the wrong value) the File case would be wrongly filtered.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dir.path().canonicalize().expect("canonicalize");
+        let origin_str = origin.to_str().expect("utf-8 path");
+        let target = origin.join("ignored_dir");
+        fs::create_dir_all(&target).expect("mkdir target");
+
+        let filterer =
+            watch_filterer::create_filter(origin_str, &["ignored_dir/".to_string()], false)
+                .expect("filter");
+
+        let as_folder = RawWatchEvent::new(
+            notify::Event::new(EventKind::Create(CreateKind::Folder)).add_path(target.clone()),
+        );
+        let as_file = RawWatchEvent::new(
+            notify::Event::new(EventKind::Create(CreateKind::File)).add_path(target.clone()),
+        );
+
+        assert!(
+            !filterer.check_event(&as_folder),
+            "Create(Folder) for ignored_dir/ should be filtered (is_dir from kind = true)"
+        );
+        assert!(
+            filterer.check_event(&as_file),
+            "Create(File) named ignored_dir should pass the dir-only pattern (is_dir from kind = false), even though it is a directory on disk"
+        );
+    }
+
+    #[test]
     fn git_style_unlink_then_write_yields_create() {
         // Regression: `git checkout` does unlink+create on tracked
         // files. Pre-fix the accumulator's "Delete always wins" rule

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -116,6 +116,10 @@ struct WatchPipeline {
     ignore_globs: Arc<NxGlobSet>,
 
     accumulator: HashMap<PathBuf, WatchEventInternal>,
+    /// The backend reported dropped events (notify's Rescan flag, e.g. an
+    /// inotify queue overflow). Per-path events are incomplete from that
+    /// moment, so the next flush emits a single rescan event instead.
+    pending_rescan: bool,
     burst_start: Option<Instant>,
     flush_deadline: Option<Instant>,
 }
@@ -156,6 +160,7 @@ impl WatchPipeline {
             #[cfg(not(target_os = "macos"))]
             ignore_globs: build_ignore_glob_set(),
             accumulator: HashMap::new(),
+            pending_rescan: false,
             burst_start: None,
             flush_deadline: None,
         })
@@ -182,11 +187,24 @@ impl WatchPipeline {
     }
 
     fn snapshot_events(&self) -> Vec<WatchEvent> {
+        // A rescan supersedes the accumulated events: the consumer re-walks,
+        // which covers everything a per-path event could have said.
+        if self.pending_rescan {
+            return vec![WatchEvent {
+                path: String::new(),
+                r#type: EventType::rescan,
+            }];
+        }
         self.accumulator.values().map(|e| e.into()).collect()
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.accumulator.is_empty() || self.pending_rescan
     }
 
     fn reset_burst(&mut self) {
         self.accumulator.clear();
+        self.pending_rescan = false;
         self.burst_start = None;
         self.flush_deadline = None;
     }
@@ -265,6 +283,15 @@ impl WatchPipeline {
                 return Ok(());
             }
         };
+
+        if event.need_rescan() {
+            tracing::warn!("backend dropped events (rescan flag); scheduling a rescan flush");
+            self.pending_rescan = true;
+            let now = Instant::now();
+            let bs = *self.burst_start.get_or_insert(now);
+            self.flush_deadline = Some((now + IDLE_WINDOW).min(bs + MAX_WAIT));
+            return Ok(());
+        }
 
         let raw = RawWatchEvent::new(event);
 
@@ -353,7 +380,7 @@ impl WatchPipeline {
                         // FORCE_FLUSH_QUIET window so a trickle isn't cut
                         // mid-stream. Bounded by FORCE_FLUSH_MAX.
                         let deadline = handler_started_at + FORCE_FLUSH_MAX;
-                        let mut burst_in_progress = !self.accumulator.is_empty();
+                        let mut burst_in_progress = self.has_pending();
                         while fatal.is_none() {
                             let now = Instant::now();
                             if now >= deadline {
@@ -406,7 +433,7 @@ impl WatchPipeline {
                     Err(_) => break, // struct dropped or stop() called
                 },
                 default(idle_wait) => {
-                    if !self.accumulator.is_empty() {
+                    if self.has_pending() {
                         let events = self.snapshot_events();
                         debug!(count = events.len(), "idle-window emitting events");
                         for e in &events {
@@ -586,6 +613,37 @@ mod tests {
 
     fn find_event<'a>(events: &'a [WatchEvent], name: &str) -> Option<&'a WatchEvent> {
         events.iter().find(|e| e.path.ends_with(name))
+    }
+
+    #[test]
+    fn rescan_flag_supersedes_accumulated_events() {
+        use notify::event::{CreateKind, Flag};
+
+        let dir = tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        let mut pipeline = WatchPipeline::new(
+            canonical.to_str().expect("utf-8 path").to_string(),
+            &[],
+            false,
+        )
+        .expect("pipeline");
+
+        let file = canonical.join("file.txt");
+        fs::write(&file, "x").expect("write");
+        let create = notify::Event::new(notify::EventKind::Create(CreateKind::File)).add_path(file);
+        pipeline.ingest_event(Ok(create)).expect("ingest create");
+        assert!(pipeline.has_pending());
+
+        let overflow = notify::Event::new(notify::EventKind::Other).set_flag(Flag::Rescan);
+        pipeline.ingest_event(Ok(overflow)).expect("ingest rescan");
+
+        let events = pipeline.snapshot_events();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].r#type, EventType::rescan));
+        assert_eq!(events[0].path, "");
+
+        pipeline.reset_burst();
+        assert!(!pipeline.has_pending());
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -1,5 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+use std::collections::HashSet;
 use std::path::{MAIN_SEPARATOR, Path, PathBuf};
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -10,10 +13,10 @@ use notify::{RecursiveMode, Watcher as NotifyWatcher};
 use parking_lot::Mutex;
 use tracing::{debug, trace};
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use crate::native::glob::{NxGlobSet, build_glob_set};
 use crate::native::walker::HARDCODED_IGNORE_PATTERNS;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use crate::native::walker::create_walker;
 use crate::native::watch::types::{
     EventType, RawWatchEvent, WatchEvent, WatchEventInternal, transform_event_to_watch_events,
@@ -52,7 +55,7 @@ const FORCE_FLUSH_QUIET: Duration = Duration::from_millis(50);
 /// a late reply isn't read as "no changes".
 const FORCE_FLUSH_MAX: Duration = Duration::from_millis(250);
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn build_ignore_glob_set() -> Arc<NxGlobSet> {
     build_glob_set(HARDCODED_IGNORE_PATTERNS).expect("These static ignores always build")
 }
@@ -60,7 +63,7 @@ fn build_ignore_glob_set() -> Arc<NxGlobSet> {
 /// Returns Err on `MaxFilesWatch` — the inotify limit is fatal since
 /// every subsequent registration would fail too. Other errors are
 /// warn-logged and skipped.
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn register_watches<I, P>(
     watcher: &mut notify::RecommendedWatcher,
     paths: I,
@@ -81,7 +84,7 @@ where
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn enumerate_watch_paths<P: AsRef<Path>>(directory: P, use_ignores: bool) -> HashSet<PathBuf> {
     let walker = create_walker(&directory, use_ignores);
     let mut path_set: HashSet<PathBuf> = HashSet::new();
@@ -109,10 +112,12 @@ type ForceFlushReply = Sender<Vec<WatchEvent>>;
 struct WatchPipeline {
     filterer: watch_filterer::WatchFilterer,
     notify_rx: Receiver<NotifyResult>,
+    /// Held to keep the registrations alive — dropping it stops delivery.
+    #[cfg_attr(any(target_os = "macos", target_os = "windows"), allow(dead_code))]
     watcher: notify::RecommendedWatcher,
     /// `origin` with a trailing path separator.
     origin_path: String,
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     ignore_globs: Arc<NxGlobSet>,
 
     accumulator: HashMap<PathBuf, WatchEventInternal>,
@@ -139,11 +144,14 @@ impl WatchPipeline {
         })
         .map_err(|e| format!("failed to create file watcher: {e}"))?;
 
-        #[cfg(target_os = "macos")]
+        // FSEvents and ReadDirectoryChangesW recurse in the kernel. notify
+        // accepts RecursiveMode::Recursive on inotify and kqueue too, but
+        // emulates it by registering every directory - without nx's ignores.
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
         if let Err(e) = watcher.watch(Path::new(&origin), RecursiveMode::Recursive) {
             tracing::error!(?e, "failed to watch root directory");
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         register_watches(&mut watcher, enumerate_watch_paths(&origin, use_ignore))
             .map_err(|e| format!("failed to register initial watches: {e}"))?;
 
@@ -157,7 +165,7 @@ impl WatchPipeline {
             notify_rx,
             watcher,
             origin_path,
-            #[cfg(not(target_os = "macos"))]
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
             ignore_globs: build_ignore_glob_set(),
             accumulator: HashMap::new(),
             pending_rescan: false,
@@ -209,7 +217,7 @@ impl WatchPipeline {
         self.flush_deadline = None;
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     fn new_directories_from_event(&self, event: &RawWatchEvent) -> Vec<PathBuf> {
         use crate::native::watch::types::meta_is_dir;
         use notify::{EventKind, event::CreateKind};
@@ -231,7 +239,7 @@ impl WatchPipeline {
     /// Synchronously register watches for new directories, walk them to
     /// backfill files written before the watch was active, and recurse
     /// into any nested subdirectories. Returns Err on `MaxFilesWatch`.
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     fn register_and_backfill_new_dirs(
         &mut self,
         dirs: &[PathBuf],
@@ -312,7 +320,7 @@ impl WatchPipeline {
             );
         }
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         {
             let new_dirs = self.new_directories_from_event(&raw);
             if !new_dirs.is_empty() {
@@ -569,7 +577,7 @@ mod tests {
     use super::*;
     use crate::native::watch::types::EventType;
     use std::fs;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tempfile::tempdir;
 
@@ -583,8 +591,9 @@ mod tests {
         // Canonicalize: on macOS `/tmp` symlinks to `/private/tmp`, so
         // events arrive with the canonical prefix while origin would
         // not. The filterer's `path.starts_with(origin)` check needs
-        // them to agree.
-        let canonical = dir.canonicalize().expect("canonicalize tempdir");
+        // them to agree. dunce, not std: std returns a `\\?\` verbatim
+        // path on Windows, which no workspace root ever has.
+        let canonical = dunce::canonicalize(dir).expect("canonicalize tempdir");
         let mut w = Watcher::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             None,
@@ -613,6 +622,23 @@ mod tests {
 
     fn find_event<'a>(events: &'a [WatchEvent], name: &str) -> Option<&'a WatchEvent> {
         events.iter().find(|e| e.path.ends_with(name))
+    }
+
+    /// Poll both delivery paths until `path` shows up. Force-flush and the
+    /// idle-window callback race, and force-flush resets the accumulator, so
+    /// an event is reported through exactly one of them.
+    fn wait_for_path(watcher: &Watcher, captured: &Captured, path: &str, msg: &str) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let flushed = watcher.force_flush_pending();
+            let seen = flushed.iter().any(|e| e.path == path)
+                || captured.lock().unwrap().iter().any(|e| e.path == path);
+            if seen {
+                return;
+            }
+            assert!(Instant::now() < deadline, "{msg}");
+            std::thread::sleep(Duration::from_millis(50));
+        }
     }
 
     #[test]
@@ -865,7 +891,7 @@ mod tests {
         // watch() returns is never missed. No settling sleep on purpose —
         // start_watcher() is not used because it sleeps after registration.
         let dir = tempdir().expect("tempdir");
-        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        let canonical = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
         let mut watcher = Watcher::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             None,
@@ -882,24 +908,12 @@ mod tests {
 
         fs::write(canonical.join("boot.txt"), "x").expect("write");
 
-        let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            let flushed = watcher.force_flush_pending();
-            let seen = flushed.iter().any(|e| e.path == "boot.txt")
-                || captured
-                    .lock()
-                    .unwrap()
-                    .iter()
-                    .any(|e| e.path == "boot.txt");
-            if seen {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "write immediately after watch registration was never reported"
-            );
-            std::thread::sleep(Duration::from_millis(50));
-        }
+        wait_for_path(
+            &watcher,
+            &captured,
+            "boot.txt",
+            "write immediately after watch registration was never reported",
+        );
     }
 
     #[test]
@@ -961,6 +975,26 @@ mod tests {
             matches!(new_evt.r#type, EventType::create),
             "rename destination should classify as Create; got {:?}",
             new_evt.r#type
+        );
+    }
+
+    #[test]
+    fn files_in_directories_created_after_watch_start_are_reported() {
+        // Per-directory backends register new directories as they appear;
+        // recursive ones leave it to the kernel. Both have to report a file
+        // written into a directory that did not exist when watching began.
+        let dir = tempdir().expect("tempdir");
+        let (watcher, captured) = start_watcher(dir.path());
+
+        let nested = dir.path().join("libs/new-lib/src");
+        fs::create_dir_all(&nested).expect("mkdir nested");
+        fs::write(nested.join("index.ts"), "x").expect("write");
+
+        wait_for_path(
+            &watcher,
+            &captured,
+            "libs/new-lib/src/index.ts",
+            "file in a directory created after watch start was never reported",
         );
     }
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -296,7 +296,13 @@ impl WatchPipeline {
         };
 
         if event.need_rescan() {
-            tracing::warn!("backend dropped events (rescan flag); scheduling a rescan flush");
+            // The backend can raise the flag hundreds of times before the
+            // flush drains, but they coalesce into one rescan. Log only the
+            // first of a burst: warning per raw flag floods the daemon log
+            // and slows the drain path that the overflow is already straining.
+            if !self.pending_rescan {
+                tracing::warn!("backend dropped events (rescan flag); scheduling a rescan flush");
+            }
             self.pending_rescan = true;
             let now = Instant::now();
             let bs = *self.burst_start.get_or_insert(now);

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -195,15 +195,18 @@ impl WatchPipeline {
     }
 
     fn snapshot_events(&self) -> Vec<WatchEvent> {
-        // A rescan supersedes the accumulated events: the consumer re-walks,
-        // which covers everything a per-path event could have said.
+        let mut events: Vec<WatchEvent> = self.accumulator.values().map(|e| e.into()).collect();
+        // The rescan marker accompanies the accumulated batch rather than
+        // replacing it: the daemon's ignore-file and server-process intercepts
+        // read the raw events before per-path routing, so dropping them would
+        // leave the native filterer's ignore rules stale after an overflow.
         if self.pending_rescan {
-            return vec![WatchEvent {
+            events.push(WatchEvent {
                 path: String::new(),
                 r#type: EventType::rescan,
-            }];
+            });
         }
-        self.accumulator.values().map(|e| e.into()).collect()
+        events
     }
 
     fn has_pending(&self) -> bool {
@@ -642,7 +645,7 @@ mod tests {
     }
 
     #[test]
-    fn rescan_flag_supersedes_accumulated_events() {
+    fn rescan_flag_accompanies_accumulated_events() {
         use notify::event::{CreateKind, Flag};
 
         let dir = tempdir().expect("tempdir");
@@ -663,10 +666,21 @@ mod tests {
         let overflow = notify::Event::new(notify::EventKind::Other).set_flag(Flag::Rescan);
         pipeline.ingest_event(Ok(overflow)).expect("ingest rescan");
 
+        // The rescan marker rides alongside the accumulated per-path event, not
+        // in place of it, so the daemon's ignore-file/server-process intercepts
+        // still see the path they key on.
         let events = pipeline.snapshot_events();
-        assert_eq!(events.len(), 1);
-        assert!(matches!(events[0].r#type, EventType::rescan));
-        assert_eq!(events[0].path, "");
+        assert_eq!(events.len(), 2);
+        let rescan = events
+            .iter()
+            .find(|e| matches!(e.r#type, EventType::rescan))
+            .expect("rescan marker present");
+        assert_eq!(rescan.path, "");
+        let created = events
+            .iter()
+            .find(|e| matches!(e.r#type, EventType::create))
+            .expect("accumulated create preserved");
+        assert!(created.path.ends_with("file.txt"));
 
         pipeline.reset_burst();
         assert!(!pipeline.has_pending());

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -696,6 +696,51 @@ mod tests {
     }
 
     #[test]
+    fn rescan_flag_rearms_per_burst_so_a_later_overflow_is_not_swallowed() {
+        // The overflow warn is logged once per burst, gated on the
+        // pending_rescan false->true transition. This pins that the gate
+        // re-arms after a flush: a second overflow within a burst coalesces
+        // into the one already-scheduled re-walk (recovered, logged once),
+        // and a genuine new burst after a flush re-arms the flag (logged and
+        // recovered again). The flag can never persist across a flush, so no
+        // real overflow goes unlogged.
+        use notify::event::Flag;
+
+        let dir = tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize");
+        let mut pipeline = WatchPipeline::new(
+            canonical.to_str().expect("utf-8 path").to_string(),
+            &[],
+            false,
+        )
+        .expect("pipeline");
+        let overflow = || notify::Event::new(notify::EventKind::Other).set_flag(Flag::Rescan);
+
+        // First overflow of a burst: the flag was clear, so the gate logs.
+        assert!(!pipeline.pending_rescan);
+        pipeline.ingest_event(Ok(overflow())).expect("rescan 1");
+        assert!(pipeline.pending_rescan, "first overflow arms the flag");
+
+        // A second flag in the same burst coalesces: one marker, no re-log.
+        pipeline.ingest_event(Ok(overflow())).expect("rescan 1b");
+        let events = pipeline.snapshot_events();
+        assert_eq!(events.len(), 1, "coalesced to a single rescan marker");
+        assert!(matches!(events[0].r#type, EventType::rescan));
+
+        // The flush clears the flag.
+        pipeline.reset_burst();
+        assert!(!pipeline.pending_rescan, "flush clears the flag");
+
+        // A new burst re-arms: the gate would log again and the marker fires
+        // again, so the later overflow is neither swallowed nor unrecovered.
+        pipeline.ingest_event(Ok(overflow())).expect("rescan 2");
+        assert!(pipeline.pending_rescan, "a new burst re-arms the flag");
+        let events = pipeline.snapshot_events();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].r#type, EventType::rescan));
+    }
+
+    #[test]
     fn is_dir_from_kind_only_answers_definitive_kinds() {
         use crate::native::watch::types::is_dir_from_kind;
         use notify::EventKind;

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -789,6 +789,61 @@ mod tests {
     }
 
     #[test]
+    fn dot_ignore_beats_a_same_dir_gitignore_negation() {
+        // The ignore crate ranks .ignore above .gitignore. A pkg/.gitignore
+        // that un-ignores a path a pkg/.ignore excludes must stay excluded, or
+        // the watcher admits a file the walk drops and reports it deleted.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dir.path().canonicalize().expect("canonicalize");
+        let pkg = origin.join("pkg");
+        fs::create_dir_all(&pkg).expect("mkdir pkg");
+        fs::write(pkg.join(".gitignore"), "!conflict.log\n").expect("write .gitignore");
+        fs::write(pkg.join(".ignore"), "conflict.log\n").expect("write .ignore");
+
+        let filterer = watch_filterer::create_filter(origin.to_str().expect("utf-8"), &[], true)
+            .expect("filter");
+
+        let event = RawWatchEvent::new(
+            notify::Event::new(EventKind::Create(CreateKind::File))
+                .add_path(pkg.join("conflict.log")),
+        );
+        assert!(
+            !filterer.check_event(&event),
+            ".ignore excludes conflict.log and outranks the .gitignore negation"
+        );
+    }
+
+    #[test]
+    fn a_path_outside_origin_does_not_panic_the_veto() {
+        // canonicalize_event_paths can resolve a symlink out of the workspace,
+        // and matched_path_or_any_parents panics on a path outside the matcher
+        // root. check_event must handle it, not crash the pipeline thread.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dir.path().join("workspace");
+        fs::create_dir_all(&origin).expect("mkdir origin");
+        let origin = origin.canonicalize().expect("canonicalize");
+        let outside = dir
+            .path()
+            .join("elsewhere")
+            .join("node_modules")
+            .join("x.js");
+
+        let filterer = watch_filterer::create_filter(origin.to_str().expect("utf-8"), &[], true)
+            .expect("filter");
+        let event = RawWatchEvent::new(
+            notify::Event::new(EventKind::Create(CreateKind::File)).add_path(outside),
+        );
+        // Must not panic; an out-of-origin path is not subject to workspace rules.
+        assert!(filterer.check_event(&event));
+    }
+
+    #[test]
     fn git_info_exclude_is_honoured_like_the_walker() {
         // `.git/info/exclude` is where local, uncommittable exclusions live
         // (scratch dirs, secrets). create_walker honours it, so the filterer

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -1380,9 +1380,15 @@ mod tests {
             is_dir_from_kind(&EventKind::Remove(RemoveKind::Folder)),
             Some(true)
         );
+        // FSEvents does not distinguish files from directories, so macOS
+        // classifies a data change from the stat instead of the kind.
         assert_eq!(
             is_dir_from_kind(&EventKind::Modify(ModifyKind::Data(DataChange::Any))),
-            Some(false)
+            if cfg!(target_os = "macos") {
+                None
+            } else {
+                Some(false)
+            }
         );
 
         // Ambiguous kinds must fall back to a stat, never guess.

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -741,6 +741,40 @@ mod tests {
     }
 
     #[test]
+    fn git_info_exclude_is_honoured_like_the_walker() {
+        // `.git/info/exclude` is where local, uncommittable exclusions live
+        // (scratch dirs, secrets). create_walker honours it, so the filterer
+        // must too — otherwise those files reach the daemon, get hashed into
+        // the file map, and are broadcast to nx watch. The .gitignore control
+        // proves the exclude path is what does the filtering.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dir.path().canonicalize().expect("canonicalize");
+        let origin_str = origin.to_str().expect("utf-8 path");
+        fs::create_dir_all(origin.join(".git/info")).expect("mkdir .git/info");
+        fs::write(origin.join(".git/info/exclude"), "secrets/\n").expect("write exclude");
+
+        let filterer = watch_filterer::create_filter(origin_str, &[], true).expect("filter");
+
+        let event = |rel: &str| {
+            RawWatchEvent::new(
+                notify::Event::new(EventKind::Create(CreateKind::File)).add_path(origin.join(rel)),
+            )
+        };
+
+        assert!(
+            !filterer.check_event(&event("secrets/deploy.key")),
+            "a path excluded via .git/info/exclude must be filtered, matching the walker"
+        );
+        assert!(
+            filterer.check_event(&event("src/index.ts")),
+            "an unexcluded path still passes"
+        );
+    }
+
+    #[test]
     fn hardcoded_ignores_veto_a_gitignore_negation() {
         // A Yarn Berry zero-install workspace ships `!.yarn/cache`, which as a
         // plain gitignore entry would un-ignore a hardcoded-ignored path. The

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -151,8 +151,9 @@ impl WatchPipeline {
         // in the transform (origin_path below), and the watch registration all
         // agree on the workspace root. Event paths arrive realpath'd
         // (canonicalize_event_paths on Linux, FSEvents on macOS), so a symlinked
-        // NX_WORKSPACE_ROOT_PATH left un-canonicalized would pass the filter but
-        // fail relative_to_origin and emit absolute paths.
+        // NX_WORKSPACE_ROOT_PATH left un-canonicalized would no longer match
+        // filter_path's origin prefix — every realpath'd event would be dropped
+        // and the daemon would see no changes at all.
         let origin = dunce::canonicalize(&origin)
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or(origin);

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -929,10 +929,29 @@ mod tests {
         assert!(!filterer.check_event(&event));
     }
 
-    // Symlink creation on Windows needs elevation/developer mode, so this pins
-    // the platform-independent canonicalization on unix. The behaviour it guards
-    // matters most on Windows (the recursive root), but the logic is the same.
-    #[cfg(unix)]
+    /// Create a directory symlink cross-platform. Windows needs
+    /// SeCreateSymbolicLinkPrivilege (Developer Mode or an elevated process); a
+    /// caller that gets an error skips rather than fails, so a symlink test still
+    /// runs on every platform that allows it instead of being compiled out.
+    fn make_dir_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(target, link)
+        }
+        #[cfg(windows)]
+        {
+            std::os::windows::fs::symlink_dir(target, link)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = (target, link);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "directory symlinks are unsupported on this platform",
+            ))
+        }
+    }
+
     #[test]
     fn new_canonicalizes_origin_so_a_symlinked_root_strips_to_relative() {
         // NX_WORKSPACE_ROOT_PATH can be a symlink. Event paths arrive realpath'd
@@ -947,7 +966,13 @@ mod tests {
         let real = dunce::canonicalize(&real).expect("canonicalize real");
 
         let link = dir.path().join("linked");
-        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+        if let Err(e) = make_dir_symlink(&real, &link) {
+            eprintln!(
+                "skipping new_canonicalizes_origin_so_a_symlinked_root_strips_to_relative: \
+                 cannot create a directory symlink here ({e})"
+            );
+            return;
+        }
 
         let pipeline = WatchPipeline::new(link.to_str().expect("utf-8").to_string(), &[], false)
             .expect("pipeline");
@@ -962,14 +987,12 @@ mod tests {
         );
     }
 
-    // Real-backend proof of the same fix: start the watcher on a symlinked
-    // root and confirm a write under it is delivered with a workspace-relative
-    // path. This exercises the platform's actual backend, where the failure
-    // modes differed — on macOS FSEvents drops any path not under the watched
-    // dir, so a symlinked root delivered nothing at all; on Linux the event
-    // arrived realpath'd and an un-canonical origin emitted an absolute path.
-    // Windows symlink creation needs elevation, so this is unix-only.
-    #[cfg(unix)]
+    // Real-backend proof of the same fix: start the watcher on a symlinked root
+    // and confirm a write under it is delivered with a workspace-relative path.
+    // This exercises the platform's actual backend, where the failure modes
+    // differ — on Linux the event arrives realpath'd and an un-canonical origin
+    // emits an absolute path; on macOS FSEvents echoes the watched path (so the
+    // fix is a no-op there). Skips on Windows without symlink privilege.
     #[test]
     fn a_symlinked_root_delivers_relative_events_end_to_end() {
         let dir = tempdir().expect("tempdir");
@@ -977,7 +1000,13 @@ mod tests {
         fs::create_dir_all(real.join("src")).expect("mkdir workspace/src");
 
         let link = dir.path().join("linked");
-        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+        if let Err(e) = make_dir_symlink(&real, &link) {
+            eprintln!(
+                "skipping a_symlinked_root_delivers_relative_events_end_to_end: \
+                 cannot create a directory symlink here ({e})"
+            );
+            return;
+        }
 
         // Start on the SYMLINK, non-canonical, as NX_WORKSPACE_ROOT_PATH may be.
         let mut w = Watcher::new(link.to_str().expect("utf-8").to_string(), None, Some(false));
@@ -992,16 +1021,30 @@ mod tests {
         std::thread::sleep(Duration::from_millis(300));
         captured.lock().unwrap().clear();
 
-        fs::write(link.join("src/x.ts"), "export const x = 1;").expect("write");
+        fs::write(link.join("src").join("x.ts"), "export const x = 1;").expect("write");
 
-        // wait_for_path matches e.path == "src/x.ts" exactly, so it proves both
-        // delivery and that the path is workspace-relative, not absolute.
-        wait_for_path(
-            &w,
-            &captured,
-            "src/x.ts",
-            "a write under a symlinked root must be delivered with a relative path",
-        );
+        // Proves both delivery and that the path is workspace-relative: an
+        // absolute path would carry the root/drive and never normalize to
+        // "src/x.ts". Separators are normalized so the check holds on Windows.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let norm = |p: &str| p.replace('\\', "/");
+            let flushed = w.force_flush_pending();
+            let seen = flushed.iter().any(|e| norm(&e.path) == "src/x.ts")
+                || captured
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .any(|e| norm(&e.path) == "src/x.ts");
+            if seen {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "a write under a symlinked root must be delivered with a relative path"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -41,6 +41,10 @@ const IDLE_WINDOW: Duration = Duration::from_millis(100);
 /// Starvation cap from the start of a burst — flush even if events keep
 /// arriving faster than IDLE_WINDOW.
 const MAX_WAIT: Duration = Duration::from_millis(500);
+/// A rescan marker is held until the overflow burst settles so a storm that
+/// drops events across many flushes recovers with a single re-walk, not one
+/// per flush. This bounds that hold so an unending storm still recovers.
+const RESCAN_MAX_WAIT: Duration = Duration::from_secs(2);
 /// Grace for the kernel→notify hop before the first event arrives; short so an
 /// idle force-flush adds no latency. macOS FSEvents lags more than inotify.
 #[cfg(target_os = "macos")]
@@ -125,6 +129,9 @@ struct WatchPipeline {
     /// inotify queue overflow). Per-path events are incomplete from that
     /// moment, so the next flush emits a single rescan event instead.
     pending_rescan: bool,
+    /// Cap for holding a pending rescan across a sustained storm; `None` when
+    /// no rescan is pending.
+    rescan_deadline: Option<Instant>,
     burst_start: Option<Instant>,
     flush_deadline: Option<Instant>,
 }
@@ -169,6 +176,7 @@ impl WatchPipeline {
             ignore_globs: build_ignore_glob_set(),
             accumulator: HashMap::new(),
             pending_rescan: false,
+            rescan_deadline: None,
             burst_start: None,
             flush_deadline: None,
         })
@@ -194,19 +202,31 @@ impl WatchPipeline {
         }
     }
 
-    fn snapshot_events(&self) -> Vec<WatchEvent> {
+    fn snapshot_events(&self, include_rescan: bool) -> Vec<WatchEvent> {
         let mut events: Vec<WatchEvent> = self.accumulator.values().map(|e| e.into()).collect();
         // The rescan marker accompanies the accumulated batch rather than
         // replacing it: the daemon's ignore-file and server-process intercepts
         // read the raw events before per-path routing, so dropping them would
         // leave the native filterer's ignore rules stale after an overflow.
-        if self.pending_rescan {
+        if include_rescan && self.pending_rescan {
             events.push(WatchEvent {
                 path: String::new(),
                 r#type: EventType::rescan,
             });
         }
         events
+    }
+
+    /// Whether a pending rescan should be emitted now rather than held. It is
+    /// held while a storm is still delivering (`storm_ongoing`) so many dropped
+    /// flushes coalesce into one re-walk, and released once the storm settles
+    /// or `RESCAN_MAX_WAIT` elapses.
+    fn rescan_due(&self, storm_ongoing: bool) -> bool {
+        self.pending_rescan
+            && (!storm_ongoing
+                || self
+                    .rescan_deadline
+                    .is_some_and(|deadline| Instant::now() >= deadline))
     }
 
     fn has_pending(&self) -> bool {
@@ -216,6 +236,7 @@ impl WatchPipeline {
     fn reset_burst(&mut self) {
         self.accumulator.clear();
         self.pending_rescan = false;
+        self.rescan_deadline = None;
         self.burst_start = None;
         self.flush_deadline = None;
     }
@@ -305,6 +326,7 @@ impl WatchPipeline {
             }
             self.pending_rescan = true;
             let now = Instant::now();
+            self.rescan_deadline.get_or_insert(now + RESCAN_MAX_WAIT);
             let bs = *self.burst_start.get_or_insert(now);
             self.flush_deadline = Some((now + IDLE_WINDOW).min(bs + MAX_WAIT));
             return Ok(());
@@ -425,7 +447,10 @@ impl WatchPipeline {
                                 }
                             }
                         }
-                        let watch_events = self.snapshot_events();
+                        // A force-flush answers a graph request, so deliver the
+                        // rescan now rather than holding it — the caller needs
+                        // current state.
+                        let watch_events = self.snapshot_events(true);
                         debug!(
                             count = watch_events.len(),
                             replies = replies.len(),
@@ -454,14 +479,37 @@ impl WatchPipeline {
                 },
                 default(idle_wait) => {
                     if self.has_pending() {
-                        let events = self.snapshot_events();
+                        // Hold a pending rescan while the storm is still
+                        // delivering (more events already queued), so a burst
+                        // that overflows across many flushes coalesces into one
+                        // re-walk instead of one per flush.
+                        let storm_ongoing = !self.notify_rx.is_empty();
+                        let rescan_due = self.rescan_due(storm_ongoing);
+                        let events = self.snapshot_events(rescan_due);
                         debug!(count = events.len(), "idle-window emitting events");
                         for e in &events {
                             debug!("  [{:?}] {}", e.r#type, e.path);
                         }
-                        callback(Ok(events));
+                        if !events.is_empty() {
+                            callback(Ok(events));
+                        }
+
+                        // Clear the per-path burst either way. Keep the pending
+                        // rescan when it was held; the queued events drive the
+                        // next flush, and the cap releases it if the storm never
+                        // settles.
+                        self.accumulator.clear();
+                        self.burst_start = None;
+                        self.flush_deadline = None;
+                        if rescan_due || !self.pending_rescan {
+                            self.pending_rescan = false;
+                            self.rescan_deadline = None;
+                        } else {
+                            self.flush_deadline = self.rescan_deadline;
+                        }
+                    } else {
+                        self.reset_burst();
                     }
-                    self.reset_burst();
                 }
             }
         }
@@ -678,7 +726,7 @@ mod tests {
         // The rescan marker rides alongside the accumulated per-path event, not
         // in place of it, so the daemon's ignore-file/server-process intercepts
         // still see the path they key on.
-        let events = pipeline.snapshot_events();
+        let events = pipeline.snapshot_events(true);
         assert_eq!(events.len(), 2);
         let rescan = events
             .iter()
@@ -723,7 +771,7 @@ mod tests {
 
         // A second flag in the same burst coalesces: one marker, no re-log.
         pipeline.ingest_event(Ok(overflow())).expect("rescan 1b");
-        let events = pipeline.snapshot_events();
+        let events = pipeline.snapshot_events(true);
         assert_eq!(events.len(), 1, "coalesced to a single rescan marker");
         assert!(matches!(events[0].r#type, EventType::rescan));
 
@@ -735,7 +783,7 @@ mod tests {
         // again, so the later overflow is neither swallowed nor unrecovered.
         pipeline.ingest_event(Ok(overflow())).expect("rescan 2");
         assert!(pipeline.pending_rescan, "a new burst re-arms the flag");
-        let events = pipeline.snapshot_events();
+        let events = pipeline.snapshot_events(true);
         assert_eq!(events.len(), 1);
         assert!(matches!(events[0].r#type, EventType::rescan));
     }
@@ -818,6 +866,57 @@ mod tests {
         assert!(
             filterer.check_event(&event("kept.log")),
             "a non-hardcoded whitelist is still honoured — the veto is hardcoded-only"
+        );
+    }
+
+    #[test]
+    fn rescan_is_held_until_the_storm_settles() {
+        // A sustained overflow drops events across many flushes. The marker is
+        // held while the storm is still delivering so it coalesces into a single
+        // re-walk, and released when the storm settles or the cap fires.
+        use notify::event::Flag;
+
+        let dir = tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize");
+        let mut pipeline = WatchPipeline::new(
+            canonical.to_str().expect("utf-8 path").to_string(),
+            &[],
+            false,
+        )
+        .expect("pipeline");
+        let overflow = || notify::Event::new(notify::EventKind::Other).set_flag(Flag::Rescan);
+
+        pipeline
+            .ingest_event(Ok(overflow()))
+            .expect("ingest rescan");
+        assert!(pipeline.pending_rescan);
+
+        // Held while the storm is still delivering: no marker emitted.
+        assert!(
+            !pipeline.rescan_due(true),
+            "held while the storm is ongoing"
+        );
+        assert!(
+            pipeline
+                .snapshot_events(pipeline.rescan_due(true))
+                .is_empty(),
+            "no marker while held"
+        );
+
+        // Released once the storm settles.
+        assert!(
+            pipeline.rescan_due(false),
+            "released when the storm settles"
+        );
+        let events = pipeline.snapshot_events(pipeline.rescan_due(false));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].r#type, EventType::rescan));
+
+        // The cap releases a held rescan even if the storm never settles.
+        pipeline.rescan_deadline = Some(Instant::now() - Duration::from_secs(1));
+        assert!(
+            pipeline.rescan_due(true),
+            "cap releases a held rescan during an unending storm"
         );
     }
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -848,10 +848,10 @@ mod tests {
     }
 
     #[test]
-    fn dot_ignore_beats_a_same_dir_gitignore_negation() {
-        // The ignore crate ranks .ignore above .gitignore. A pkg/.gitignore
-        // that un-ignores a path a pkg/.ignore excludes must stay excluded, or
-        // the watcher admits a file the walk drops and reports it deleted.
+    fn dot_ignore_is_not_an_ignore_source() {
+        // `.ignore` is a ripgrep convention nx never adopted, and create_walker
+        // now turns it off. The watcher must not read it either, or it drops a
+        // file the walk keeps and never reports it at all.
         use notify::EventKind;
         use notify::event::CreateKind;
 
@@ -859,7 +859,6 @@ mod tests {
         let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
         let pkg = origin.join("pkg");
         fs::create_dir_all(&pkg).expect("mkdir pkg");
-        fs::write(pkg.join(".gitignore"), "!conflict.log\n").expect("write .gitignore");
         fs::write(pkg.join(".ignore"), "conflict.log\n").expect("write .ignore");
 
         let filterer = watch_filterer::create_filter(origin.to_str().expect("utf-8"), &[], true)
@@ -870,16 +869,17 @@ mod tests {
                 .add_path(pkg.join("conflict.log")),
         );
         assert!(
-            !filterer.check_event(&event),
-            ".ignore excludes conflict.log and outranks the .gitignore negation"
+            filterer.check_event(&event),
+            "a .ignore entry must not exclude conflict.log"
         );
     }
 
     #[test]
-    fn nested_nxignore_outranks_a_same_dir_dot_ignore() {
-        // The ignore crate ranks a custom ignore file (.nxignore) above .ignore.
-        // A nested pkg/.nxignore that excludes a path a pkg/.ignore un-ignores
-        // must win. Pins the .nxignore rank above .ignore in git_ignores.
+    fn nested_nxignore_outranks_a_same_dir_gitignore_negation() {
+        // The ignore crate ranks a custom ignore file (.nxignore) above
+        // .gitignore. A nested pkg/.nxignore that excludes a path a
+        // pkg/.gitignore un-ignores must win, or the watcher admits a file the
+        // walk drops and reports it deleted on the next rescan.
         use notify::EventKind;
         use notify::event::CreateKind;
 
@@ -887,7 +887,7 @@ mod tests {
         let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
         let pkg = origin.join("pkg");
         fs::create_dir_all(&pkg).expect("mkdir pkg");
-        fs::write(pkg.join(".ignore"), "!keep.tmp\n").expect("write .ignore");
+        fs::write(pkg.join(".gitignore"), "!keep.tmp\n").expect("write .gitignore");
         fs::write(pkg.join(".nxignore"), "keep.tmp\n").expect("write .nxignore");
 
         let filterer = watch_filterer::create_filter(origin.to_str().expect("utf-8"), &[], true)
@@ -897,8 +897,82 @@ mod tests {
         );
         assert!(
             !filterer.check_event(&event),
-            ".nxignore excludes keep.tmp and outranks the .ignore negation"
+            ".nxignore excludes keep.tmp and outranks the .gitignore negation"
         );
+    }
+
+    #[test]
+    fn nested_nxignore_outranks_a_deeper_gitignore_negation() {
+        // The crate keeps the deepest match per CLASS and then prefers the
+        // higher class, so a .nxignore beats a .gitignore at any depth. Pins
+        // rank-before-depth in the git_ignores sort: ordering by depth first
+        // lets the deeper negation un-ignore the file.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
+        let deep = origin.join("pkg").join("deep");
+        fs::create_dir_all(&deep).expect("mkdir deep");
+        fs::write(origin.join("pkg").join(".nxignore"), "keep.tmp\n").expect("write .nxignore");
+        fs::write(deep.join(".gitignore"), "!keep.tmp\n").expect("write .gitignore");
+
+        let filterer = watch_filterer::create_filter(origin.to_str().expect("utf-8"), &[], true)
+            .expect("filter");
+        let event = RawWatchEvent::new(
+            notify::Event::new(EventKind::Create(CreateKind::File)).add_path(deep.join("keep.tmp")),
+        );
+        assert!(
+            !filterer.check_event(&event),
+            "the shallower .nxignore outranks the deeper .gitignore negation"
+        );
+    }
+
+    #[test]
+    fn a_nested_nxignore_outranks_the_root_nxignore() {
+        // Same class, so the deeper file wins — the root .nxignore is an
+        // ordinary git_ignores entry, not a slot above everything. The walk
+        // resolves it this way, and a watcher that admitted the file would
+        // report it deleted on the next rescan.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
+        let pkg = origin.join("pkg");
+        fs::create_dir_all(&pkg).expect("mkdir pkg");
+        fs::write(origin.join(".nxignore"), "!keep.tmp\n").expect("write root .nxignore");
+        fs::write(pkg.join(".nxignore"), "keep.tmp\n").expect("write nested .nxignore");
+
+        let filterer = watch_filterer::create_filter(origin.to_str().expect("utf-8"), &[], true)
+            .expect("filter");
+        let event = RawWatchEvent::new(
+            notify::Event::new(EventKind::Create(CreateKind::File)).add_path(pkg.join("keep.tmp")),
+        );
+        assert!(
+            !filterer.check_event(&event),
+            "the nested .nxignore excludes keep.tmp and outranks the root negation"
+        );
+    }
+
+    #[test]
+    fn the_root_nxignore_applies_even_when_git_ignores_are_off() {
+        // .nxignore is nx's own opt-out, not a git source, so use_ignore=false
+        // must not disable it. Folding it into git_ignores could have lost this.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
+        fs::write(origin.join(".nxignore"), "scratch.tmp\n").expect("write .nxignore");
+
+        let filterer = watch_filterer::create_filter(origin.to_str().expect("utf-8"), &[], false)
+            .expect("filter");
+        let event = RawWatchEvent::new(
+            notify::Event::new(EventKind::Create(CreateKind::File))
+                .add_path(origin.join("scratch.tmp")),
+        );
+        assert!(!filterer.check_event(&event));
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -765,7 +765,7 @@ mod tests {
         use notify::event::{CreateKind, Flag};
 
         let dir = tempdir().expect("tempdir");
-        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        let canonical = dunce::canonicalize(dir.path()).expect("canonicalize tempdir");
         let mut pipeline = WatchPipeline::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             &[],
@@ -814,7 +814,7 @@ mod tests {
         use notify::event::Flag;
 
         let dir = tempdir().expect("tempdir");
-        let canonical = dir.path().canonicalize().expect("canonicalize");
+        let canonical = dunce::canonicalize(dir.path()).expect("canonicalize");
         let mut pipeline = WatchPipeline::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             &[],
@@ -856,7 +856,7 @@ mod tests {
         use notify::event::CreateKind;
 
         let dir = tempdir().expect("tempdir");
-        let origin = dir.path().canonicalize().expect("canonicalize");
+        let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
         let pkg = origin.join("pkg");
         fs::create_dir_all(&pkg).expect("mkdir pkg");
         fs::write(pkg.join(".gitignore"), "!conflict.log\n").expect("write .gitignore");
@@ -884,7 +884,7 @@ mod tests {
         use notify::event::CreateKind;
 
         let dir = tempdir().expect("tempdir");
-        let origin = dir.path().canonicalize().expect("canonicalize");
+        let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
         let pkg = origin.join("pkg");
         fs::create_dir_all(&pkg).expect("mkdir pkg");
         fs::write(pkg.join(".ignore"), "!keep.tmp\n").expect("write .ignore");
@@ -914,7 +914,7 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let origin = dir.path().join("workspace");
         fs::create_dir_all(&origin).expect("mkdir origin");
-        let origin = origin.canonicalize().expect("canonicalize");
+        let origin = dunce::canonicalize(&origin).expect("canonicalize");
         let outside = dir
             .path()
             .join("elsewhere")
@@ -944,7 +944,7 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let real = dir.path().join("workspace");
         fs::create_dir_all(&real).expect("mkdir real");
-        let real = real.canonicalize().expect("canonicalize real");
+        let real = dunce::canonicalize(&real).expect("canonicalize real");
 
         let link = dir.path().join("linked");
         std::os::unix::fs::symlink(&real, &link).expect("symlink");
@@ -962,6 +962,48 @@ mod tests {
         );
     }
 
+    // Real-backend proof of the same fix: start the watcher on a symlinked
+    // root and confirm a write under it is delivered with a workspace-relative
+    // path. This exercises the platform's actual backend, where the failure
+    // modes differed — on macOS FSEvents drops any path not under the watched
+    // dir, so a symlinked root delivered nothing at all; on Linux the event
+    // arrived realpath'd and an un-canonical origin emitted an absolute path.
+    // Windows symlink creation needs elevation, so this is unix-only.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_root_delivers_relative_events_end_to_end() {
+        let dir = tempdir().expect("tempdir");
+        let real = dir.path().join("workspace");
+        fs::create_dir_all(real.join("src")).expect("mkdir workspace/src");
+
+        let link = dir.path().join("linked");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        // Start on the SYMLINK, non-canonical, as NX_WORKSPACE_ROOT_PATH may be.
+        let mut w = Watcher::new(link.to_str().expect("utf-8").to_string(), None, Some(false));
+        let captured: Captured = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_cb = captured.clone();
+        let callback: WatchEventCallback = Box::new(move |res| {
+            if let Ok(events) = res {
+                captured_for_cb.lock().unwrap().extend(events);
+            }
+        });
+        w.watch_inner(callback).expect("start watch");
+        std::thread::sleep(Duration::from_millis(300));
+        captured.lock().unwrap().clear();
+
+        fs::write(link.join("src/x.ts"), "export const x = 1;").expect("write");
+
+        // wait_for_path matches e.path == "src/x.ts" exactly, so it proves both
+        // delivery and that the path is workspace-relative, not absolute.
+        wait_for_path(
+            &w,
+            &captured,
+            "src/x.ts",
+            "a write under a symlinked root must be delivered with a relative path",
+        );
+    }
+
     #[test]
     fn git_info_exclude_is_honoured_like_the_walker() {
         // `.git/info/exclude` is where local, uncommittable exclusions live
@@ -973,7 +1015,7 @@ mod tests {
         use notify::event::CreateKind;
 
         let dir = tempdir().expect("tempdir");
-        let origin = dir.path().canonicalize().expect("canonicalize");
+        let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
         let origin_str = origin.to_str().expect("utf-8 path");
         fs::create_dir_all(origin.join(".git/info")).expect("mkdir .git/info");
         fs::write(origin.join(".git/info/exclude"), "secrets/\n").expect("write exclude");
@@ -1007,7 +1049,7 @@ mod tests {
         use notify::event::CreateKind;
 
         let dir = tempdir().expect("tempdir");
-        let origin = dir.path().canonicalize().expect("canonicalize");
+        let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
         let origin_str = origin.to_str().expect("utf-8 path");
 
         // `!.yarn/cache` negates a hardcoded ignore; `!kept.log` is a normal
@@ -1052,7 +1094,7 @@ mod tests {
         use notify::event::Flag;
 
         let dir = tempdir().expect("tempdir");
-        let canonical = dir.path().canonicalize().expect("canonicalize");
+        let canonical = dunce::canonicalize(dir.path()).expect("canonicalize");
         let (pipeline, tx) = WatchPipeline::with_test_channel(canonical.to_str().expect("utf-8"));
 
         let (ff_tx, ff_rx) = bounded::<ForceFlushReply>(0);
@@ -1103,7 +1145,7 @@ mod tests {
         use notify::event::Flag;
 
         let dir = tempdir().expect("tempdir");
-        let canonical = dir.path().canonicalize().expect("canonicalize");
+        let canonical = dunce::canonicalize(dir.path()).expect("canonicalize");
         let mut pipeline = WatchPipeline::new(
             canonical.to_str().expect("utf-8 path").to_string(),
             &[],
@@ -1198,7 +1240,7 @@ mod tests {
         use notify::event::CreateKind;
 
         let dir = tempdir().expect("tempdir");
-        let origin = dir.path().canonicalize().expect("canonicalize");
+        let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
         let origin_str = origin.to_str().expect("utf-8 path");
         let target = origin.join("ignored_dir");
         fs::create_dir_all(&target).expect("mkdir target");

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -1082,12 +1082,54 @@ mod tests {
     }
 
     #[test]
-    fn hardcoded_ignores_veto_a_gitignore_negation() {
-        // A Yarn Berry zero-install workspace ships `!.yarn/cache`, which as a
-        // plain gitignore entry would un-ignore a hardcoded-ignored path. The
-        // filterer must veto it anyway, matching create_walker: otherwise the
-        // watcher admits `.yarn/cache` files the walk drops, and every rescan
-        // reports them deleted. A non-hardcoded whitelist is still honoured.
+    fn a_user_gitignore_negation_cannot_beat_the_hardcoded_veto() {
+        // A Yarn Berry zero-install ships `!.yarn/cache` in a real .gitignore.
+        // The filterer must veto it anyway, matching create_walker: a USER ignore
+        // file cannot un-ignore a hardcoded path, or the watcher admits
+        // .yarn/cache files the walk drops and reports them deleted every rescan.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
+        let origin_str = origin.to_str().expect("utf-8 path");
+        fs::write(
+            origin.join(".gitignore"),
+            "!.yarn/cache\n*.log\n!kept.log\n",
+        )
+        .expect("write .gitignore");
+
+        let filterer = watch_filterer::create_filter(origin_str, &[], true).expect("filter");
+
+        let event = |rel: &str| {
+            RawWatchEvent::new(
+                notify::Event::new(EventKind::Create(CreateKind::File)).add_path(origin.join(rel)),
+            )
+        };
+
+        assert!(
+            !filterer.check_event(&event(".yarn/cache/pkg.zip")),
+            "a .gitignore `!.yarn/cache` negation must not un-ignore a hardcoded path"
+        );
+        assert!(
+            !filterer.check_event(&event("node_modules/pkg/index.js")),
+            "node_modules stays vetoed even without an explicit rule"
+        );
+        assert!(
+            filterer.check_event(&event("kept.log")),
+            "a non-hardcoded gitignore whitelist is still honoured — the veto is hardcoded-only"
+        );
+    }
+
+    #[test]
+    fn nx_own_globs_outrank_the_hardcoded_veto() {
+        // watchOutputFiles passes `!.nx/workspace-data/.../server-process.json`
+        // as an additional glob (use_ignore=false). `.nx/workspace-data` is a
+        // hardcoded ignore, so if the veto beat nx's own glob the outputs watcher
+        // would never see server-process.json and a superseded daemon could never
+        // self-terminate — it would linger holding its watches and file map. nx's
+        // internal globs are an opt-in and must win; the veto only stops USER
+        // ignore files un-ignoring hardcoded paths.
         use notify::EventKind;
         use notify::event::CreateKind;
 
@@ -1095,12 +1137,10 @@ mod tests {
         let origin = dunce::canonicalize(dir.path()).expect("canonicalize");
         let origin_str = origin.to_str().expect("utf-8 path");
 
-        // `!.yarn/cache` negates a hardcoded ignore; `!kept.log` is a normal
-        // whitelist the filterer should honour.
         let filterer = watch_filterer::create_filter(
             origin_str,
             &[
-                "!.yarn/cache".to_string(),
+                "!.nx/workspace-data/d/server-process.json".to_string(),
                 "*.log".to_string(),
                 "!kept.log".to_string(),
             ],
@@ -1115,16 +1155,20 @@ mod tests {
         };
 
         assert!(
-            !filterer.check_event(&event(".yarn/cache/pkg.zip")),
-            ".yarn/cache is a hardcoded ignore; a `!.yarn/cache` negation must not un-ignore it"
+            filterer.check_event(&event(".nx/workspace-data/d/server-process.json")),
+            "nx's own whitelist must punch through the hardcoded veto so the outputs watcher sees server-process.json"
+        );
+        assert!(
+            !filterer.check_event(&event(".nx/workspace-data/d/other.dat")),
+            "other .nx/workspace-data churn stays vetoed — only the whitelisted path punches through"
         );
         assert!(
             !filterer.check_event(&event("node_modules/pkg/index.js")),
-            "node_modules stays vetoed even without an explicit rule"
+            "node_modules stays vetoed"
         );
         assert!(
             filterer.check_event(&event("kept.log")),
-            "a non-hardcoded whitelist is still honoured — the veto is hardcoded-only"
+            "a non-hardcoded additional-glob whitelist is honoured"
         );
     }
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -147,6 +147,16 @@ impl WatchPipeline {
         additional_globs: &[String],
         use_ignore: bool,
     ) -> std::result::Result<Self, String> {
+        // Canonicalize once, up front, so the filterer, the origin-prefix strip
+        // in the transform (origin_path below), and the watch registration all
+        // agree on the workspace root. Event paths arrive realpath'd
+        // (canonicalize_event_paths on Linux, FSEvents on macOS), so a symlinked
+        // NX_WORKSPACE_ROOT_PATH left un-canonicalized would pass the filter but
+        // fail relative_to_origin and emit absolute paths.
+        let origin = dunce::canonicalize(&origin)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or(origin);
+
         let filterer = watch_filterer::create_filter(&origin, additional_globs, use_ignore)
             .map_err(|e| format!("failed to create watch filter: {e}"))?;
 
@@ -916,6 +926,39 @@ mod tests {
             notify::Event::new(EventKind::Create(CreateKind::File)).add_path(outside),
         );
         assert!(!filterer.check_event(&event));
+    }
+
+    // Symlink creation on Windows needs elevation/developer mode, so this pins
+    // the platform-independent canonicalization on unix. The behaviour it guards
+    // matters most on Windows (the recursive root), but the logic is the same.
+    #[cfg(unix)]
+    #[test]
+    fn new_canonicalizes_origin_so_a_symlinked_root_strips_to_relative() {
+        // NX_WORKSPACE_ROOT_PATH can be a symlink. Event paths arrive realpath'd
+        // (canonicalize_event_paths on Linux, FSEvents on macOS), so if
+        // origin_path kept the symlink form, relative_to_origin would fail its
+        // prefix strip and emit absolute paths into the file map and nx watch.
+        // new() canonicalizes once and threads that through create_filter and
+        // origin_path so the filter and the transform agree.
+        let dir = tempdir().expect("tempdir");
+        let real = dir.path().join("workspace");
+        fs::create_dir_all(&real).expect("mkdir real");
+        let real = real.canonicalize().expect("canonicalize real");
+
+        let link = dir.path().join("linked");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let pipeline = WatchPipeline::new(link.to_str().expect("utf-8").to_string(), &[], false)
+            .expect("pipeline");
+
+        let mut expected = real.to_str().expect("utf-8").to_string();
+        if !expected.ends_with(MAIN_SEPARATOR) {
+            expected.push(MAIN_SEPARATOR);
+        }
+        assert_eq!(
+            pipeline.origin_path, expected,
+            "origin_path must be canonical so realpath'd events strip to workspace-relative"
+        );
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -741,6 +741,53 @@ mod tests {
     }
 
     #[test]
+    fn hardcoded_ignores_veto_a_gitignore_negation() {
+        // A Yarn Berry zero-install workspace ships `!.yarn/cache`, which as a
+        // plain gitignore entry would un-ignore a hardcoded-ignored path. The
+        // filterer must veto it anyway, matching create_walker: otherwise the
+        // watcher admits `.yarn/cache` files the walk drops, and every rescan
+        // reports them deleted. A non-hardcoded whitelist is still honoured.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dir.path().canonicalize().expect("canonicalize");
+        let origin_str = origin.to_str().expect("utf-8 path");
+
+        // `!.yarn/cache` negates a hardcoded ignore; `!kept.log` is a normal
+        // whitelist the filterer should honour.
+        let filterer = watch_filterer::create_filter(
+            origin_str,
+            &[
+                "!.yarn/cache".to_string(),
+                "*.log".to_string(),
+                "!kept.log".to_string(),
+            ],
+            false,
+        )
+        .expect("filter");
+
+        let event = |rel: &str| {
+            RawWatchEvent::new(
+                notify::Event::new(EventKind::Create(CreateKind::File)).add_path(origin.join(rel)),
+            )
+        };
+
+        assert!(
+            !filterer.check_event(&event(".yarn/cache/pkg.zip")),
+            ".yarn/cache is a hardcoded ignore; a `!.yarn/cache` negation must not un-ignore it"
+        );
+        assert!(
+            !filterer.check_event(&event("node_modules/pkg/index.js")),
+            "node_modules stays vetoed even without an explicit rule"
+        );
+        assert!(
+            filterer.check_event(&event("kept.log")),
+            "a non-hardcoded whitelist is still honoured — the veto is hardcoded-only"
+        );
+    }
+
+    #[test]
     fn is_dir_from_kind_only_answers_definitive_kinds() {
         use crate::native::watch::types::is_dir_from_kind;
         use notify::EventKind;

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -547,7 +547,13 @@ impl WatchPipeline {
                             self.pending_rescan = false;
                             self.rescan_deadline = None;
                         } else {
-                            self.flush_deadline = self.rescan_deadline;
+                            // Poll within IDLE_WINDOW, capped by the deadline, so
+                            // the rescan releases shortly after the storm settles
+                            // even if only filtered events (which return early
+                            // without refreshing flush_deadline) kept it held.
+                            self.flush_deadline = self
+                                .rescan_deadline
+                                .map(|d| d.min(Instant::now() + IDLE_WINDOW));
                         }
                     } else {
                         self.reset_burst();
@@ -859,10 +865,38 @@ mod tests {
     }
 
     #[test]
-    fn a_path_outside_origin_does_not_panic_the_veto() {
-        // canonicalize_event_paths can resolve a symlink out of the workspace,
-        // and matched_path_or_any_parents panics on a path outside the matcher
-        // root. check_event must handle it, not crash the pipeline thread.
+    fn nested_nxignore_outranks_a_same_dir_dot_ignore() {
+        // The ignore crate ranks a custom ignore file (.nxignore) above .ignore.
+        // A nested pkg/.nxignore that excludes a path a pkg/.ignore un-ignores
+        // must win. Pins the .nxignore rank above .ignore in git_ignores.
+        use notify::EventKind;
+        use notify::event::CreateKind;
+
+        let dir = tempdir().expect("tempdir");
+        let origin = dir.path().canonicalize().expect("canonicalize");
+        let pkg = origin.join("pkg");
+        fs::create_dir_all(&pkg).expect("mkdir pkg");
+        fs::write(pkg.join(".ignore"), "!keep.tmp\n").expect("write .ignore");
+        fs::write(pkg.join(".nxignore"), "keep.tmp\n").expect("write .nxignore");
+
+        let filterer = watch_filterer::create_filter(origin.to_str().expect("utf-8"), &[], true)
+            .expect("filter");
+        let event = RawWatchEvent::new(
+            notify::Event::new(EventKind::Create(CreateKind::File)).add_path(pkg.join("keep.tmp")),
+        );
+        assert!(
+            !filterer.check_event(&event),
+            ".nxignore excludes keep.tmp and outranks the .ignore negation"
+        );
+    }
+
+    #[test]
+    fn a_path_outside_origin_is_rejected_not_admitted() {
+        // canonicalize_event_paths can resolve a symlink out of the workspace.
+        // Such a path must be rejected, not admitted: admitting emits an
+        // out-of-workspace path into the file map and nx watch. Rejecting also
+        // avoids the matched_path_or_any_parents panic on a path outside the
+        // matcher root — reverting the origin guard makes the veto panic here.
         use notify::EventKind;
         use notify::event::CreateKind;
 
@@ -881,8 +915,7 @@ mod tests {
         let event = RawWatchEvent::new(
             notify::Event::new(EventKind::Create(CreateKind::File)).add_path(outside),
         );
-        // Must not panic; an out-of-origin path is not subject to workspace rules.
-        assert!(filterer.check_event(&event));
+        assert!(!filterer.check_event(&event));
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -1130,10 +1130,10 @@ mod tests {
         // watchOutputFiles passes `!.nx/workspace-data/.../server-process.json`
         // as an additional glob (use_ignore=false). `.nx/workspace-data` is a
         // hardcoded ignore, so if the veto beat nx's own glob the outputs watcher
-        // would never see server-process.json and a superseded daemon could never
-        // self-terminate — it would linger holding its watches and file map. nx's
-        // internal globs are an opt-in and must win; the veto only stops USER
-        // ignore files un-ignoring hardcoded paths.
+        // would never see server-process.json and would lose its prompt shutdown
+        // signal — server.ts's 20ms poll is the backstop, not this. nx's internal
+        // globs are an opt-in and must win; the veto only stops USER ignore files
+        // un-ignoring hardcoded paths.
         use notify::EventKind;
         use notify::event::CreateKind;
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -1119,6 +1119,10 @@ mod tests {
             filterer.check_event(&event("kept.log")),
             "a non-hardcoded gitignore whitelist is still honoured — the veto is hardcoded-only"
         );
+        assert!(
+            !filterer.check_event(&event("dropped.log")),
+            "the *.log ignore still drops a non-whitelisted log — the control that makes kept.log meaningful"
+        );
     }
 
     #[test]
@@ -1169,6 +1173,10 @@ mod tests {
         assert!(
             filterer.check_event(&event("kept.log")),
             "a non-hardcoded additional-glob whitelist is honoured"
+        );
+        assert!(
+            !filterer.check_event(&event("dropped.log")),
+            "a non-whitelisted *.log additional glob still blocks — the control that makes kept.log meaningful"
         );
     }
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -134,6 +134,11 @@ struct WatchPipeline {
     rescan_deadline: Option<Instant>,
     burst_start: Option<Instant>,
     flush_deadline: Option<Instant>,
+    /// When the last event arrived. A flush firing within `IDLE_WINDOW` of it
+    /// was forced by the MAX_WAIT cap during an ongoing storm, not by silence —
+    /// the notify channel is empty by construction when the idle arm runs, so
+    /// this is how the pipeline tells a storm from a settle.
+    last_event_at: Instant,
 }
 
 impl WatchPipeline {
@@ -179,6 +184,7 @@ impl WatchPipeline {
             rescan_deadline: None,
             burst_start: None,
             flush_deadline: None,
+            last_event_at: Instant::now(),
         })
     }
 
@@ -215,6 +221,13 @@ impl WatchPipeline {
             });
         }
         events
+    }
+
+    /// Whether events are still streaming, told by recency rather than the
+    /// notify channel (which the idle arm always finds empty). A flush within
+    /// `IDLE_WINDOW` of the last event was cap-forced mid-storm, not idle.
+    fn storm_ongoing(&self) -> bool {
+        self.last_event_at.elapsed() < IDLE_WINDOW
     }
 
     /// Whether a pending rescan should be emitted now rather than held. It is
@@ -315,6 +328,7 @@ impl WatchPipeline {
                 return Ok(());
             }
         };
+        self.last_event_at = Instant::now();
 
         if event.need_rescan() {
             // The backend can raise the flag hundreds of times before the
@@ -380,6 +394,35 @@ impl WatchPipeline {
         let bs = *self.burst_start.get_or_insert(now);
         self.flush_deadline = Some((now + IDLE_WINDOW).min(bs + MAX_WAIT));
         Ok(())
+    }
+
+    /// Build a pipeline whose notify channel is driven by the returned sender
+    /// instead of a real backend, so a test can inject a precise event sequence
+    /// through `run()`.
+    #[cfg(test)]
+    fn with_test_channel(origin: &str) -> (Self, Sender<NotifyResult>) {
+        let filterer = watch_filterer::create_filter(origin, &[], false).expect("test filter");
+        let (notify_tx, notify_rx) = unbounded::<NotifyResult>();
+        let watcher = notify::recommended_watcher(|_res| {}).expect("test watcher");
+        let mut origin_path = origin.to_string();
+        if !origin_path.ends_with(MAIN_SEPARATOR) {
+            origin_path.push(MAIN_SEPARATOR);
+        }
+        let pipeline = WatchPipeline {
+            filterer,
+            notify_rx,
+            watcher,
+            origin_path,
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            ignore_globs: build_ignore_glob_set(),
+            accumulator: HashMap::new(),
+            pending_rescan: false,
+            rescan_deadline: None,
+            burst_start: None,
+            flush_deadline: None,
+            last_event_at: Instant::now(),
+        };
+        (pipeline, notify_tx)
     }
 
     /// Drives the pipeline until force_flush_rx disconnects.
@@ -479,12 +522,11 @@ impl WatchPipeline {
                 },
                 default(idle_wait) => {
                     if self.has_pending() {
-                        // Hold a pending rescan while the storm is still
-                        // delivering (more events already queued), so a burst
-                        // that overflows across many flushes coalesces into one
-                        // re-walk instead of one per flush.
-                        let storm_ongoing = !self.notify_rx.is_empty();
-                        let rescan_due = self.rescan_due(storm_ongoing);
+                        // Hold a pending rescan while a storm is still
+                        // delivering, so a burst that overflows across many
+                        // flushes coalesces into one re-walk instead of one per
+                        // flush.
+                        let rescan_due = self.rescan_due(self.storm_ongoing());
                         let events = self.snapshot_events(rescan_due);
                         debug!(count = events.len(), "idle-window emitting events");
                         for e in &events {
@@ -921,6 +963,58 @@ mod tests {
         assert!(
             filterer.check_event(&event("kept.log")),
             "a non-hardcoded whitelist is still honoured — the veto is hardcoded-only"
+        );
+    }
+
+    #[test]
+    fn run_coalesces_a_sustained_storm_into_one_rescan() {
+        // Drives run() so it binds the storm-detection wiring, not just the
+        // rescan_due helper. A sustained overflow denser than IDLE_WINDOW and
+        // longer than MAX_WAIT forces several cap flushes; all but the settling
+        // one must hold the rescan, so the daemon re-walks once, not per flush.
+        use notify::event::Flag;
+
+        let dir = tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize");
+        let (pipeline, tx) = WatchPipeline::with_test_channel(canonical.to_str().expect("utf-8"));
+
+        let (ff_tx, ff_rx) = bounded::<ForceFlushReply>(0);
+        let captured: Captured = Arc::new(Mutex::new(Vec::new()));
+        let cap = captured.clone();
+        let handle = std::thread::spawn(move || {
+            pipeline.run(
+                ff_rx,
+                Box::new(move |res| {
+                    if let Ok(events) = res {
+                        cap.lock().unwrap().extend(events);
+                    }
+                }),
+            );
+        });
+
+        let overflow = || notify::Event::new(notify::EventKind::Other).set_flag(Flag::Rescan);
+        // Sustained storm: > MAX_WAIT (so several cap flushes fire) with events
+        // < IDLE_WINDOW apart (so each cap flush sees an ongoing storm).
+        let storm_end = Instant::now() + Duration::from_millis(1200);
+        while Instant::now() < storm_end {
+            tx.send(Ok(overflow())).expect("send overflow");
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        // Settle so the held rescan is released exactly once.
+        std::thread::sleep(Duration::from_millis(400));
+        drop(tx);
+        drop(ff_tx);
+        handle.join().expect("join");
+
+        let rescans = captured
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|e| matches!(e.r#type, EventType::rescan))
+            .count();
+        assert_eq!(
+            rescans, 1,
+            "a sustained storm should coalesce into a single rescan; got {rescans}"
         );
     }
 

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -534,9 +534,11 @@ impl FilesWorker {
         };
 
         // Walk before locking. The walk is the slow part and readers should not
-        // block on it. A change landing between the walk and the swap is picked
-        // up as an ordinary watch event or by the next rescan; over-reporting is
-        // absorbed by re-hashing downstream, under-reporting would not be.
+        // block on it. Nothing can interleave in practice — `rescanAndDiff` is a
+        // synchronous napi call on the daemon's single JS thread, so no
+        // `incremental_update` runs during it. Note the downstream asymmetry if
+        // that ever changes: an over-reported create/update is collapsed by
+        // re-hashing, but an over-reported delete is taken at face value.
         let fresh = gather_and_hash_files(workspace_root, cache_dir);
 
         let (files_lock, cvar) = files_sync.deref();
@@ -1018,7 +1020,7 @@ mod tests {
             .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
             .collect();
         entries.sort();
-        assert_eq!(entries, vec!["nx_files.lock", "nx_files.nxt"]);
+        assert_eq!(entries, vec!["nx_files.lock", "nx_files_v2.nxt"]);
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -12,7 +12,7 @@ use crate::native::project_graph::utils::{ProjectRootMappings, find_project_for_
 use crate::native::types::FileData;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::native::utils::file_lock::FileLock;
-use crate::native::utils::{Normalize, NxCondvar, NxMutex, path::get_child_files};
+use crate::native::utils::{Normalize, NxCondvar, NxMutex, gather_stamp, path::get_child_files};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::native::workspace::files_archive::archive_modified_at;
 use crate::native::workspace::files_archive::{
@@ -36,6 +36,8 @@ use xxhash_rust::xxh3;
 pub struct WorkspaceContext {
     pub workspace_root: String,
     workspace_root_path: PathBuf,
+    /// Retained so `rescan_and_diff` can re-gather through the same files
+    /// archive the initial gather used, keeping the walk incremental.
     cache_dir: String,
     files_worker: FilesWorker,
 }
@@ -272,16 +274,60 @@ fn acquire_files(
     }
 }
 
+/// What a rescan re-walk found had changed while the watcher was not being told.
+#[napi(object)]
+#[derive(Default)]
+pub struct RescanDiff {
+    pub created_files: Vec<FileData>,
+    pub updated_files: Vec<FileData>,
+    pub deleted_files: Vec<String>,
+}
+
+fn diff_files(before: &Files, after: &Files) -> RescanDiff {
+    // Keyed lookup with `remove`, so "absent" and "present with an odd value"
+    // stay distinguishable — a map keyed on the hash could not tell them apart,
+    // and a path mistaken for absent would be reported created AND deleted.
+    let mut previous: HashMap<&PathBuf, &String> =
+        before.iter().map(|(path, hash)| (path, hash)).collect();
+    let mut created_files = Vec::new();
+    let mut updated_files = Vec::new();
+
+    for (path, hash) in after {
+        let file = FileData {
+            file: path.to_normalized_string(),
+            hash: hash.clone(),
+        };
+        match previous.remove(path) {
+            None => created_files.push(file),
+            Some(previous_hash) if previous_hash != hash => updated_files.push(file),
+            Some(_) => {}
+        }
+    }
+
+    RescanDiff {
+        // Whatever the walk did not find is gone. Ground truth, not inference
+        // from a prior event stream that is by definition incomplete here.
+        deleted_files: previous.keys().map(|p| p.to_normalized_string()).collect(),
+        created_files,
+        updated_files,
+    }
+}
+
 fn gather_and_hash_files(workspace_root: &Path, cache_dir: String) -> Vec<(PathBuf, String)> {
     let archived_files = read_files_archive(&cache_dir);
 
     trace!("Gathering files in {}", workspace_root.display());
     let now = std::time::Instant::now();
+    // Taken before the walk, not after: an entry read at any point from here on
+    // may be rewritten within its own mtime tick, so the next gather has to
+    // re-hash it rather than trust the timestamp. See `selective_files_hash`.
+    let gathered_at = gather_stamp();
     let file_hashes = if let Some(archived_files) = archived_files {
         selective_files_hash(workspace_root, &archived_files)
     } else {
         full_files_hash(workspace_root)
-    };
+    }
+    .with_gathered_at(gathered_at);
 
     write_files_archive(&cache_dir, &file_hashes);
 
@@ -477,6 +523,31 @@ impl FilesWorker {
         } else {
             vec![]
         }
+    }
+
+    /// Re-walk the workspace, diff it against the map we are holding, then adopt
+    /// the fresh map. Used to recover after the kernel dropped watch events, so
+    /// the per-path stream cannot be trusted complete.
+    fn rescan_and_diff(&self, workspace_root: &Path, cache_dir: String) -> RescanDiff {
+        let Some(files_sync) = &self.0 else {
+            return RescanDiff::default();
+        };
+
+        // Walk before locking. The walk is the slow part and readers should not
+        // block on it. A change landing between the walk and the swap is picked
+        // up as an ordinary watch event or by the next rescan; over-reporting is
+        // absorbed by re-hashing downstream, under-reporting would not be.
+        let fresh = gather_and_hash_files(workspace_root, cache_dir);
+
+        let (files_lock, cvar) = files_sync.deref();
+        let files = files_lock.lock().expect("Should be able to lock files");
+        let mut files = cvar
+            .wait(files, |guard| guard.len() == 0)
+            .expect("Should be able to wait for files");
+
+        let diff = diff_files(&files, &fresh);
+        *files = fresh;
+        diff
     }
 
     pub fn update_files(
@@ -806,6 +877,16 @@ impl WorkspaceContext {
         self.files_worker.get_files()
     }
 
+    /// Recover from dropped watch events: re-walk, and report what changed
+    /// against the map this context was holding. The fresh map is adopted, so
+    /// the caller only has to feed the returned changes through its normal
+    /// recomputation path.
+    #[napi]
+    pub fn rescan_and_diff(&self) -> RescanDiff {
+        self.files_worker
+            .rescan_and_diff(&self.workspace_root_path, self.cache_dir.clone())
+    }
+
     #[napi]
     pub fn get_files_in_directory(&self, directory: String) -> Vec<String> {
         get_child_files(directory, self.files_worker.get_files())
@@ -821,6 +902,43 @@ impl Drop for WorkspaceContext {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn diff_files_classifies_created_updated_unchanged_and_deleted() {
+        use super::diff_files;
+        use std::path::PathBuf;
+
+        let before = vec![
+            (PathBuf::from("a.ts"), String::from("1")),
+            (PathBuf::from("b.ts"), String::from("2")),
+            (PathBuf::from("c.ts"), String::from("3")),
+        ];
+        let after = vec![
+            (PathBuf::from("b.ts"), String::from("2")),
+            (PathBuf::from("c.ts"), String::from("changed")),
+            (PathBuf::from("d.ts"), String::from("4")),
+        ];
+
+        let diff = diff_files(&before, &after);
+
+        // Created carries its hash: the collector records one for every file.
+        assert_eq!(
+            diff.created_files
+                .iter()
+                .map(|f| (f.file.as_str(), f.hash.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("d.ts", "4")]
+        );
+        // b.ts is unchanged and must not appear anywhere.
+        assert_eq!(
+            diff.updated_files
+                .iter()
+                .map(|f| (f.file.as_str(), f.hash.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("c.ts", "changed")]
+        );
+        assert_eq!(diff.deleted_files, vec![String::from("a.ts")]);
+    }
     use super::*;
     use crate::native::workspace::files_archive::{NxFileHashed, archive_path};
     use assert_fs::TempDir;

--- a/packages/nx/src/native/workspace/files_archive.rs
+++ b/packages/nx/src/native/workspace/files_archive.rs
@@ -16,19 +16,37 @@ pub struct NxFileHashed(pub String, pub i64);
 
 #[derive(Archive, Deserialize, Serialize, Debug, PartialEq)]
 #[archive(check_bytes)]
-pub struct NxFileHashes(HashMap<String, NxFileHashed>);
+pub struct NxFileHashes {
+    files: HashMap<String, NxFileHashed>,
+    /// The value `gather_stamp()` returned when the gather that wrote this
+    /// archive began. An entry whose mtime is at or after it was read while the
+    /// workspace could still change within the same mtime tick, so its hash may
+    /// already be stale and must not be reused. See `selective_files_hash`.
+    gathered_at: i64,
+}
+
+impl NxFileHashes {
+    pub fn gathered_at(&self) -> i64 {
+        self.gathered_at
+    }
+
+    pub fn with_gathered_at(mut self, gathered_at: i64) -> Self {
+        self.gathered_at = gathered_at;
+        self
+    }
+}
 
 impl Deref for NxFileHashes {
     type Target = HashMap<String, NxFileHashed>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.files
     }
 }
 
 impl DerefMut for NxFileHashes {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.files
     }
 }
 
@@ -37,7 +55,7 @@ impl IntoIterator for NxFileHashes {
     type IntoIter = hashbrown::hash_map::IntoIter<String, NxFileHashed>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.files.into_iter()
     }
 }
 
@@ -45,7 +63,12 @@ impl FromIterator<(String, NxFileHashed)> for NxFileHashes {
     fn from_iter<T: IntoIterator<Item = (String, NxFileHashed)>>(iter: T) -> NxFileHashes {
         let mut map = HashMap::with_hasher(Default::default());
         map.extend(iter);
-        NxFileHashes(map)
+        // 0 makes every entry ambiguous until a gather stamps it, so a hash is
+        // never reused on the strength of an unset timestamp.
+        NxFileHashes {
+            files: map,
+            gathered_at: 0,
+        }
     }
 }
 
@@ -85,21 +108,27 @@ impl FilesArchive {
     }
 
     pub fn len(&self) -> usize {
-        self.archived().0.len()
+        self.archived().files.len()
     }
 
     /// The recorded hash and modification time for a workspace-relative path.
     pub fn get(&self, path: &str) -> Option<(&str, i64)> {
         self.archived()
-            .0
+            .files
             .get(path)
             .map(|hashed| (hashed.0.as_str(), hashed.1))
+    }
+
+    /// The stamp the gather that wrote this archive began at. See
+    /// `NxFileHashes::gathered_at` and `selective_files_hash`.
+    pub fn gathered_at(&self) -> i64 {
+        self.archived().gathered_at
     }
 
     /// Every entry as (path, hash, modification time).
     pub fn iter(&self) -> impl Iterator<Item = (&str, &str, i64)> {
         self.archived()
-            .0
+            .files
             .iter()
             .map(|(path, hashed)| (path.as_str(), hashed.0.as_str(), hashed.1))
     }

--- a/packages/nx/src/native/workspace/files_archive.rs
+++ b/packages/nx/src/native/workspace/files_archive.rs
@@ -8,7 +8,10 @@ use std::time::{Duration, SystemTime};
 
 use tracing::trace;
 
-const NX_FILES_ARCHIVE: &str = "nx_files.nxt";
+// v2 carries `gathered_at`. The filename is the format key: rkyv's layout check
+// does reject a v1 buffer, but relying on that makes the break implicit and
+// leaves "what if it validated anyway?" to be argued rather than answered.
+const NX_FILES_ARCHIVE: &str = "nx_files_v2.nxt";
 
 #[derive(Archive, Serialize, Deserialize, PartialEq, Debug)]
 #[archive(check_bytes)]
@@ -244,6 +247,13 @@ pub fn write_files_archive<P: AsRef<Path>>(cache_dir: P, files: &NxFileHashes) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rkyv::Archive as RkyvArchive;
+
+    /// The shape `NxFileHashes` had before it carried `gathered_at`.
+    #[derive(RkyvArchive, Serialize)]
+    #[archive(check_bytes)]
+    struct LegacyNxFileHashes(HashMap<String, NxFileHashed>);
+
     use assert_fs::TempDir;
     use assert_fs::prelude::*;
 
@@ -265,7 +275,7 @@ mod tests {
     #[test]
     fn a_write_sweeps_orphaned_staging_files_and_keeps_live_ones() {
         let cache = TempDir::new().unwrap();
-        let orphan = cache.child("nx_files.nxt.1.deadbeef.tmp");
+        let orphan = cache.child("nx_files_v2.nxt.1.deadbeef.tmp");
         orphan.write_str("x").unwrap();
         std::fs::File::options()
             .write(true)
@@ -273,10 +283,10 @@ mod tests {
             .unwrap()
             .set_modified(SystemTime::now() - STAGING_ORPHAN_AGE * 2)
             .unwrap();
-        let live = cache.child("nx_files.nxt.2.cafebabe.tmp");
+        let live = cache.child("nx_files_v2.nxt.2.cafebabe.tmp");
         live.write_str("x").unwrap();
         // Old neighbours that are not staging files stay, whatever their age.
-        for name in ["other.tmp", "nx_files.nxt.bak"] {
+        for name in ["other.tmp", "nx_files_v2.nxt.bak"] {
             let neighbour = cache.child(name);
             neighbour.write_str("x").unwrap();
             std::fs::File::options()
@@ -292,9 +302,9 @@ mod tests {
         assert_eq!(
             names_in(cache.path()),
             vec![
-                "nx_files.nxt",
-                "nx_files.nxt.2.cafebabe.tmp",
-                "nx_files.nxt.bak",
+                "nx_files_v2.nxt",
+                "nx_files_v2.nxt.2.cafebabe.tmp",
+                "nx_files_v2.nxt.bak",
                 "other.tmp"
             ]
         );
@@ -311,20 +321,20 @@ mod tests {
         .into_iter()
         .collect();
         write_files_archive(cache.path(), &two_files);
-        assert_eq!(names_in(cache.path()), vec!["nx_files.nxt"]);
+        assert_eq!(names_in(cache.path()), vec!["nx_files_v2.nxt"]);
         assert_eq!(read_files_archive(cache.path()).unwrap().len(), 2);
     }
 
     #[test]
     fn staging_paths_differ_between_writes_of_one_process() {
-        let archive = Path::new("/cache/nx_files.nxt");
+        let archive = Path::new("/cache/nx_files_v2.nxt");
         let first = staging_path(archive);
         let second = staging_path(archive);
         assert_ne!(first, second);
         for path in [&first, &second] {
             let name = path.file_name().unwrap().to_string_lossy();
             assert!(
-                name.starts_with("nx_files.nxt.") && name.ends_with(".tmp"),
+                name.starts_with("nx_files_v2.nxt.") && name.ends_with(".tmp"),
                 "{name}"
             );
             assert_eq!(path.parent(), archive.parent());
@@ -335,7 +345,7 @@ mod tests {
     fn a_write_refuses_a_staging_path_something_already_occupies() {
         let cache = TempDir::new().unwrap();
         let archive = archive_path(cache.path());
-        let planted = cache.child("nx_files.nxt.7.0000000000000001.tmp");
+        let planted = cache.child("nx_files_v2.nxt.7.0000000000000001.tmp");
         planted.write_str("planted").unwrap();
 
         let err = write_files_archive_at(&archive, planted.path(), &one_file()).unwrap_err();
@@ -346,5 +356,43 @@ mod tests {
         );
         assert_eq!(std::fs::read_to_string(planted.path()).unwrap(), "planted");
         assert!(!archive.exists());
+    }
+
+    #[test]
+    fn an_archive_in_the_pre_gathered_at_format_is_rejected_not_misread() {
+        // Adding `gathered_at` changed the archived layout. If a stale archive
+        // could be read as the new shape, every hash in it would be trusted
+        // against a garbage timestamp — silently wrong hashes for the whole
+        // workspace. It must fail the check and force a full re-hash instead.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut legacy = HashMap::with_hasher(Default::default());
+        legacy.insert(
+            String::from("a.ts"),
+            NxFileHashed(String::from("hash-a"), 1234),
+        );
+        let bytes = rkyv::to_bytes::<_, 2048>(&LegacyNxFileHashes(legacy)).expect("serialize");
+        std::fs::write(dir.path().join(NX_FILES_ARCHIVE), &bytes).expect("write legacy archive");
+
+        assert!(
+            read_files_archive(dir.path()).is_none(),
+            "a pre-gathered_at archive must be rejected, not deserialized as the new shape"
+        );
+    }
+
+    #[test]
+    fn a_current_format_archive_round_trips_with_its_stamp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let hashes: NxFileHashes = vec![(
+            String::from("a.ts"),
+            NxFileHashed(String::from("hash-a"), 1234),
+        )]
+        .into_iter()
+        .collect::<NxFileHashes>()
+        .with_gathered_at(9999);
+
+        write_files_archive(dir.path(), &hashes);
+        let read = read_files_archive(dir.path()).expect("current-format archive should read back");
+        assert_eq!(read.gathered_at(), 9999);
+        assert_eq!(read.get("a.ts").expect("entry").0, "hash-a");
     }
 }

--- a/packages/nx/src/native/workspace/files_hashing.rs
+++ b/packages/nx/src/native/workspace/files_hashing.rs
@@ -160,13 +160,13 @@ mod tests {
 
         let archived_files = FilesArchive::from_hashes(&archived_files).unwrap();
         let hashed_files = super::selective_files_hash(temp.path(), &archived_files);
-        let mut hashed_files = hashed_files
+        let mut paths = hashed_files
             .iter()
             .map(|(path, _)| path.as_str())
             .collect::<Vec<_>>();
-        hashed_files.sort();
+        paths.sort();
         assert_eq!(
-            hashed_files,
+            paths,
             vec![
                 "bar.txt",
                 "baz/new.txt",
@@ -174,7 +174,21 @@ mod tests {
                 "modified.txt",
                 "test.txt"
             ]
-        )
+        );
+
+        // Assert the hashes, not just the paths. `selective_files_hash` returns
+        // every walked file whether it was reused or re-hashed, so a path-set
+        // assertion passes identically either way and cannot fail for the
+        // selectivity this test is named after.
+        let hash_of = |name: &str| hashed_files.get(name).expect(name).0.clone();
+        assert_eq!(hash_of("test.txt"), "hash1", "unmodified: reused");
+        assert_eq!(hash_of("foo.txt"), "hash2", "unmodified: reused");
+        assert_eq!(hash_of("bar.txt"), "hash3", "unmodified: reused");
+        assert_ne!(
+            hash_of("modified.txt"),
+            "hash4",
+            "mtime moved past the archive entry: must be re-hashed"
+        );
     }
 
     #[test]

--- a/packages/nx/src/native/workspace/files_hashing.rs
+++ b/packages/nx/src/native/workspace/files_hashing.rs
@@ -21,11 +21,12 @@ pub fn selective_files_hash(workspace_root: &Path, archived_files: &FilesArchive
     let mut not_archived = vec![];
     let now = std::time::Instant::now();
     // Entries read during the previous gather cannot be trusted on an mtime
-    // match alone: mtime resolution is coarse (a whole second on unix, the
-    // system-clock tick on Windows), so a rewrite landing in the same tick as
-    // the read leaves the timestamp identical and the archived hash silently
-    // stale. Re-hash those; they are a handful of files touched during the
-    // gather window, not the workspace.
+    // match alone: where mtime resolution is coarse — the ~15.6ms system tick
+    // on Windows, whole seconds on some filesystems (ext4 and APFS record
+    // nanoseconds, where this is rare) — a rewrite within that tick leaves the
+    // timestamp identical and the archived hash silently stale. Re-hash those;
+    // they are a handful of files touched during the gather window, not the
+    // workspace.
     let gathered_at = archived_files.gathered_at();
 
     for file in files {

--- a/packages/nx/src/native/workspace/files_hashing.rs
+++ b/packages/nx/src/native/workspace/files_hashing.rs
@@ -21,9 +21,9 @@ pub fn selective_files_hash(workspace_root: &Path, archived_files: &FilesArchive
     let mut not_archived = vec![];
     let now = std::time::Instant::now();
     // Entries read during the previous gather cannot be trusted on an mtime
-    // match alone: where mtime resolution is coarse — the ~15.6ms system tick
-    // on Windows, whole seconds on some filesystems (ext4 and APFS record
-    // nanoseconds, where this is rare) — a rewrite within that tick leaves the
+    // match alone. get_mod_time reports whole seconds on unix (st_mtime/mtime(),
+    // regardless of filesystem — the sub-second field is discarded) and the
+    // ~15.6ms system tick on Windows, so a rewrite inside that window leaves the
     // timestamp identical and the archived hash silently stale. Re-hash those;
     // they are a handful of files touched during the gather window, not the
     // workspace.

--- a/packages/nx/src/native/workspace/files_hashing.rs
+++ b/packages/nx/src/native/workspace/files_hashing.rs
@@ -20,10 +20,16 @@ pub fn selective_files_hash(workspace_root: &Path, archived_files: &FilesArchive
     let mut archived = vec![];
     let mut not_archived = vec![];
     let now = std::time::Instant::now();
+    // Entries read during the previous gather cannot be trusted on an mtime
+    // match alone: where mtime is whole-second (every platform but Windows), a
+    // rewrite landing in the same second as the read leaves the timestamp
+    // identical and the archived hash silently stale. Re-hash those; they are a
+    // handful of files touched during the gather window, not the workspace.
+    let gathered_at = archived_files.gathered_at();
 
     for file in files {
         if let Some((hash, mod_time)) = archived_files.get(&file.normalized_path) {
-            if mod_time == file.mod_time {
+            if mod_time == file.mod_time && file.mod_time < gathered_at {
                 archived.push((
                     file.normalized_path,
                     NxFileHashed(hash.to_owned(), mod_time),
@@ -146,7 +152,11 @@ mod tests {
             ),
         ]
         .into_iter()
-        .collect::<NxFileHashes>();
+        .collect::<NxFileHashes>()
+        // Stamped past every file's mtime so the unmodified entries are eligible
+        // for reuse; without a stamp an archive is treated as entirely
+        // untrustworthy. See `should_rehash_entries_read_during_the_gather_window`.
+        .with_gathered_at(get_mod_time(&temp.child("test.txt").metadata().unwrap()) + 1);
 
         let archived_files = FilesArchive::from_hashes(&archived_files).unwrap();
         let hashed_files = super::selective_files_hash(temp.path(), &archived_files);
@@ -165,5 +175,59 @@ mod tests {
                 "test.txt"
             ]
         )
+    }
+
+    #[test]
+    fn should_rehash_entries_read_during_the_gather_window() {
+        // An entry whose mtime is at or after the gather's own stamp was read
+        // while the workspace could still change inside that same mtime tick, so
+        // a matching timestamp does not prove the content matches. Reusing the
+        // archived hash here is how a rewrite goes missing permanently.
+        let temp = TempDir::new().unwrap();
+        temp.child("same-tick.txt").write_str("rewritten").unwrap();
+        let mod_time = get_mod_time(&temp.child("same-tick.txt").metadata().unwrap());
+
+        let archived = vec![(
+            String::from("same-tick.txt"),
+            NxFileHashed(String::from("stale-hash"), mod_time),
+        )]
+        .into_iter()
+        .collect::<NxFileHashes>()
+        .with_gathered_at(mod_time);
+        let archived = FilesArchive::from_hashes(&archived).unwrap();
+
+        let hashed = super::selective_files_hash(temp.path(), &archived);
+        assert_ne!(
+            hashed.get("same-tick.txt").unwrap().0,
+            "stale-hash",
+            "an entry read during the gather window must be re-hashed, not reused"
+        );
+    }
+
+    #[test]
+    fn should_still_reuse_entries_settled_before_the_gather() {
+        // The optimization has to survive the fix: an entry that stopped changing
+        // before the gather began cannot have been rewritten inside the read's
+        // tick, so it is reused without the file being touched. If this breaks,
+        // every rescan degrades into a full re-hash of the workspace.
+        let temp = TempDir::new().unwrap();
+        temp.child("settled.txt").write_str("rewritten").unwrap();
+        let mod_time = get_mod_time(&temp.child("settled.txt").metadata().unwrap());
+
+        let archived = vec![(
+            String::from("settled.txt"),
+            NxFileHashed(String::from("archived-hash"), mod_time),
+        )]
+        .into_iter()
+        .collect::<NxFileHashes>()
+        .with_gathered_at(mod_time + 1);
+        let archived = FilesArchive::from_hashes(&archived).unwrap();
+
+        let hashed = super::selective_files_hash(temp.path(), &archived);
+        assert_eq!(
+            hashed.get("settled.txt").unwrap().0,
+            "archived-hash",
+            "an entry settled before the gather should still be reused"
+        );
     }
 }

--- a/packages/nx/src/native/workspace/files_hashing.rs
+++ b/packages/nx/src/native/workspace/files_hashing.rs
@@ -21,10 +21,11 @@ pub fn selective_files_hash(workspace_root: &Path, archived_files: &FilesArchive
     let mut not_archived = vec![];
     let now = std::time::Instant::now();
     // Entries read during the previous gather cannot be trusted on an mtime
-    // match alone: where mtime is whole-second (every platform but Windows), a
-    // rewrite landing in the same second as the read leaves the timestamp
-    // identical and the archived hash silently stale. Re-hash those; they are a
-    // handful of files touched during the gather window, not the workspace.
+    // match alone: mtime resolution is coarse (a whole second on unix, the
+    // system-clock tick on Windows), so a rewrite landing in the same tick as
+    // the read leaves the timestamp identical and the archived hash silently
+    // stale. Re-hash those; they are a handful of files touched during the
+    // gather window, not the workspace.
     let gathered_at = archived_files.gathered_at();
 
     for file in files {

--- a/packages/nx/src/utils/workspace-context.ts
+++ b/packages/nx/src/utils/workspace-context.ts
@@ -150,6 +150,19 @@ export async function getAllFileDataInContext(workspaceRoot: string) {
   return daemonClient.getWorkspaceContextFileData();
 }
 
+/**
+ * Re-walk the workspace and report what changed against the map the context is
+ * holding, adopting the fresh map. Used to recover after the kernel dropped
+ * watch events, so the per-path stream cannot be trusted complete.
+ *
+ * Daemon-only: it mutates the context in place, which is safe only where the
+ * context is the single source of truth for watched state.
+ */
+export function rescanAndDiffInContext(workspaceRoot: string) {
+  ensureContextAvailable(workspaceRoot);
+  return workspaceContext.rescanAndDiff();
+}
+
 export async function getFilesInDirectoryUsingContext(
   workspaceRoot: string,
   dir: string

--- a/packages/nx/vitest.setup.mts
+++ b/packages/nx/vitest.setup.mts
@@ -138,6 +138,13 @@ vi.doMock(workspaceContextPath, async () => {
     getAllFileDataInContext: guarded('getAllFileDataInContext', () =>
       Promise.resolve([])
     ),
+    // Guarded like its siblings: a rescan against the real workspace root would
+    // re-walk this repo. Specs that exercise it point at a TempFs root.
+    rescanAndDiffInContext: guarded('rescanAndDiffInContext', () => ({
+      createdFiles: [],
+      updatedFiles: [],
+      deletedFiles: [],
+    })),
     getFilesInDirectoryUsingContext: guarded(
       'getFilesInDirectoryUsingContext',
       () => Promise.resolve([])


### PR DESCRIPTION
## Current Behavior

On Windows the Nx daemon registers one non-recursive `notify` watch per directory, for both the source watcher and the outputs watcher. That costs 2 kernel handles per directory (measured slope 2.000008/dir in #36563, corroborated at 2.12/dir on a second harness), memory that grows linearly with directory count, and a volume-wide file-operation slowdown while the daemon runs. A large workspace reaches ~192,000 handles and ~1.6 GB with a 34s watcher startup.

Separately, when the kernel cannot deliver every file event, Nx loses the difference silently and permanently. On Linux an inotify queue overflow arrives as notify's rescan flag and Nx discards it (45-61% of a forced burst lost with no signal). On Windows the loss is structurally invisible: notify 8 never raises rescan there, and Nx handles rescan on no platform. The daemon's view of the workspace diverges from disk until someone runs `nx reset`.

## Expected Behavior

This branch combines the two open PRs that together fix both halves, so the whole Windows watcher slice can be tested as one unit:

- **#36811 (christopher-buss)** widens the recursive-root watch strategy from macOS to Windows: one registration, constant handle and memory cost, no volume-wide tax. In an A/B on real hardware this is 205 handles flat against 3,423 on base.
- **#36566 (Stephen/Jupiter Jayna)** makes kernel event loss visible and bounded: the native watcher recognises notify's rescan flag and emits a single rescan event; the daemon re-walks the workspace, diffs against its known file map, and synthesizes exactly the missed events through the normal recomputation path. A no-change rescan preserves the cached graph.

The two compose cleanly (both cherry-picks applied without conflict; `cargo check -p nx` green). #36811's recursive root is what makes the rescan recovery necessary on Windows, and the recovery is what makes the recursive root safe.

On top of the two combined PRs, the slice adds:

- **Recovery correctness.** The rescan marker accompanies the accumulated batch rather than replacing it, so ignore-file and `server-process.json` events in the same overflow burst still reach the daemon's intercepts (which read the raw array ahead of per-path routing). The recovery walk and diff run inside the workspace context, so a rescan no longer materialises the full file list across the napi boundary twice.
- **`notify` bumped to `9.0.0-rc.5`** (notify-rs/notify#964), the first release that raises the rescan flag on Windows. Under notify 8 the recovery path is Linux-only. Pinned exactly because it is a prerelease.
- **Ignore parity with the walk.** The recursive root makes the runtime filterer the only ignore gate on Windows. It now enforces the hardcoded ignores (`node_modules`, `.git`, `.nx/cache`, `.yarn/cache`) as an unbeatable veto, and reads the same sources `create_walker` does: `.gitignore`, `.git/info/exclude`, the global `core.excludesFile`, and nested `.nxignore`. Precedence matches the ignore crate in both directions, so the higher class wins at any depth and the deeper file wins within a class. Neither side reads `.ignore`, which is a ripgrep convention nx never chose. Without this the watcher would admit files the rescan walk drops and report them deleted on every overflow.
- **Fewer stats, fewer walks.** Per-path stats are taken lazily and only for ambiguous event kinds (the elimination lands on Linux; on Windows notify has already stat'd). Rescan markers are coalesced across a sustained storm so recovery re-walks once, not once per flush.

Two user-visible behavior changes fall out of this:

- **Editing a watched ignore file restarts the daemon.** The native filterer's ignore rules are fixed when the watcher starts, so a change to a watched `.gitignore` or `.nxignore` now stops the daemon and it restarts on the next command with the rules reloaded. That holds when the edit is only recovered through a rescan after an overflow. Previously an ignore-file edit could go unreflected until the next daemon start.
- **One full re-hash on the first run after upgrade.** The files-archive format changes (`nx_files.nxt` → `nx_files_v2.nxt`), because an mtime match alone can reuse a stale hash for a file rewritten within the gather window. The first daemon run after upgrading discards the old archive and pays one full workspace re-hash; steady state is unchanged.

Rust watch tests: 31/31 on macOS locally. Linux and Windows run on CI.

## Related Issue(s)

Addresses #36563. Combines #36566 and #36811.

Co-authored-by: Jupiter Jayna <636020+sdjayna@users.noreply.github.com>
Co-authored-by: Christopher Buss <christopher.buss+github@protonmail.com>


