### PR TITLE
fix(core): avoid mutating target options when resolving configurations

### DIFF
--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -81,6 +81,20 @@ describe('params', () => {
       expect(options).toEqual({
         overriddenOpt: 'config value',
       });
+
+      expect(target.options).toEqual({
+        overriddenOpt: 'target value',
+      });
+      expect(
+        combineOptionsForExecutor(
+          {},
+          undefined,
+          target,
+          schema,
+          'proj',
+          process.cwd()
+        )
+      ).toEqual({ overriddenOpt: 'target value' });
     });
 
     it('should combine target, configuration, and passed options', () => {

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -683,7 +683,7 @@ export function combineOptionsForExecutor(
     schema,
     false
   );
-  let combined = target.options || {};
+  let combined = { ...target.options };
   if (config && target.configurations && target.configurations[config]) {
     Object.assign(combined, target.configurations[config]);
   }


### PR DESCRIPTION
## Current Behavior

Resolving executor options for a named configuration can change the target's base options in the project graph. The selected configuration is supposed to apply to that execution, but its overrides remain on the shared target object afterward.

For example, consider this target:

```json
{
  "executor": "nx:run-commands",
  "options": {
    "command": "echo default"
  },
  "configurations": {
    "production": {
      "command": "echo production"
    }
  }
}
```

Resolving it with `production` correctly returns `echo production`. However, it also replaces `target.options.command` with `echo production`. Resolving the same target object again without a configuration then returns `echo production` instead of `echo default`.

This also matters for caching: Nx includes target options in the project's `ProjectConfiguration` hash. Mutating those options changes the hash without a source-file change. We investigated cache misses between runs of identical source trees and reproduced the observed project-configuration hash differences by applying only this mutation. The exact scheduling that exposed the mutated graph in those runs has not been reproduced end to end.

The cause is in `combineOptionsForExecutor`:

```ts
let combined = target.options || {};
Object.assign(combined, target.configurations[config]);
```

`combined` references the original options object, so merging the configuration modifies the target itself.

## Expected Behavior

Resolve options for an execution without modifying the target's base options. This PR makes a shallow copy before merging configuration overrides:

```ts
let combined = { ...target.options };
```

Configuration precedence stays the same: the configured execution still receives its override, and a later default resolution still receives the original base value. The change addresses the top-level mutation demonstrated above; it does not change the hashing algorithm.

The existing configuration-merging test now checks all three outcomes: the configured result is correct, the original target options remain unchanged, and resolving the same target without a configuration returns its base options.

### Validation

- The added assertion fails on unmodified master; all 99 tests in `params.spec.ts` pass with the fix using `pnpm exec vitest run --config packages/nx/vitest.config.mts packages/nx/src/utils/params.spec.ts`.
- Oxfmt check passes for both changed files.
- Targeted Oxlint exits successfully; its project-graph-dependent module-boundary rule is skipped because the graph is unavailable.
- `pnpm nx prepush` is blocked during project-graph creation by the missing .NET SDK: `spawn dotnet ENOENT`. Full workspace validation remains for CI.

## Related Issue(s)

No existing issue linked.
