### PR TITLE
fix(core): remove terminal output files during cache size eviction

### DIFF
--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -369,7 +369,10 @@ impl NxCache {
                     if let Ok((hash, size)) = row {
                         cache_size -= size;
                         db.execute("DELETE FROM cache_outputs WHERE hash = ?1", params![hash])?;
-                        remove_items(&[self.cache_path.join(&hash)])?;
+                        remove_items(&[
+                            self.cache_path.join(&hash),
+                            self.get_task_outputs_path_internal(&hash),
+                        ])?;
                     }
                     // We've deleted enough cache entries to be under the
                     // target cache size, stop looking for more.

--- a/packages/nx/src/native/tests/cache.spec.ts
+++ b/packages/nx/src/native/tests/cache.spec.ts
@@ -1,12 +1,13 @@
 import { TaskDetails, NxCache } from '../index';
 import { join } from 'path';
 import { TempFs } from '../../internal-testing-utils/temp-fs';
-import { rmSync } from 'fs';
+import { existsSync, rmSync } from 'fs';
 import { getDbConnection } from '../../utils/db-connection';
 import { randomBytes } from 'crypto';
 
 describe('Cache', () => {
   let cache: NxCache;
+  let dbConnection: ReturnType<typeof getDbConnection>;
   let tempFs: TempFs;
   let taskDetails: TaskDetails;
 
@@ -14,7 +15,7 @@ describe('Cache', () => {
   beforeEach(() => {
     tempFs = new TempFs('cache');
 
-    const dbConnection = getDbConnection({
+    dbConnection = getDbConnection({
       directory: join(__dirname, dbOutputFolder),
       dbName: `temp-db-${randomBytes(4).toString('hex')}`,
     });
@@ -68,5 +69,37 @@ describe('Cache', () => {
   it('should handle storing hashes that already exist in the cache', async () => {
     cache.put('123', 'output 123', ['dist'], 0);
     expect(() => cache.put('123', 'output 123', ['dist'], 0)).not.toThrow();
+  });
+
+  it('should remove terminal output files when evicting by cache size', () => {
+    taskDetails.recordTaskDetails([
+      {
+        hash: '456',
+        project: 'proj',
+        target: 'test',
+        configuration: 'production',
+      },
+    ]);
+    const limitedCache = new NxCache(
+      tempFs.tempDir,
+      join(tempFs.tempDir, '.cache'),
+      dbConnection,
+      undefined,
+      15
+    );
+
+    limitedCache.put('123', 'output 123', [], 0);
+    limitedCache.put('456', 'output 456', [], 0);
+
+    const hashes = ['123', '456'];
+    const cachedHashes = hashes.filter((hash) =>
+      existsSync(join(tempFs.tempDir, '.cache', hash))
+    );
+    const terminalOutputHashes = hashes.filter((hash) =>
+      existsSync(limitedCache.getTaskOutputsPath(hash))
+    );
+
+    expect(cachedHashes).toHaveLength(1);
+    expect(terminalOutputHashes).toEqual(cachedHashes);
   });
 });


### PR DESCRIPTION
## Current Behavior

Size-based cache eviction removes the cache entry and artifact directory but leaves its terminal output file in `terminalOutputs/`.

## Expected Behavior

Size eviction removes the terminal output together with the artifact directory, matching age-based cache cleanup. This is complementary to #36703, which records terminal outputs written without cache rows.

## Related Issue(s)

Fixes #36928

## Verification

- Added a native cache test that forces one eviction from two 10-byte entries and checks that terminal outputs remain only for surviving cache entries.
- `pnpm exec vitest run --config packages/nx/vitest.config.mts packages/nx/src/native/tests/cache.spec.ts`
