### PR TITLE
fix(maven): emit POSIX paths so the project graph builds on Windows

### DIFF
--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
@@ -229,13 +229,16 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
 
   private fun generateCreateNodesResults(inMemoryAnalyses: List<ProjectAnalysis>): JsonArray {
     val createNodesResults = JsonArray()
+    val pathFormatter = PathFormatter()
 
     // Build a deduplicated map of all external nodes across all projects
     val allExternalNodes = buildExternalNodes(inMemoryAnalyses)
 
     inMemoryAnalyses.forEach { analysis ->
       val resultTuple = JsonArray()
-      resultTuple.add(analysis.pomFile.canonicalFile.relativeTo(workspaceRoot).path) // Root path (workspace root)
+      resultTuple.add(pathFormatter.normalizeRelativePath(
+        analysis.pomFile.canonicalFile.relativeTo(workspaceRoot).path
+      )) // Root path (workspace root)
 
       val projects = JsonObject()
 

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/PathFormatter.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/PathFormatter.kt
@@ -13,7 +13,7 @@ class PathFormatter {
 
   fun toDependentTaskOutputs(path: File, projectRoot: File): DependentTaskOutputs {
     val relativePath = path.relativeTo(projectRoot)
-    return DependentTaskOutputs(relativePath.path)
+    return DependentTaskOutputs(relativePath.invariantSeparatorsPath)
   }
 
   fun formatOutputPath(path: File, projectRoot: File): String {
@@ -23,16 +23,22 @@ class PathFormatter {
   fun toProjectPath(path: File, projectRoot: File): String {
     val relativePath = path.relativeToOrSelf(projectRoot)
 
-    return "{projectRoot}/$relativePath"
+    return "{projectRoot}/${relativePath.invariantSeparatorsPath}"
   }
 
   fun toWorkspacePath(path: File, workspaceRoot: File): String {
     val relativePath = path.canonicalFile.relativeTo(workspaceRoot.canonicalFile)
 
-    return "{workspaceRoot}/$relativePath"
+    return "{workspaceRoot}/${relativePath.invariantSeparatorsPath}"
   }
 
-  fun normalizeRelativePath(path: String): String = path.takeIf { it.isNotEmpty() } ?: "."
+  /**
+   * Nx addresses projects and files with `/` on every platform, but Kotlin's
+   * relative-path APIs use the OS separator, so on Windows they yield
+   * `backend\common`. Emitting that makes Nx fail to resolve the project.
+   */
+  fun normalizeRelativePath(path: String): String =
+    path.replace('\\', '/').takeIf { it.isNotEmpty() } ?: "."
 }
 
 data class DependentTaskOutputs(val path: String, val transitive: Boolean = true)

--- a/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/utils/PathFormatterTest.kt
+++ b/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/utils/PathFormatterTest.kt
@@ -1,0 +1,51 @@
+package dev.nx.maven.utils
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+class PathFormatterTest {
+
+  private val pathFormatter = PathFormatter()
+
+  // Nx looks projects up by their `/`-separated root. A Windows-separated root
+  // misses that lookup and the project graph fails with
+  // `Source file "backend\common\pom.xml" does not exist in the workspace.`
+  @Test
+  fun `normalizeRelativePath converts Windows separators to forward slashes`() {
+    assertEquals("backend/common", pathFormatter.normalizeRelativePath("backend\\common"))
+    assertEquals(
+      "backend/common/pom.xml",
+      pathFormatter.normalizeRelativePath("backend\\common\\pom.xml")
+    )
+  }
+
+  @Test
+  fun `normalizeRelativePath leaves POSIX paths untouched`() {
+    assertEquals("backend/common", pathFormatter.normalizeRelativePath("backend/common"))
+  }
+
+  @Test
+  fun `normalizeRelativePath maps the workspace root itself to a dot`() {
+    assertEquals(".", pathFormatter.normalizeRelativePath(""))
+  }
+
+  @Test
+  fun `toProjectPath emits forward slashes for nested paths`() {
+    val projectRoot = File("root")
+    val target = File("root", "target${File.separator}classes")
+
+    assertEquals("{projectRoot}/target/classes", pathFormatter.toProjectPath(target, projectRoot))
+  }
+
+  @Test
+  fun `toDependentTaskOutputs emits forward slashes for nested paths`() {
+    val projectRoot = File("root")
+    val target = File("root", "target${File.separator}classes")
+
+    assertEquals(
+      "target/classes",
+      pathFormatter.toDependentTaskOutputs(target, projectRoot).path
+    )
+  }
+}

--- a/packages/maven/src/plugins/dependencies.spec.ts
+++ b/packages/maven/src/plugins/dependencies.spec.ts
@@ -1,0 +1,50 @@
+import { createDependencies } from './dependencies';
+import { getCurrentMavenData } from './maven-data-cache';
+import type { CreateDependenciesContext } from '@nx/devkit';
+
+jest.mock('./maven-data-cache');
+
+describe('createDependencies', () => {
+  const context = {
+    projects: {
+      'koala-common': { name: 'koala-common', root: 'backend/common' },
+    },
+  } as unknown as CreateDependenciesContext;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  // A cache written by an older plugin is keyed on project hashes alone, so it
+  // survives an upgrade and can still hold the Windows-separated paths that
+  // version emitted. Without normalizing on read, the project root misses the
+  // lookup and `sourceFile` fails validation against Nx's POSIX file map.
+  it('should resolve dependencies from OS-separated cached paths', async () => {
+    (getCurrentMavenData as jest.Mock).mockReturnValue({
+      createNodesResults: [],
+      createDependenciesResults: [
+        {
+          type: 'static',
+          source: 'backend\\common',
+          target: 'maven:org.springframework:spring-core',
+          sourceFile: 'backend\\common\\pom.xml',
+        },
+      ],
+    });
+
+    const dependencies = await createDependencies({}, context);
+
+    expect(dependencies).toEqual([
+      {
+        type: 'static',
+        source: 'koala-common',
+        target: 'maven:org.springframework:spring-core',
+        sourceFile: 'backend/common/pom.xml',
+      },
+    ]);
+  });
+
+  it('should return no dependencies when the analyzer produced no data', async () => {
+    (getCurrentMavenData as jest.Mock).mockReturnValue(null);
+
+    expect(await createDependencies({}, context)).toEqual([]);
+  });
+});

--- a/packages/maven/src/plugins/dependencies.ts
+++ b/packages/maven/src/plugins/dependencies.ts
@@ -1,4 +1,4 @@
-import { CreateDependencies, logger } from '@nx/devkit';
+import { CreateDependencies, logger, normalizePath } from '@nx/devkit';
 import { getCurrentMavenData } from './maven-data-cache';
 import { createProjectRootMappingsFromProjectConfigurations } from '@nx/devkit/internal';
 
@@ -31,17 +31,20 @@ export const createDependencies: CreateDependencies = async (
     context.projects
   );
 
-  // Extract and transform dependencies from the mavenData
+  // A cache written by an older plugin is keyed on project hashes alone, so it
+  // survives an upgrade and can still hold OS-separated paths. Normalize on
+  // read as well, or the graph keeps failing until the user runs `nx reset`.
   const transformedDependencies = mavenData.createDependenciesResults.map(
     (dep) => ({
       ...dep,
+      sourceFile: normalizePath(dep.sourceFile),
       source: dep.source.startsWith('maven:')
         ? dep.source
-        : rootToProjectMap.get(dep.source),
+        : rootToProjectMap.get(normalizePath(dep.source)),
       // External deps use maven: prefix — pass through as-is
       target: dep.target.startsWith('maven:')
         ? dep.target
-        : rootToProjectMap.get(dep.target),
+        : rootToProjectMap.get(normalizePath(dep.target)),
     })
   );
 

--- a/packages/maven/src/plugins/nodes.spec.ts
+++ b/packages/maven/src/plugins/nodes.spec.ts
@@ -1,0 +1,67 @@
+import { createNodes } from './nodes';
+import { runMavenAnalysis } from './maven-analyzer';
+import { readMavenCache, writeMavenCache } from './maven-data-cache';
+import { calculateHashesForCreateNodes } from '@nx/devkit/internal';
+import type { CreateNodesContext } from '@nx/devkit';
+
+jest.mock('./maven-analyzer');
+jest.mock('./maven-data-cache', () => ({
+  ...jest.requireActual('./maven-data-cache'),
+  readMavenCache: jest.fn(),
+  writeMavenCache: jest.fn(),
+}));
+jest.mock('@nx/devkit/internal', () => ({
+  ...jest.requireActual('@nx/devkit/internal'),
+  calculateHashesForCreateNodes: jest.fn(),
+}));
+
+describe('createNodes', () => {
+  const [, createNodesFn] = createNodes;
+
+  const workspaceRoot = '/workspace';
+  const context = { workspaceRoot } as CreateNodesContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (calculateHashesForCreateNodes as jest.Mock).mockResolvedValue(['hash']);
+    (readMavenCache as jest.Mock).mockReturnValue({
+      get: () => null,
+      set: jest.fn(),
+    });
+    (writeMavenCache as jest.Mock).mockImplementation(() => {});
+  });
+
+  // Nx resolves projects against a `/`-separated file map, so a config file
+  // spelled `backend\common\pom.xml` is never found and the graph fails with
+  // `Source file "backend\common\pom.xml" does not exist in the workspace.`
+  //
+  // The backslash below is a separator on Windows and a legal filename
+  // character on POSIX, so `relative` returns a Windows-separated path on
+  // either host and the assertion pins the conversion on both.
+  it('should emit config file paths with forward slashes', async () => {
+    (runMavenAnalysis as jest.Mock).mockResolvedValue({
+      createNodesResults: [
+        [
+          `${workspaceRoot}/backend\\common/pom.xml`,
+          { projects: { 'backend/common': { root: 'backend/common' } } },
+        ],
+      ],
+      createDependenciesResults: [],
+    });
+
+    const results = await createNodesFn(['pom.xml'], {}, context);
+
+    expect(results[0][0]).toBe('backend/common/pom.xml');
+  });
+
+  it('should return an empty result when the workspace has no root pom.xml', async () => {
+    const results = await createNodesFn(
+      ['backend/common/pom.xml'],
+      {},
+      context
+    );
+
+    expect(results).toEqual([]);
+    expect(runMavenAnalysis).not.toHaveBeenCalled();
+  });
+});

--- a/packages/maven/src/plugins/nodes.ts
+++ b/packages/maven/src/plugins/nodes.ts
@@ -1,4 +1,9 @@
-import { CreateNodesResultArray, CreateNodes, hashArray } from '@nx/devkit';
+import {
+  CreateNodesResultArray,
+  CreateNodes,
+  hashArray,
+  normalizePath,
+} from '@nx/devkit';
 import { calculateHashesForCreateNodes, hashObject } from '@nx/devkit/internal';
 import { dirname, relative } from 'path';
 import { DEFAULT_OPTIONS, MavenPluginOptions } from './types';
@@ -83,7 +88,8 @@ export const createNodes: CreateNodes<MavenPluginOptions> = [
       return mavenData.createNodesResults.map(
         ([configFile, createNodesResult]) => {
           return [
-            relative(context.workspaceRoot, configFile),
+            // `relative` yields OS separators; Nx addresses config files with `/`.
+            normalizePath(relative(context.workspaceRoot, configFile)),
             createNodesResult,
           ];
         }


### PR DESCRIPTION
## Current Behavior

On native Windows (no WSL), every `nx` command in a Maven workspace fails while the project graph is built:

```
NX   Failed to process project graph.
The "@nx/maven" plugin threw an error while creating dependencies:
Source file "backend\common\pom.xml" does not exist in the workspace.
```

Nx addresses projects and its file map with `/` on every platform, but `@nx/maven` produces paths with the OS separator at two independent points:

- **Kotlin analyzer** — `NxProjectAnalyzer` and `NxProjectAnalyzerMojo` build the project `root`, `sourceRoot` and each dependency's `sourceFile` from `File.relativeTo(...).path`, and `PathFormatter` builds `{projectRoot}/…` / `{workspaceRoot}/…` inputs and outputs the same way. `normalizeRelativePath` only mapped the empty string to `.` — it never touched separators, despite the name.
- **TypeScript plugin** — `createNodes` returns `relative(context.workspaceRoot, configFile)` unnormalized.

So on Windows the analyzer reports `backend\common` as a project root and `backend\common\pom.xml` as a dependency source file, the lookups against the POSIX file map miss, and `project-graph-builder` throws. Contributors on WSL never hit this, so a Maven workspace silently required WSL on Windows.

There is a third effect that makes fixing only the emit sites insufficient. The plugin cache is keyed on project file hashes and the plugin options alone — the plugin version is part of neither the key nor the cache file name (`maven-${optionsHash}.hash`). A cache written by the buggy version survives the upgrade, `createNodes` restores it via `setCurrentMavenData`, and `createDependencies` reads the stale OS-separated paths straight back out. Without normalizing on read, users would upgrade and still see the same error until they happened to run `nx reset`.

## Expected Behavior

Every path the plugin hands to Nx is `/`-separated, on every platform, whether it was just produced or restored from cache.

- `PathFormatter` uses `invariantSeparatorsPath`, and `normalizeRelativePath` now normalizes separators as its name implies.
- `NxProjectAnalyzerMojo.generateCreateNodesResults` routes the config file path through `normalizeRelativePath` (the sibling external-dependency branch already did).
- `createNodes` wraps `relative` in `normalizePath` — the same treatment [`@nx/gradle` already applies](https://github.com/nrwl/nx/blob/master/packages/gradle/src/plugin/nodes.ts) to its project roots.
- `createDependencies` normalizes `sourceFile` and the project-root lookups on read, covering the stale-cache path.

### Tests

Three new specs, each confirmed to fail with its fix reverted:

| Test | Reverted fix produces |
| --- | --- |
| `PathFormatterTest` (Kotlin) | `Expected <backend/common>, actual <backend\common>` |
| `nodes.spec.ts` | `Received: "backend\common/pom.xml"` |
| `dependencies.spec.ts` | `"sourceFile": "backend\\common\\pom.xml"` |

The assertions deliberately pin the *conversion* rather than the platform, because there is no Windows job in CI to run them on (`ci.yml` is ubuntu + macos; the Windows entries in `e2e-matrix.yml` and `nightly/process-matrix.ts` are commented out pending the gradle-wrapper fix). `dependencies.spec.ts` feeds Windows-separated paths in directly, and `nodes.spec.ts` uses a path whose backslash is a separator on Windows and a legal filename character on POSIX, so `relative` returns a Windows-separated path on either host. Both are therefore meaningful on the runners that actually exist.

Two of the five `PathFormatterTest` cases are the exception: `toProjectPath` and `toDependentTaskOutputs` take a `File`, and `invariantSeparatorsPath` is a no-op where `File.separatorChar` is already `/`, so those two only guard once a Windows runner is available. I kept them as the assertion of intent; the three string-based cases carry the actual coverage.

Verified locally on macOS: full `nx-maven-plugin` suite 22/22, `packages/maven/src/plugins` Jest 18/18. I have no Windows machine, so the end-to-end Windows run is unverified.

## Related Issue(s)

No existing issue found for this; related path-separator fixes in other plugins: #34680, #10122, #6968.