### PR TITLE
fix(vitest): infer inputs for setup files outside the project root

### DIFF
--- a/packages/vitest/src/plugins/plugin-vitest-glob.spec.ts
+++ b/packages/vitest/src/plugins/plugin-vitest-glob.spec.ts
@@ -122,6 +122,89 @@ describe('@nx/vitest glob discovery against a real filesystem', () => {
     jest.clearAllMocks();
   });
 
+  describe('setup file inputs', () => {
+    it('should declare a setup file outside the project root, and its tsconfig', async () => {
+      await temp.createFiles({
+        'libs/lib1/vitest.config.ts': '',
+        'libs/lib1/package.json': '{"name":"lib1"}',
+        'libs/lib1/src/a.spec.ts': '',
+        'tools/vitest/setup.mts': '',
+        'tools/vitest/tsconfig.json': '{"compilerOptions":{}}',
+      });
+      // What `root: import.meta.dirname` produces.
+      mockResolvedTestConfig(
+        { setupFiles: ['../../tools/vitest/setup.mts'] },
+        join(temp.tempDir, 'libs/lib1')
+      );
+
+      const targets = await getProjectTargets('libs/lib1/vitest.config.ts');
+
+      expect(targets['test'].inputs).toContainEqual(
+        '{workspaceRoot}/tools/vitest/setup.mts'
+      );
+      expect(targets['test'].inputs).toContainEqual({
+        json: '{workspaceRoot}/tools/vitest/tsconfig.json',
+        fields: ['compilerOptions'],
+      });
+    });
+
+    it('should declare it for a config that authors no root', async () => {
+      await temp.createFiles({
+        'libs/lib1/vitest.config.ts': '',
+        'libs/lib1/package.json': '{"name":"lib1"}',
+        'libs/lib1/src/a.spec.ts': '',
+        'tools/vitest/setup.mts': '',
+      });
+      // No `rawRoot`: vite would report its own cwd, but the task runs from
+      // the project root.
+      mockResolvedTestConfig({ setupFiles: ['../../tools/vitest/setup.mts'] });
+
+      const targets = await getProjectTargets('libs/lib1/vitest.config.ts');
+
+      expect(targets['test'].inputs).toContainEqual(
+        '{workspaceRoot}/tools/vitest/setup.mts'
+      );
+    });
+
+    it('should resolve entries against an authored root outside the project', async () => {
+      await temp.createFiles({
+        'libs/lib1/vitest.config.ts': '',
+        'libs/lib1/package.json': '{"name":"lib1"}',
+        'libs/lib1/src/a.spec.ts': '',
+        'libs/shared/setup.mts': '',
+      });
+      // A root that is NOT the project directory: if the authored root were
+      // dropped and the project root used instead, this entry would resolve to
+      // a file that does not exist and nothing would be declared.
+      mockResolvedTestConfig(
+        { setupFiles: ['./shared/setup.mts'] },
+        join(temp.tempDir, 'libs')
+      );
+
+      const targets = await getProjectTargets('libs/lib1/vitest.config.ts');
+
+      expect(targets['test'].inputs).toContainEqual(
+        '{workspaceRoot}/libs/shared/setup.mts'
+      );
+    });
+
+    it('should carry the setup file input into the atomized targets', async () => {
+      await temp.createFiles({
+        'libs/lib1/vitest.config.ts': '',
+        'libs/lib1/package.json': '{"name":"lib1"}',
+        'libs/lib1/src/a.spec.ts': '',
+        'tools/vitest/setup.mts': '',
+      });
+      mockResolvedTestConfig({ setupFiles: ['../../tools/vitest/setup.mts'] });
+
+      const targets = await getProjectTargets('libs/lib1/vitest.config.ts');
+
+      expect(targets['test-ci--src/a.spec.ts'].inputs).toContainEqual(
+        '{workspaceRoot}/tools/vitest/setup.mts'
+      );
+    });
+  });
+
   it('should discover spec files matching the Vitest extglob default include', async () => {
     await temp.createFiles({
       'libs/lib1/vitest.config.ts': '',

--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -34,6 +34,7 @@ import {
   loadViteDynamicImport,
   loadVitestConfigDynamicImport,
 } from '../utils/executor-utils';
+import { collectSetupFileInputs } from './setup-file-inputs';
 
 export interface VitestPluginOptions {
   testTargetName?: string;
@@ -239,10 +240,26 @@ async function buildVitestTargets(
   }
 
   const { resolveConfig } = await loadViteDynamicImport();
+  // Vite fills a missing `root` with `process.cwd()`, which at graph time is
+  // the workspace root - not where the task runs. Capture what the config
+  // actually authored so a relative path can be resolved the way Vitest will.
+  let authoredViteRoot: string | undefined;
   const viteBuildConfig = await resolveConfig(
     {
       configFile: absoluteConfigFilePath,
       mode: 'development',
+      plugins: [
+        {
+          name: 'nx-capture-authored-vitest-root',
+          enforce: 'post' as const,
+          config: {
+            order: 'post' as const,
+            handler(config: { root?: string }) {
+              authoredViteRoot = config.root;
+            },
+          },
+        },
+      ],
     },
     'build'
   );
@@ -272,6 +289,12 @@ async function buildVitestTargets(
   // if file is vitest.config or vite.config has definition for test, create targets for test and/or atomized tests
   if (configFilePath.includes('vitest.config') || hasTest) {
     const isTypecheckEnabled = !!viteBuildConfig.test?.typecheck?.enabled;
+    const setupFileInputs = collectSetupFileInputs(
+      viteBuildConfig,
+      projectRoot,
+      context.workspaceRoot,
+      authoredViteRoot
+    );
     targets[options.testTargetName] = await testTarget(
       namedInputs,
       testOutputs,
@@ -279,7 +302,8 @@ async function buildVitestTargets(
       options.testMode,
       pmc,
       isTypecheckEnabled,
-      tsconfigInputs
+      [...tsconfigInputs, ...setupFileInputs.tsconfigs],
+      setupFileInputs.files
     );
 
     if (options.ciTargetName) {
@@ -495,7 +519,8 @@ async function testTarget(
   testMode: 'watch' | 'run' = 'watch',
   pmc: ReturnType<typeof getPackageManagerCommand>,
   isTypecheckEnabled: boolean,
-  tsconfigInputs: string[]
+  tsconfigInputs: string[],
+  setupFileInputs: string[] = []
 ) {
   const command = testMode === 'run' ? 'vitest run' : 'vitest';
   const depOutputsGlob = isTypecheckEnabled ? '**/*.{js,d.ts}' : '**/*.js';
@@ -529,6 +554,9 @@ async function testTarget(
         json: `{workspaceRoot}/${f}`,
         fields: ['compilerOptions'],
       })),
+      // Whole-file, not just `compilerOptions`: these are sources Vitest
+      // executes, so any change to them changes the run.
+      ...setupFileInputs.map((f) => `{workspaceRoot}/${f}`),
       {
         externalDependencies: ['vitest'],
       },

--- a/packages/vitest/src/plugins/setup-file-inputs.spec.ts
+++ b/packages/vitest/src/plugins/setup-file-inputs.spec.ts
@@ -1,0 +1,179 @@
+import { join } from 'node:path';
+import { TempFs } from '@nx/devkit/internal-testing-utils';
+import type { ResolvedConfig } from 'vite';
+import { collectSetupFileInputs } from './setup-file-inputs';
+
+describe('collectSetupFileInputs', () => {
+  let tempFs: TempFs;
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    tempFs = new TempFs('vitest-setup-file-inputs');
+    workspaceRoot = tempFs.tempDir;
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+  });
+
+  /**
+   * `root` mirrors what vite resolves: it is always populated, defaulting to
+   * the graph process's cwd. `authoredRoot` is what the config actually wrote.
+   */
+  const collect = (
+    test: Record<string, unknown>,
+    {
+      projectRoot = 'packages/lib',
+      authoredRoot,
+    }: { projectRoot?: string; authoredRoot?: string } = {}
+  ) =>
+    collectSetupFileInputs(
+      {
+        root: authoredRoot ?? workspaceRoot,
+        test,
+      } as unknown as ResolvedConfig,
+      projectRoot,
+      workspaceRoot,
+      authoredRoot
+    );
+
+  it('should declare a setup file that lives outside the project root', async () => {
+    await tempFs.createFiles({ 'tools/vitest/setup.mts': '' });
+
+    expect(
+      collect({ setupFiles: ['../../tools/vitest/setup.mts'] }).files
+    ).toEqual(['tools/vitest/setup.mts']);
+  });
+
+  it('should declare the tsconfig vite resolves for the setup file and its extends chain', async () => {
+    await tempFs.createFiles({
+      'tools/vitest/setup.mts': '',
+      'tools/vitest/tsconfig.json': JSON.stringify({
+        extends: '../../tsconfig.shared.json',
+      }),
+      'tsconfig.shared.json': JSON.stringify({ compilerOptions: {} }),
+    });
+
+    expect(
+      collect({ setupFiles: ['../../tools/vitest/setup.mts'] }).tsconfigs
+    ).toEqual(['tools/vitest/tsconfig.json', 'tsconfig.shared.json']);
+  });
+
+  it('should walk up to the nearest tsconfig when the setup file has no sibling one', async () => {
+    await tempFs.createFiles({
+      'tools/vitest/nested/setup.mts': '',
+      'tools/tsconfig.json': JSON.stringify({ compilerOptions: {} }),
+    });
+
+    expect(
+      collect({ setupFiles: ['../../tools/vitest/nested/setup.mts'] }).tsconfigs
+    ).toEqual(['tools/tsconfig.json']);
+  });
+
+  it('should declare globalSetup, including the single-string form', async () => {
+    await tempFs.createFiles({ 'tools/vitest/global.mts': '' });
+
+    expect(
+      collect({ globalSetup: '../../tools/vitest/global.mts' }).files
+    ).toEqual(['tools/vitest/global.mts']);
+  });
+
+  it('should accept an absolute path', async () => {
+    await tempFs.createFiles({ 'tools/vitest/setup.mts': '' });
+
+    expect(
+      collect({
+        setupFiles: [join(workspaceRoot, 'tools/vitest/setup.mts')],
+      }).files
+    ).toEqual(['tools/vitest/setup.mts']);
+  });
+
+  it('should not declare a setup file inside the project root, which `default` already covers', async () => {
+    await tempFs.createFiles({ 'packages/lib/setup.ts': '' });
+
+    expect(collect({ setupFiles: ['./setup.ts'] })).toEqual({
+      files: [],
+      tsconfigs: [],
+    });
+  });
+
+  it('should not declare a setup file from node_modules, which the lockfile already covers', async () => {
+    await tempFs.createFiles({ 'node_modules/pkg/setup.js': '' });
+
+    expect(
+      collect({ setupFiles: ['../../node_modules/pkg/setup.js'] })
+    ).toEqual({
+      files: [],
+      tsconfigs: [],
+    });
+  });
+
+  it('should skip an entry that does not exist', () => {
+    expect(collect({ setupFiles: ['../../tools/vitest/missing.mts'] })).toEqual(
+      {
+        files: [],
+        tsconfigs: [],
+      }
+    );
+  });
+
+  it('should declare nothing for a root project, where `default` covers the workspace', async () => {
+    await tempFs.createFiles({ 'tools/vitest/setup.mts': '' });
+
+    // The entry resolves inside the workspace, so without the root-project
+    // guard it would be declared.
+    expect(
+      collect(
+        { setupFiles: ['./tools/vitest/setup.mts'] },
+        {
+          projectRoot: '.',
+        }
+      )
+    ).toEqual({ files: [], tsconfigs: [] });
+  });
+
+  it('should resolve against the project root when the config authors no root', async () => {
+    await tempFs.createFiles({ 'tools/vitest/setup.mts': '' });
+
+    // Vite reports root as its cwd (the workspace root) here; the task runs
+    // with cwd = the project root, so the entry must resolve from there.
+    expect(
+      collect({ setupFiles: ['../../tools/vitest/setup.mts'] }).files
+    ).toEqual(['tools/vitest/setup.mts']);
+  });
+
+  it('should not mistake a workspace-root file for the setup file when no root is authored', async () => {
+    await tempFs.createFiles({ 'setup-at-root.mts': '' });
+
+    expect(collect({ setupFiles: ['./setup-at-root.mts'] }).files).toEqual([]);
+  });
+
+  it('should resolve a relative test.root against the project root', async () => {
+    await tempFs.createFiles({
+      'packages/lib/sub/x': '',
+      'tools/vitest/setup.mts': '',
+    });
+
+    expect(
+      collect({
+        root: 'sub',
+        setupFiles: ['../../../tools/vitest/setup.mts'],
+      }).files
+    ).toEqual(['tools/vitest/setup.mts']);
+  });
+
+  it('should honor an absolute authored root', async () => {
+    await tempFs.createFiles({ 'tools/vitest/setup.mts': '' });
+
+    expect(
+      collect(
+        { setupFiles: ['../../tools/vitest/setup.mts'] },
+        { authoredRoot: join(workspaceRoot, 'packages/lib') }
+      ).files
+    ).toEqual(['tools/vitest/setup.mts']);
+  });
+
+  it('should declare nothing when the config has no setup entries', () => {
+    expect(collect({})).toEqual({ files: [], tsconfigs: [] });
+  });
+});

--- a/packages/vitest/src/plugins/setup-file-inputs.ts
+++ b/packages/vitest/src/plugins/setup-file-inputs.ts
@@ -1,0 +1,119 @@
+import { walkTsconfigExtendsChain } from '@nx/js/internal';
+import type { RawTsconfigJsonCache } from '@nx/js/internal';
+import { getRootTsConfigFileName } from '@nx/js';
+import { existsSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import type { ResolvedConfig } from 'vite';
+
+/**
+ * Collects the files Vitest loads from outside the project root - `setupFiles`
+ * and `globalSetup` - together with the tsconfigs Vite reads to transform them.
+ *
+ * `default` covers everything under `{projectRoot}`, and `^production` covers a
+ * dependency's sources, but a setup file in a shared directory is neither. Left
+ * undeclared, editing it does not invalidate the task and the suite replays a
+ * stale cache hit.
+ *
+ * Reads the build-resolved config, as the inferred target's inputs are built
+ * from it. Setup files contributed by an `apply: 'serve'` plugin are therefore
+ * invisible here - the same build/serve divergence the atomized path documents.
+ *
+ * Solution-style tsconfigs are deliberately not followed. When the nearest
+ * tsconfig of a setup file is a solution file, Vite walks its `references` and
+ * reads every project's tsconfig; declaring those would attach one input per
+ * project in the workspace. Keep the setup file inside a project (or beside a
+ * leaf tsconfig) instead.
+ */
+export function collectSetupFileInputs(
+  viteConfig: ResolvedConfig,
+  projectRoot: string,
+  workspaceRoot: string,
+  /** `root` as the config authored it, before vite defaults it to `cwd`. */
+  authoredViteRoot?: string
+): { files: string[]; tsconfigs: string[] } {
+  // At the workspace root everything is already covered by `default`.
+  if (projectRoot === '.') return { files: [], tsconfigs: [] };
+
+  const entries = [
+    viteConfig.test?.setupFiles,
+    viteConfig.test?.globalSetup,
+  ].flatMap((value) =>
+    typeof value === 'string' ? [value] : Array.isArray(value) ? value : []
+  );
+  if (entries.length === 0) return { files: [], tsconfigs: [] };
+
+  // Vitest resolves both options against its root, and the inferred target
+  // runs with `cwd` set to the project root - so a config that authors no
+  // root resolves them against the project, not `viteConfig.root` (which vite
+  // has already defaulted to the graph process's cwd). Mirrors
+  // `effectiveVitestRoot` in plugin.ts.
+  const fullProjectRoot = resolve(workspaceRoot, projectRoot);
+  const authoredRoot = viteConfig.test?.root ?? authoredViteRoot;
+  const configRoot = !authoredRoot
+    ? fullProjectRoot
+    : isAbsolute(authoredRoot)
+      ? authoredRoot
+      : resolve(fullProjectRoot, authoredRoot);
+  const jsonCache: RawTsconfigJsonCache = new Map();
+  const rootTsConfigName = getRootTsConfigFileName();
+  const projectPrefix = `${projectRoot}/`;
+  const files: string[] = [];
+  const tsconfigs: string[] = [];
+  const seen = new Set<string>();
+
+  /** Workspace-relative path, or null when it is not ours to declare. */
+  const declarable = (absolutePath: string): string | null => {
+    const wsRelative = relative(workspaceRoot, absolutePath)
+      .split(sep)
+      .join('/');
+    if (seen.has(wsRelative)) return null;
+    seen.add(wsRelative);
+    // Outside the workspace → cannot be expressed as an input.
+    if (wsRelative.startsWith('../') || wsRelative === '..') return null;
+    // Inside node_modules → invalidated via the lockfile.
+    if (
+      wsRelative.startsWith('node_modules/') ||
+      wsRelative.includes('/node_modules/')
+    )
+      return null;
+    // Inside the project → covered by `default`.
+    if (wsRelative === projectRoot || wsRelative.startsWith(projectPrefix))
+      return null;
+    return wsRelative;
+  };
+
+  for (const entry of entries) {
+    const absolutePath = isAbsolute(entry) ? entry : resolve(configRoot, entry);
+    if (!existsSync(absolutePath)) continue;
+
+    const wsRelative = declarable(absolutePath);
+    if (!wsRelative) continue;
+    files.push(wsRelative);
+
+    // The tsconfig Vite resolves for the file: the nearest one walking up,
+    // plus its extends chain.
+    let dir = dirname(absolutePath);
+    while (dir.startsWith(workspaceRoot)) {
+      const candidate = join(dir, 'tsconfig.json');
+      if (existsSync(candidate)) {
+        walkTsconfigExtendsChain(
+          candidate,
+          (absPath) => {
+            const relativePath = declarable(absPath);
+            if (relativePath && relativePath !== rootTsConfigName) {
+              tsconfigs.push(relativePath);
+            }
+            return 'continue';
+          },
+          { jsonCache }
+        );
+        break;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+
+  return { files, tsconfigs };
+}


### PR DESCRIPTION
## Current Behavior

`test.setupFiles` and `test.globalSetup` can point anywhere. When they resolve outside the project root, the inferred `test` target declares nothing for them:

- `default` only covers `{projectRoot}/**/*`
- `^production` only covers a *dependency's* sources
- the existing tsconfig inference starts from the project root, so it never sees the setup file's own tsconfig either

A shared setup file in, say, `tools/vitest/setup.mts` is therefore invisible to the hash. Editing it does not invalidate the task, and every suite that loads it replays a stale cache hit. There is no error and nothing in the task output to suggest the run was wrong.

The plugin already resolves the config through vite, so `test.setupFiles` is sitting in the resolved config at the point the inputs are built — it was simply never read.

## Expected Behavior

Setup entries that resolve outside the project root become inputs, along with the tsconfig vite reads to transform them (nearest walking up, plus its `extends` chain), matching what `collectTsconfigInputsByProjectRoot` already does from the project root.

Entries are skipped when they are already covered or cannot be expressed:

| entry | why it is skipped |
| --- | --- |
| inside `{projectRoot}` | covered by `default` |
| inside `node_modules` | invalidated via the lockfile |
| outside the workspace | not expressible as an input |
| non-existent | nothing to hash |
| root project (`.`) | `default` covers the workspace |

The setup files themselves are declared whole-file rather than as `{json: ..., fields: ['compilerOptions']}` like the tsconfigs: these are sources Vitest executes, so any edit changes the run.

### Resolving relative entries

Vite fills a missing `root` with `process.cwd()`, which at graph time is the workspace root — but the inferred target runs Vitest with `cwd` set to the project root. Reading the resolved `root` would therefore resolve relative entries against the wrong base, and a config that authors no `root` would silently get no inputs at all.

So the build `resolveConfig` call now carries a no-op `enforce: 'post'` plugin that observes the config's *authored* `root` before vite defaults it. The base is `test.root ?? authoredRoot ?? projectRoot`, with a relative value resolved against the project root — the same semantics `effectiveVitestRoot` already uses for coverage directories.

### Deliberately not following solution-style tsconfigs

If the nearest tsconfig of a setup file is a solution file, vite walks its `references` and reads every referenced project's tsconfig. Declaring those would attach one input per project in the workspace — in this repo that is 114 — so a tsconfig edit anywhere would invalidate every vitest suite. This PR stops at the nearest tsconfig and its `extends` chain, and the module comment records why. The fix for that layout is to keep the setup file inside a project (or beside a leaf tsconfig), which is what #36896 does.

### Known limitation

The collector reads the build-resolved config, since that is what the target's inputs are built from. Setup files contributed by an `apply: 'serve'` plugin are therefore invisible to it — the same build/serve divergence the atomized path already documents. Closing it would mean resolving the serve config for every project at graph time, which today only happens when `ciTargetName` is set; that cost did not seem worth paying without a real case.

## Testing

`setup-file-inputs.spec.ts` covers the collector against a real temp filesystem: outside/inside the project root, the tsconfig chain, walking up to a non-sibling tsconfig, `globalSetup` in both array and single-string form, absolute paths, `node_modules`, missing entries, the root project, and each shape of authored root (absent, relative, and pointing outside the project).

`plugin-vitest-glob.spec.ts` covers the wiring end to end through `createNodesV2` against a real workspace: the setup file and its tsconfig reaching `targets['test'].inputs`, a config that authors no root, an authored root outside the project, and propagation into the atomized `test-ci--<spec>` targets.

Both guarantees are mutation-verified rather than assumed — each of these fails the suite:

| mutation | caught by |
| --- | --- |
| drop the authored-root argument at the call site | the authored-root-outside-the-project wiring case |
| remove the root-project early return | the root-project unit case |

`nx run-many -t test,lint,oxlint,build -p vitest` is green (236 tests).

## Related Issue(s)

Found while migrating `packages/workspace` to vitest (#36896), where a shared setup file at the workspace root surfaced this gap as a sandbox violation.

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Migrate-packages-workspace-unit-tests-to-vitest-a01a636a">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->