### PR TITLE
fix(repo): provision JDK 17 for Gradle builds with mise

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,23 @@ This repo contains a mix of different technologies, including:
 
 ## Development Workstation Setup
 
+For local development with [mise](https://mise.jdx.dev/), install the tools declared in `mise.toml`:
+
+```bash
+mise install
+```
+
+Activate mise in your shell, or prefix commands with `mise exec --`. The configuration keeps Java 24 as the default runtime and installs Temurin JDK 17 for Gradle compilation. Mise sets `JAVA17_HOME`, which `gradle.properties` uses to discover that compiler toolchain. Gradle's automatic JDK downloads are disabled, so installing Java 24 alone is insufficient.
+
+To verify toolchain discovery and start the documentation site with its build dependencies:
+
+```bash
+mise exec -- pnpm nx run ':gradle-batch-runner:gradle:javaToolchains' --skipNxCache
+mise exec -- pnpm nx serve astro-docs
+```
+
+The toolchain report should list JDK 17 as detected through `JAVA17_HOME` and Java 24 as the current JVM. With mise activated, you can run the same `pnpm nx` commands directly.
+
 If you are using `VSCode`, and provided you have [Docker](https://docker.com) installed on your machine, then you can leverage [Dev Containers](https://containers.dev) through this [VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), to easily setup your development environment, with everything needed to contribute to Nx, already installed (namely `NodeJS`, `Yarn`, `Rust`, `Cargo`, plus some useful extensions like `Nx Console`).
 
 To do so, simply:

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,6 @@ org.gradle.caching=true
 org.gradle.configuration-cache=false
 
 # Use system JDK from mise instead of Gradle's auto-provisioning (foojay)
+org.gradle.java.installations.fromEnv=JAVA17_HOME
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=false

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 bun = "1.3"
-java = "24"
+# Keep Java 24 as the default runtime; Gradle compiles with JDK 17.
+java = ["24", "temurin-17"]
 node = "{{ env['NODE_VERSION'] | default(value='26.7.0') }}"
 maven = "3.9.11"
 rust = "1.95.0"
@@ -15,3 +16,8 @@ vale = "3.13.1"
 [tools.dotnet]
 version = "9"
 os = ["linux", "macos"]
+
+[env]
+# Match the second Java version above and expose it to Gradle toolchain discovery.
+# It may not exist yet while mise installs tools on a fresh machine.
+JAVA17_HOME = { value = "{{ tools.java[1].path | default(value='') }}", tools = true }


### PR DESCRIPTION
## Summary

`pnpm nx serve astro-docs` can stop before Astro starts because its Gradle prerequisites require JDK 17, while mise provisions only Java 24 and Gradle auto-download is disabled.

Provision Temurin 17 alongside Java 24, retain Java 24 as the default runtime, and expose `JAVA17_HOME` for Gradle toolchain discovery. Handle missing tools during initial installation and document setup and verification in CONTRIBUTING.md.

Validated isolated JDK installation, uncached Gradle compilation, 294 Gradle unit tests, lint, affected build/test/lint checks, and `nx prepush`. Normal docs startup was verified in Chrome and confirmed by the author. Affected e2e tests were blocked before execution by local-registry population failing during `nx release version`.