### PR TITLE
feat(nx-cloud): add nx cloud demo link to cloud prompts

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
@@ -2,6 +2,7 @@ import {
   isEnterpriseCloudUrl,
   getBannerVariant,
   getFlowVariant,
+  NX_CLOUD_DEMO_HYPERLINK,
   NX_CLOUD_HYPERLINK,
   NX_CLOUD_URL,
   PromptMessages,
@@ -178,6 +179,17 @@ describe('NX_CLOUD_HYPERLINK', () => {
 
     expect(link).toBe(url);
   });
+
+  it('points the demo link at the demo with the same attribution', () => {
+    process.env.FORCE_HYPERLINK = '1';
+    const { NX_CLOUD_DEMO_HYPERLINK: link, NX_CLOUD_DEMO_URL: url } =
+      jest.requireActual('./ab-testing') as typeof import('./ab-testing');
+
+    expect(link).toContain(`${BEL}${url}${OSC}`);
+    expect(link).toContain(
+      `${url}?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=create-nx-workspace`
+    );
+  });
 });
 
 describe('cloud prompt footers', () => {
@@ -201,6 +213,7 @@ describe('cloud prompt footers', () => {
     (key) => {
       const { footer } = new PromptMessages().getPrompt(key);
       expect(footer).toContain(NX_CLOUD_HYPERLINK);
+      expect(footer).toContain(NX_CLOUD_DEMO_HYPERLINK);
     }
   );
 });

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -14,6 +14,10 @@ import { terminalLink } from '../terminal-link';
 import type { BannerVariant, CompletionMessageKey } from './messages';
 
 export const NX_CLOUD_URL = 'https://nx.dev/nx-cloud';
+export const NX_CLOUD_DEMO_URL = 'https://cloud.nx.app/demo/intro';
+
+const UTM_QUERY =
+  '?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=create-nx-workspace';
 
 /**
  * Clickable Nx Cloud marketing link for cloud prompt footers. Every
@@ -24,7 +28,13 @@ export const NX_CLOUD_URL = 'https://nx.dev/nx-cloud';
  */
 export const NX_CLOUD_HYPERLINK = terminalLink(
   NX_CLOUD_URL,
-  `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=create-nx-workspace`
+  `${NX_CLOUD_URL}${UTM_QUERY}`
+);
+
+/** Same as `NX_CLOUD_HYPERLINK`, pointing at the Nx Cloud demo (CLOUD-4640). */
+export const NX_CLOUD_DEMO_HYPERLINK = terminalLink(
+  NX_CLOUD_DEMO_URL,
+  `${NX_CLOUD_DEMO_URL}${UTM_QUERY}`
 );
 
 // Flow variant controls both tracking and banner display (CLOUD-4235)
@@ -196,7 +206,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'circleci', name: 'Circle CI\n' },
         { value: 'skip', name: 'Do it later' },
       ],
-      footer: `\nSelf-healing CI, remote caching, and task distribution are provided by Nx Cloud: ${NX_CLOUD_HYPERLINK}`,
+      footer: `\nSelf-healing CI, remote caching, and task distribution are provided by Nx Cloud: ${NX_CLOUD_HYPERLINK}\nSee it in action: ${NX_CLOUD_DEMO_HYPERLINK}`,
       fallback: { value: 'skip', key: 'setupNxCloud' },
       completionMessage: 'ci-setup',
     },
@@ -214,7 +224,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'yes', name: 'Yes' },
         { value: 'skip', name: 'Skip' },
       ],
-      footer: `\nAutomatically fix broken PRs, 70% faster CI: ${NX_CLOUD_HYPERLINK}`,
+      footer: `\nAutomatically fix broken PRs, 70% faster CI: ${NX_CLOUD_HYPERLINK}\nSee it in action: ${NX_CLOUD_DEMO_HYPERLINK}`,
       fallback: undefined,
       completionMessage: 'platform-setup',
     },
@@ -232,7 +242,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'skip', name: 'Skip for now' },
         { value: 'never', name: chalk.dim("No, don't ask again") },
       ],
-      footer: `\nFree for small teams. Remote caching and task distribution. 2-minute setup: ${NX_CLOUD_HYPERLINK}`,
+      footer: `\nFree for small teams. Remote caching and task distribution. 2-minute setup: ${NX_CLOUD_HYPERLINK}\nSee it in action: ${NX_CLOUD_DEMO_HYPERLINK}`,
       fallback: undefined,
       completionMessage: 'platform-setup',
     },

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -19,6 +19,7 @@ import {
   MessageOptionKey,
   recordStat,
   messages,
+  nxCloudDemoHyperlink,
   nxCloudHyperlink,
 } from '../../../utils/ab-testing';
 import { nxVersion } from '../../../utils/versions';
@@ -313,7 +314,11 @@ async function nxCloudPrompt(
   const { message, choices, initial, footer, hint } = messages.getPrompt(key);
 
   // No separate footer/hint slot, so both are folded into the message.
-  const suffix = [hint, footer && `${footer} ${nxCloudHyperlink(utmContent)}`]
+  const suffix = [
+    hint,
+    footer && `${footer} ${nxCloudHyperlink(utmContent)}`,
+    `See it in action: ${nxCloudDemoHyperlink(utmContent)}`,
+  ]
     .filter(Boolean)
     .map((t) => pc.dim(t));
 

--- a/packages/nx/src/utils/ab-testing.spec.ts
+++ b/packages/nx/src/utils/ab-testing.spec.ts
@@ -1,4 +1,9 @@
-import { NX_CLOUD_URL, nxCloudHyperlink } from './ab-testing';
+import {
+  NX_CLOUD_DEMO_URL,
+  NX_CLOUD_URL,
+  nxCloudDemoHyperlink,
+  nxCloudHyperlink,
+} from './ab-testing';
 
 describe('nxCloudHyperlink', () => {
   const BEL = '\u0007';
@@ -32,5 +37,18 @@ describe('nxCloudHyperlink', () => {
   it('falls back to the bare URL when hyperlinks are unsupported', () => {
     process.env.FORCE_HYPERLINK = '0';
     expect(nxCloudHyperlink('nx-migrate')).toBe(NX_CLOUD_URL);
+  });
+
+  it('points the demo link at the demo with the same attribution', () => {
+    process.env.FORCE_HYPERLINK = '1';
+    const link = nxCloudDemoHyperlink('nx-migrate');
+
+    expect(link).toContain(`${BEL}${NX_CLOUD_DEMO_URL}${OSC}`);
+    expect(link).toContain(
+      `${NX_CLOUD_DEMO_URL}?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=nx-migrate`
+    );
+
+    process.env.FORCE_HYPERLINK = '0';
+    expect(nxCloudDemoHyperlink('nx-migrate')).toBe(NX_CLOUD_DEMO_URL);
   });
 });

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -6,6 +6,7 @@ import { terminalLink } from './terminal-link';
 import * as pc from 'picocolors';
 
 export const NX_CLOUD_URL = 'https://nx.dev/nx-cloud';
+export const NX_CLOUD_DEMO_URL = 'https://cloud.nx.app/demo/intro';
 
 /**
  * Clickable Nx Cloud marketing link for cloud prompt footers. The visible text
@@ -15,8 +16,19 @@ export const NX_CLOUD_URL = 'https://nx.dev/nx-cloud';
  * different commands.
  */
 export function nxCloudHyperlink(utmContent: string): string {
-  const tracked = `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=${utmContent}`;
-  return terminalLink(NX_CLOUD_URL, tracked);
+  return trackedHyperlink(NX_CLOUD_URL, utmContent);
+}
+
+/** Same as `nxCloudHyperlink`, pointing at the Nx Cloud demo (CLOUD-4640). */
+export function nxCloudDemoHyperlink(utmContent: string): string {
+  return trackedHyperlink(NX_CLOUD_DEMO_URL, utmContent);
+}
+
+function trackedHyperlink(url: string, utmContent: string): string {
+  return terminalLink(
+    url,
+    `${url}?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=${utmContent}`
+  );
 }
 
 /**


### PR DESCRIPTION
## Current Behavior

Cloud prompt footers in `nx init`, `nx migrate`, and `create-nx-workspace` link only to the nx.dev marketing page.

## Expected Behavior

Footers keep that link and add a "See it in action" line pointing at https://cloud.nx.app/demo/intro, with the same UTM params as the existing link.

```
Speed up GitHub Actions, GitLab CI, and more with Nx Cloud?
Free for small teams. Remote caching and task distribution. 2-minute setup: https://nx.dev/nx-cloud
See it in action: https://cloud.nx.app/demo/intro
```

<img width="868" height="216" alt="image" src="https://github.com/user-attachments/assets/bdc63194-ddd3-4290-8444-31740f735ede" />


## Related Issue(s)

CLOUD-4640

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/eager-swan-03b3b475">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->