### PR TITLE
chore(repo): check the wasm target on PRs that touch rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           pnpm nx run-many -t check-imports check-lock-files check-codeowners --parallel=1 --no-dte &
           pids+=($!)
 
-          pnpm nx affected --targets=lint,oxlint,test,build,e2e,e2e-ci,format-native,lint-native,gradle:build-ci,vale,run,validate-example &
+          pnpm nx affected --targets=lint,oxlint,test,build,e2e,e2e-ci,format-native,lint-native,check-native-wasm,gradle:build-ci,vale,run,validate-example &
           pids+=($!)
 
           for pid in "${pids[@]}"; do

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -10,6 +10,13 @@
     }
   },
   "targets": {
+    "check-native-wasm": {
+      "cache": true,
+      "inputs": ["native", "{workspaceRoot}/scripts/check-wasm-target.sh"],
+      "outputs": [],
+      "parallelism": false,
+      "command": "./scripts/check-wasm-target.sh"
+    },
     "build-native-wasm": {
       "cache": true,
       "inputs": ["native"],

--- a/scripts/check-wasm-target.sh
+++ b/scripts/check-wasm-target.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Type-checks the native crate for wasm. `cargo check` never links, so it needs none
+# of the wasi-sdk / cmake / sqlite machinery a full `pnpm build:wasm` does.
+set -euo pipefail
+
+# Keep in sync with the `build:wasm` script in package.json. `packages/nx/src/lib.rs`
+# puts `wasi_ext` behind `#![feature]`, which stable rejects with E0554 before it
+# typechecks anything, so a stable toolchain reports the wrong error here.
+TOOLCHAIN=nightly-2026-03-01
+TARGET=wasm32-wasip1-threads
+
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "check-native-wasm needs rustup to provide $TOOLCHAIN. See https://rustup.rs." >&2
+  exit 1
+fi
+
+if ! rustup toolchain list | grep -q "^$TOOLCHAIN"; then
+  echo "Installing the $TOOLCHAIN toolchain (a few hundred MB under ~/.rustup, once)."
+  rustup toolchain install "$TOOLCHAIN" --profile minimal --target "$TARGET"
+elif ! rustup target list --toolchain "$TOOLCHAIN" --installed | grep -qx "$TARGET"; then
+  rustup target add --toolchain "$TOOLCHAIN" "$TARGET"
+fi
+
+# napi-build reads this; nothing is linked, but the build script still resolves it.
+export EMNAPI_LINK_DIR="$PWD/node_modules/emnapi/lib/wasm32-wasi-threads"
+
+# `rustup run` rather than RUSTUP_TOOLCHAIN: mise puts its own non-shim `cargo` on
+# PATH (the `rust` pin in mise.toml), and that one ignores RUSTUP_TOOLCHAIN.
+exec rustup run "$TOOLCHAIN" cargo check -p nx --target "$TARGET"


### PR DESCRIPTION
> Stacked on #36924 — that PR carries the `walker.rs` fix this check needs in order to pass. Review this one on top of it; the base will retarget to `master` once #36924 lands.

## Current Behavior

Nothing in PR CI builds or type-checks the wasm target. `pnpm build:wasm` only runs in `publish.yml`, so a wasm-only compile break is invisible until publish time — which is exactly how the stray `#[cfg]` in #36924 escaped review:

```
error[E0599]: no method named `to_normalized_string` found for reference `&std::path::Path`
  --> packages/nx/src/native/walker.rs:94:40
```

## Expected Behavior

A PR that touches Rust type-checks the native crate for `wasm32-wasip1-threads`, so the next one of these fails on the PR.

This is an nx task rather than a separate workflow job, so it inherits three things instead of re-implementing them:

- **Affected detection.** The `native` named input already covers `**/*.rs`, `**/Cargo.*`, the workspace `Cargo.toml`/`Cargo.lock`, `clippy.toml` and `.cargo/config.toml` — a content-hashed superset of what a `paths` filter or a `git diff | grep` gate would match.
- **Nx Cloud caching.** `cache: true` with no outputs makes it a pass/fail verdict keyed on those inputs, so an unchanged rerun costs nothing.
- **DTE distribution.** It joins the existing `nx affected` sweep and lands on an agent, so it adds no wall clock to `main-linux` and needs no second runner, checkout, mise, corepack, pnpm store cache or install.

`cargo check` never links, so it needs none of the wasi-sdk, cmake and sqlite machinery a full `pnpm build:wasm` does.

### Notes

- The script is itself an input. The `native` named input carries `{"runtime": "rustc --version"}`, which reports the **stable** rustc from `mise.toml` — without the script in `inputs`, changing the pinned nightly would not invalidate the cache.
- `parallelism: false`, since the task may invoke `rustup`, which is not safe against concurrent writes to the same `RUSTUP_HOME`.
- The nightly is required, not a preference: `packages/nx/src/lib.rs` puts `wasi_ext` behind `#![feature]`, which stable rejects with E0554 before it type-checks anything.
- Dispatch is `rustup run <toolchain>` rather than `RUSTUP_TOOLCHAIN`, because mise puts its own non-shim `cargo` on `PATH` (the `rust` pin in `mise.toml`) and that one ignores the variable.
- The toolchain install is conditional, and lands under `~/.rustup` on contributor machines. It does not change the active or default toolchain — `rustup toolchain install` only unpacks, `rustup run` scopes to one child process, and `rust-toolchain.toml` pins 1.95.0 inside the repo regardless.

### Verification

Run against the stray-`#[cfg]` code, the task reproduces the `E0599` above; with #36924's fix applied it passes. So it is real coverage rather than a check that cannot fail.

## Related Issue(s)

None.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Check-the-wasm-target-in-PR-CI-0794fa76">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->