### PR TITLE
fix(core): hide Windows consoles for task and plugin workers

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -6,7 +6,7 @@ import {
   interpolate,
 } from '@nx/devkit/internal';
 import chalk from 'chalk';
-import { ChildProcess, fork } from 'child_process';
+import { ChildProcess, fork, ForkOptions, SpawnOptions } from 'child_process';
 import {
   ExecutorContext,
   isDaemonEnabled,
@@ -183,10 +183,9 @@ export async function* nodeExecutor(
                 ? 'node-with-esm-loader'
                 : 'node-with-require-overrides';
 
-            task.childProcess = fork(
-              join(__dirname, loaderFile),
-              options.args ?? [],
+            const forkOptions: ForkOptions & Pick<SpawnOptions, 'windowsHide'> =
               {
+                windowsHide: true,
                 execArgv: getExecArgv(options),
                 stdio: [0, 'pipe', 'pipe', 'ipc'],
                 env: {
@@ -194,7 +193,11 @@ export async function* nodeExecutor(
                   NX_FILE_TO_RUN: fileToRunCorrectPath(fileToRun),
                   NX_MAPPINGS: JSON.stringify(mappings),
                 },
-              }
+              };
+            task.childProcess = fork(
+              join(__dirname, loaderFile),
+              options.args ?? [],
+              forkOptions
             );
 
             task.childProcess.stdout?.on('data', (data) => {
@@ -308,6 +311,11 @@ export async function* nodeExecutor(
       const runBuild = async () => {
         let childProcess: ChildProcess = null;
         const whenReady = new Promise<{ success: boolean }>(async (resolve) => {
+          const forkOptions: ForkOptions & Pick<SpawnOptions, 'windowsHide'> = {
+            windowsHide: true,
+            cwd: context.root,
+            stdio: 'inherit',
+          };
           childProcess = fork(
             require.resolve('nx/bin/nx.js'),
             [
@@ -316,10 +324,7 @@ export async function* nodeExecutor(
                 buildTarget.configuration ? `:${buildTarget.configuration}` : ''
               }`,
             ],
-            {
-              cwd: context.root,
-              stdio: 'inherit',
-            }
+            forkOptions
           );
           childProcess.once('exit', (code) => {
             if (code === 0) resolve({ success: true });

--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -1,6 +1,12 @@
 import { ExecutorContext, logger } from '@nx/devkit';
 import { signalToCode, readModulePackageJson } from '@nx/devkit/internal';
-import { ChildProcess, execSync, fork } from 'child_process';
+import {
+  ChildProcess,
+  execSync,
+  fork,
+  ForkOptions,
+  SpawnOptions,
+} from 'child_process';
 import detectPort from 'detect-port';
 import { existsSync, rmSync } from 'node:fs';
 import { dirname, join, resolve } from 'path';
@@ -96,19 +102,19 @@ function startVerdaccio(
   workspaceRoot: string
 ) {
   return new Promise((resolve, reject) => {
+    const forkOptions: ForkOptions & Pick<SpawnOptions, 'windowsHide'> = {
+      windowsHide: true,
+      env: {
+        ...process.env,
+        VERDACCIO_HANDLE_KILL_SIGNALS: 'true',
+        ...(options.storage ? { VERDACCIO_STORAGE_PATH: options.storage } : {}),
+      },
+      stdio: 'inherit',
+    };
     childProcess = fork(
       getVerdaccioBinPath(),
       createVerdaccioOptions(options, workspaceRoot),
-      {
-        env: {
-          ...process.env,
-          VERDACCIO_HANDLE_KILL_SIGNALS: 'true',
-          ...(options.storage
-            ? { VERDACCIO_STORAGE_PATH: options.storage }
-            : {}),
-        },
-        stdio: 'inherit',
-      }
+      forkOptions
     );
 
     childProcess.on('error', (err) => {

--- a/packages/js/src/plugins/jest/start-local-registry.ts
+++ b/packages/js/src/plugins/jest/start-local-registry.ts
@@ -1,5 +1,5 @@
 import { signalToCode } from '@nx/devkit/internal';
-import { execSync, fork } from 'child_process';
+import { execSync, fork, ForkOptions, SpawnOptions } from 'child_process';
 
 /**
  * This function is used to start a local registry for testing purposes.
@@ -27,6 +27,10 @@ export function startLocalRegistry({
     throw new Error(`localRegistryTarget is required`);
   }
   return new Promise<() => void>((resolve, reject) => {
+    const forkOptions: ForkOptions & Pick<SpawnOptions, 'windowsHide'> = {
+      stdio: 'pipe',
+      windowsHide: true,
+    };
     const childProcess = fork(
       require.resolve('nx/bin/nx'),
       [
@@ -35,7 +39,7 @@ export function startLocalRegistry({
         }`.split(' '),
         ...(storage ? [`--storage`, storage] : []),
       ],
-      { stdio: 'pipe' }
+      forkOptions
     );
 
     const listener = (data) => {

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -2180,6 +2180,7 @@ async function getPackageMigrationsUsingInstallImpl(
     const addCommand = `${pmc.add} ${packageName}@${packageVersion}`;
     try {
       await execAsync(addCommand, {
+        windowsHide: true,
         cwd: dir,
         env: {
           ...process.env,

--- a/packages/nx/src/tasks-runner/fork.ts
+++ b/packages/nx/src/tasks-runner/fork.ts
@@ -1,4 +1,4 @@
-import { fork, Serializable } from 'child_process';
+import { fork, ForkOptions, Serializable, SpawnOptions } from 'child_process';
 import { join } from 'path';
 import { PseudoIPCClient } from './pseudo-ipc';
 import { signalToCode } from '../utils/exit-codes';
@@ -14,11 +14,13 @@ if (process.env['NX_PSEUDO_TERMINAL_EXEC_ARGV']) {
   delete process.env['NX_PSEUDO_TERMINAL_EXEC_ARGV'];
 }
 
-const childProcess = fork(script, {
+const forkOptions: ForkOptions & Pick<SpawnOptions, 'windowsHide'> = {
+  windowsHide: true,
   stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
   env: process.env,
   execArgv,
-});
+};
+const childProcess = fork(script, forkOptions);
 
 const pseudoIPC = new PseudoIPCClient(pseudoIPCPath);
 

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -1,4 +1,4 @@
-import { fork, Serializable } from 'child_process';
+import { fork, ForkOptions, Serializable, SpawnOptions } from 'child_process';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { ProjectGraph } from '../config/project-graph';
@@ -68,13 +68,15 @@ export class ForkedProcessTaskRunner {
       output.logCommand(args.join(' '));
     }
 
-    const p = fork(workerPath, {
+    const forkOptions: ForkOptions & Pick<SpawnOptions, 'windowsHide'> = {
+      windowsHide: true,
       stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
       env: {
         ...env,
         NX_FORKED_TASK_EXECUTOR: 'true',
       },
-    });
+    };
+    const p = fork(workerPath, forkOptions);
 
     // Register batch worker process with all tasks
     if (p.pid) {
@@ -284,13 +286,15 @@ export class ForkedProcessTaskRunner {
         output.logCommand(args.join(' '));
       }
 
-      const p = fork(this.cliPath, {
+      const forkOptions: ForkOptions & Pick<SpawnOptions, 'windowsHide'> = {
+        windowsHide: true,
         stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
         env: {
           ...env,
           NX_FORKED_TASK_EXECUTOR: 'true',
         },
-      });
+      };
+      const p = fork(this.cliPath, forkOptions);
 
       // Register forked process for metrics collection
       if (p.pid) {
@@ -350,13 +354,15 @@ export class ForkedProcessTaskRunner {
       if (streamOutput) {
         output.logCommand(args.join(' '));
       }
-      const p = fork(this.cliPath, {
+      const forkOptions: ForkOptions & Pick<SpawnOptions, 'windowsHide'> = {
+        windowsHide: true,
         stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
         env: {
           ...env,
           NX_FORKED_TASK_EXECUTOR: 'true',
         },
-      });
+      };
+      const p = fork(this.cliPath, forkOptions);
 
       // Register forked process for metrics collection
       if (p.pid) {


### PR DESCRIPTION
## Current Behavior

Several Node child-process launches omit `windowsHide`, allowing separate console windows to appear when Nx runs under a Windows host without an attached console. The daemon and isolated plugin launchers already hide their windows, but that option does not apply automatically to descendants.

## Expected Behavior

Task/batch workers, the pseudo-terminal executor wrapper, migration package installation, and the `@nx/js` Node/build and local-registry workers explicitly set `windowsHide: true`. Existing arguments, environment variables, stdio and IPC are preserved.

This covers nine launches across six files. It does not change Vite, Vitest, Stryker, or third-party workspace hooks.

Node forwards fork options to spawn at runtime, but the current Node typings omit `windowsHide` from `ForkOptions`. The fork launches use local options typed as `ForkOptions & Pick<SpawnOptions, 'windowsHide'>` so the additional option is checked without a type assertion.

## Validation

- Formatted all six changed files with the repository's oxfmt 0.60.0 and passed `git diff --check`.
- TypeScript transpilation passed for all changed files.
- All eight extracted fork declarations and calls passed a focused semantic check against `@types/node` 24.12.3. A control using the original inline literals caught all eight excess-property errors.
- A temporary Windows smoke harness exercised the edited task-runner source with real Node child processes and existing Nx 23.2.0 supporting modules. Piped/inherited stdout and stderr, environment forwarding, task exit status, and batch IPC results all passed.
- Full upstream validation remains unverified: the frozen dependency install repeatedly retried npm registry requests with error (23) and was stopped while incomplete. `pnpm nx prepush` was attempted but failed before checks because `.modules.yaml` and workspace plugin dependencies were unavailable.

## Related Issue(s)

No linked issue. These omissions were identified while investigating Windows console popups; the individual Nx launch sites have not all been independently reproduced as visible-window sources.

Generated with Codex.
