### PR TITLE
fix(testing): invalidate inference caches for shared config imports

### DIFF
--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -108,10 +108,13 @@ Changing one of those doesn't re-infer the address.
 `CI` itself isn't filtered, so changing it re-infers the address.
 Running `nx reset` also discards the cached address.
 
-Files the config imports from outside its project, such as a shared helper in `tools/`, are not
-part of the cache either.
-Editing one doesn't refresh an already-cached address.
-Run `nx reset` to re-infer it.
+Nx also fingerprints workspace files referenced by literal imports or `require()` calls,
+including transitive helpers outside the project, such as a shared helper in `tools/`.
+Editing one refreshes the cached address when inference runs again.
+Nx doesn't track computed imports, arbitrary filesystem reads, or files outside the workspace.
+Run `nx reset` when those inputs change.
+You may also need to reset Nx when ignored files don't trigger a graph update or a reused loader
+retains transitive ECMAScript modules.
 
 A task dependency can't carry a target configuration, so the address is always inferred without
 one and a configuration-scoped env file such as `.env.e2e.production` never affects it.

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -7,6 +7,17 @@ import { nxE2EPreset } from '../../plugins/cypress-preset';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { resetWorkspaceContext } from '@nx/devkit/internal';
 
+var mockWorkspaceDataDir = '';
+jest.mock('nx/src/utils/cache-directory', () => {
+  const actual = jest.requireActual('nx/src/utils/cache-directory');
+  return {
+    ...actual,
+    get workspaceDataDirectory() {
+      return mockWorkspaceDataDir || actual.workspaceDataDirectory;
+    },
+  };
+});
+
 describe('@nx/cypress/plugin', () => {
   let createNodesFunction = createNodesV2[1];
   let context: CreateNodesContext;
@@ -41,6 +52,7 @@ describe('@nx/cypress/plugin', () => {
     };
 
     process.chdir(tempFs.tempDir);
+    mockWorkspaceDataDir = join(tempFs.tempDir, '.nx', 'workspace-data');
     originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
     process.env.NX_CACHE_PROJECT_GRAPH = 'false';
   });
@@ -55,6 +67,64 @@ describe('@nx/cypress/plugin', () => {
 
   afterAll(() => {
     resetWorkspaceContext();
+  });
+
+  it('accepts an empty config list with a virtual workspace root', async () => {
+    await expect(
+      createNodesFunction(
+        [],
+        {},
+        {
+          ...context,
+          workspaceRoot: join(tempFs.tempDir, 'virtual'),
+        }
+      )
+    ).resolves.toEqual([]);
+  });
+
+  it('refreshes cached atomized targets and outputs after only a shared transitive config changes', async () => {
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    await tempFs.createFiles({
+      'apps/e2e/package.json': '{}',
+      'apps/e2e/cypress.config.cjs': `globalThis.__cypressInferenceLoads = (globalThis.__cypressInferenceLoads ?? 0) + 1; module.exports = require('../../shared/config.cjs');`,
+      'apps/e2e/specs/a.cy.ts': '',
+      'apps/e2e/specs/b.cy.ts': '',
+      'shared/config.cjs': `const { selected } = require('./selection.json'); module.exports = { e2e: { specPattern: 'specs/' + selected + '.cy.ts', videosFolder: '../../out/' + selected, env: { ciWebServerCommand: 'echo ready' } } };`,
+      'shared/selection.json': '{"selected":"a"}',
+      'shared/unrelated.cjs': 'module.exports = 1;',
+    });
+    const infer = async () => {
+      // Clear Jest's module registry while retaining the plugin's disk cache.
+      jest.resetModules();
+      const nodes = await createNodesFunction(
+        ['apps/e2e/cypress.config.cjs'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+        context
+      );
+      return nodes[0][1].projects['apps/e2e'].targets;
+    };
+    try {
+      const first = await infer();
+      expect(first['e2e-ci--specs/a.cy.ts']).toBeDefined();
+      expect(first['e2e'].outputs.join()).toContain('out/a');
+      expect((globalThis as any).__cypressInferenceLoads).toBe(1);
+
+      tempFs.writeFile('shared/unrelated.cjs', 'module.exports = 2;');
+      expect(await infer()).toEqual(first);
+      expect((globalThis as any).__cypressInferenceLoads).toBe(1);
+
+      tempFs.writeFile('shared/selection.json', '{"selected":"b"}');
+      const second = await infer();
+      expect(second['e2e-ci--specs/a.cy.ts']).toBeUndefined();
+      expect(second['e2e-ci--specs/b.cy.ts']).toBeDefined();
+      expect(second['e2e'].outputs.join()).toContain('out/b');
+      expect((globalThis as any).__cypressInferenceLoads).toBe(2);
+    } finally {
+      delete (globalThis as any).__cypressInferenceLoads;
+    }
   });
 
   it('should add a target for e2e', async () => {
@@ -1745,10 +1815,10 @@ describe('@nx/cypress/plugin', () => {
   });
 
   function mockCypressConfig(cypressConfig: Cypress.ConfigOptions) {
-    // This isn't JS, but all that really matters here
-    // is that the hash is different after updating the
-    // config file. The actual config read is mocked below.
-    tempFs.createFileSync('cypress.config.js', JSON.stringify(cypressConfig));
+    tempFs.createFileSync(
+      'cypress.config.js',
+      `module.exports = ${JSON.stringify(cypressConfig)}`
+    );
     jest.mock(
       join(tempFs.tempDir, 'cypress.config.js'),
       () => ({

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -22,6 +22,7 @@ import {
   type TargetConfiguration,
 } from '@nx/devkit';
 import { getLockFileName } from '@nx/js';
+import { createConfigFileDependencyCollector } from '@nx/js/internal';
 import { readdirSync } from 'fs';
 import { dirname, join, relative, resolve } from 'path';
 import { NX_PLUGIN_OPTIONS } from '../utils/constants';
@@ -66,6 +67,12 @@ export const createNodes: CreateNodes<CypressPluginOptions> = [
         context
       );
 
+      const collectConfigDependencies = createConfigFileDependencyCollector(
+        context.workspaceRoot
+      );
+      const configHashes = entries.map(
+        (e) => collectConfigDependencies(e.configFile).hash
+      );
       const projectHashes = await calculateHashesForCreateNodes(
         entries.map((e) => e.projectRoot),
         normalizedOptions,
@@ -84,7 +91,9 @@ export const createNodes: CreateNodes<CypressPluginOptions> = [
               ctx,
               pluginCache,
               pmc,
-              projectHashes[idx]
+              configHashes[idx] === undefined
+                ? undefined
+                : projectHashes[idx] + configHashes[idx]
             ),
           entries.map((e) => e.configFile),
           options,
@@ -118,24 +127,23 @@ async function createNodesInternal(
   context: CreateNodesContext,
   pluginCache: PluginCache<CypressTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
-  projectHash: string
+  projectHash: string | undefined
 ) {
   const projectRoot = dirname(configFilePath);
-  const hash = projectHash + configFilePath;
+  const hash = projectHash && projectHash + configFilePath;
 
-  if (!pluginCache.has(hash)) {
-    pluginCache.set(
-      hash,
-      await buildCypressTargets(
-        configFilePath,
-        projectRoot,
-        options,
-        context,
-        pmc
-      )
+  let cypressTargets = hash ? pluginCache.get(hash) : undefined;
+  if (!cypressTargets) {
+    cypressTargets = await buildCypressTargets(
+      configFilePath,
+      projectRoot,
+      options,
+      context,
+      pmc
     );
+    if (hash) pluginCache.set(hash, cypressTargets);
   }
-  const { targets, metadata } = pluginCache.get(hash);
+  const { targets, metadata } = cypressTargets;
 
   const project: Omit<ProjectConfiguration, 'root'> = {
     projectType: 'application',

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -22,6 +22,7 @@ export {
   applyDaemonEnvFromClient,
   getGraphTimeDotEnvForTask,
   hashDaemonClientEnv,
+  createTsConfigPathMatcher,
 } from 'nx/src/devkit-internals';
 
 // Formatter detection and setup. `@nx/js` needs these to write and detect a

--- a/packages/js/internal.ts
+++ b/packages/js/internal.ts
@@ -103,6 +103,7 @@ export {
 export { findNpmDependencies } from './src/utils/find-npm-dependencies';
 
 // Plugin helpers
+export { createConfigFileDependencyCollector } from './src/utils/config-file-dependencies';
 export {
   addBuildAndWatchDepsTargets,
   isValidPackageJsonBuildConfig,

--- a/packages/js/src/utils/config-file-dependencies.spec.ts
+++ b/packages/js/src/utils/config-file-dependencies.spec.ts
@@ -1,0 +1,278 @@
+import { TempFs } from '@nx/devkit/internal-testing-utils';
+import { join } from 'node:path';
+import { createConfigFileDependencyCollector } from './config-file-dependencies';
+
+describe('config file dependencies', () => {
+  let fs: TempFs;
+  const collect = (config = 'apps/e2e/config.cjs') =>
+    createConfigFileDependencyCollector(fs.tempDir)(config);
+
+  beforeEach(() => {
+    fs = new TempFs('config-dependencies');
+    fs.createFilesSync({
+      'package.json': '{}',
+      'apps/e2e/config.cjs': `module.exports = require('./helper.cjs');`,
+      'apps/e2e/helper.cjs': `module.exports = require('../../shared/config.cjs');`,
+      'shared/config.cjs': `module.exports = require('./selection.json');`,
+      'shared/selection.json': '{"selected":"a"}',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fs.cleanup();
+  });
+
+  it('hashes transitive imports, including ignored files, without unrelated workspace files', () => {
+    fs.createFilesSync({
+      '.gitignore': 'shared/selection.json\n',
+      'unrelated.cjs': 'module.exports = 1;',
+    });
+    const first = collect();
+    expect(first.files).toEqual([
+      'apps/e2e/config.cjs',
+      'apps/e2e/helper.cjs',
+      'package.json',
+      'shared/config.cjs',
+      'shared/selection.json',
+    ]);
+    expect(collect().hash).toBe(first.hash);
+    fs.writeFile('unrelated.cjs', 'module.exports = 2;');
+    expect(collect().hash).toBe(first.hash);
+    fs.writeFile('shared/selection.json', '{"selected":"b"}');
+    expect(collect().hash).not.toBe(first.hash);
+  });
+
+  it('revisits removed, created and changed imports and terminates cycles', () => {
+    fs.writeFile(
+      'shared/config.cjs',
+      `require('../apps/e2e/config.cjs'); module.exports = require('./selection.json'); try { require('./optional.cjs'); } catch {}`
+    );
+    const first = collect().hash;
+    fs.removeFileSync('shared/selection.json');
+    expect(collect().hash).not.toBe(first);
+    const removed = collect().hash;
+    fs.createFileSync('shared/optional.cjs', 'module.exports = 1;');
+    expect(collect().hash).not.toBe(removed);
+  });
+
+  it('follows exports, dynamic imports, TS runtime fallbacks, and URL imports', () => {
+    fs.createFilesSync({
+      'apps/e2e/config.mts': `export * from '../../shared/entry.js'; const value = await import('../../shared/lazy.mjs?mode=x');`,
+      'shared/entry.ts': `import data = require('./selection.json'); export { data };`,
+      'shared/lazy.mjs': `export { default } from './selection.json' with { type: 'json' };`,
+    });
+    expect(collect('apps/e2e/config.mts').files).toEqual(
+      expect.arrayContaining([
+        'shared/entry.ts',
+        'shared/lazy.mjs',
+        'shared/selection.json',
+      ])
+    );
+    fs.createFileSync('shared/entry.js', 'export const selected = "real-js";');
+    const files = collect('apps/e2e/config.mts').files;
+    expect(files).toContain('shared/entry.js');
+    expect(files).not.toContain('shared/entry.ts');
+  });
+
+  it('follows cooked template literals without expressions', () => {
+    fs.createFilesSync({
+      'apps/e2e/config.cjs':
+        'module.exports = require(`../../shared/selection\\x2ejson`); import(`../../shared/lazy.cjs`);',
+      'shared/lazy.cjs': 'module.exports = {};',
+    });
+    const first = collect();
+    expect(first.files).toEqual(
+      expect.arrayContaining(['shared/selection.json', 'shared/lazy.cjs'])
+    );
+    fs.writeFile('shared/selection.json', '{"selected":"b"}');
+    expect(collect().hash).not.toBe(first.hash);
+  });
+
+  it('preserves CommonJS filenames that are not valid file URLs', () => {
+    fs.createFilesSync({
+      'apps/e2e/config.cjs':
+        "module.exports = require('../../shared/50%.cjs'); require('../../shared/selection%2F.json');",
+      'shared/50%.cjs': 'module.exports = {};',
+      'shared/selection%2F.json': '{}',
+    });
+    expect(collect().files).toEqual(
+      expect.arrayContaining(['shared/50%.cjs', 'shared/selection%2F.json'])
+    );
+  });
+
+  it('resolves inherited aliases to runtime package entries, not declarations', () => {
+    fs.createFilesSync({
+      'apps/e2e/tsconfig.json': '{"extends":"../../tsconfig.base.json"}',
+      'tsconfig.base.json':
+        '{"compilerOptions":{"paths":{"@settings":["shared/settings"]}}}',
+      'apps/e2e/config.cjs': `module.exports = require('@settings');`,
+      'shared/settings/package.json':
+        '{"main":"runtime.cjs","types":"index.d.ts"}',
+      'shared/settings/runtime.cjs': `module.exports = require('../selection.json');`,
+      'shared/settings/index.d.ts': 'export declare const selected: string;',
+    });
+    const first = collect();
+    expect(first.files).toEqual(
+      expect.arrayContaining([
+        'apps/e2e/tsconfig.json',
+        'tsconfig.base.json',
+        'shared/settings/package.json',
+        'shared/settings/runtime.cjs',
+        'shared/selection.json',
+      ])
+    );
+    expect(first.files).not.toContain('shared/settings/index.d.ts');
+    fs.writeFile('shared/selection.json', '{"selected":"b"}');
+    expect(collect().hash).not.toBe(first.hash);
+  });
+
+  it('matches runtime alias resolution when multiple extends define paths', () => {
+    fs.createFilesSync({
+      'apps/e2e/tsconfig.json':
+        '{"extends":["../../shared/a/tsconfig.json","../../shared/b/tsconfig.json"]}',
+      'apps/e2e/config.cjs': "module.exports = require('@settings');",
+      'shared/a/tsconfig.json':
+        '{"compilerOptions":{"paths":{"@settings":["./runtime.cjs"]}}}',
+      'shared/b/tsconfig.json':
+        '{"compilerOptions":{"paths":{"@settings":["./runtime.cjs"]}}}',
+      'shared/a/runtime.cjs': 'module.exports = "a";',
+      'shared/b/runtime.cjs': 'module.exports = "unused";',
+    });
+    // registerTsConfigPaths currently resolves this shared path against A.
+    const first = collect();
+    expect(first.files).toEqual(
+      expect.arrayContaining([
+        'shared/a/tsconfig.json',
+        'shared/b/tsconfig.json',
+        'shared/a/runtime.cjs',
+      ])
+    );
+    expect(first.files).not.toContain('shared/b/runtime.cjs');
+    fs.writeFile('shared/b/runtime.cjs', 'module.exports = "still-unused";');
+    expect(collect().hash).toBe(first.hash);
+    fs.writeFile('shared/a/runtime.cjs', 'module.exports = "b";');
+    expect(collect().hash).not.toBe(first.hash);
+  });
+
+  it('reuses shared probes and edges while retaining each config dependency set', () => {
+    fs.createFilesSync({
+      'apps/e2e/tsconfig.json': '{"extends":"../../tsconfig.base.json"}',
+      'apps/other/tsconfig.json': '{"extends":"../../tsconfig.base.json"}',
+      'tsconfig.base.json':
+        '{"compilerOptions":{"paths":{"@selection":["shared/selection.json"]}}}',
+      'shared/config.cjs': "module.exports = require('@selection');",
+      'apps/other/config.cjs':
+        "module.exports = require('../../shared/config.cjs'); require('./only.cjs');",
+      'apps/other/only.cjs': 'module.exports = {};',
+      'apps/alone/config.cjs': 'module.exports = {};',
+    });
+    const nodeFs = require('node:fs');
+    const probes = ['realpathSync', 'statSync', 'existsSync'].map((method) =>
+      jest.spyOn(nodeFs, method)
+    );
+    const sharedProbes = () =>
+      probes.map(
+        (probe) =>
+          probe.mock.calls.filter(([path]) =>
+            String(path).includes(join(fs.tempDir, 'shared'))
+          ).length
+      );
+    const collectPass = createConfigFileDependencyCollector(fs.tempDir);
+    collectPass('apps/e2e/config.cjs');
+    const initialProbes = sharedProbes();
+    expect(initialProbes.reduce((sum, count) => sum + count)).toBeGreaterThan(
+      0
+    );
+
+    const second = collectPass('apps/other/config.cjs');
+    expect(sharedProbes()).toEqual(initialProbes);
+    expect(second.files).toEqual(
+      expect.arrayContaining([
+        'shared/config.cjs',
+        'shared/selection.json',
+        'apps/other/only.cjs',
+      ])
+    );
+    expect(second.files).not.toContain('apps/e2e/helper.cjs');
+    expect(second.files).not.toContain('apps/e2e/config.cjs');
+    expect(collectPass('apps/alone/config.cjs').files).not.toContain(
+      'shared/selection.json'
+    );
+  });
+
+  it('keeps cached edges separate when configs have different aliases', () => {
+    fs.createFilesSync({
+      'apps/e2e/tsconfig.json':
+        '{"compilerOptions":{"paths":{"@selection":["../../shared/a.json"]}}}',
+      'apps/other/tsconfig.json':
+        '{"compilerOptions":{"paths":{"@selection":["../../shared/b.json"]}}}',
+      'apps/other/config.cjs':
+        "module.exports = require('../../shared/config.cjs');",
+      'shared/config.cjs': "module.exports = require('@selection');",
+      'shared/a.json': '"a"',
+      'shared/b.json': '"b"',
+    });
+    const collectPass = createConfigFileDependencyCollector(fs.tempDir);
+    const first = collectPass('apps/e2e/config.cjs');
+    const second = collectPass('apps/other/config.cjs');
+    expect(first.files).toContain('shared/a.json');
+    expect(first.files).not.toContain('shared/b.json');
+    expect(second.files).toContain('shared/b.json');
+    expect(second.files).not.toContain('shared/a.json');
+  });
+
+  it('tracks both runtime conditions of workspace package exports, including ESM-only exports', () => {
+    fs.createFilesSync({
+      'apps/e2e/config.cjs': `module.exports = require('@workspace/settings'); import('@workspace/settings/esm');`,
+      'shared/settings/package.json': JSON.stringify({
+        name: '@workspace/settings',
+        exports: {
+          '.': {
+            import: './import.mjs',
+            require: './require.cjs',
+            types: './index.d.ts',
+          },
+          './esm': { import: './import.mjs' },
+        },
+      }),
+      'shared/settings/import.mjs': `export { default } from '../selection.json' with { type: 'json' };`,
+      'shared/settings/require.cjs': 'module.exports = {};',
+      'shared/settings/index.d.ts': 'export declare const selected: string;',
+    });
+    fs.createSymlinkSync(
+      'shared/settings',
+      'node_modules/@workspace/settings',
+      'dir'
+    );
+    const first = collect();
+    expect(first.files).toEqual(
+      expect.arrayContaining([
+        'shared/settings/package.json',
+        'shared/settings/import.mjs',
+        'shared/settings/require.cjs',
+        'shared/selection.json',
+      ])
+    );
+    fs.writeFile('shared/selection.json', '{"selected":"b"}');
+    expect(collect().hash).not.toBe(first.hash);
+  });
+
+  it('accepts CJS returns and decorated TypeScript without running Babel configs', () => {
+    fs.createFilesSync({
+      'babel.config.cjs': `throw new Error('must not evaluate');`,
+      'apps/e2e/config.cjs': `if (false) return; module.exports = require('../../shared/config.ts');`,
+      'shared/config.ts': `// nx-ignore-next-line\nimport data from './selection.json'; function decorator(target: any) {} @decorator class Config {} export default data;`,
+    });
+    expect(collect().files).toContain('shared/selection.json');
+    expect(collect().hash).toBeDefined();
+  });
+
+  it('disables caching when syntax or tsconfig resolution prevents a complete closure', () => {
+    fs.writeFile('shared/config.cjs', 'unsupported future syntax');
+    expect(collect().hash).toBeUndefined();
+    fs.writeFile('shared/config.cjs', 'module.exports = {};');
+    fs.createFileSync('apps/e2e/tsconfig.json', 'invalid JSON');
+    expect(collect().hash).toBeUndefined();
+  });
+});

--- a/packages/js/src/utils/config-file-dependencies.ts
+++ b/packages/js/src/utils/config-file-dependencies.ts
@@ -1,0 +1,431 @@
+import { hashArray, normalizePath, readJsonFile } from '@nx/devkit';
+import { createTsConfigPathMatcher, hashFile } from '@nx/devkit/internal';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { createRequire, isBuiltin } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { walkTsconfigExtendsChain } from './typescript/raw-tsconfig';
+
+/**
+ * Creates a per-inference-pass collector for the workspace files imported by a
+ * config. It does not evaluate the config or reuse resolution from an earlier
+ * pass: imports, package exports and tsconfig paths may all have changed.
+ *
+ * ponytail: only literal module references are discoverable here; computed
+ * imports and arbitrary fs reads need runtime dependency tracking.
+ */
+export function createConfigFileDependencyCollector(workspaceRoot: string) {
+  let canonicalWorkspaceRoot: string;
+  const imports = new Map<string, string[] | null>();
+  const json = new Map<string, any>();
+  const hashes = new Map<string, string>();
+  const workspacePaths = new Map<string, string | undefined>();
+  const existingPaths = new Map<string, boolean>();
+  const filePaths = new Map<string, boolean>();
+  const packageScopes = new Map<string, string | undefined>();
+  const dependencies = new Map<string, Map<string, string[] | null>>();
+  const tsconfigs = new Map<
+    string,
+    {
+      files: string[];
+      matcher?: ReturnType<typeof createTsConfigPathMatcher>;
+      complete: boolean;
+    }
+  >();
+
+  function workspacePath(path: string): string | undefined {
+    if (workspacePaths.has(path)) return workspacePaths.get(path);
+    const original = path;
+    try {
+      path = realpathSync(path);
+    } catch (error) {
+      if (
+        ['ENOENT', 'ENOTDIR'].includes((error as NodeJS.ErrnoException).code)
+      ) {
+        workspacePaths.set(original, undefined);
+        return undefined;
+      }
+      throw error;
+    }
+    const rel = relative(workspaceRoot, path);
+    if (
+      rel === '..' ||
+      rel.startsWith(`..${sep}`) ||
+      isAbsolute(rel) ||
+      rel.split(sep).some((part) => part === 'node_modules' || part === '.yarn')
+    ) {
+      workspacePaths.set(original, undefined);
+      return undefined;
+    }
+    workspacePaths.set(original, path);
+    workspacePaths.set(path, path);
+    return path;
+  }
+
+  function exists(path: string): boolean {
+    if (!existingPaths.has(path)) existingPaths.set(path, existsSync(path));
+    return existingPaths.get(path);
+  }
+
+  function isFile(path: string): boolean {
+    if (!filePaths.has(path)) {
+      try {
+        filePaths.set(path, statSync(path).isFile());
+      } catch (error) {
+        if (
+          !['ENOENT', 'ENOTDIR'].includes((error as NodeJS.ErrnoException).code)
+        )
+          throw error;
+        filePaths.set(path, false);
+      }
+    }
+    return filePaths.get(path);
+  }
+
+  function packageScope(file: string): string | undefined {
+    let directory = dirname(file);
+    const visited: string[] = [];
+    let scope: string | undefined;
+    while (workspacePath(directory)) {
+      if (packageScopes.has(directory)) {
+        scope = packageScopes.get(directory);
+        break;
+      }
+      visited.push(directory);
+      const manifest = join(directory, 'package.json');
+      if (exists(manifest)) {
+        scope = manifest;
+        break;
+      }
+      if (directory === workspaceRoot) break;
+      directory = dirname(directory);
+    }
+    for (const directory of visited) packageScopes.set(directory, scope);
+    return scope;
+  }
+
+  function readJson(path: string) {
+    if (!json.has(path)) {
+      try {
+        json.set(path, readJsonFile(path));
+      } catch {
+        json.set(path, undefined);
+      }
+    }
+    return json.get(path);
+  }
+
+  function getTsconfig(configFile: string) {
+    const path = [
+      join(dirname(configFile), 'tsconfig.json'),
+      join(workspaceRoot, 'tsconfig.base.json'),
+      join(workspaceRoot, 'tsconfig.json'),
+    ].find(exists);
+    if (!path) return { files: [], complete: true };
+    if (!tsconfigs.has(path)) {
+      const files: string[] = [];
+      walkTsconfigExtendsChain(
+        path,
+        (file) => {
+          files.push(file);
+          return 'continue';
+        },
+        { jsonCache: json }
+      );
+      try {
+        tsconfigs.set(path, {
+          files,
+          matcher: createTsConfigPathMatcher(path),
+          complete: true,
+        });
+      } catch {
+        // JavaScript configs may load without consulting a malformed tsconfig.
+        tsconfigs.set(path, { files, complete: false });
+      }
+    }
+    return tsconfigs.get(path);
+  }
+
+  function getImports(file: string): string[] | null {
+    if (!imports.has(file)) {
+      const {
+        parseSync,
+        traverse,
+      }: typeof import('@babel/core') = require('@babel/core');
+      const found = new Set<string>();
+      const source = readFileSync(file, 'utf8');
+      let ast: ReturnType<typeof parseSync>;
+      try {
+        ast = parseSync(source, {
+          filename: file,
+          babelrc: false,
+          configFile: false,
+          sourceType: 'unambiguous',
+          parserOpts: {
+            allowReturnOutsideFunction: true,
+            allowAwaitOutsideFunction: true,
+            plugins: [
+              'typescript',
+              'decorators-legacy',
+              ...(file.endsWith('x') ? ['jsx' as const] : []),
+            ],
+          },
+        });
+      } catch (error) {
+        if ((error as any).code !== 'BABEL_PARSE_ERROR') throw error;
+        // The loader may support syntax this parser does not. Let it evaluate
+        // the config, but never reuse a cache key with an unknown closure.
+        imports.set(file, null);
+        return null;
+      }
+      traverse(ast, {
+        noScope: true,
+        enter({ node }) {
+          if (
+            node.type === 'ImportDeclaration' ||
+            node.type === 'ExportAllDeclaration' ||
+            node.type === 'ExportNamedDeclaration'
+          ) {
+            if (node.source) found.add(node.source.value);
+          } else if (
+            node.type === 'CallExpression' &&
+            (node.callee.type === 'Import' ||
+              (node.callee.type === 'Identifier' &&
+                node.callee.name === 'require'))
+          ) {
+            const argument = node.arguments[0];
+            if (argument?.type === 'StringLiteral') {
+              found.add(argument.value);
+            } else if (
+              argument?.type === 'TemplateLiteral' &&
+              argument.expressions.length === 0 &&
+              argument.quasis[0].value.cooked != null
+            ) {
+              found.add(argument.quasis[0].value.cooked);
+            }
+          } else if (
+            node.type === 'TSImportEqualsDeclaration' &&
+            node.moduleReference.type === 'TSExternalModuleReference'
+          ) {
+            found.add(node.moduleReference.expression.value);
+          }
+        },
+      });
+      imports.set(file, [...found]);
+    }
+    return imports.get(file);
+  }
+
+  function getDependencies(
+    importer: string,
+    matcher: ReturnType<typeof createTsConfigPathMatcher>
+  ): string[] | null {
+    const key = matcher?.key ?? '';
+    if (!dependencies.has(key)) dependencies.set(key, new Map());
+    const resolved = dependencies.get(key);
+    if (resolved.has(importer)) return resolved.get(importer);
+
+    const specifiers = getImports(importer);
+    if (specifiers === null) {
+      resolved.set(importer, null);
+      return null;
+    }
+    const result = new Set<string>();
+    const add = (path: string) => {
+      const local = workspacePath(path);
+      if (local) result.add(local);
+    };
+    const requireFrom = createRequire(importer);
+    const scope = packageScope(importer);
+
+    function resolveImport(specifier: string, seen: Set<string>) {
+      if (isBuiltin(specifier) || seen.has(specifier)) return;
+      seen.add(specifier);
+      if (
+        specifier.startsWith('file:') ||
+        (specifier.startsWith('.') && /[?#%]/.test(specifier))
+      ) {
+        let path: string | undefined;
+        try {
+          path = fileURLToPath(new URL(specifier, pathToFileURL(importer)));
+        } catch {
+          // A CommonJS filename can contain a literal, unescaped percent sign.
+        }
+        if (path) resolveImport(path, seen);
+        if (specifier.startsWith('file:')) return;
+      }
+      const relativePath =
+        specifier.startsWith('.') || isAbsolute(specifier)
+          ? resolve(dirname(importer), specifier)
+          : undefined;
+      let resolvedPath =
+        relativePath && isFile(relativePath) ? relativePath : undefined;
+      if (!resolvedPath) {
+        try {
+          resolvedPath = requireFrom.resolve(specifier);
+        } catch {
+          // Missing optional imports must not prevent config evaluation. A newly
+          // created file will be discovered when this pass is run again.
+        }
+      }
+      if (resolvedPath) add(resolvedPath);
+      if (
+        !resolvedPath &&
+        (specifier.startsWith('.') || isAbsolute(specifier))
+      ) {
+        const path = resolve(dirname(importer), specifier);
+        for (const candidate of [
+          path,
+          ...(/\.[cm]?js$/.test(path)
+            ? [
+                path.replace(/\.js$/, '.ts'),
+                path.replace(/\.js$/, '.tsx'),
+                path.replace(/\.mjs$/, '.mts'),
+                path.replace(/\.cjs$/, '.cts'),
+              ]
+            : []),
+          ...[
+            '.ts',
+            '.tsx',
+            '.mts',
+            '.cts',
+            '.js',
+            '.jsx',
+            '.mjs',
+            '.cjs',
+            '.json',
+          ].flatMap((extension) => [
+            path + extension,
+            join(path, 'index' + extension),
+          ]),
+        ]) {
+          if (isFile(candidate)) add(candidate);
+        }
+      }
+      if (matcher) {
+        const mapped = matcher.matchPath(
+          specifier,
+          (file) => {
+            add(file);
+            return readJson(file);
+          },
+          isFile,
+          ['.js', '.json', '.ts', '.tsx', '.mts', '.cts', '.mjs', '.cjs']
+        );
+        if (mapped) resolveImport(mapped, seen);
+      }
+      if (specifier.startsWith('.') || isAbsolute(specifier)) return;
+
+      if (specifier.startsWith('#')) {
+        for (const target of packageTargets(
+          readJson(scope)?.imports,
+          specifier
+        )) {
+          if (target.startsWith('.')) add(resolve(dirname(scope), target));
+          else resolveImport(target, seen);
+        }
+        return;
+      }
+      const parts = specifier.split('/');
+      const name = parts.slice(0, specifier.startsWith('@') ? 2 : 1).join('/');
+      const subpath = '.' + specifier.slice(name.length);
+      const candidates = [
+        ...(scope && readJson(scope)?.name === name ? [scope] : []),
+        ...(requireFrom.resolve.paths(specifier) ?? []).map((directory) =>
+          join(directory, name, 'package.json')
+        ),
+      ];
+      const manifest = candidates.find(exists);
+      if (!manifest || !workspacePath(manifest)) return;
+      add(manifest);
+      const pkg = readJson(manifest);
+      // Hash every applicable conditional target, so ESM-only exports are
+      // covered even on a host that only exposes require.resolve().
+      for (const target of packageTargets(pkg?.exports, subpath)) {
+        if (target.startsWith('./')) add(resolve(dirname(manifest), target));
+      }
+    }
+
+    for (const specifier of specifiers) resolveImport(specifier, new Set());
+    resolved.set(importer, [...result]);
+    return resolved.get(importer);
+  }
+
+  return (
+    configFile: string
+  ): { files: string[]; hash: string | undefined } => {
+    if (!canonicalWorkspaceRoot) {
+      workspaceRoot = canonicalWorkspaceRoot = realpathSync(workspaceRoot);
+    }
+    const result = new Set<string>();
+    const visited = new Set<string>();
+    const tsconfig = getTsconfig(resolve(workspaceRoot, configFile));
+    let complete = tsconfig.complete;
+    const add = (path: string) => {
+      const local = workspacePath(path);
+      if (local) result.add(normalizePath(relative(workspaceRoot, local)));
+      return local;
+    };
+    tsconfig.files.forEach(add);
+
+    function visit(file: string) {
+      file = add(file);
+      if (!file || visited.has(file)) return;
+      visited.add(file);
+      const scope = packageScope(file);
+      if (scope) add(scope);
+      if (!/\.[cm]?[jt]sx?$/.test(file) || /\.d\.[cm]?ts$/.test(file)) return;
+      const dependencies = getDependencies(file, tsconfig.matcher);
+      if (dependencies === null) {
+        complete = false;
+        return;
+      }
+      dependencies.forEach(visit);
+    }
+
+    visit(resolve(workspaceRoot, configFile));
+    const files = [...result].sort();
+    return {
+      files,
+      // Workspace glob hashing excludes ignored files. An explicitly imported
+      // config still affects inference, so fingerprint its content directly.
+      hash: complete
+        ? hashArray(
+            files.flatMap((file) => {
+              if (!hashes.has(file))
+                hashes.set(file, hashFile(join(workspaceRoot, file)));
+              return [file, hashes.get(file)];
+            })
+          )
+        : undefined,
+    };
+  };
+}
+
+function packageTargets(exports: unknown, subpath: string): string[] {
+  const leaves = (value: unknown): string[] =>
+    typeof value === 'string'
+      ? [value]
+      : value && typeof value === 'object'
+        ? Object.values(value).flatMap(leaves)
+        : [];
+  if (!exports || typeof exports !== 'object' || Array.isArray(exports)) {
+    return subpath === '.' ? leaves(exports) : [];
+  }
+  const entries = Object.entries(exports);
+  if (!entries.some(([key]) => key.startsWith('.') || key.startsWith('#'))) {
+    return subpath === '.' ? leaves(exports) : [];
+  }
+  return entries.flatMap(([key, value]) => {
+    if (key === subpath) return leaves(value);
+    const star = key.indexOf('*');
+    if (
+      star < 0 ||
+      !subpath.startsWith(key.slice(0, star)) ||
+      !subpath.endsWith(key.slice(star + 1))
+    )
+      return [];
+    const match = subpath.slice(star, subpath.length - key.length + star + 1);
+    return leaves(value).map((target) => target.replaceAll('*', match));
+  });
+}

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -90,6 +90,7 @@ export {
   isRequireInEsmScopeError,
   isTsEsmNamedExportLinkageError,
   requireWithTsconfigFallback,
+  createTsConfigPathMatcher,
 } from './plugins/js/utils/register';
 export { interpolate } from './tasks-runner/utils';
 export {

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -1267,6 +1267,28 @@ export function registerTsConfigPaths(tsConfigPath): () => void {
   throw new Error(`Unable to load ${tsConfigPath}`);
 }
 
+export function createTsConfigPathMatcher(tsConfigPath: string):
+  | {
+      matchPath: ReturnType<typeof import('tsconfig-paths').createMatchPath>;
+      key: string;
+    }
+  | undefined {
+  const tsconfigPaths = loadTsConfigPaths();
+  const config = tsconfigPaths?.loadConfig(tsConfigPath);
+  if (
+    config?.resultType !== 'success' ||
+    !config.paths ||
+    Object.keys(config.paths).length === 0
+  ) {
+    return undefined;
+  }
+  const baseUrl = resolvePathsBaseUrl(tsConfigPath);
+  return {
+    matchPath: tsconfigPaths.createMatchPath(baseUrl, config.paths),
+    key: JSON.stringify([baseUrl, config.paths]),
+  };
+}
+
 function readCompilerOptions(tsConfigPath): {
   compilerOptions: CompilerOptions;
   tsConfigRaw?: unknown;

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -101,6 +101,65 @@ describe('@nx/playwright/plugin', () => {
     process.env.NX_CACHE_PROJECT_GRAPH = originalCacheProjectGraph;
   });
 
+  it('accepts an empty config list with a virtual workspace root', async () => {
+    await expect(
+      createNodesFunction(
+        [],
+        {},
+        {
+          ...context,
+          workspaceRoot: join(tempFs.tempDir, 'virtual'),
+        }
+      )
+    ).resolves.toEqual([]);
+  });
+
+  it('refreshes cached atomized targets and outputs after only a shared transitive config changes', async () => {
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    await tempFs.createFiles({
+      'apps/e2e/package.json': '{}',
+      'apps/e2e/playwright.config.cjs': `globalThis.__playwrightInferenceLoads = (globalThis.__playwrightInferenceLoads ?? 0) + 1; module.exports = require('../../shared/config.cjs');`,
+      'apps/e2e/specs/a.spec.ts': '',
+      'apps/e2e/specs/b.spec.ts': '',
+      'shared/config.cjs': `const { selected } = require('./selection.json'); module.exports = { testDir: 'specs', testMatch: '**/' + selected + '.spec.ts', outputDir: '../../out/' + selected };`,
+      'shared/selection.json': '{"selected":"a"}',
+      'shared/unrelated.cjs': 'module.exports = 1;',
+    });
+    const infer = async () => {
+      // Clear Jest's module registry while retaining the plugin's disk cache.
+      jest.resetModules();
+      const nodes = await createNodesFunction(
+        ['apps/e2e/playwright.config.cjs'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+          waitForWebServer: false,
+        },
+        context
+      );
+      return nodes[0][1].projects['apps/e2e'].targets;
+    };
+    try {
+      const first = await infer();
+      expect(first['e2e-ci--specs/a.spec.ts']).toBeDefined();
+      expect(first['e2e'].outputs.join()).toContain('out/a');
+      expect((globalThis as any).__playwrightInferenceLoads).toBe(1);
+
+      tempFs.writeFile('shared/unrelated.cjs', 'module.exports = 2;');
+      expect(await infer()).toEqual(first);
+      expect((globalThis as any).__playwrightInferenceLoads).toBe(1);
+
+      tempFs.writeFile('shared/selection.json', '{"selected":"b"}');
+      const second = await infer();
+      expect(second['e2e-ci--specs/a.spec.ts']).toBeUndefined();
+      expect(second['e2e-ci--specs/b.spec.ts']).toBeDefined();
+      expect(second['e2e'].outputs.join()).toContain('out/b');
+      expect((globalThis as any).__playwrightInferenceLoads).toBe(2);
+    } finally {
+      delete (globalThis as any).__playwrightInferenceLoads;
+    }
+  });
+
   it('should create nodes with default playwright configuration', async () => {
     await mockPlaywrightConfig(tempFs, {});
     const results = await createNodesFunction(

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -28,7 +28,10 @@ import {
   type TargetDependencyConfig,
 } from '@nx/devkit';
 import { getLockFileName, getRootTsConfigFileName } from '@nx/js';
-import { walkTsconfigExtendsChain } from '@nx/js/internal';
+import {
+  createConfigFileDependencyCollector,
+  walkTsconfigExtendsChain,
+} from '@nx/js/internal';
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { minimatch } from 'minimatch';
 import { existsSync, readdirSync } from 'node:fs';
@@ -132,6 +135,12 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
         context
       );
 
+      const collectConfigDependencies = createConfigFileDependencyCollector(
+        context.workspaceRoot
+      );
+      const configHashes = entries.map(
+        (e) => collectConfigDependencies(e.configFile).hash
+      );
       const projectHashes = await calculateHashesForCreateNodes(
         entries.map((e) => e.projectRoot),
         { ...normalizedOptions, ambientEnvHash },
@@ -164,7 +173,9 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
               pluginCache,
               pmc,
               entries[idx].externalTsconfigInputs,
-              projectHashes[idx],
+              configHashes[idx] === undefined
+                ? undefined
+                : projectHashes[idx] + configHashes[idx],
               dotEnvFileHashes
             ),
           entries.map((e) => e.configFile),
@@ -210,7 +221,7 @@ async function createNodesInternal(
   pluginCache: PluginCache<PlaywrightTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   externalTsconfigInputs: string[],
-  hash: string,
+  hash: string | undefined,
   dotEnvFileHashes: Map<string, string | null>
 ) {
   const projectRoot = dirname(configFilePath);
@@ -240,7 +251,7 @@ async function createNodesInternal(
     npmConfigProxy,
   })}`;
 
-  let playwrightTargets = pluginCache.get(cacheKey);
+  let playwrightTargets = hash ? pluginCache.get(cacheKey) : undefined;
   if (!playwrightTargets) {
     const { taskEnvEvalFailed, ...built } = await buildPlaywrightTargets(
       configFilePath,
@@ -256,7 +267,7 @@ async function createNodesInternal(
     // The key encodes nothing about evaluation success, so caching a failed
     // evaluation's gate-less fallback would make a transient failure (a
     // timeout, a fork error) permanent; leave it out so the next pass retries.
-    if (!taskEnvEvalFailed) {
+    if (hash && !taskEnvEvalFailed) {
       pluginCache.set(cacheKey, built);
     }
     playwrightTargets = built;


### PR DESCRIPTION
## Current Behavior

Cypress and Playwright reuse cached inferred targets after a configuration imports a shared workspace helper and only that helper changes. For example, changing a shared spec selection from A to B or changing an output directory can leave the warm graph with A and the old outputs. Normal task inputs do not invalidate this plugin inference cache.

[Reproduction](https://github.com/llwt/nx-shared-config-inference-cache-repro)

## Expected Behavior

Fingerprint statically resolvable workspace imports before reading either plugin's inference cache, including transitive helpers, static template literals, workspace package references and TypeScript aliases. Shared configuration edits refresh atomized target membership and outputs when inference runs again. Existing hash inputs remain in place, and parser failures bypass cache reuse.

The shared collector uses existing dependencies and memoizes file resolution within each inference pass. Regression tests exercise actual disk-cache reuse in both plugins, including continued hits after unrelated edits.

Computed imports, arbitrary filesystem reads and files outside the workspace remain outside this tracking boundary. Ignored-file graph triggers and reused transitive ESM module registries retain their existing limits, which are documented.

## Validation

- Builds and lint pass for nx, devkit, js, cypress and playwright.
- Full js, devkit, cypress and playwright unit suites pass.
- Compiled packages pass direct, transitive, template-literal and TypeScript-alias scenarios for both plugins in an independent consumer using fresh CLI processes. Warm B matches cold B for targets and outputs.
- `pnpm nx prepush`, documentation style checks and commit-message hooks pass.
- Affected build/test/lint completes 176 tasks before a native hasher worker error. That error and an intermittent native watcher assertion reproduce on the unchanged base with the same installed dependencies and native binary.
- Affected `e2e-local` is blocked by an occupied Docker registry port 5000.

## Related Issue(s)

Fixes #36968