### PR TITLE
feat(core): report the cache location alongside usage

### DIFF
--- a/packages/nx/src/command-line/report/report.spec.ts
+++ b/packages/nx/src/command-line/report/report.spec.ts
@@ -1,0 +1,59 @@
+import { homedir } from 'os';
+import { join, sep } from 'path';
+import { cacheSectionLines } from './report';
+
+describe('cacheSectionLines', () => {
+  it('should report usage as a share of the max', () => {
+    expect(
+      cacheSectionLines({
+        used: 512 * 1024 * 1024,
+        max: 1024 * 1024 * 1024,
+        location: '/tmp/nx-cache',
+      })
+    ).toEqual([
+      'Cache',
+      '- Usage: 512.00 MB / 1.00 GB (50.0%)',
+      '- Location: /tmp/nx-cache',
+    ]);
+  });
+
+  it('should omit the share when the max is unlimited', () => {
+    expect(
+      cacheSectionLines({
+        used: 512 * 1024 * 1024,
+        max: 0,
+        location: '/tmp/nx-cache',
+      })
+    ).toEqual(['Cache', '- Usage: 512.00 MB / ∞', '- Location: /tmp/nx-cache']);
+  });
+
+  it('should elide the home directory from the location', () => {
+    expect(
+      cacheSectionLines({
+        used: 1024,
+        max: 1024,
+        location: join(homedir(), '.nx', 'abc123', 'cache'),
+      })[2]
+    ).toEqual(`- Location: ${join('~', '.nx', 'abc123', 'cache')}`);
+  });
+
+  it('should leave a location outside the home directory absolute', () => {
+    expect(
+      cacheSectionLines({
+        used: 1024,
+        max: 1024,
+        location: join(sep, 'mnt', 'build-cache'),
+      })[2]
+    ).toEqual(`- Location: ${join(sep, 'mnt', 'build-cache')}`);
+  });
+
+  it('should round the share to one decimal place', () => {
+    expect(
+      cacheSectionLines({
+        used: 200 * 1024 * 1024,
+        max: 100 * 1024 * 1024 * 1024,
+        location: '/tmp/nx-cache',
+      })[1]
+    ).toEqual('- Usage: 200.00 MB / 100.00 GB (0.2%)');
+  });
+});

--- a/packages/nx/src/command-line/report/report.ts
+++ b/packages/nx/src/command-line/report/report.ts
@@ -1,6 +1,7 @@
 import * as pc from 'picocolors';
 import { output } from '../../utils/output';
-import { join } from 'path';
+import { join, sep } from 'path';
+import { homedir } from 'os';
 import {
   detectPackageManager,
   getPackageManagerCommand,
@@ -39,6 +40,7 @@ import {
   formatCacheSize,
   resolveMaxCacheSize,
 } from '../../tasks-runner/cache';
+import { cacheDir } from '../../utils/cache-directory';
 import { daemonClient } from '../../daemon/client/client';
 import { readNxPackageGroup } from '../../utils/nx-package-group';
 
@@ -216,11 +218,7 @@ export async function reportHandler() {
 
   if (cache) {
     bodyLines.push(LINE_SEPARATOR);
-    bodyLines.push(
-      `Cache Usage: ${formatCacheSize(cache.used)} / ${
-        cache.max === 0 ? '∞' : formatCacheSize(cache.max)
-      }`
-    );
+    bodyLines.push(...cacheSectionLines(cache));
   }
 
   if (outOfSyncPackageGroup) {
@@ -276,6 +274,33 @@ export async function reportHandler() {
   });
 }
 
+/**
+ * The report is meant to be pasted into public issues, so the home directory
+ * is elided rather than printing the user's account name.
+ */
+function collapseHome(path: string): string {
+  const home = homedir();
+  return path === home || path.startsWith(home + sep)
+    ? `~${path.slice(home.length)}`
+    : path;
+}
+
+export function cacheSectionLines(
+  cache: NonNullable<ReportData['cache']>
+): string[] {
+  const unlimited = cache.max === 0;
+  const max = unlimited ? '∞' : formatCacheSize(cache.max);
+  const share = unlimited
+    ? ''
+    : ` (${((cache.used / cache.max) * 100).toFixed(1)}%)`;
+
+  return [
+    'Cache',
+    `- Usage: ${formatCacheSize(cache.used)} / ${max}${share}`,
+    `- Location: ${collapseHome(cache.location)}`,
+  ];
+}
+
 export interface ReportData {
   pm: PackageManager;
   pmVersion: string;
@@ -312,6 +337,7 @@ export interface ReportData {
   cache: {
     max: number;
     used: number;
+    location: string;
   } | null;
 }
 
@@ -426,6 +452,7 @@ export async function getReportData(): Promise<ReportData> {
     ? {
         max: resolveMaxCacheSize(nxJson),
         used: new DbCache({ nxCloudRemoteCache: null }).getUsedCacheSpace(),
+        location: cacheDir,
       }
     : null;
 


### PR DESCRIPTION
## Current Behavior

<!-- This is the behavior we have today -->

The report prints one line for the cache and never says where the cache is. It lives in a shared per-user directory keyed on workspace identity, not the `.nx/cache` inside the checkout that people expect.

```
Cache Usage: 209.89 MB / 92.64 GB
```

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

```
Cache
- Usage: 209.89 MB / 92.64 GB (0.2%)
- Location: ~/.nx/58c4a7e2fc1d7c3d/cache
```

The default max cache size is 10% of the disk, so the share needs a decimal place to not read `0%`. We elide the home directory since we tell people to paste this into issues.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/report-cache-dir-0bf840a1">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->