### PR TITLE
fix(core): restore the wasm walker imports dropped by a stray cfg attribute

### DIFF
--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use crate::native::glob::build_glob_set;
 
-#[cfg(not(target_arch = "wasm32"))]
 use crate::native::utils::{Normalize, get_mod_time, git::parent_gitignore_files};
 use walkdir::WalkDir;
 


### PR DESCRIPTION
## Current Behavior

`#[cfg]` binds to the single item that follows it. When #36895 removed the `enable_logger` import from `walker.rs`, the `#[cfg(not(target_arch = "wasm32"))]` above it landed on the `utils` import instead, gating `Normalize`, `get_mod_time` and `parent_gitignore_files` out of the wasm build. All three are still used there.

```
error[E0599]: no method named `to_normalized_string` found for reference `&std::path::Path` in the current scope
  --> packages/nx/src/native/walker.rs:94:40
```

Nothing in PR CI compiles for wasm32, so this only showed up in `pnpm build:wasm` at publish time. A CI check for that is worth adding, but it needs a second Rust toolchain wired up, so it is being handled separately rather than here.

## Expected Behavior

The wasm build compiles. None of those imports need gating.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
