### PR TITLE
fix(core): carry pnpm's package-manager document into the pruned lockfile

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2400,6 +2400,142 @@ snapshots:
       });
       expect(nodes['npm:pnpm']).toBeUndefined();
     });
+
+    it('should carry the package-manager document into the pruned lockfile', () => {
+      const envDocument = `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-pnpm-metadata}
+`;
+      const lockFile = `---
+${envDocument}
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-lodash}
+
+snapshots:
+
+  lodash@4.17.21: {}
+`;
+
+      const packageJson = {
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: { lodash: '^4.17.21' },
+      };
+      const graph: ProjectGraph = {
+        nodes: {},
+        dependencies: {},
+        externalNodes: {
+          'npm:lodash': {
+            type: 'npm',
+            name: 'npm:lodash',
+            data: {
+              version: '4.17.21',
+              packageName: 'lodash',
+              hash: 'sha512-lodash',
+            },
+          },
+        },
+      };
+
+      const result = stringifyPnpmLockfile(
+        pruneProjectGraph(graph, packageJson),
+        lockFile,
+        packageJson,
+        '/virtual'
+      );
+
+      expect(result.startsWith(`---\n${envDocument}\n---\n`)).toBe(true);
+      expect(result).toContain('packageManagerDependencies');
+      expect(result.slice(`---\n${envDocument}\n---\n`.length)).toEqual(
+        stringifyPnpmLockfile(
+          pruneProjectGraph(graph, packageJson),
+          lockFile.slice(`---\n${envDocument}\n---\n`.length),
+          packageJson,
+          '/virtual'
+        )
+      );
+    });
+
+    it('should leave a single-document lockfile unchanged', () => {
+      const lockFile = `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-lodash}
+
+snapshots:
+
+  lodash@4.17.21: {}
+`;
+      const packageJson = {
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: { lodash: '^4.17.21' },
+      };
+      const graph: ProjectGraph = {
+        nodes: {},
+        dependencies: {},
+        externalNodes: {
+          'npm:lodash': {
+            type: 'npm',
+            name: 'npm:lodash',
+            data: {
+              version: '4.17.21',
+              packageName: 'lodash',
+              hash: 'sha512-lodash',
+            },
+          },
+        },
+      };
+
+      const result = stringifyPnpmLockfile(
+        pruneProjectGraph(graph, packageJson),
+        lockFile,
+        packageJson,
+        '/virtual'
+      );
+
+      expect(result.startsWith('---')).toBe(false);
+      expect(result).not.toContain('packageManagerDependencies');
+    });
   });
 
   describe('patched dependencies', () => {

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -5,7 +5,9 @@ import type {
   ProjectSnapshot,
 } from '@pnpm/lockfile-types';
 import {
+  extractEnvLockfileDocument,
   isV5Syntax,
+  joinPnpmLockfileDocuments,
   loadPnpmHoistedDepsDefinition,
   parseAndNormalizePnpmLockfile,
   stringifyToPnpmYaml,
@@ -927,7 +929,10 @@ export function stringifyPnpmLockfile(
 
   stripStandaloneLockfileConfig(output);
 
-  return stringifyToPnpmYaml(output);
+  return joinPnpmLockfileDocuments(
+    extractEnvLockfileDocument(rootLockFileContent),
+    stringifyToPnpmYaml(output)
+  );
 }
 
 /**

--- a/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
@@ -88,6 +88,34 @@ export function extractMainLockfileDocument(content: string): string {
   return content.slice(separatorIndex + YAML_DOCUMENT_SEPARATOR.length);
 }
 
+// The package-manager document (`packageManagerDependencies`) must ship with a
+// pruned lockfile whenever the pruned manifest keeps `packageManager`: pnpm
+// refuses a frozen install when the pin is not recorded in the lockfile.
+export function extractEnvLockfileDocument(content: string): string | null {
+  content = content.replace(/\r\n/g, '\n');
+  if (!content.startsWith(YAML_DOCUMENT_START)) {
+    return null;
+  }
+  const separatorIndex = content.indexOf(
+    YAML_DOCUMENT_SEPARATOR,
+    YAML_DOCUMENT_START.length
+  );
+  if (separatorIndex === -1) {
+    return null;
+  }
+  return content.slice(YAML_DOCUMENT_START.length, separatorIndex);
+}
+
+export function joinPnpmLockfileDocuments(
+  envDocument: string | null,
+  mainDocument: string
+): string {
+  if (envDocument === null) {
+    return mainDocument;
+  }
+  return `${YAML_DOCUMENT_START}${envDocument}${YAML_DOCUMENT_SEPARATOR}${mainDocument}`;
+}
+
 // https://github.com/pnpm/pnpm/blob/50e37072f42bcca6d393a74bed29f7f0e029805d/lockfile/lockfile-file/src/write.ts#L22
 const LOCKFILE_YAML_FORMAT = {
   blankLines: true,


### PR DESCRIPTION
## Current Behavior

When the root `package.json` pins pnpm ≥ 12 via `packageManager`, pnpm writes a two-document `pnpm-lock.yaml`: the first document records the pin under `packageManagerDependencies`, the second is the workspace lockfile.

`generatePackageJson` keeps `packageManager` in the pruned `package.json` but emits only the second document in the pruned lockfile. pnpm then sees an unrecorded pin and a frozen install in the pruned output aborts:

```
ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE
Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date
```

This breaks the documented Docker flow of copying `dist/apps/<app>/{package.json,pnpm-lock.yaml}` and running `pnpm install --prod --frozen-lockfile`. Observed with Nx 23.1.0, pnpm 12.3.4, Node 24 on Linux (macOS pnpm silently writes the missing document even in frozen mode). Workaround: `--config.pm-on-fail=ignore`.

## Expected Behavior

The pruned `pnpm-lock.yaml` carries the package-manager document through verbatim, so the pin recorded in the pruned `package.json` is also recorded in the pruned lockfile and a frozen install succeeds.

Changes:

- `pnpm-normalizer.ts`: add `extractEnvLockfileDocument` (the counterpart of `extractMainLockfileDocument`) and `joinPnpmLockfileDocuments`, which re-emit the first document using pnpm's own document markers.
- `pnpm-parser.ts`: `stringifyPnpmLockfile` prepends the env document when the root lockfile has one. Single-document lockfiles are unchanged.
- `pnpm-parser.spec.ts`: covers both the two-document and the single-document case.

The env document describes the package manager, not dependencies, so pruning does not apply to it. Dropping `packageManager` from the pruned manifest instead was considered and rejected, since consumers read it to pick the pnpm version to install.

Verification: `pnpm-parser.spec.ts` passes (78 tests), `tsc` on `packages/nx` is clean, and eslint/oxfmt/commit-lint pass. The full `nx prepush` could not run on the author's machine because the project graph needs dotnet and a Java 24 toolchain that are not installed there.

## Related Issue(s)

No existing issue was found for this; the problem is described in full above.
