### PR TITLE
docs(misc): swap DTE page video for the new Nx Agents CI clip

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
@@ -8,8 +8,8 @@ filter: 'type:Features'
 ---
 
 {% youtube
-src="https://youtu.be/XS-exYYP_Gg"
-title="Nx Agents Walkthrough"
+src="https://youtu.be/9JkEbqgS8cY"
+title="How Nx Agents Distribute Tasks Across Machines in CI"
 /%}
 
 Nx Agents is a **distributed task execution system that intelligently allocates tasks across multiple machines**, optimizing your CI pipeline for speed and efficiency. While using [Nx Affected](/docs/features/ci-features/affected) and [remote caching](/docs/features/ci-features/remote-cache) can significantly speed up your CI pipeline, you might still encounter bottlenecks as your codebase scales. Combining affected runs and remote caching with task distribution is key to maintaining low CI times. Nx Agents handles this distribution efficiently, avoiding the complexity and maintenance required if you were to set it up manually.


### PR DESCRIPTION
## Current Behavior

The [Distribute Task Execution (Nx Agents)](https://nx.dev/docs/features/ci-features/distribute-task-execution) page embeds the older "Nx Agents Walkthrough" video (`https://youtu.be/XS-exYYP_Gg`).

## Expected Behavior

The page embeds the new animated Nx Agents CI clip (`https://youtu.be/9JkEbqgS8cY`), which walks through the two config files that turn distribution on, tasks being pulled from a shared pile as agents free up, and a task going back on the pile when an agent dies mid-test.

The clip is uploaded **unlisted** to the Nx YouTube channel. It covers task distribution and flaky retries; dynamic agent scaling was deliberately left out to keep it focused, and could be a separate variation later.

Only the `src` and `title` attributes of the `{% youtube %}` tag change. A repo-wide search for `XS-exYYP_Gg` found exactly one occurrence, this page, so no other docs page embeds the old walkthrough.

Source composition: `NxAgentsCi` in [nrwl/content-animations#5](https://github.com/nrwl/content-animations/pull/5).

## Related Issue(s)

Closes DOC-674

https://claude.ai/code/session_013S9uV2RHAhG2WGbiuWHHNm

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/update-nx-agents-video-7c8d5978">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->