### PR TITLE
fix(maven): match gitignore rules against POSIX paths

### DIFF
--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/GitIgnoreClassifier.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/GitIgnoreClassifier.kt
@@ -109,9 +109,11 @@ class GitIgnoreClassifier(
         continue
       }
 
-      // Get path relative to this directory's .gitignore
+      // Get path relative to this directory's .gitignore.
+      // JGit matches gitignore patterns against `/`-separated paths, so the
+      // OS separator would make every nested rule miss on Windows.
       val relativePath = try {
-        path.relativeTo(directory).path
+        path.relativeTo(directory).invariantSeparatorsPath
       } catch (e: IllegalArgumentException) {
         continue
       }

--- a/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/GitIgnoreClassifierTest.kt
+++ b/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/GitIgnoreClassifierTest.kt
@@ -1,0 +1,38 @@
+package dev.nx.maven
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GitIgnoreClassifierTest {
+
+  @TempDir
+  lateinit var workspaceRoot: File
+
+  private fun write(relativePath: String, content: String): File {
+    val file = File(workspaceRoot, relativePath)
+    file.parentFile?.mkdirs()
+    file.writeText(content)
+    return file
+  }
+
+  // The rule is matched against the path relative to the .gitignore that
+  // declared it, so anything below the first level carries a separator.
+  @Test
+  fun `nested gitignore applies to a file below it`() {
+    write("module/.gitignore", "generated/\n")
+    val generated = write("module/generated/Api.java", "")
+
+    assertTrue(GitIgnoreClassifier(workspaceRoot).isIgnored(generated))
+  }
+
+  @Test
+  fun `tracked source file is not ignored`() {
+    write("module/.gitignore", "generated/\n")
+    val source = write("module/src/main/java/App.java", "")
+
+    assertFalse(GitIgnoreClassifier(workspaceRoot).isIgnored(source))
+  }
+}


### PR DESCRIPTION
## Current Behavior

`GitIgnoreClassifier.isIgnored` walks from a file up to the workspace root and, for each enclosing `.gitignore`, matches the file against that directory's rules using the path relative to it:

```kotlin
val relativePath = try {
  path.relativeTo(directory).path
} catch (e: IllegalArgumentException) {
  continue
}
...
if (rule.isMatch(relativePath, isDirectory))
```

`File.relativeTo(...).path` uses the OS separator, but JGit's `FastIgnoreRule` matches against `/`-separated paths. On Windows any rule that reaches past the first level — `generated/`, `**/dist/**` — is therefore compared against `module\generated\Api.java` and silently fails to match.

The classifier is not cosmetic: `MojoAnalyzer` uses it to decide whether a resolved mojo path becomes a literal input or a `DependentTaskOutputs` entry. A missed match puts generated files into a task's inputs.

## Expected Behavior

Rules are matched against `/`-separated paths on every platform, so nested gitignore rules apply on Windows as they already do elsewhere.

### Tests

`GitIgnoreClassifier` had no tests; this adds the first two, covering the nested-rule path that carries a separator and the negative case.

I want to be straightforward about their limits: `invariantSeparatorsPath` is a no-op where `File.separatorChar` is already `/`, so these tests assert the intended behavior rather than mechanically guarding the change on the runners that exist today — `ci.yml` is ubuntu + macos, and the Windows entries in `e2e-matrix.yml` and `nightly/process-matrix.ts` are commented out pending the gradle-wrapper fix. Constructing a `File` with a Windows separator on POSIX is not possible, so there is no way to make them platform-independent. They will guard the change if a Windows runner returns.

Verified locally on macOS: full `nx-maven-plugin` suite 19/19.

## Related Issue(s)

Same defect class as #36941 (project graph fails to build on Windows), but an independent code path — the two PRs touch disjoint files and can merge in either order.