### PR TITLE
fix(nest): support NestJS 12

### DIFF
--- a/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
@@ -21,15 +21,15 @@ Many conventions and best practices used in Angular applications can be also be 
 
 The `@nx/nest` plugin supports the following NestJS package versions.
 
-| Package        | Supported Versions   |
-| -------------- | -------------------- |
-| `@nestjs/core` | ^10.0.0 \|\| ^11.0.0 |
+| Package        | Supported Versions                  |
+| -------------- | ----------------------------------- |
+| `@nestjs/core` | ^10.0.0 \|\| ^11.0.0 \|\| ^12.0.0 |
 
-The plugin detects the installed `@nestjs/core` major and routes the rest of the `@nestjs/*` family (plus `rxjs` and `reflect-metadata`) to versions that pair with it. Fresh installs default to NestJS v11.
+The plugin detects the installed `@nestjs/core` major and routes the rest of the `@nestjs/*` family (plus `rxjs` and `reflect-metadata`) to versions that pair with it. Fresh installs default to NestJS v12.
 
 | Nx Version     | Default NestJS Version |
 | -------------- | ---------------------- |
-| 23.x (current) | ^11.0.0                |
+| 23.x (current) | ^12.0.0                |
 | 22.x           | ^11.0.0                |
 | 21.x           | ^11.0.0                |
 | 20.x           | ^10.0.0                |

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -59,7 +59,7 @@
     }
   },
   "dependencies": {
-    "@nestjs/schematics": "^11.0.0",
+    "@nestjs/schematics": ">=11.0.0 <13.0.0",
     "@nx/devkit": "workspace:*",
     "@nx/js": "workspace:*",
     "@nx/eslint": "workspace:*",
@@ -68,8 +68,8 @@
     "tslib": "catalog:typescript"
   },
   "peerDependencies": {
-    "@nestjs/core": ">=10.0.0 <12.0.0",
-    "@nestjs/common": ">=10.0.0 <12.0.0",
+    "@nestjs/core": ">=10.0.0 <13.0.0",
+    "@nestjs/common": ">=10.0.0 <13.0.0",
     "reflect-metadata": ">=0.1.0 <0.3.0",
     "rxjs": "^7.0.0"
   },

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -392,15 +392,15 @@ describe('application generator', () => {
       expect(readJson(tree, 'myapp/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {
-            "@nestjs/common": "^11.0.0",
-            "@nestjs/core": "^11.0.0",
-            "@nestjs/platform-express": "^11.0.0",
+            "@nestjs/common": "^12.0.0",
+            "@nestjs/core": "^12.0.0",
+            "@nestjs/platform-express": "^12.0.0",
             "reflect-metadata": "^0.2.0",
             "rxjs": "^7.8.0",
             "tslib": "^2.3.0",
           },
           "devDependencies": {
-            "@nestjs/testing": "^11.0.0",
+            "@nestjs/testing": "^12.0.0",
           },
           "name": "@proj/myapp",
           "nx": {

--- a/packages/nest/src/utils/versions.spec.ts
+++ b/packages/nest/src/utils/versions.spec.ts
@@ -1,0 +1,72 @@
+import { type Tree, updateJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { versions } from './versions';
+
+describe('versions', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  function declareNestJs(
+    version: string,
+    field: 'dependencies' | 'devDependencies' = 'dependencies'
+  ): void {
+    updateJson(tree, 'package.json', (json) => {
+      json[field] = { ...json[field], '@nestjs/core': version };
+      return json;
+    });
+  }
+
+  it('installs the latest supported major when NestJS is absent', () => {
+    expect(versions(tree)).toEqual({
+      nestJsVersion: '^12.0.0',
+      nestJsSchematicsVersion: '^12.0.0',
+      rxjsVersion: '^7.8.0',
+      reflectMetadataVersion: '^0.2.0',
+    });
+  });
+
+  // Asserting the whole object catches a major that silently borrows another
+  // one's versions, which is how a v12 workspace ended up on v11.
+  it.each([
+    [
+      '^10.0.0',
+      {
+        nestJsVersion: '^10.0.2',
+        nestJsSchematicsVersion: '^10.0.1',
+        rxjsVersion: '^7.8.0',
+        reflectMetadataVersion: '^0.1.13',
+      },
+    ],
+    [
+      '^11.0.0',
+      {
+        nestJsVersion: '^11.0.0',
+        nestJsSchematicsVersion: '^11.0.0',
+        rxjsVersion: '^7.8.0',
+        reflectMetadataVersion: '^0.2.0',
+      },
+    ],
+    [
+      '^12.0.1',
+      {
+        nestJsVersion: '^12.0.0',
+        nestJsSchematicsVersion: '^12.0.0',
+        rxjsVersion: '^7.8.0',
+        reflectMetadataVersion: '^0.2.0',
+      },
+    ],
+  ])('keeps a workspace on %s at its own major', (declared, expected) => {
+    declareNestJs(declared);
+
+    expect(versions(tree)).toEqual(expected);
+  });
+
+  it('reads @nestjs/core from devDependencies', () => {
+    declareNestJs('^10.0.0', 'devDependencies');
+
+    expect(versions(tree)).toMatchObject({ nestJsVersion: '^10.0.2' });
+  });
+});

--- a/packages/nest/src/utils/versions.ts
+++ b/packages/nest/src/utils/versions.ts
@@ -11,13 +11,13 @@ export const nxVersion = require(join('@nx/nest', 'package.json')).version;
 export const tsLibVersion = '^2.3.0';
 
 // NestJS has no public LTS table; cadence is roughly one major per year.
-// Support window: v10 + v11 (Rule 2 — N & N-1 — since v10.4.x still receives
-// upstream patches).
+// Support window: v11 + v12 (Rule 2 — N & N-1), with v10 kept while v10.4.x
+// still receives upstream patches.
 export const minSupportedNestJsVersion = '10.0.0';
 
 // Fresh-install constants — latest supported major.
-export const nestJsVersion = '^11.0.0';
-export const nestJsSchematicsVersion = '^11.0.0';
+export const nestJsVersion = '^12.0.0';
+export const nestJsSchematicsVersion = '^12.0.0';
 export const rxjsVersion = '^7.8.0';
 export const reflectMetadataVersion = '^0.2.0';
 
@@ -35,13 +35,21 @@ const latestVersions: NestJsVersions = {
   reflectMetadataVersion,
 };
 
-type CompatVersions = 10;
+// Every major below the latest carries its own entry; the latest one is
+// latestVersions, which a major above the support window also falls back to.
+type CompatVersions = 10 | 11;
 const versionMap: Record<CompatVersions, NestJsVersions> = {
   10: {
     nestJsVersion: '^10.0.2',
     nestJsSchematicsVersion: '^10.0.1',
     rxjsVersion: '^7.8.0',
     reflectMetadataVersion: '^0.1.13',
+  },
+  11: {
+    nestJsVersion: '^11.0.0',
+    nestJsSchematicsVersion: '^11.0.0',
+    rxjsVersion: '^7.8.0',
+    reflectMetadataVersion: '^0.2.0',
   },
 };
 


### PR DESCRIPTION
## Current Behavior

NestJS 12.0.0 has been the `latest` tag on npm since 27 August 2026, and `@nx/nest` cannot be used with it.

The peer range stops below v12, so the install fails outright:

```
npm error code ERESOLVE
npm error peerOptional @nestjs/common@">=10.0.0 <12.0.0" from @nx/nest@23.2.0
npm error Conflicting peer dependency: @nestjs/common@11.2.3
```

`versions.ts` maps only major 10, so every other major falls through to the v11 constants. The resulting `package.json` contradicts itself:

```
@nestjs/core             ^12.0.1
@nestjs/platform-express ^11.0.0
@nestjs/schematics       ^11.0.0
@nestjs/testing          ^11.0.0
```

## Expected Behavior

`@nx/nest` installs next to NestJS 12, and each supported major keeps its own versions.

- The peer range moves to `>=10.0.0 <13.0.0`, one major above the newest supported one. This follows `@nx/cypress` (`>= 13 < 16` for majors 13 to 15) and `@nx/storybook` (`>=8.0.0 <11.0.0` for majors 8 to 10).
- v11 gains its own `versionMap` entry, so a v11 workspace stays on v11 once the fresh-install constants point at v12. v12 itself resolves through `latestVersions`, which is how `@nx/cypress` treats its newest major.
- The package's own `@nestjs/schematics` dependency becomes `>=11.0.0 <13.0.0` rather than `^12.0.0`. `@nestjs/schematics@12` requires TypeScript 6 and adds a `prettier` peer, and Nx still supports TypeScript 5. A range lets each workspace resolve the schematics major that matches its TypeScript.

`versions.spec.ts` is new. It asserts the complete version object for each major, so a major that silently borrows another one's `rxjs` or `reflect-metadata` fails the test.

Two things this PR does not do. `migrations.json` gains no v12 entry, since this only unblocks installation. And a workspace above the support window still falls back to the newest constants, which is the existing behavior in this package and in `@nx/cypress`.

## Related Issue(s)

Fixes #36936
