### PR TITLE
fix(core): only defer hashing on dependencies that produce outputs

### DIFF
--- a/packages/nx/src/hasher/check-task-files.ts
+++ b/packages/nx/src/hasher/check-task-files.ts
@@ -19,6 +19,7 @@ import { splitTarget } from '../utils/split-target';
 import { workspaceRoot as defaultWorkspaceRoot } from '../utils/workspace-root';
 import { HashPlanInspector } from './hash-plan-inspector';
 import { type ExpandedDepsOutput, getInputs } from './task-hasher';
+import { collectUpstreamTaskIds } from '../tasks-runner/task-graph-utils';
 
 // ── Module-level context (loaded once per process) ───────────────────────────
 
@@ -267,26 +268,6 @@ function getDepsOutputs(
 
   depsOutputsCache.set(taskId, result);
   return result;
-}
-
-function collectUpstreamTaskIds(
-  taskGraph: TaskGraph,
-  rootTaskId: string,
-  transitive: boolean
-): string[] {
-  const direct = taskGraph.dependencies[rootTaskId] ?? [];
-  if (!transitive) return [...direct];
-
-  const collected = new Set<string>();
-  const walk = (id: string): void => {
-    for (const dep of taskGraph.dependencies[id] ?? []) {
-      if (collected.has(dep)) continue;
-      collected.add(dep);
-      walk(dep);
-    }
-  };
-  walk(rootTaskId);
-  return [...collected];
 }
 
 /**

--- a/packages/nx/src/hasher/hash-task.spec.ts
+++ b/packages/nx/src/hasher/hash-task.spec.ts
@@ -1,0 +1,100 @@
+import { ProjectGraph } from '../config/project-graph';
+import { Task, TaskGraph } from '../config/task-graph';
+import { hashTasksThatDoNotDependOnOutputsOfOtherTasks } from './hash-task';
+
+vi.mock('../tasks-runner/task-env', async () => ({
+  ...(await vi.importActual('../tasks-runner/task-env')),
+  getTaskSpecificEnv: vi.fn(() => process.env),
+}));
+
+vi.mock('../tasks-runner/utils', async () => ({
+  ...(await vi.importActual('../tasks-runner/utils')),
+  getCustomHasher: vi.fn(() => null),
+}));
+
+describe('hashTasksThatDoNotDependOnOutputsOfOtherTasks', () => {
+  function createTask(id: string, outputs: string[]): Task {
+    const [project, target] = id.split(':');
+    return {
+      id,
+      target: { project, target },
+      overrides: {},
+      outputs,
+      projectRoot: project,
+      cache: true,
+      parallelism: true,
+    } as Task;
+  }
+
+  const projectGraph = {
+    nodes: {
+      app: {
+        name: 'app',
+        type: 'app',
+        data: {
+          root: 'app',
+          targets: {
+            build: {
+              inputs: [
+                { dependentTasksOutputFiles: '**/*.d.ts', transitive: true },
+              ],
+            },
+          },
+        },
+      },
+      lib: {
+        name: 'lib',
+        type: 'lib',
+        data: { root: 'lib', targets: { build: {} } },
+      },
+      tool: {
+        name: 'tool',
+        type: 'lib',
+        data: { root: 'tool', targets: { install: {} } },
+      },
+    },
+    dependencies: { app: [], lib: [], tool: [] },
+    externalNodes: {},
+  } as unknown as ProjectGraph;
+
+  function hashedIds(taskGraph: TaskGraph) {
+    const hasher = {
+      hashTasks: vi.fn(async (tasks: Task[]) =>
+        tasks.map((t) => ({ value: `${t.id}|hash`, details: {} }))
+      ),
+    };
+    return hashTasksThatDoNotDependOnOutputsOfOtherTasks(
+      hasher as any,
+      projectGraph,
+      taskGraph,
+      {},
+      null
+    ).then(() => hasher.hashTasks.mock.calls[0][0].map((t: Task) => t.id));
+  }
+
+  it('defers a task whose dep outputs feed its hash', async () => {
+    const taskGraph: TaskGraph = {
+      roots: ['lib:build'],
+      tasks: {
+        'app:build': createTask('app:build', ['dist/app']),
+        'lib:build': createTask('lib:build', ['dist/lib']),
+      },
+      dependencies: { 'app:build': ['lib:build'], 'lib:build': [] },
+      continuousDependencies: { 'app:build': [], 'lib:build': [] },
+    };
+    expect(await hashedIds(taskGraph)).toEqual(['lib:build']);
+  });
+
+  it('hashes a task up front when its only deps declare no outputs', async () => {
+    const taskGraph: TaskGraph = {
+      roots: ['tool:install'],
+      tasks: {
+        'app:build': createTask('app:build', ['dist/app']),
+        'tool:install': createTask('tool:install', []),
+      },
+      dependencies: { 'app:build': ['tool:install'], 'tool:install': [] },
+      continuousDependencies: { 'app:build': [], 'tool:install': [] },
+    };
+    expect(await hashedIds(taskGraph)).toEqual(['app:build', 'tool:install']);
+  });
+});

--- a/packages/nx/src/hasher/hash-task.ts
+++ b/packages/nx/src/hasher/hash-task.ts
@@ -7,7 +7,7 @@ import { getTaskIOService } from '../tasks-runner/task-io-service';
 import { getTaskSpecificEnv } from '../tasks-runner/task-env';
 import { getCustomHasher } from '../tasks-runner/utils';
 import { getDbConnection } from '../utils/db-connection';
-import { getInputs, TaskHasher } from './task-hasher';
+import { getDependenciesWithOutputsToHash, TaskHasher } from './task-hasher';
 
 let taskDetails: TaskDetails;
 
@@ -48,9 +48,9 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
         return false;
       }
 
-      return !(
-        taskGraph.dependencies[task.id].length > 0 &&
-        getInputs(task, projectGraph, nxJson).depsOutputs.length > 0
+      return (
+        getDependenciesWithOutputsToHash(task, taskGraph, projectGraph, nxJson)
+          .length === 0
       );
     })
     .map((t) => t.task);

--- a/packages/nx/src/hasher/task-hasher.spec.ts
+++ b/packages/nx/src/hasher/task-hasher.spec.ts
@@ -4,6 +4,7 @@ import {
   expandNamedInput,
   expandSingleProjectInputs,
   filterUsingGlobPatterns,
+  getDependenciesWithOutputsToHash,
   splitInputsIntoSelfAndDependencies,
 } from './task-hasher';
 
@@ -186,6 +187,105 @@ describe('TaskHasher', () => {
         { fileset: '{projectRoot}/**/*.json', dependencies: true },
       ]);
       expect(result.depsInputs).toEqual([]);
+    });
+  });
+
+  describe('getDependenciesWithOutputsToHash', () => {
+    const task = (id: string, outputs: string[]) => {
+      const [project, target] = id.split(':');
+      return { id, target: { project, target }, outputs } as any;
+    };
+    const graph = (
+      tasks: any[],
+      dependencies: Record<string, string[]>
+    ): any => ({
+      roots: [],
+      tasks: Object.fromEntries(tasks.map((t) => [t.id, t])),
+      dependencies,
+      continuousDependencies: {},
+    });
+    const projectGraph = (inputs: any[] | undefined): any => ({
+      nodes: {
+        app: {
+          name: 'app',
+          type: 'app',
+          data: {
+            root: 'app',
+            targets: { build: { ...(inputs ? { inputs } : {}) } },
+          },
+        },
+      },
+      dependencies: {},
+    });
+    const nxJson: any = { namedInputs: {} };
+    const app = task('app:build', ['dist/app']);
+    const depsOutputs = (transitive?: boolean) =>
+      projectGraph([{ dependentTasksOutputFiles: '**/*.d.ts', transitive }]);
+
+    it('returns nothing when the task has no dependentTasksOutputFiles input', () => {
+      const tg = graph([app, task('lib:build', ['dist/lib'])], {
+        'app:build': ['lib:build'],
+        'lib:build': [],
+      });
+      expect(
+        getDependenciesWithOutputsToHash(
+          app,
+          tg,
+          projectGraph([{ fileset: '{projectRoot}/**/*' }]),
+          nxJson
+        )
+      ).toEqual([]);
+    });
+
+    it('skips dependencies that declare no outputs', () => {
+      const tg = graph(
+        [app, task('tool:install', []), task('lib:build', ['dist/lib'])],
+        {
+          'app:build': ['tool:install', 'lib:build'],
+          'tool:install': [],
+          'lib:build': [],
+        }
+      );
+      expect(
+        getDependenciesWithOutputsToHash(app, tg, depsOutputs(), nxJson)
+      ).toEqual(['lib:build']);
+    });
+
+    it('only walks direct dependencies unless transitive', () => {
+      const tg = graph(
+        [app, task('mid:build', []), task('leaf:build', ['dist/leaf'])],
+        {
+          'app:build': ['mid:build'],
+          'mid:build': ['leaf:build'],
+          'leaf:build': [],
+        }
+      );
+      expect(
+        getDependenciesWithOutputsToHash(app, tg, depsOutputs(false), nxJson)
+      ).toEqual([]);
+      expect(
+        getDependenciesWithOutputsToHash(app, tg, depsOutputs(true), nxJson)
+      ).toEqual(['leaf:build']);
+    });
+
+    it('visits diamond dependencies once', () => {
+      const tg = graph(
+        [
+          app,
+          task('a:build', ['dist/a']),
+          task('b:build', ['dist/b']),
+          task('shared:build', ['dist/shared']),
+        ],
+        {
+          'app:build': ['a:build', 'b:build'],
+          'a:build': ['shared:build'],
+          'b:build': ['shared:build'],
+          'shared:build': [],
+        }
+      );
+      expect(
+        getDependenciesWithOutputsToHash(app, tg, depsOutputs(true), nxJson)
+      ).toEqual(['a:build', 'b:build', 'shared:build']);
     });
   });
 

--- a/packages/nx/src/hasher/task-hasher.spec.ts
+++ b/packages/nx/src/hasher/task-hasher.spec.ts
@@ -284,7 +284,12 @@ describe('TaskHasher', () => {
         }
       );
       expect(
-        getDependenciesWithOutputsToHash(app, tg, depsOutputs(true), nxJson)
+        getDependenciesWithOutputsToHash(
+          app,
+          tg,
+          depsOutputs(true),
+          nxJson
+        ).sort()
       ).toEqual(['a:build', 'b:build', 'shared:build']);
     });
   });

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -352,6 +352,47 @@ export function getInputs(
   return { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets };
 }
 
+/**
+ * Ids of dependency tasks whose outputs feed `task`'s hash through a
+ * `dependentTasksOutputFiles` input. Mirrors `process_tasks_outputs` in
+ * native/tasks/dep_outputs.rs: a dependency with no `outputs` contributes
+ * nothing, so it does not need to finish before `task` can be hashed.
+ */
+export function getDependenciesWithOutputsToHash(
+  task: Task,
+  taskGraph: TaskGraph,
+  projectGraph: ProjectGraph,
+  nxJson: NxJsonConfiguration
+): string[] {
+  const { depsOutputs } = getInputs(task, projectGraph, nxJson);
+  if (depsOutputs.length === 0) {
+    return [];
+  }
+  // The transitive set is a superset of the direct one, so any transitive
+  // entry widens the walk for all of them.
+  const transitive = depsOutputs.some((d) => d.transitive);
+
+  const result: string[] = [];
+  const visited = new Set<string>();
+  const queue = [task.id];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    for (const depId of taskGraph.dependencies[current] ?? []) {
+      if (visited.has(depId)) continue;
+      visited.add(depId);
+      const dep = taskGraph.tasks[depId];
+      if (!dep) continue;
+      if (dep.outputs.length > 0) {
+        result.push(depId);
+      }
+      if (transitive) {
+        queue.push(depId);
+      }
+    }
+  }
+  return result;
+}
+
 export function splitInputsIntoSelfAndDependencies(
   inputs: ReadonlyArray<InputDefinition | string>,
   namedInputs: { [inputName: string]: ReadonlyArray<InputDefinition | string> }

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -13,6 +13,7 @@ import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { workspaceRoot } from '../utils/workspace-root';
 import { HashInputs, NxWorkspaceFilesExternals } from '../native';
 import { getTaskIOService } from '../tasks-runner/task-io-service';
+import { collectUpstreamTaskIds } from '../tasks-runner/task-graph-utils';
 
 // Re-export HashInputs from native module for public API
 export { HashInputs };
@@ -371,26 +372,9 @@ export function getDependenciesWithOutputsToHash(
   // The transitive set is a superset of the direct one, so any transitive
   // entry widens the walk for all of them.
   const transitive = depsOutputs.some((d) => d.transitive);
-
-  const result: string[] = [];
-  const visited = new Set<string>();
-  const queue = [task.id];
-  while (queue.length > 0) {
-    const current = queue.shift();
-    for (const depId of taskGraph.dependencies[current] ?? []) {
-      if (visited.has(depId)) continue;
-      visited.add(depId);
-      const dep = taskGraph.tasks[depId];
-      if (!dep) continue;
-      if (dep.outputs.length > 0) {
-        result.push(depId);
-      }
-      if (transitive) {
-        queue.push(depId);
-      }
-    }
-  }
-  return result;
+  return collectUpstreamTaskIds(taskGraph, task.id, transitive).filter(
+    (id) => taskGraph.tasks[id]?.outputs.length > 0
+  );
 }
 
 export function splitInputsIntoSelfAndDependencies(

--- a/packages/nx/src/tasks-runner/task-graph-utils.ts
+++ b/packages/nx/src/tasks-runner/task-graph-utils.ts
@@ -241,6 +241,27 @@ class DependingOnNonParallelContinuousTaskError extends Error {
   }
 }
 
+/** Ids of `rootTaskId`'s dependencies — direct only, or the whole subtree. */
+export function collectUpstreamTaskIds(
+  taskGraph: TaskGraph,
+  rootTaskId: string,
+  transitive: boolean
+): string[] {
+  const direct = taskGraph.dependencies[rootTaskId] ?? [];
+  if (!transitive) return [...direct];
+
+  const collected = new Set<string>();
+  const walk = (id: string): void => {
+    for (const dep of taskGraph.dependencies[id] ?? []) {
+      if (collected.has(dep)) continue;
+      collected.add(dep);
+      walk(dep);
+    }
+  };
+  walk(rootTaskId);
+  return [...collected];
+}
+
 export function getLeafTasks(taskGraph: TaskGraph): Set<string> {
   const reversed = reverseTaskGraph(taskGraph);
   const leafTasks = new Set<string>();

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -176,6 +176,29 @@ describe('TaskOrchestrator', () => {
       expect(hasher.hashTasks).toHaveBeenCalledTimes(2);
       expect(consumer.hash).toBe('consumer:build|call-2');
     });
+
+    it('should not re-hash when the only non-cached dep has no outputs', async () => {
+      // dep runs (cache miss) but declares no outputs, so it contributes
+      // nothing to the consumer's dependentTasksOutputFiles hash.
+      const dep = { ...createTask('dep:build'), outputs: [] };
+      const consumer = createTask('consumer:build');
+      const taskGraph: TaskGraph = {
+        roots: ['dep:build'],
+        tasks: { 'dep:build': dep, 'consumer:build': consumer },
+        dependencies: { 'dep:build': [], 'consumer:build': ['dep:build'] },
+        continuousDependencies: { 'dep:build': [], 'consumer:build': [] },
+      };
+      const { orchestrator, hasher } = createOrchestrator(taskGraph);
+
+      await orchestrator.applyFromCacheOrRunBatch(
+        true,
+        { id: 'batch-1', executorName: 'my-plugin:batch', taskGraph },
+        0
+      );
+
+      expect(hasher.hashTasks).toHaveBeenCalledTimes(2);
+      expect(consumer.hash).toBe('consumer:build|call-2');
+    });
   });
 
   describe('cached failures (NX_CACHE_FAILURES)', () => {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -11,7 +11,10 @@ import { DaemonClient } from '../daemon/client/client';
 import { runCommands } from '../executors/run-commands/run-commands.impl';
 import { getTaskDetails, hashTask, hashTasks } from '../hasher/hash-task';
 import { walkTaskGraph } from './task-graph-utils';
-import { getInputs, TaskHasher } from '../hasher/task-hasher';
+import {
+  getDependenciesWithOutputsToHash,
+  TaskHasher,
+} from '../hasher/task-hasher';
 import {
   BatchStatus,
   IS_WASM,
@@ -316,9 +319,12 @@ export class TaskOrchestrator {
           .filter(
             (t) =>
               !t.hash &&
-              this.taskGraph.dependencies[t.id].every((depId) =>
-                this.completedTasks.has(depId)
-              )
+              getDependenciesWithOutputsToHash(
+                t,
+                this.taskGraph,
+                this.projectGraph,
+                this.nxJson
+              ).every((depId) => this.completedTasks.has(depId))
           );
         if (unhashed.length > 0) {
           const perTaskEnvs: Record<string, NodeJS.ProcessEnv> = {};
@@ -643,9 +649,9 @@ export class TaskOrchestrator {
    * Hash all batch tasks and resolve cache hits topologically.
    *
    * Walks the task graph level by level. Every task gets a preliminary hash
-   * (so startTasks always has a valid hash for Cloud). Tasks with depsOutputs
-   * whose deps weren't cached are ineligible for cache lookup but still
-   * receive a preliminary hash — they'll be re-hashed after execution.
+   * (so startTasks always has a valid hash for Cloud). Tasks whose hash reads
+   * outputs of a dep that wasn't cached are ineligible for cache lookup but
+   * still receive a preliminary hash — they'll be re-hashed after execution.
    */
   private async applyBatchCachedResults(
     batch: Batch,
@@ -674,13 +680,14 @@ export class TaskOrchestrator {
 
       const eligible: Task[] = [];
       for (const task of rootTasks) {
-        const depIds = batch.taskGraph.dependencies[task.id];
-        const hasNonCachedDep = depIds.some((id) => nonCachedTaskIds.has(id));
+        const hasNonCachedOutputDep = getDependenciesWithOutputsToHash(
+          task,
+          batch.taskGraph,
+          this.projectGraph,
+          this.nxJson
+        ).some((id) => nonCachedTaskIds.has(id));
 
-        if (
-          hasNonCachedDep &&
-          getInputs(task, this.projectGraph, this.nxJson).depsOutputs.length > 0
-        ) {
+        if (hasNonCachedOutputDep) {
           nonCachedTaskIds.add(task.id);
           needsRehashAfterExecution.add(task.id);
         } else {


### PR DESCRIPTION
## Current Behavior

`hashTasksThatDoNotDependOnOutputsOfOtherTasks` drops a task from the up-front batch as soon as it has any dependency and a `dependentTasksOutputFiles` input, before the hasher plans it. The planner already leaves such a task out only when its plan reads an output an upstream task declares (`HashPlans.deferred`), and a dependency with no `outputs` never contributes one (`process_tasks_outputs`). The TypeScript pre-filter is therefore stricter than the rule the hasher applies, and a task whose only dependencies produce nothing is deferred for no reason.

Consequences:

- The task reaches Nx Cloud with no hash, so it can never be classified as a remote cache hit at DTE start and is always distributed and executed.
- Once deferred, the coordinator loop waits for every direct dependency to complete before hashing it, output-less ones included.
- Batch executors re-run a task whenever any direct dependency misses the cache, even one that produced nothing.

Example in this repo: `e2e-maven:e2e-ci--*` depends on `nx-maven-plugin:install`, which has no outputs and cannot affect the e2e task's hash.

## Expected Behavior

Only a declared output can reach a task's hash, so only tasks that declare one hold hashing back.

- The up-front batch offers every task without a custom hasher to the hasher, whose plan decides what waits. A task whose dependencies declare no outputs is hashed up front.
- A task the batch left out is hashed once the upstream tasks that declare outputs have completed, walked transitively so an output behind an output-less dependency still counts. Output-less dependencies are not waited on.
- `applyBatchCachedResults` re-runs a task only when a dependency that feeds its `dependentTasksOutputFiles` input was a cache miss.
- `collectUpstreamTaskIds` moves from `check-task-files.ts` into `task-graph-utils.ts`, with `collectUpstreamTaskIdsWithOutputs` beside it, so the hasher and the orchestrator share one traversal.

Tasks whose only relevant dependencies are output-less now get a hash up front, which lets Nx Cloud consider them for a remote cache hit and lets batch executors replay them instead of re-running.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Output-aware-gating-for-dependentTasksOutputFiles-6c867402">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->