### PR TITLE
fix(bundling): avoid recursive require.resolve in CJS path resolver

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -1,5 +1,9 @@
-import { buildEsbuildOptions } from './build-esbuild-options';
+import { buildEsbuildOptions, getRegisterFileContent } from './build-esbuild-options';
 import { ExecutorContext } from '@nx/devkit';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import path = require('path');
 
 describe('buildEsbuildOptions', () => {
@@ -603,6 +607,96 @@ describe('buildEsbuildOptions', () => {
       outExtension: {
         '.js': '.js',
       },
+    });
+  });
+
+  describe('getRegisterFileContent', () => {
+    const project = {
+      type: 'app' as const,
+      name: 'myapp',
+      data: { root: 'apps/myapp' },
+    };
+
+    it('should not use require.resolve in the CJS isFile helper', () => {
+      const content = getRegisterFileContent(
+        project,
+        { '@acme/lib': ['libs/lib/src/index.ts'] },
+        './apps/myapp/src/main.js',
+        '.js',
+        'cjs'
+      );
+
+      expect(content).not.toContain('require.resolve');
+      expect(content).toContain('fs.statSync(candidate).isFile()');
+    });
+
+    it('should resolve workspace imports without recursion', () => {
+      const distPath = mkdtempSync(join(tmpdir(), 'nx-esbuild-isfile-'));
+      const appMain = join(distPath, 'apps/myapp/src/main.js');
+      mkdirSync(join(distPath, 'apps/myapp/src'), { recursive: true });
+      mkdirSync(join(distPath, 'libs/lib/src'), { recursive: true });
+      writeFileSync(appMain, "module.exports = require('@acme/lib');");
+      writeFileSync(
+        join(distPath, 'libs/lib/src/index.js'),
+        'module.exports = { ok: true };'
+      );
+
+      const content = getRegisterFileContent(
+        project,
+        { '@acme/lib': ['libs/lib/src/index.ts'] },
+        './apps/myapp/src/main.js',
+        '.js',
+        'cjs'
+      );
+
+      writeFileSync(join(distPath, 'main.js'), content);
+
+      const start = Date.now();
+      const output = execFileSync(
+        process.execPath,
+        [
+          '-e',
+          `console.log(JSON.stringify(require(${JSON.stringify(
+            join(distPath, 'main.js')
+          )})))`,
+        ],
+        { encoding: 'utf8' }
+      );
+      expect(JSON.parse(output.trim())).toEqual({ ok: true });
+      expect(Date.now() - start).toBeLessThan(1000);
+    });
+
+    it('should resolve wildcard paths to index.js without recursion', () => {
+      const distPath = mkdtempSync(join(tmpdir(), 'nx-esbuild-isfile-'));
+      const appMain = join(distPath, 'apps/myapp/src/main.js');
+      mkdirSync(join(distPath, 'apps/myapp/src/config'), { recursive: true });
+      writeFileSync(appMain, "module.exports = require('@app/config');");
+      writeFileSync(
+        join(distPath, 'apps/myapp/src/config/index.js'),
+        'module.exports = { ok: true };'
+      );
+
+      const content = getRegisterFileContent(
+        project,
+        { '@app/*': ['apps/myapp/src/*'] },
+        './apps/myapp/src/main.js',
+        '.js',
+        'cjs'
+      );
+
+      writeFileSync(join(distPath, 'main.js'), content);
+
+      const output = execFileSync(
+        process.execPath,
+        [
+          '-e',
+          `console.log(JSON.stringify(require(${JSON.stringify(
+            join(distPath, 'main.js')
+          )})))`,
+        ],
+        { encoding: 'utf8' }
+      );
+      expect(JSON.parse(output.trim())).toEqual({ ok: true });
     });
   });
 

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -471,12 +471,15 @@ Module._resolveFilename = function(request, parent) {
 };
 
 function isFile(s) {
-  try {
-    require.resolve(s);
-    return true;
-  } catch (_e) {
-    return false;
+  const candidates = [s, s + '.js', path.join(s, 'index.js')];
+  for (const candidate of candidates) {
+    try {
+      if (fs.statSync(candidate).isFile()) {
+        return true;
+      }
+    } catch (_e) {}
   }
+  return false;
 }
 
 // Call the user-defined main.


### PR DESCRIPTION
## Summary

Fixes #37072

When `@nx/esbuild` emits the CJS `main-with-require-overrides` helper (`bundle: false`, `format: cjs`), `isFile()` calls `require.resolve()` from inside a patched `Module._resolveFilename`. That re-enters the hook and can recurse until the stack overflows (~1k+ frames). `isFile()` catches the `RangeError`, so small apps may still start; large unbundled graphs can spend tens of seconds on startup or appear hung.

This requires tsconfig `paths` entries that compile to **unanchored** regexes matching real module IDs or file paths (e.g. `src/*`, `libs/*`, `apps/*`, or a catch-all `*` mapping). **Scoped aliases alone** (e.g. `@org/package`) usually do not trigger it.

Replace `require.resolve()` with `fs.statSync` and explicit `.js` / `index.js` candidates so wildcard resolution from #23098 still works without re-entering the hook.

## Reproduction

Minimal reproduction: https://github.com/Yedidyar/nx-esbuild-cjs-hang-repro

```bash
node repro.cjs           # buggy helper — high resolver depth
node repro.cjs --fixed   # fs.statSync — no deep recursion
node repro.cjs --scoped  # scoped paths only — no recursion
```

## Current behavior

```js
function isFile(s) {
  try {
    require.resolve(s);
    return true;
  } catch (_e) {
    return false;
  }
}
```

Wildcard path matches during resolution lead to repeated stack overflows inside `isFile`, scaled by how many imports hit the hook.

Introduced in #23098.

## Expected behavior

```js
function isFile(s) {
  const candidates = [s, s + '.js', path.join(s, 'index.js')];
  for (const candidate of candidates) {
    try {
      if (fs.statSync(candidate).isFile()) {
        return true;
      }
    } catch (_e) {}
  }
  return false;
}
```

## Test plan

- [ ] Updated unit tests for the path resolver / generated helper
- [ ] `nx format:check` passes
- [ ] Repro commands above behave as expected

## Related

- Fixes #37072  
- Regression from #23098