### PR TITLE
feat(nest): support NestJS v12 with per-major bundler and test-runner

### DIFF
--- a/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
@@ -23,13 +23,13 @@ The `@nx/nest` plugin supports the following NestJS package versions.
 
 | Package        | Supported Versions   |
 | -------------- | -------------------- |
-| `@nestjs/core` | ^10.0.0 \|\| ^11.0.0 |
+| `@nestjs/core` | ^10.0.0 \|\| ^11.0.0 \|\| ^12.0.0 |
 
-The plugin detects the installed `@nestjs/core` major and routes the rest of the `@nestjs/*` family (plus `rxjs` and `reflect-metadata`) to versions that pair with it. Fresh installs default to NestJS v11.
+The plugin detects the installed `@nestjs/core` major and routes the rest of the `@nestjs/*` family (plus `rxjs` and `reflect-metadata`) to versions that pair with it. Fresh installs default to NestJS v12.
 
 | Nx Version     | Default NestJS Version |
 | -------------- | ---------------------- |
-| 23.x (current) | ^11.0.0                |
+| 23.x (current) | ^12.0.0                |
 | 22.x           | ^11.0.0                |
 | 21.x           | ^11.0.0                |
 | 20.x           | ^10.0.0                |

--- a/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
@@ -21,8 +21,8 @@ Many conventions and best practices used in Angular applications can be also be 
 
 The `@nx/nest` plugin supports the following NestJS package versions.
 
-| Package        | Supported Versions   |
-| -------------- | -------------------- |
+| Package        | Supported Versions                |
+| -------------- | --------------------------------- |
 | `@nestjs/core` | ^10.0.0 \|\| ^11.0.0 \|\| ^12.0.0 |
 
 The plugin detects the installed `@nestjs/core` major and routes the rest of the `@nestjs/*` family (plus `rxjs` and `reflect-metadata`) to versions that pair with it. Fresh installs default to NestJS v12.

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -68,8 +68,8 @@
     "tslib": "catalog:typescript"
   },
   "peerDependencies": {
-    "@nestjs/core": ">=10.0.0 <12.0.0",
-    "@nestjs/common": ">=10.0.0 <12.0.0",
+    "@nestjs/core": ">=10.0.0 <13.0.0",
+    "@nestjs/common": ">=10.0.0 <13.0.0",
     "reflect-metadata": ">=0.1.0 <0.3.0",
     "rxjs": "^7.0.0"
   },

--- a/packages/nest/src/generators/application/lib/normalize-options.ts
+++ b/packages/nest/src/generators/application/lib/normalize-options.ts
@@ -6,6 +6,8 @@ import {
 import { isTypedLintingEnabled } from '@nx/eslint/internal';
 import { isUsingTsSolutionSetup, normalizeLinterOption } from '@nx/js/internal';
 import type { Schema as NodeApplicationGeneratorOptions } from '@nx/node/internal';
+import { getDefaultBundler } from '../../../utils/default-bundler';
+import { getDefaultUnitTestRunner } from '../../../utils/default-unit-test-runner';
 import type { ApplicationGeneratorOptions, NormalizedOptions } from '../schema';
 
 export async function normalizeOptions(
@@ -34,8 +36,9 @@ export async function normalizeOptions(
     appProjectName,
     appProjectRoot,
     linter: await normalizeLinterOption(tree, options.linter),
-    unitTestRunner: options.unitTestRunner ?? 'jest',
+    unitTestRunner: options.unitTestRunner ?? getDefaultUnitTestRunner(tree),
     e2eTestRunner: options.e2eTestRunner ?? 'jest',
+    bundler: options.bundler ?? getDefaultBundler(tree),
     useProjectJson: options.useProjectJson ?? !isUsingTsSolutionSetup(tree),
   };
 }
@@ -56,7 +59,7 @@ export function toNodeApplicationGeneratorOptions(
     e2eTestRunner: options.e2eTestRunner,
     enableTypedLinting: isTypedLintingEnabled(options),
     rootProject: options.rootProject,
-    bundler: 'webpack', // Some features require webpack plugins such as TS transformers
+    bundler: options.bundler,
     isNest: true,
     addPlugin: options.addPlugin,
     useProjectJson: options.useProjectJson,

--- a/packages/nest/src/generators/application/schema.d.ts
+++ b/packages/nest/src/generators/application/schema.d.ts
@@ -18,6 +18,7 @@ export interface ApplicationGeneratorOptions {
   setParserOptionsProject?: boolean;
   rootProject?: boolean;
   strict?: boolean;
+  bundler?: 'rspack' | 'webpack';
   addPlugin?: boolean;
   useTsSolution?: boolean;
   useProjectJson?: boolean;

--- a/packages/nest/src/generators/application/schema.json
+++ b/packages/nest/src/generators/application/schema.json
@@ -85,6 +85,12 @@
     "useProjectJson": {
       "type": "boolean",
       "description": "Use a `project.json` configuration file instead of inlining the Nx configuration in the `package.json` file."
+    },
+    "bundler": {
+      "description": "The bundler to use to build the application. Defaults to `rspack` for NestJS v12 and `webpack` for v10/v11; use `webpack` explicitly if the app relies on webpack-only build features (e.g. TypeScript compiler-based transformer plugins).",
+      "type": "string",
+      "enum": ["rspack", "webpack"],
+      "x-priority": "important"
     }
   },
   "additionalProperties": false,

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -11,6 +11,7 @@ import {
   normalizeLinterOption,
 } from '@nx/js/internal';
 import type { LibraryGeneratorSchema as JsLibraryGeneratorSchema } from '@nx/js/internal';
+import { getDefaultUnitTestRunner } from '../../../utils/default-unit-test-runner';
 import type { LibraryGeneratorOptions, NormalizedOptions } from '../schema';
 export async function normalizeOptions(
   tree: Tree,
@@ -62,7 +63,7 @@ export async function normalizeOptions(
     service: options.service ?? false,
     target: options.target ?? 'es6',
     testEnvironment: options.testEnvironment ?? 'node',
-    unitTestRunner: options.unitTestRunner ?? 'jest',
+    unitTestRunner: options.unitTestRunner ?? getDefaultUnitTestRunner(tree),
     isUsingTsSolutionsConfig,
     useProjectJson: options.useProjectJson ?? !isUsingTsSolutionsConfig,
   };

--- a/packages/nest/src/utils/default-bundler.ts
+++ b/packages/nest/src/utils/default-bundler.ts
@@ -1,0 +1,10 @@
+import type { Tree } from '@nx/devkit';
+import { major } from 'semver';
+import { getInstalledNestJsVersion } from './versions';
+
+// NestJS v12 recommends Rspack over Webpack; v10/v11 workspaces keep the
+// existing Webpack default so nothing changes under them.
+export function getDefaultBundler(tree: Tree): 'rspack' | 'webpack' {
+  const installed = getInstalledNestJsVersion(tree);
+  return installed && major(installed) >= 12 ? 'rspack' : 'webpack';
+}

--- a/packages/nest/src/utils/default-unit-test-runner.ts
+++ b/packages/nest/src/utils/default-unit-test-runner.ts
@@ -1,0 +1,10 @@
+import type { Tree } from '@nx/devkit';
+import { major } from 'semver';
+import { getInstalledNestJsVersion } from './versions';
+
+// NestJS v12 recommends Vitest over Jest; v10/v11 workspaces keep the
+// existing Jest default so nothing changes under them.
+export function getDefaultUnitTestRunner(tree: Tree): 'jest' | 'vitest' {
+  const installed = getInstalledNestJsVersion(tree);
+  return installed && major(installed) >= 12 ? 'vitest' : 'jest';
+}

--- a/packages/nest/src/utils/versions.ts
+++ b/packages/nest/src/utils/versions.ts
@@ -11,13 +11,13 @@ export const nxVersion = require(join('@nx/nest', 'package.json')).version;
 export const tsLibVersion = '^2.3.0';
 
 // NestJS has no public LTS table; cadence is roughly one major per year.
-// Support window: v10 + v11 (Rule 2 — N & N-1 — since v10.4.x still receives
+// Support window: v10 + v11 + v12 (Rule 2 — N & N-1 — since v10.4.x still receives
 // upstream patches).
 export const minSupportedNestJsVersion = '10.0.0';
 
 // Fresh-install constants — latest supported major.
-export const nestJsVersion = '^11.0.0';
-export const nestJsSchematicsVersion = '^11.0.0';
+export const nestJsVersion = '^12.0.0';
+export const nestJsSchematicsVersion = '^12.0.0';
 export const rxjsVersion = '^7.8.0';
 export const reflectMetadataVersion = '^0.2.0';
 
@@ -35,13 +35,25 @@ const latestVersions: NestJsVersions = {
   reflectMetadataVersion,
 };
 
-type CompatVersions = 10;
+type CompatVersions = 10 | 11 | 12;
 const versionMap: Record<CompatVersions, NestJsVersions> = {
   10: {
     nestJsVersion: '^10.0.2',
     nestJsSchematicsVersion: '^10.0.1',
     rxjsVersion: '^7.8.0',
     reflectMetadataVersion: '^0.1.13',
+  },
+  11: {
+    nestJsVersion: '^11.0.2',
+    nestJsSchematicsVersion: '^11.0.0',
+    rxjsVersion: '^7.8.0',
+    reflectMetadataVersion: '^0.2.0',
+  },
+  12: {
+    nestJsVersion: '^12.0.0',
+    nestJsSchematicsVersion: '^12.0.0',
+    rxjsVersion: '^7.8.0',
+    reflectMetadataVersion: '^0.2.0',
   },
 };
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -82,6 +82,7 @@
   "devDependencies": {
     "nx": "workspace:*",
     "@nx/webpack": "workspace:*",
+    "@nx/rspack": "workspace:*",
     "@nx/vitest": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -157,6 +157,19 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
         })
       );
     }
+  } else if (options.bundler === 'rspack' && !options.skipPackageJson) {
+    // The init generator has no `skipPackageJson` option, and it writes
+    // dependencies eagerly, so it's skipped entirely rather than only its
+    // install task when the caller asked not to touch package.json.
+    const { rspackInitGenerator } = ensurePackage<typeof import('@nx/rspack')>(
+      '@nx/rspack',
+      nxVersion
+    );
+    const rspackInitTask = await rspackInitGenerator(tree, {
+      framework: 'none',
+      addPlugin: options.addPlugin,
+    });
+    tasks.push(rspackInitTask);
   }
 
   addAppFiles(tree, options);

--- a/packages/node/src/generators/application/files/common/rspack.config.js__tmpl__
+++ b/packages/node/src/generators/application/files/common/rspack.config.js__tmpl__
@@ -1,0 +1,54 @@
+<%_ if (rspackPluginOptions) { _%>
+const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+const { join } = require('path');
+
+module.exports = {
+  output: {
+    path: join(__dirname, '<%= rspackPluginOptions.outputPath %>'),
+    clean: true,
+    ...(process.env.NODE_ENV !== 'production' && {
+      devtoolModuleFilenameTemplate: '[absolute-resource-path]',
+    }),
+  },
+  plugins: [
+    new NxAppRspackPlugin({
+      target: 'node',
+      main: '<%= rspackPluginOptions.main %>',
+      tsConfig: '<%= rspackPluginOptions.tsConfig %>',
+      assets: <%- JSON.stringify(rspackPluginOptions.assets) %>,
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: <%= rspackPluginOptions.generatePackageJson %>,
+      sourceMap: true,
+    })
+  ],
+};
+<%_ } else { _%>
+const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+const { join } = require('path');
+
+module.exports = {
+  target: 'node',
+  output: {
+    path: join(__dirname, '<%= offset %>dist/<%= rootProject ? name : root %>'),
+    clean: true,
+    ...(process.env.NODE_ENV !== 'production' && {
+      devtoolModuleFilenameTemplate: '[absolute-resource-path]',
+    }),
+  },
+  devtool: 'source-map',
+  plugins: [
+    new NxAppRspackPlugin({
+      target: 'node',
+      main: './src/main<%= js ? ".js" : ".ts" %>',
+      tsConfig: './tsconfig.app.json',
+      assets: ['./src/assets'],
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: true,
+      sourceMap: true,
+    }),
+    // Add plugins here, e.g. `new MyPlugin()`.
+  ],
+};
+<%_ } _%>

--- a/packages/node/src/generators/application/lib/add-dependencies.ts
+++ b/packages/node/src/generators/application/lib/add-dependencies.ts
@@ -29,6 +29,9 @@ export function addProjectDependencies(
       '@nx/esbuild': nxVersion,
       esbuild: esbuildVersion,
     },
+    rspack: {
+      '@nx/rspack': nxVersion,
+    },
   };
 
   const exprPkgVersions = expressVersions(tree);

--- a/packages/node/src/generators/application/lib/create-files.ts
+++ b/packages/node/src/generators/application/lib/create-files.ts
@@ -8,6 +8,7 @@ import {
 import { getRelativePathToRootTsConfig } from '@nx/js';
 import { join } from 'path';
 import { hasWebpackPlugin } from '../../../utils/has-webpack-plugin';
+import { hasRspackPlugin } from '../../../utils/has-rspack-plugin';
 import { addVSCodeDebugConfiguration } from '../../../utils/vscode-debug-config';
 import { NormalizedSchema } from './normalized-schema';
 
@@ -42,11 +43,30 @@ export function addAppFiles(tree: Tree, options: NormalizedSchema) {
               generatePackageJson: !options.isUsingTsSolutionConfig,
             }
           : null,
+      rspackPluginOptions:
+        hasRspackPlugin(tree) && options.addPlugin !== false
+          ? {
+              outputPath: options.isUsingTsSolutionConfig
+                ? 'dist'
+                : joinPathFragments(
+                    offsetFromRoot(options.appProjectRoot),
+                    'dist',
+                    options.rootProject ? options.name : options.appProjectRoot
+                  ),
+              main: './src/main' + (options.js ? '.js' : '.ts'),
+              tsConfig: './tsconfig.app.json',
+              assets: ['./src/assets'],
+              generatePackageJson: !options.isUsingTsSolutionConfig,
+            }
+          : null,
     }
   );
 
   if (options.bundler !== 'webpack') {
     tree.delete(joinPathFragments(options.appProjectRoot, 'webpack.config.js'));
+  }
+  if (options.bundler !== 'rspack') {
+    tree.delete(joinPathFragments(options.appProjectRoot, 'rspack.config.js'));
   }
 
   if (options.framework && options.framework !== 'none') {

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -16,11 +16,13 @@ import {
   type MatchedTargetRef,
 } from '@nx/js/internal';
 import { hasWebpackPlugin } from '../../../utils/has-webpack-plugin';
+import { hasRspackPlugin } from '../../../utils/has-rspack-plugin';
 import { NormalizedSchema } from './normalized-schema';
 import {
   getEsBuildConfig,
   getServeConfig,
   getWebpackBuildConfig,
+  getRspackBuildConfig,
   getPruneTargets,
 } from './create-targets';
 
@@ -57,6 +59,15 @@ export function addProject(
         ...pnpmDeployInputs,
       ]);
       project.targets.build = getWebpackBuildConfig(tree, project, options);
+      ensurePnpmDeployInputs(tree, options, project.targets.build);
+    }
+  } else if (options.bundler === 'rspack') {
+    if (!hasRspackPlugin(tree) && options.addPlugin === false) {
+      addBuildTargetDefaults(tree, `@nx/rspack:rspack`, 'build', [
+        TS_SOLUTION_SETUP_TSCONFIG_INPUT,
+        ...pnpmDeployInputs,
+      ]);
+      project.targets.build = getRspackBuildConfig(tree, project, options);
       ensurePnpmDeployInputs(tree, options, project.targets.build);
     }
   }

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -49,6 +49,42 @@ export function getWebpackBuildConfig(
   };
 }
 
+export function getRspackBuildConfig(
+  tree: Tree,
+  project: ProjectConfiguration,
+  options: NormalizedSchema
+): TargetConfiguration {
+  const sourceRoot = getProjectSourceRoot(project, tree);
+  return {
+    executor: `@nx/rspack:rspack`,
+    outputs: ['{options.outputPath}'],
+    defaultConfiguration: 'production',
+    options: {
+      target: 'node',
+      outputPath: options.outputPath,
+      main: joinPathFragments(
+        sourceRoot,
+        'main' + (options.js ? '.js' : '.ts')
+      ),
+      tsConfig: joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
+      assets: [joinPathFragments(sourceRoot, 'assets')],
+      rspackConfig: joinPathFragments(
+        options.appProjectRoot,
+        'rspack.config.js'
+      ),
+      generatePackageJson: options.isUsingTsSolutionConfig ? undefined : true,
+    },
+    configurations: {
+      development: {
+        outputHashing: 'none',
+      },
+      production: {
+        ...(options.docker && { generateLockfile: true }),
+      },
+    },
+  };
+}
+
 export function getEsBuildConfig(
   tree: Tree,
   project: ProjectConfiguration,

--- a/packages/node/src/generators/application/schema.d.ts
+++ b/packages/node/src/generators/application/schema.d.ts
@@ -20,7 +20,7 @@ export interface Schema {
    * @deprecated Use `enableTypedLinting` instead. This option will be removed in Nx v24.
    */
   setParserOptionsProject?: boolean;
-  bundler?: 'esbuild' | 'webpack';
+  bundler?: 'esbuild' | 'webpack' | 'rspack';
   framework?: NodeJsFrameWorks;
   port?: number;
   rootProject?: boolean;

--- a/packages/node/src/generators/application/schema.json
+++ b/packages/node/src/generators/application/schema.json
@@ -99,7 +99,7 @@
     "bundler": {
       "description": "Bundler which is used to package the application",
       "type": "string",
-      "enum": ["esbuild", "webpack"],
+      "enum": ["esbuild", "webpack", "rspack"],
       "default": "esbuild",
       "x-priority": "important"
     },

--- a/packages/node/src/utils/has-rspack-plugin.ts
+++ b/packages/node/src/utils/has-rspack-plugin.ts
@@ -1,0 +1,10 @@
+import { readNxJson, Tree } from '@nx/devkit';
+
+export function hasRspackPlugin(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  return !!nxJson.plugins?.some((p) =>
+    typeof p === 'string'
+      ? p === '@nx/rspack/plugin'
+      : p.plugin === '@nx/rspack/plugin'
+  );
+}


### PR DESCRIPTION
## Current Behavior

  `@nx/nest` only supports NestJS v10 and v11. Newly generated Nest apps always default to Jest and Webpack, and `@nx/node`'s application generator only supports `esbuild` and `webpack` as bundlers.

## Expected Behavior

  - `@nx/nest`'s supported NestJS peer range widens to v10–v12 (`>=10.0.0 <13.0.0`). Nothing already supported is dropped — v10 and v11 workspaces keep working exactly as before.
  - The **unit test runner** and **bundler** defaults for newly generated Nest apps/libs now depend on the NestJS major already installed in the workspace:
    - v10 / v11 (or nothing installed yet): unchanged — `jest` + `webpack`.
    - v12: defaults to `vitest` + `rspack`, matching NestJS's own v12 migration guide recommendation.
  - A new `bundler` option (`webpack` | `rspack`) is added to `@nx/nest`'s application generator so v12 projects can still opt back into `webpack` explicitly (e.g. for TypeScript compiler-based transformer plugins, which Rspack's SWC pipeline can't run).
  - `@nx/node`'s application generator gains `rspack` as a third `bundler` option (alongside the existing `esbuild`/`webpack`), mirroring the webpack integration end-to-end: build target (`@nx/rspack:rspack` executor), inferred-plugin detection, dependency installation, and a `rspack.config.js` template built on
  `NxAppRspackPlugin` (not the deprecated `composePlugins`/`withNx` helpers).
  - No existing installation is touched automatically — there is no `nx migrate` entry that bumps anyone's NestJS version. Users upgrade to v12 themselves; `@nx/nest` then simply recognizes it and adjusts scaffolding defaults for new code going forward.

  ## Related Issue(s)
- https://github.com/nrwl/nx/issues/36936
- https://github.com/nrwl/nx/issues/36913