### PR TITLE
chore(core): nx plugin submission @loomweaver/devkit

### DIFF
--- a/astro-docs/src/content/approved-community-plugins.json
+++ b/astro-docs/src/content/approved-community-plugins.json
@@ -568,5 +568,10 @@
     "name": "@anarchitects/nx-typeorm",
     "description": "Nx plugin for TypeORM integration in Nx backend applications and libraries.",
     "url": "https://github.com/anarchitects/anarchitecture-plugins/tree/main/packages/typeorm"
+  },
+  {
+    "name": "@loomweaver/devkit",
+    "description": "Nx generators for LoomWeaver, an open-source plugin platform for Angular workbenches: weavers, distributions, frame plugins and integration seams.",
+    "url": "https://github.com/yesbert/loomweaver/tree/main/platform/libs/tooling/devkit"
   }
 ]


### PR DESCRIPTION
# Community Plugin Submission

## @loomweaver/devkit

LoomWeaver is an open-source plugin platform for Angular workbenches (Apache 2.0, https://loomweaver.dev, live demo at https://demo.loomweaver.dev), and this plugin carries its Nx generators: weavers (the plugins), distributions (the product that composes them), frame plugins (sandboxed iframe plugins), and the integration seams, plus manifest and i18n validators. It is focused on Angular workspaces and provides generators only, no executors and no graph support.

The package depends on `@nx/devkit` (`^23.1.1`) rather than declaring it a peer, lists its `repository.url` with the package directory, and the repository runs Playwright e2e tests in CI. Author and maintainer: Norbert Rosenwinkel (@yesbert). The platform's own demo application is the reference consumer.