### PR TITLE
docs(misc): cover oxlint on the module boundaries pages

### DIFF
--- a/astro-docs/src/assets/features/module-boundaries-violation.svg
+++ b/astro-docs/src/assets/features/module-boundaries-violation.svg
@@ -1,0 +1,20 @@
+<svg width="730" height="170" viewBox="0 0 730 170" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">
+<defs>
+<marker id="arrow-gray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M1 1L9 5L1 9" stroke="#94A3B8" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></marker>
+<marker id="arrow-rose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M1 1L9 5L1 9" stroke="#F43F5E" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></marker>
+</defs>
+<rect x="150" y="20" width="110" height="50" rx="8" fill="#94A3B8"/>
+<text x="205" y="42" text-anchor="middle" font-size="15" fill="white">client</text>
+<text x="205" y="60" text-anchor="middle" font-size="11" fill="white" fill-opacity="0.85">scope:client</text>
+<rect x="470" y="20" width="110" height="50" rx="8" fill="#94A3B8"/>
+<text x="525" y="42" text-anchor="middle" font-size="15" fill="white">admin</text>
+<text x="525" y="60" text-anchor="middle" font-size="11" fill="white" fill-opacity="0.85">scope:admin</text>
+<rect x="310" y="100" width="110" height="50" rx="8" fill="#F43F5E"/>
+<text x="365" y="122" text-anchor="middle" font-size="15" fill="white">utils</text>
+<text x="365" y="140" text-anchor="middle" font-size="11" fill="white" fill-opacity="0.85">scope:shared</text>
+<path d="M205 72V100C205 114 215 125 235 125H308" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow-gray)"/>
+<path d="M525 72V100C525 114 515 125 495 125H422" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow-gray)"/>
+<path d="M355 98Q355 45 264 45" stroke="#F43F5E" stroke-width="3" stroke-linecap="round" stroke-dasharray="8 8" marker-end="url(#arrow-rose)"/>
+<circle cx="332" cy="58" r="11" fill="#F43F5E"/>
+<path d="M327.5 53.5L336.5 62.5M336.5 53.5L327.5 62.5" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -19,7 +19,7 @@ title="Applying Module Boundaries"
 
 Nx offers two complementary approaches to enforce module boundaries:
 
-**Lint rule integration** - For JavaScript/TypeScript projects, enforce boundaries on code imports using the `@nx/enforce-module-boundaries` rule. This checks TypeScript imports and `package.json` dependencies during linting. The rule runs on ESLint and Oxlint.
+**Lint rule integration** - For JavaScript/TypeScript projects, enforce boundaries on code imports with a lint rule for ESLint or Oxlint. This checks TypeScript imports and `package.json` dependencies during linting.
 
 **Language-Agnostic Conformance** - For any project type (e.g. Java, Python, PHP, JavaScript, etc.), use the [Conformance plugin's Enforce Project Boundaries rule](/docs/enterprise/conformance). This rule checks dependencies in the Nx graph during `nx conformance:check`. Requires [Nx Enterprise plan](https://nx.dev/enterprise).
 

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -25,7 +25,7 @@ Nx offers two complementary approaches to enforce module boundaries:
 
 Both approaches use the same tag-based constraint system described below.
 
-In the example on this page, `client` and `admin` may depend on the shared `utils` library, but `utils` must not import from either of them. The lint rule and the conformance check both report the dependency that crosses that boundary.
+Say `client` and `admin` may depend on a shared `utils` library, but `utils` must not import from either of them. The lint rule and the conformance check both report the dependency that crosses that boundary.
 
 ![utils importing from client is reported as a violation](../../../assets/features/module-boundaries-violation.svg)
 

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -19,7 +19,7 @@ title="Applying Module Boundaries"
 
 Nx offers two complementary approaches to enforce module boundaries:
 
-**Lint rule integration** - For JavaScript/TypeScript projects, enforce boundaries on code imports using the `@nx/enforce-module-boundaries` rule. This checks TypeScript imports and `package.json` dependencies during linting. ESLint runs the rule natively, and `@nx/oxlint` bridges it into Oxlint.
+**Lint rule integration** - For JavaScript/TypeScript projects, enforce boundaries on code imports using the `@nx/enforce-module-boundaries` rule. This checks TypeScript imports and `package.json` dependencies during linting. The rule runs on ESLint and Oxlint.
 
 **Language-Agnostic Conformance** - For any project type (e.g. Java, Python, PHP, JavaScript, etc.), use the [Conformance plugin's Enforce Project Boundaries rule](/docs/enterprise/conformance). This rule checks dependencies in the Nx graph during `nx conformance:check`. Requires [Nx Enterprise plan](https://nx.dev/enterprise).
 
@@ -199,18 +199,17 @@ Read more about [ESLint rule options](/docs/kb/enforce-module-boundaries).
 {% /tabitem %}
 {% tabitem label="Oxlint" %}
 
-[`@nx/oxlint`](/docs/technologies/oxlint/introduction) exposes the same rule to Oxlint as a JavaScript plugin.
-It reads the project graph and takes the same options as the ESLint rule, so your constraints carry over unchanged.
+[`@nx/oxlint`](/docs/technologies/oxlint/introduction) runs the same rule with the same options, so your constraints carry over unchanged.
 
 {% aside type="caution" title="Experimental" %}
-The bridge depends on the Oxlint JavaScript plugin API. Oxlint excludes that API from its semantic versioning policy, so it can change in any release.
+Module boundaries on Oxlint depend on the Oxlint JavaScript plugin API. Oxlint excludes that API from its semantic versioning policy, so it can change in any release.
 {% /aside %}
 
 ```shell
 nx add @nx/oxlint
 ```
 
-Register the bridge and configure the rule in `.oxlintrc.json`:
+Register the plugin and configure the rule in `.oxlintrc.json`:
 
 ```json
 {

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -199,12 +199,16 @@ Read more about [ESLint rule options](/docs/kb/enforce-module-boundaries).
 {% /tabitem %}
 {% tabitem label="Oxlint" %}
 
-[`@nx/oxlint`](/docs/technologies/oxlint/introduction) exposes the rule to Oxlint as a JavaScript plugin.
-It reads the project graph and takes the options documented for ESLint, so your constraints carry over unchanged.
+[`@nx/oxlint`](/docs/technologies/oxlint/introduction) exposes the same rule to Oxlint as a JavaScript plugin.
+It reads the project graph and takes the same options as the ESLint rule, so your constraints carry over unchanged.
 
 {% aside type="caution" title="Experimental" %}
 The bridge depends on the Oxlint JavaScript plugin API. Oxlint excludes that API from its semantic versioning policy, so it can change in any release.
 {% /aside %}
+
+```shell
+nx add @nx/oxlint
+```
 
 Register the bridge and configure the rule in `.oxlintrc.json`:
 

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -199,7 +199,7 @@ Read more about [ESLint rule options](/docs/kb/enforce-module-boundaries).
 {% /tabitem %}
 {% tabitem label="Oxlint" %}
 
-[`@nx/oxlint`](/docs/technologies/oxlint/introduction) runs the same rule with the same options, so your constraints carry over unchanged.
+For JavaScript/TypeScript projects, configure the `@nx/enforce-module-boundaries` rule from [`@nx/oxlint`](/docs/technologies/oxlint/introduction):
 
 {% aside type="caution" title="Experimental" %}
 Module boundaries on Oxlint depend on the Oxlint JavaScript plugin API. Oxlint excludes that API from its semantic versioning policy, so it can change in any release.
@@ -238,6 +238,8 @@ Register the plugin and configure the rule in `.oxlintrc.json`:
   }
 }
 ```
+
+Read more about [rule options](/docs/kb/enforce-module-boundaries).
 
 {% /tabitem %}
 {% tabitem label="Conformance" %}

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -25,6 +25,10 @@ Nx offers two complementary approaches to enforce module boundaries:
 
 Both approaches use the same tag-based constraint system described below.
 
+In the example on this page, `client` and `admin` may depend on the shared `utils` library, but `utils` must not import from either of them. The lint rule and the conformance check both report the dependency that crosses that boundary.
+
+![utils importing from client is reported as a violation](../../../assets/features/module-boundaries-violation.svg)
+
 ## Tags
 
 Nx comes with a generic mechanism for expressing constraints on project dependencies: tags.

--- a/astro-docs/src/content/docs/guides/Enforce Module Boundaries/ban-external-imports.mdoc
+++ b/astro-docs/src/content/docs/guides/Enforce Module Boundaries/ban-external-imports.mdoc
@@ -1,10 +1,10 @@
 ---
 title: Ban External Imports
-description: Learn how to use ESLint module boundary constraints to prevent projects from importing specific external packages and enforce separation of concerns.
+description: Learn how to use module boundary constraints to prevent projects from importing specific external packages and enforce separation of concerns.
 filter: 'type:Guides'
 ---
 
-**This constraint is only available for projects using ESLint.**
+This constraint is only available in the `@nx/enforce-module-boundaries` lint rule, on ESLint or Oxlint. The [Conformance rule](/docs/enterprise/conformance) has no equivalent.
 
 You may want to constrain what external packages a project may import. For example, you may want to prevent backend projects from importing packages related to your frontend framework. You can ban these imports using `bannedExternalImports` property in your dependency constraints configuration.
 
@@ -82,6 +82,37 @@ export default [
 ```
 
 {% /tabitem %}
+{% tabitem label="Oxlint" %}
+
+```json
+// .oxlintrc.json
+{
+  // @nx/oxlint/boundaries-plugin should already be registered under "jsPlugins"
+  "rules": {
+    "@nx/enforce-module-boundaries": [
+      "error",
+      {
+        "allow": [],
+        // update depConstraints based on your tags
+        "depConstraints": [
+          // projects tagged with "frontend" can't import from "@nestjs/common"
+          {
+            "sourceTag": "frontend",
+            "bannedExternalImports": ["@nestjs/common"]
+          },
+          // projects tagged with "backend" can't import from "@angular/core"
+          {
+            "sourceTag": "backend",
+            "bannedExternalImports": ["@angular/core"]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+{% /tabitem %}
 {% /tabs %}
 
 Another common example is ensuring that util libraries stay framework-free by banning imports from these frameworks. You can use wildcard `*` to match multiple projects e.g. `react*` would match `react`, but also `react-dom`, `react-native` etc. You can also have multiple wildcards e.g. `*react*` would match any package with word `react` in it's name. A workspace using React would have a configuration like this.
@@ -143,6 +174,32 @@ export default [
   ],
 
   // ... more ESLint config here
+}
+```
+
+{% /tabitem %}
+{% tabitem label="Oxlint" %}
+
+```json
+// .oxlintrc.json
+{
+  // @nx/oxlint/boundaries-plugin should already be registered under "jsPlugins"
+  "rules": {
+    "@nx/enforce-module-boundaries": [
+      "error",
+      {
+        "allow": [],
+        // update depConstraints based on your tags
+        "depConstraints": [
+          // projects tagged with "type:util" can't import from "react" or related projects
+          {
+            "sourceTag": "type:util",
+            "bannedExternalImports": ["*react*"]
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 
@@ -238,6 +295,46 @@ export default [
       ],
     },
   ],
+}
+```
+
+{% /tabitem %}
+{% tabitem label="Oxlint" %}
+
+```json
+// .oxlintrc.json
+{
+  // @nx/oxlint/boundaries-plugin should already be registered under "jsPlugins"
+  "rules": {
+    "@nx/enforce-module-boundaries": [
+      "error",
+      {
+        "allow": [],
+        // update depConstraints based on your tags
+        "depConstraints": [
+          // limiting the dependencies of util libraries to the bare minimum
+          // projects tagged with "type:util" can only import from "date-fns"
+          {
+            "sourceTag": "type:util",
+            "allowedExternalImports": ["date-fns"]
+          },
+          // ui libraries clean from data access concerns
+          // projects tagged with "type:ui" can only import packages matching "@angular/*" except "@angular/common/http"
+          {
+            "sourceTag": "type:ui",
+            "allowedExternalImports": ["@angular/*"],
+            "bannedExternalImports": ["@angular/common/http"]
+          },
+          // keeping the domain logic clean from infrastructure concerns
+          // projects tagged with "type:core" can't import any external packages.
+          {
+            "sourceTag": "type:core",
+            "allowedExternalImports": []
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 

--- a/astro-docs/src/content/docs/guides/Enforce Module Boundaries/tag-multiple-dimensions.mdoc
+++ b/astro-docs/src/content/docs/guides/Enforce Module Boundaries/tag-multiple-dimensions.mdoc
@@ -197,6 +197,55 @@ export default [
 ```
 
 {% /tabitem %}
+{% tabitem label="Oxlint" %}
+
+```json
+// .oxlintrc.json
+{
+  // @nx/oxlint/boundaries-plugin should already be registered under "jsPlugins"
+  "rules": {
+    "@nx/enforce-module-boundaries": [
+      "error",
+      {
+        "allow": [],
+        // update depConstraints based on your tags
+        "depConstraints": [
+          {
+            "sourceTag": "scope:shared",
+            "onlyDependOnLibsWithTags": ["scope:shared"]
+          },
+          {
+            "sourceTag": "scope:admin",
+            "onlyDependOnLibsWithTags": ["scope:shared", "scope:admin"]
+          },
+          {
+            "sourceTag": "scope:client",
+            "onlyDependOnLibsWithTags": ["scope:shared", "scope:client"]
+          },
+          {
+            "sourceTag": "type:app",
+            "onlyDependOnLibsWithTags": ["type:feature", "type:ui", "type:util"]
+          },
+          {
+            "sourceTag": "type:feature",
+            "onlyDependOnLibsWithTags": ["type:ui", "type:util"]
+          },
+          {
+            "sourceTag": "type:ui",
+            "onlyDependOnLibsWithTags": ["type:ui", "type:util"]
+          },
+          {
+            "sourceTag": "type:util",
+            "onlyDependOnLibsWithTags": ["type:util"]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+{% /tabitem %}
 {% /tabs %}
 
 There are no limits to the number of tags, but as you add more tags the complexity of your dependency constraints rises exponentially. It's always good to draw a diagram and carefully plan the boundaries.
@@ -285,6 +334,43 @@ export default [
   ],
 
   // ... more ESLint config here
+}
+```
+
+{% /tabitem %}
+{% tabitem label="Oxlint" %}
+
+```json
+// .oxlintrc.json
+{
+  // @nx/oxlint/boundaries-plugin should already be registered under "jsPlugins"
+  "rules": {
+    "@nx/enforce-module-boundaries": [
+      "error",
+      {
+        "allow": [],
+        // update depConstraints based on your tags
+        "depConstraints": [
+          {
+            // this constraint applies to all "admin" projects
+            "sourceTag": "scope:admin",
+            "onlyDependOnLibsWithTags": ["scope:shared", "scope:admin"]
+          },
+          {
+            "sourceTag": "type:ui",
+            "onlyDependOnLibsWithTags": ["type:ui", "type:util"]
+          },
+          {
+            // we don't want our admin ui components to depend on anything except utilities,
+            // and we also want to ban router imports
+            "allSourceTags": ["scope:admin", "type:ui"],
+            "onlyDependOnLibsWithTags": ["type:util"],
+            "bannedExternalImports": ["*router*"]
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 

--- a/astro-docs/src/content/docs/kb/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/kb/enforce-module-boundaries.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Enforce Module Boundaries ESLint Rule
-description: Learn how to use the @nx/enforce-module-boundaries ESLint rule to define strict rules for accessing resources between different projects in your Nx workspace.
+title: Enforce Module Boundaries Rule
+description: Learn how to use the @nx/enforce-module-boundaries lint rule on ESLint or Oxlint to define strict rules for accessing resources between different projects in your Nx workspace.
 sidebar:
   label: The enforce-module-boundaries rule
 filter: 'type:Guides'
@@ -8,7 +8,7 @@ topics:
   - 'ESLint'
 ---
 
-The `@nx/enforce-module-boundaries` ESLint rule enables you to define strict rules for accessing resources between
+The `@nx/enforce-module-boundaries` lint rule enables you to define strict rules for accessing resources between
 different projects in the repository. Enforcing strict boundaries helps to prevent unplanned cross-dependencies.
 
 {% aside type="note" %}
@@ -17,7 +17,7 @@ This rule only works for JavaScript/TypeScript projects. It runs on ESLint, and 
 
 ## Usage
 
-You can use the `enforce-module-boundaries` rule by adding it to your ESLint rules configuration:
+Add the rule to your linter configuration:
 
 {% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
@@ -65,6 +65,24 @@ export default [
     },
     // ... more ESLint overrides here
   ],
+}
+```
+
+{% /tabitem %}
+{% tabitem label="Oxlint" %}
+
+```json
+// .oxlintrc.json
+{
+  "jsPlugins": ["@nx/oxlint/boundaries-plugin"],
+  "rules": {
+    "@nx/enforce-module-boundaries": [
+      "error",
+      {
+        // ...rule specific configuration
+      }
+    ]
+  }
 }
 ```
 

--- a/astro-docs/src/content/docs/technologies/oxlint/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/oxlint/introduction.mdoc
@@ -11,7 +11,7 @@ filter: 'type:References'
 The `@nx/oxlint` plugin runs it as a cacheable Nx task, so a change re-lints only the projects it affects.
 
 {% aside type="caution" title="Experimental" %}
-`@nx/oxlint` is experimental. The module boundaries bridge depends on the Oxlint JavaScript plugin API, which Oxlint excludes from its semantic versioning policy and can change in any release.
+`@nx/oxlint` is experimental. Module boundaries support depends on the Oxlint JavaScript plugin API, which Oxlint excludes from its semantic versioning policy and can change in any release.
 {% /aside %}
 
 ## Set up
@@ -60,7 +60,7 @@ invalidates the cache. The task does not use the `default` named input, so what
 re-lints does not depend on how the workspace defines it.
 
 Dependencies are hashed only when the config registers the
-[module boundaries](#module-boundaries) bridge, because that is the one rule
+[module boundaries](#module-boundaries) plugin, because that is the one rule
 that looks across projects. A `jsPlugins` package or workspace project becomes a
 dependency of every project linted under that config, so upgrading or editing
 the plugin invalidates the cache and marks those projects as affected.
@@ -131,7 +131,7 @@ Turn them on for a single run with `nx lint my-app --type-aware`, which Nx forwa
 
 ## Module boundaries
 
-`@nx/oxlint` exposes the project-graph-aware `enforce-module-boundaries` rule as an Oxlint JavaScript plugin. Register the bridge in `.oxlintrc.json`:
+`@nx/oxlint` ships the `@nx/enforce-module-boundaries` rule as an Oxlint JavaScript plugin. Register it in `.oxlintrc.json`:
 
 ```json
 {


### PR DESCRIPTION
## Current Behavior

The module boundaries guides show ESLint config only. `ban-external-imports` says the constraint needs ESLint, and the kb rule page is titled as an ESLint rule. The features page has no picture of what the rule stops.

## Expected Behavior

Oxlint tab on the kb rule page and the `ban-external-imports` / `tag-multiple-dimensions` guides. `nx add @nx/oxlint` step on the features page Oxlint tab, which reads on its own. `ban-external-imports` says the constraint lives in the lint rule, not Conformance. A graphic before the Tags section shows `utils` (scope:shared) importing `client` being flagged.

## Preview

- https://deploy-preview-36957--nx-docs.netlify.app/docs/features/enforce-module-boundaries (graphic before Tags, Oxlint tab)
- https://deploy-preview-36957--nx-docs.netlify.app/docs/kb/enforce-module-boundaries
- https://deploy-preview-36957--nx-docs.netlify.app/docs/guides/enforce-module-boundaries/ban-external-imports
- https://deploy-preview-36957--nx-docs.netlify.app/docs/guides/enforce-module-boundaries/tag-multiple-dimensions
- https://deploy-preview-36957--nx-docs.netlify.app/docs/technologies/oxlint/introduction (wording only, "bridge" removed)

## Related Issue(s)

DOC-643

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/shiny-wombat-07048972">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->