### PR TITLE
fix(core): read the pnpm 12 min-release-age policy instead of deferring to an install

### DIFF
--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
@@ -562,9 +562,58 @@ describe('pnpm min-release-age behavior', () => {
       expect(result.outcome).toBe('inactive');
     });
 
-    it('pnpm 12+ -> ambiguous', async () => {
-      const result = await readPnpmPolicy('/root', '12.0.0');
+    it('pnpm 13+ -> ambiguous', async () => {
+      const result = await readPnpmPolicy('/root', '13.0.0');
       expect(result.outcome).toBe('ambiguous');
+    });
+
+    it.each(['12.0.0', '12.3.1'])(
+      'v%s no explicit window -> active loose default 1440',
+      async (version) => {
+        await mockPnpmConfig({});
+        const result = await readPnpmPolicy('/root', version);
+        expect(result.outcome).toBe('active');
+        if (result.outcome === 'active') {
+          expect(result.policy.windowMs).toBe(1440 * MINUTE);
+          const behavior = pnpmBehavior(result.policy.behavior);
+          expect(behavior.strict).toBe(false);
+          expect(behavior.looseFallback).toBe(true);
+          expect(behavior.missingTimeMap).toBe('skip');
+          expect(behavior.writesExcludes).toBe(true);
+        }
+      }
+    );
+
+    it('v12 explicit window auto-enables strict', async () => {
+      await mockPnpmConfig({ minimumReleaseAge: 2880 });
+      const result = await readPnpmPolicy('/root', '12.3.1');
+      expect(result.outcome).toBe('active');
+      if (result.outcome === 'active') {
+        expect(result.policy.windowMs).toBe(2880 * MINUTE);
+        const behavior = pnpmBehavior(result.policy.behavior);
+        expect(behavior.strict).toBe(true);
+        expect(behavior.looseFallback).toBe(false);
+      }
+    });
+
+    it('v12 explicit strict:false wins over the auto-on rule', async () => {
+      await mockPnpmConfig({
+        minimumReleaseAge: 2880,
+        minimumReleaseAgeStrict: false,
+      });
+      const result = await readPnpmPolicy('/root', '12.3.1');
+      expect(result.outcome).toBe('active');
+      if (result.outcome === 'active') {
+        const behavior = pnpmBehavior(result.policy.behavior);
+        expect(behavior.strict).toBe(false);
+        expect(behavior.looseFallback).toBe(true);
+      }
+    });
+
+    it('v12 zero window -> inactive', async () => {
+      await mockPnpmConfig({ minimumReleaseAge: 0 });
+      const result = await readPnpmPolicy('/root', '12.3.1');
+      expect(result.outcome).toBe('inactive');
     });
 
     it('unable to read pnpm config -> ambiguous (defer to install)', async () => {

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
@@ -32,7 +32,7 @@ interface PnpmBehaviorRow {
   // Inclusive lower bound; the first row whose bound is <= the version wins
   // when iterating newest-bound-first.
   minVersion: string;
-  major: 10 | 11;
+  major: 10 | 11 | 12;
   // v10 is hardcoded strict; v11 defaults loose with optional auto-strict.
   strictMode: 'always' | 'default-loose';
   // >=11.0.4: window explicitly set on any surface auto-enables strict.
@@ -43,6 +43,14 @@ interface PnpmBehaviorRow {
 
 // Ordered newest-bound-first so the first matching row applies.
 const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
+  {
+    minVersion: '12.0.0',
+    major: 12,
+    strictMode: 'default-loose',
+    strictAutoOnWhenExplicit: true,
+    excludeGrammar: 'v2-globs-unions',
+    writesExcludes: true,
+  },
   {
     minVersion: '11.1.3',
     major: 11,
@@ -198,7 +206,7 @@ export async function readPnpmPolicy(
 ): Promise<MinReleaseAgePolicyReadResult> {
   // A pnpm major newer than the table knows can behave differently; defer to a
   // real install rather than guessing.
-  if (gte(pmVersion, '12.0.0')) {
+  if (gte(pmVersion, '13.0.0')) {
     return {
       outcome: 'ambiguous',
       reason: `pnpm ${pmVersion} is newer than the known cooldown behavior table.`,
@@ -227,14 +235,14 @@ export async function readPnpmPolicy(
   } = parseCooldownConfig(config);
 
   // An explicitly configured window (from whatever surface pnpm honors) wins;
-  // otherwise v11 falls back to its built-in 1440-minute (1 day) default, while
-  // v10 has no default (no cooldown).
+  // otherwise v11 and v12 fall back to the built-in 1440-minute (1 day) default,
+  // while v10 has no default (no cooldown).
   let windowMinutes: number;
   let windowExplicit: boolean;
   if (explicitWindow !== undefined) {
     windowMinutes = explicitWindow;
     windowExplicit = true;
-  } else if (row.major === 11) {
+  } else if (row.major >= 11) {
     windowMinutes = 1440;
     windowExplicit = false;
   } else {
@@ -251,15 +259,15 @@ export async function readPnpmPolicy(
   const sourceDescription = `pnpm minimumReleaseAge (${windowMinutes} min)`;
 
   const strict = resolveStrict(row, strictExplicit, windowExplicit);
-  // v10 always errors on missing time; v11 defaults to skip unless a surface
-  // explicitly disabled it.
+  // v10 always errors on missing time; v11 and above default to skip unless a
+  // surface explicitly disabled it.
   const ignoreMissingTime =
-    row.major === 11 ? (ignoreMissingTimeExplicit ?? true) : false;
+    row.major >= 11 ? (ignoreMissingTimeExplicit ?? true) : false;
   const behavior: PmMinReleaseAgeBehavior = {
     packageManager: 'pnpm',
     strict,
-    // Loose fallback only exists on v11 when strict is off.
-    looseFallback: row.major === 11 && !strict,
+    // Loose fallback only exists from v11 onwards when strict is off.
+    looseFallback: row.major >= 11 && !strict,
     writesExcludes: row.writesExcludes,
     missingTimeMap:
       row.major === 10 ? 'error' : ignoreMissingTime ? 'skip' : 'error',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

`readPnpmPolicy` treats every pnpm >= 12 as unknowable, early-returning before it ever reads the pnpm config:

```ts
if (gte(pmVersion, '12.0.0')) {
  return {
    outcome: 'ambiguous',
    reason: `pnpm ${pmVersion} is newer than the known cooldown behavior table.`,
  };
}
```

`ambiguous` routes version resolution through `resolvePackageVersionUsingInstallation()` instead of the registry (`resolve-package-version.ts`), so **every** `nx migrate` on pnpm 12 shells out to `pnpm add` in a temp workspace — slower for everyone, and a hard failure for catalog users.

`copyPackageManagerConfigurationFiles` seeds that temp workspace from the real `pnpm-workspace.yaml`, and `modifyPnpmWorkspaceYamlToFitNewDirectory` strips `patchedDependencies` and `link:`/`file:` overrides but not `catalogMode`/`catalog`/`catalogs`. The temp workspace therefore carries a catalog pinning the version being upgraded *from*:

```
NX   Failed to fetch migrations for nx@23.2.0
Command failed: pnpm add -w --config.frozen-lockfile=false nx@23.2.0
Error: ERR_PNPM_CATALOG_VERSION_MISMATCH
  × adding a new package
  ╰─▶ Wanted dependency outside the version range defined in catalog
```

`migrations.json` is never written and the command exits 1, so no migration runs. There is no workspace-level escape hatch: the early return sits above the config read, so even `minimumReleaseAge: 0` has no effect.

## Expected Behavior

pnpm 12 reads as a real policy and version resolution stays on the registry path, exactly as it does on pnpm 11.

pnpm 12 carries pnpm 11's cooldown semantics, so it gets a real behavior row rather than being treated as unknowable:

- Add a `PNPM_BEHAVIOR_ROWS` entry for `12.0.0` and widen `PnpmBehaviorRow['major']` to include `12`. `writesExcludes: true` and `strictAutoOnWhenExplicit: true` match the existing `>= 11.1.3` row.
- Move the unknown-major guard from `>= 12.0.0` to `>= 13.0.0`, so a genuinely unknown future major still defers to an install.
- Relax three `row.major === 11` checks to `row.major >= 11` — the built-in 1440-minute default window, `ignoreMissingTime`, and `looseFallback`. Without this the new row would fall through to `inactive` and Nx would resolve a version that pnpm then refuses to install. The `row.major === 10` check in `missingTimeMap` is deliberately left alone, as those are v10-only semantics.

`violationDetail` is keyed on `gte(version, '11.1.3')`, so it already routes 12.x to the multi-entry `failOnImmature` form; no change needed there.

pnpm 12.3.1 behaviour was measured against the real package manager rather than assumed:

| Behaviour | pnpm 11.25.0 | pnpm 12.3.1 |
|---|---|---|
| Built-in default window (nothing configured) | ~1440 min | ~1440 min — **same** |
| Honours `minimumReleaseAge` | yes | yes (`ERR_PNPM_NO_MATURE_MATCHING_VERSION`) |
| Explicit `minimumReleaseAgeStrict: false` respected | yes | yes → `default-loose`, not `always` |
| Exclude `'pkg@*'`, `'{a,b}@*'`, `'pkg@{x,y}'` | match | match |
| Bare name `'pkg'` | no match | no match |
| Offers interactive approval writing `minimumReleaseAgeExclude` | yes | yes → `writesExcludes: true` |
| Window reported by `pnpm config list --json` | no | no |

The default window was isolated using a package version published 18.9 h earlier, with the next-oldest at 43.5 h. Requesting a range spanning both resolves to the older version on **both** pnpm 11 and 12 — i.e. the 18.9 h version is inside the cooldown. Setting `minimumReleaseAge: 0` makes both pick the newer one, confirming the demotion is the cooldown and not version ordering.

Six new unit cases cover pnpm 12 (default window loose, explicit window auto-enabling strict, an explicit `strict: false` winning over the auto-on rule, zero window → inactive), and the pnpm 13 deferral test replaces the old `pnpm 12+ -> ambiguous` one.

### Out of scope

- **The catalog leak into the temp workspace is a second, independent bug.** `modifyPnpmWorkspaceYamlToFitNewDirectory` should probably strip `catalogMode`/`catalog`/`catalogs` too, since the `ambiguous` branch stays reachable for other reasons (unreadable pnpm config, undeterminable pnpm version, invalid exclude entry). Stripping those keys from the temp `pnpm-workspace.yaml` Nx generated and rerunning the exact failing command clears the error. Happy to fold that in if preferred.
- **Pre-existing:** Nx rejects `minimumReleaseAgeExclude` entries that real pnpm accepts — e.g. `'nx@*'` and `'{typescript,vite}@*'` both yield `ambiguous` ("Invalid pnpm minimumReleaseAgeExclude entry"). This reproduces identically on pnpm 11, so it predates this change — but it does mean a workspace using glob excludes still takes the install path.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #36914
