### PR TITLE
fix(repo): guard JAVA17_HOME against an uninstalled JDK

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -18,6 +18,5 @@ version = "9"
 os = ["linux", "macos"]
 
 [env]
-# Match the second Java version above and expose it to Gradle toolchain discovery.
-# It may not exist yet while mise installs tools on a fresh machine.
-JAVA17_HOME = { value = "{{ tools.java[1].path | default(value='') }}", tools = true }
+# Second Java version above, for Gradle toolchain discovery.
+JAVA17_HOME = { value = "{% if tools.java[1] is defined %}{{ tools.java[1].path }}{% endif %}", tools = true }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`JAVA17_HOME`, added in #36965, uses a `default` filter to cope with the JDK not being installed yet. `default` substitutes a missing value, not a missing field, so until temurin-17 is installed `tools.java[1]` has no `path` and the template raises before the filter runs. Every cargo-touching task then fails with an error that names the template rather than the missing JDK:

```
mise ERROR failed to parse template: '{{ tools.java[1].path | default(value='') }}'
mise ERROR error: Field `path` is not defined
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`JAVA17_HOME` is empty until the JDK is installed, and correct once it is.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
