### PR TITLE
fix(react): make freshly generated react and rspack workspaces usable

### DIFF
--- a/e2e/nx/src/workspace.test.ts
+++ b/e2e/nx/src/workspace.test.ts
@@ -23,6 +23,9 @@ describe('@nx/workspace:infer-targets', () => {
   beforeEach(() => {
     proj = newProject({
       packages: ['@nx/playwright', '@nx/remix', '@nx/eslint', '@nx/jest'],
+      // Remix rejects TypeScript 6, so keep this workspace on the 5.x line
+      // that @nx/remix pins (packages/remix/src/utils/versions.ts).
+      typescriptVersion: '~5.9.2',
     });
   });
 

--- a/e2e/remix/src/nx-remix.test.ts
+++ b/e2e/remix/src/nx-remix.test.ts
@@ -55,6 +55,9 @@ describe('Remix E2E Tests', () => {
           '@nx/eslint',
         ],
         packageManager: 'yarn',
+        // Remix rejects TypeScript 6, so keep this workspace on the 5.x line
+        // that @nx/remix pins (packages/remix/src/utils/versions.ts).
+        typescriptVersion: '~5.9.2',
       });
     });
 
@@ -211,7 +214,12 @@ describe('Remix E2E Tests', () => {
     let proj: string;
 
     beforeAll(() => {
-      proj = newProject({ packages: ['@nx/remix'] });
+      proj = newProject({
+        packages: ['@nx/remix'],
+        // Remix rejects TypeScript 6, so keep this workspace on the 5.x line
+        // that @nx/remix pins (packages/remix/src/utils/versions.ts).
+        typescriptVersion: '~5.9.2',
+      });
     });
 
     afterAll(() => {

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -163,7 +163,12 @@ export function newProject({
         // Installing typescript directly reclaims that slot. pnpm/yarn resolve
         // peers per dependent, so they are unaffected.
         // TODO: remove once tsquery bounds its peer or nx stops depending on it.
-        if (packageManager === 'npm') {
+        // The `apps` preset pins typescript ~6.0.3, so any suite that needs an
+        // older line (Remix) re-pins regardless of package manager.
+        if (
+          packageManager === 'npm' ||
+          typescriptVersion !== defaultTypescriptVersion
+        ) {
           packageInstall('typescript', projScope, typescriptVersion);
         }
         const packageInstallEnd = performance.mark('packageInstall:end');

--- a/packages/react/src/generators/_utils/mf-dependencies.ts
+++ b/packages/react/src/generators/_utils/mf-dependencies.ts
@@ -84,6 +84,9 @@ function bundlerDeps(bundler: SupportedBundler): DepsBundle {
           '@rspack/cli': mfVersions.rspackCliVersion,
           '@rspack/core': mfVersions.rspackCoreVersion,
           '@rspack/dev-server': mfVersions.rspackDevServerVersion,
+          '@rspack/plugin-react-refresh':
+            mfVersions.rspackPluginReactRefreshVersion,
+          'react-refresh': mfVersions.reactRefreshVersion,
         },
       };
   }

--- a/packages/react/src/generators/_utils/mf-versions.ts
+++ b/packages/react/src/generators/_utils/mf-versions.ts
@@ -24,6 +24,9 @@ export const moduleFederationRsbuildPluginVersion = '^2.5.0';
 // Rspack stack.
 export const rspackCoreVersion = '^2.0.3';
 export const rspackCliVersion = '^2.0.3';
+// @rspack/plugin-react-refresh 2.x peers react-refresh >=0.10 <1.
+export const rspackPluginReactRefreshVersion = '^2.0.0';
+export const reactRefreshVersion = '~0.14.0';
 // Pinned (no ^) to dodge the broken 2.0.2 publish, which ships no dist/ so
 // @rspack/cli can't load it for `rspack serve`. Re-float to ^ once upstream
 // republishes a fixed 2.0.3+.

--- a/packages/react/src/generators/consumer/__snapshots__/consumer.spec.ts.snap
+++ b/packages/react/src/generators/consumer/__snapshots__/consumer.spec.ts.snap
@@ -290,8 +290,10 @@ exports[`@nx/react:consumer generates a consumer for the rspack bundler: rspack 
     "@rspack/cli": "^2.0.3",
     "@rspack/core": "^2.0.3",
     "@rspack/dev-server": "2.0.1",
+    "@rspack/plugin-react-refresh": "^2.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "react-refresh": "~0.14.0",
     "typescript": "~6.0.3"
   }
 }
@@ -323,6 +325,7 @@ exports[`@nx/react:consumer generates a consumer for the rspack bundler: rspack 
   "apps/my-consumer/rspack.config.ts": "import { defineConfig } from '@rspack/cli';
 import { rspack } from '@rspack/core';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -360,7 +363,9 @@ export default defineConfig((_env, argv) => {
             options: {
               jsc: {
                 parser: { syntax: 'typescript', tsx: true },
-                transform: { react: { runtime: 'automatic', development: isDev } },
+                transform: {
+                  react: { runtime: 'automatic', development: isDev, refresh: isDev },
+                },
               },
               env: { targets: 'Chrome >= 87, Firefox >= 78, Edge >= 88, Safari >= 14' },
             },
@@ -369,6 +374,7 @@ export default defineConfig((_env, argv) => {
       ],
     },
     plugins: [
+      isDev && new ReactRefreshRspackPlugin(),
       new rspack.HtmlRspackPlugin({ template: './index.html' }),
       new ModuleFederationPlugin({
         name: NAME,
@@ -376,7 +382,7 @@ export default defineConfig((_env, argv) => {
         // src/mf.ts at module load time.
         shared: ['react', 'react-dom'],
       }),
-    ],
+    ].filter(Boolean),
   };
 });
 ",

--- a/packages/react/src/generators/consumer/files/rspack/package.json__tmpl__
+++ b/packages/react/src/generators/consumer/files/rspack/package.json__tmpl__
@@ -16,8 +16,10 @@
     "@rspack/cli": "<%= versions.rspackCliVersion %>",
     "@rspack/core": "<%= versions.rspackCoreVersion %>",
     "@rspack/dev-server": "<%= versions.rspackDevServerVersion %>",
+    "@rspack/plugin-react-refresh": "<%= versions.rspackPluginReactRefreshVersion %>",
     "@types/react": "<%= versions.typesReactVersion %>",
     "@types/react-dom": "<%= versions.typesReactDomVersion %>",
+    "react-refresh": "<%= versions.reactRefreshVersion %>",
     "typescript": "<%= versions.typescriptVersion %>"
   }
 }

--- a/packages/react/src/generators/consumer/files/rspack/rspack.config.ts__tmpl__
+++ b/packages/react/src/generators/consumer/files/rspack/rspack.config.ts__tmpl__
@@ -1,6 +1,7 @@
 import { defineConfig } from '@rspack/cli';
 import { rspack } from '@rspack/core';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -38,7 +39,9 @@ export default defineConfig((_env, argv) => {
             options: {
               jsc: {
                 parser: { syntax: 'typescript', tsx: true },
-                transform: { react: { runtime: 'automatic', development: isDev } },
+                transform: {
+                  react: { runtime: 'automatic', development: isDev, refresh: isDev },
+                },
               },
               env: { targets: 'Chrome >= 87, Firefox >= 78, Edge >= 88, Safari >= 14' },
             },
@@ -47,6 +50,7 @@ export default defineConfig((_env, argv) => {
       ],
     },
     plugins: [
+      isDev && new ReactRefreshRspackPlugin(),
       new rspack.HtmlRspackPlugin({ template: './index.html' }),
       new ModuleFederationPlugin({
         name: NAME,
@@ -54,6 +58,6 @@ export default defineConfig((_env, argv) => {
         // src/mf.ts at module load time.
         shared: ['react', 'react-dom'],
       }),
-    ],
+    ].filter(Boolean),
   };
 });

--- a/packages/react/src/generators/host/host.rspack.spec.ts
+++ b/packages/react/src/generators/host/host.rspack.spec.ts
@@ -222,6 +222,40 @@ describe('hostGenerator', () => {
       expect(packageJson.devDependencies['@nx/web']).toBeDefined();
     });
 
+    it('should install @swc-node/register so the TS config loads without native type stripping', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      await hostGenerator(tree, {
+        directory: 'test',
+        style: 'css',
+        linter: 'none',
+        unitTestRunner: 'none',
+        e2eTestRunner: 'none',
+        skipFormat: true,
+        bundler: 'rspack',
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc-node/register']).toBeDefined();
+      expect(packageJson.devDependencies['@swc/core']).toBeDefined();
+    });
+
+    it('should not install @swc-node/register for a JS config', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      await hostGenerator(tree, {
+        directory: 'test',
+        style: 'css',
+        linter: 'none',
+        unitTestRunner: 'none',
+        e2eTestRunner: 'none',
+        skipFormat: true,
+        bundler: 'rspack',
+        typescriptConfiguration: false,
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc-node/register']).toBeUndefined();
+    });
+
     it('should generate host files and configs for SSR', async () => {
       await hostGenerator(tree, {
         directory: 'test',

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -29,7 +29,10 @@ import { updateModuleFederationE2eProject } from './lib/update-module-federation
 import { NormalizedSchema, Schema } from './schema';
 import { addMfEnvToTargetDefaultInputs } from '../../utils/add-mf-env-to-inputs';
 import { isValidVariable } from '@nx/js';
-import { isUsingTsSolutionSetup } from '@nx/js/internal';
+import {
+  addSwcRegisterDependencies,
+  isUsingTsSolutionSetup,
+} from '@nx/js/internal';
 import {
   expressVersion,
   httpProxyMiddlewareVersion,
@@ -199,6 +202,12 @@ export async function hostGenerator(
     true
   );
   tasks.push(installTask);
+
+  // The TS config templates use extensionless relative imports and
+  // `__dirname`, which Node's native type stripping cannot load.
+  if (options.typescriptConfiguration) {
+    tasks.push(addSwcRegisterDependencies(host));
+  }
 
   if (!options.skipFormat) {
     await formatFiles(host);

--- a/packages/react/src/generators/host/host.webpack.spec.ts
+++ b/packages/react/src/generators/host/host.webpack.spec.ts
@@ -210,6 +210,40 @@ describe('hostGenerator', () => {
       expect(packageJson.devDependencies['@nx/web']).toBeDefined();
     });
 
+    it('should install @swc-node/register so the TS config loads without native type stripping', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      await hostGenerator(tree, {
+        directory: 'test',
+        style: 'css',
+        linter: 'none',
+        unitTestRunner: 'none',
+        e2eTestRunner: 'none',
+        skipFormat: true,
+        bundler: 'webpack',
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc-node/register']).toBeDefined();
+      expect(packageJson.devDependencies['@swc/core']).toBeDefined();
+    });
+
+    it('should not install @swc-node/register for a JS config', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      await hostGenerator(tree, {
+        directory: 'test',
+        style: 'css',
+        linter: 'none',
+        unitTestRunner: 'none',
+        e2eTestRunner: 'none',
+        skipFormat: true,
+        bundler: 'webpack',
+        typescriptConfiguration: false,
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc-node/register']).toBeUndefined();
+    });
+
     it('should generate host files and configs for SSR', async () => {
       await hostGenerator(tree, {
         directory: 'test',

--- a/packages/react/src/generators/provider/__snapshots__/provider.spec.ts.snap
+++ b/packages/react/src/generators/provider/__snapshots__/provider.spec.ts.snap
@@ -232,8 +232,10 @@ exports[`@nx/react:provider generates a provider for the rspack bundler: rspack 
     "@rspack/cli": "^2.0.3",
     "@rspack/core": "^2.0.3",
     "@rspack/dev-server": "2.0.1",
+    "@rspack/plugin-react-refresh": "^2.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "react-refresh": "~0.14.0",
     "typescript": "~6.0.3"
   }
 }
@@ -265,6 +267,7 @@ exports[`@nx/react:provider generates a provider for the rspack bundler: rspack 
   "apps/my-provider/rspack.config.ts": "import { defineConfig } from '@rspack/cli';
 import { rspack } from '@rspack/core';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -307,7 +310,9 @@ export default defineConfig((_env, argv) => {
             options: {
               jsc: {
                 parser: { syntax: 'typescript', tsx: true },
-                transform: { react: { runtime: 'automatic', development: isDev } },
+                transform: {
+                  react: { runtime: 'automatic', development: isDev, refresh: isDev },
+                },
               },
               env: { targets: 'Chrome >= 87, Firefox >= 78, Edge >= 88, Safari >= 14' },
             },
@@ -316,6 +321,7 @@ export default defineConfig((_env, argv) => {
       ],
     },
     plugins: [
+      isDev && new ReactRefreshRspackPlugin(),
       // excludeChunks is REQUIRED on a provider: without it the federation
       // remoteEntry chunk gets injected into the standalone HTML and breaks
       // direct serves.
@@ -328,7 +334,7 @@ export default defineConfig((_env, argv) => {
         },
         shared: ['react', 'react-dom'],
       }),
-    ],
+    ].filter(Boolean),
   };
 });
 ",

--- a/packages/react/src/generators/provider/files/rspack/package.json__tmpl__
+++ b/packages/react/src/generators/provider/files/rspack/package.json__tmpl__
@@ -15,8 +15,10 @@
     "@rspack/cli": "<%= versions.rspackCliVersion %>",
     "@rspack/core": "<%= versions.rspackCoreVersion %>",
     "@rspack/dev-server": "<%= versions.rspackDevServerVersion %>",
+    "@rspack/plugin-react-refresh": "<%= versions.rspackPluginReactRefreshVersion %>",
     "@types/react": "<%= versions.typesReactVersion %>",
     "@types/react-dom": "<%= versions.typesReactDomVersion %>",
+    "react-refresh": "<%= versions.reactRefreshVersion %>",
     "typescript": "<%= versions.typescriptVersion %>"
   }
 }

--- a/packages/react/src/generators/provider/files/rspack/rspack.config.ts__tmpl__
+++ b/packages/react/src/generators/provider/files/rspack/rspack.config.ts__tmpl__
@@ -1,6 +1,7 @@
 import { defineConfig } from '@rspack/cli';
 import { rspack } from '@rspack/core';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -43,7 +44,9 @@ export default defineConfig((_env, argv) => {
             options: {
               jsc: {
                 parser: { syntax: 'typescript', tsx: true },
-                transform: { react: { runtime: 'automatic', development: isDev } },
+                transform: {
+                  react: { runtime: 'automatic', development: isDev, refresh: isDev },
+                },
               },
               env: { targets: 'Chrome >= 87, Firefox >= 78, Edge >= 88, Safari >= 14' },
             },
@@ -52,6 +55,7 @@ export default defineConfig((_env, argv) => {
       ],
     },
     plugins: [
+      isDev && new ReactRefreshRspackPlugin(),
       // excludeChunks is REQUIRED on a provider: without it the federation
       // remoteEntry chunk gets injected into the standalone HTML and breaks
       // direct serves.
@@ -64,6 +68,6 @@ export default defineConfig((_env, argv) => {
         },
         shared: ['react', 'react-dom'],
       }),
-    ],
+    ].filter(Boolean),
   };
 });

--- a/packages/react/src/generators/remote/remote.rspack.spec.ts
+++ b/packages/react/src/generators/remote/remote.rspack.spec.ts
@@ -269,6 +269,42 @@ describe('remote generator', () => {
       expect(packageJson.devDependencies['@nx/web']).toBeDefined();
     });
 
+    it('should install @swc-node/register so the TS config loads without native type stripping', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      await remote(tree, {
+        directory: 'test',
+        devServerPort: 4201,
+        e2eTestRunner: 'cypress',
+        linter: 'eslint',
+        skipFormat: true,
+        style: 'css',
+        unitTestRunner: 'jest',
+        bundler: 'rspack',
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc-node/register']).toBeDefined();
+      expect(packageJson.devDependencies['@swc/core']).toBeDefined();
+    });
+
+    it('should not install @swc-node/register for a JS config', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      await remote(tree, {
+        directory: 'test',
+        devServerPort: 4201,
+        e2eTestRunner: 'cypress',
+        linter: 'eslint',
+        skipFormat: true,
+        style: 'css',
+        unitTestRunner: 'jest',
+        bundler: 'rspack',
+        typescriptConfiguration: false,
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc-node/register']).toBeUndefined();
+    });
+
     it('should not set the remote as the default project', async () => {
       const tree = createTreeWithEmptyWorkspace();
       await remote(tree, {

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -19,7 +19,11 @@ import {
 import { join } from 'path';
 
 import { isValidVariable } from '@nx/js';
-import { getProjectSourceRoot, isUsingTsSolutionSetup } from '@nx/js/internal';
+import {
+  addSwcRegisterDependencies,
+  getProjectSourceRoot,
+  isUsingTsSolutionSetup,
+} from '@nx/js/internal';
 import { updateModuleFederationProject } from '../../rules/update-module-federation-project';
 import { addMfEnvToTargetDefaultInputs } from '../../utils/add-mf-env-to-inputs';
 import { normalizeRemoteName } from '../../utils/normalize-remote';
@@ -309,6 +313,12 @@ export async function remoteGenerator(host: Tree, schema: Schema) {
     true
   );
   tasks.push(installTask);
+
+  // The TS config templates use extensionless relative imports and
+  // `__dirname`, which Node's native type stripping cannot load.
+  if (options.typescriptConfiguration) {
+    tasks.push(addSwcRegisterDependencies(host));
+  }
 
   if (!options.skipFormat) {
     await formatFiles(host);

--- a/packages/react/src/generators/remote/remote.webpack.spec.ts
+++ b/packages/react/src/generators/remote/remote.webpack.spec.ts
@@ -223,6 +223,42 @@ describe('remote generator', () => {
       expect(packageJson.devDependencies['@nx/web']).toBeDefined();
     });
 
+    it('should install @swc-node/register so the TS config loads without native type stripping', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      await remote(tree, {
+        directory: 'test',
+        devServerPort: 4201,
+        e2eTestRunner: 'cypress',
+        linter: 'eslint',
+        skipFormat: true,
+        style: 'css',
+        unitTestRunner: 'jest',
+        bundler: 'webpack',
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc-node/register']).toBeDefined();
+      expect(packageJson.devDependencies['@swc/core']).toBeDefined();
+    });
+
+    it('should not install @swc-node/register for a JS config', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      await remote(tree, {
+        directory: 'test',
+        devServerPort: 4201,
+        e2eTestRunner: 'cypress',
+        linter: 'eslint',
+        skipFormat: true,
+        style: 'css',
+        unitTestRunner: 'jest',
+        bundler: 'webpack',
+        typescriptConfiguration: false,
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc-node/register']).toBeUndefined();
+    });
+
     it('should not set the remote as the default project', async () => {
       const tree = createTreeWithEmptyWorkspace();
       await remote(tree, {

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -7,6 +7,7 @@ exports[`new --preset should generate necessary npm dependencies for empty prese
     "@nx/js": "0.0.1",
     "@nx/workspace": "0.0.1",
     "nx": "0.0.1",
+    "typescript": "~6.0.3",
   },
   "license": "MIT",
   "name": "@my-workspace/source",

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -125,10 +125,18 @@ function getPresetDependencies({
   js,
 }: NormalizedSchema) {
   switch (preset) {
-    // These generate no project, so `@nx/js:init` never runs to add typescript
+    // Generates no project, but a plugin installed later (`npm i -D
+    // @nx/react`) pulls tsquery in and hoists typescript 7 unless the pin is
+    // already in package.json.
+    case Preset.Apps:
+      return {
+        dependencies: {},
+        dev: { '@nx/js': nxVersion, typescript: typescriptVersion },
+      };
+
+    // Generates no project, so `@nx/js:init` never runs to add typescript
     // and pinning it here would be net-new. The preset generator itself does
     // run - it sets up the chosen formatter.
-    case Preset.Apps:
     case Preset.NPM:
       return { dependencies: {}, dev: { '@nx/js': nxVersion } };
 

--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -95,22 +95,30 @@ describe('new', () => {
       expect(readJson(tree, 'my-workspace/package.json')).toMatchSnapshot();
     });
 
-    it('should not add typescript for presets that scaffold nothing', async () => {
-      for (const preset of [Preset.Apps, Preset.NPM]) {
-        tree = createTree();
-        tree.root = process.cwd();
+    it('should pin typescript for the apps preset', async () => {
+      await newGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-workspace',
+        directory: 'my-workspace',
+        appName: 'app',
+        preset: Preset.Apps,
+      });
 
-        await newGenerator(tree, {
-          ...defaultOptions,
-          name: 'my-workspace',
-          directory: 'my-workspace',
-          appName: 'app',
-          preset,
-        });
+      const { devDependencies } = readJson(tree, 'my-workspace/package.json');
+      expect(devDependencies.typescript).toBe(typescriptVersion);
+    });
 
-        const { devDependencies } = readJson(tree, 'my-workspace/package.json');
-        expect(devDependencies).not.toHaveProperty('typescript');
-      }
+    it('should not add typescript for the npm preset', async () => {
+      await newGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-workspace',
+        directory: 'my-workspace',
+        appName: 'app',
+        preset: Preset.NPM,
+      });
+
+      const { devDependencies } = readJson(tree, 'my-workspace/package.json');
+      expect(devDependencies).not.toHaveProperty('typescript');
     });
 
     it('should generate necessary npm dependencies for ts preset', async () => {


### PR DESCRIPTION
## Current Behavior

- `create-nx-workspace --preset=apps` pins no typescript, so a later `npm i -D @nx/react` (or `nx add @nx/react`) hoists TypeScript 7 through tsquery's `>3.0.0` peer and every generator that calls `ensureTypescript()` fails with `Cannot read properties of undefined (reading 'Latest')`.
- `@nx/react:host` / `:remote` TS configs use extensionless relative imports and `__dirname`, which Node's native type stripping cannot load, and the swc fallback is no longer installed. The project graph fails on Node 22+.
- `@nx/react:consumer` / `:provider` rspack configs wire no React Refresh, so every edit is a full reload.

## Expected Behavior

- The `apps` preset pins `typescript` so a later plugin install resolves tsquery's peer against it.
- Host / remote generators add `@swc-node/register` + `@swc/core` when they emit a TS config.
- Consumer / provider rspack templates add `@rspack/plugin-react-refresh` + `react-refresh` and enable refresh in dev mode.

## Related Issue(s)

NXC-4928

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/modest-gecko-2d419597">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->
