### PR TITLE
fix(angular-rspack): keep incremental rebuild state warm when skipTypeChecking is enabled

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -385,9 +385,7 @@ describe('AngularRspackPlugin', () => {
 
     // DiagnosticModes.All & ~DiagnosticModes.Semantic === 7 & ~4 === 3
     expect(diagnoseFiles).toHaveBeenCalledWith(3);
-    // DiagnosticModes.Semantic === 4 - run silently so NgCompiler still
-    // reaches `ensureAnalyzed()` and advances its incremental state, even
-    // though these diagnostics are never surfaced.
+    // DiagnosticModes.Semantic === 4
     expect(diagnoseFiles).toHaveBeenCalledWith(4);
     expect(diagnoseFiles).toHaveBeenCalledTimes(2);
   });
@@ -470,9 +468,7 @@ describe('AngularRspackPlugin', () => {
     } as never);
     plugin.apply(compiler as never);
 
-    // beforeRun/beforeCompile await buildAndAnalyze(), which only awaits up
-    // to starting (not resolving) the diagnostics promise, so this settles
-    // even while the surfaced call above is still pending.
+    // Keep surfaced diagnostics pending while both build-start hooks settle.
     await fireAsyncTaps(compiler.hooks.beforeRun, compiler);
     await fireAsyncTaps(compiler.hooks.beforeCompile, {});
 

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -368,6 +368,122 @@ describe('AngularRspackPlugin', () => {
     expect(compilation.errors).toHaveLength(0);
   });
 
+  it('should also silently run semantic diagnostics when type checking is skipped, to keep the incremental compilation state warm', async () => {
+    const diagnoseFiles = vi.fn().mockResolvedValue({});
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles },
+      collectedStylesheetAssets: [],
+    });
+    const compiler = createFakeCompiler();
+    const plugin = new AngularRspackPlugin({
+      ...options,
+      skipTypeChecking: true,
+    } as never);
+    plugin.apply(compiler as never);
+
+    await runBuildStart(compiler);
+
+    // DiagnosticModes.All & ~DiagnosticModes.Semantic === 7 & ~4 === 3
+    expect(diagnoseFiles).toHaveBeenCalledWith(3);
+    // DiagnosticModes.Semantic === 4 - run silently so NgCompiler still
+    // reaches `ensureAnalyzed()` and advances its incremental state, even
+    // though these diagnostics are never surfaced.
+    expect(diagnoseFiles).toHaveBeenCalledWith(4);
+    expect(diagnoseFiles).toHaveBeenCalledTimes(2);
+  });
+
+  it('should discard errors and warnings from the silent semantic warm-up pass', async () => {
+    const diagnoseFiles = vi.fn().mockImplementation((modes: number) =>
+      // DiagnosticModes.Semantic === 4
+      modes === 4
+        ? Promise.resolve({
+            errors: [{ text: 'semantic error' }],
+            warnings: [{ text: 'semantic warning' }],
+          })
+        : Promise.resolve({})
+    );
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles },
+      collectedStylesheetAssets: [],
+    });
+    const compiler = createFakeCompiler();
+    const plugin = new AngularRspackPlugin({
+      ...options,
+      skipTypeChecking: true,
+    } as never);
+    plugin.apply(compiler as never);
+
+    await runBuildStart(compiler);
+
+    const compilation = createFakeCompilation(compiler);
+    await fireAsyncTaps(compiler.hooks.emit, compilation);
+
+    expect(compilation.errors).toHaveLength(0);
+    expect(compilation.warnings).toHaveLength(0);
+  });
+
+  it('should not fail or hang the build when the silent semantic warm-up pass rejects', async () => {
+    const diagnoseFiles = vi.fn().mockImplementation((modes: number) =>
+      // DiagnosticModes.Semantic === 4
+      modes === 4
+        ? Promise.reject(new Error('semantic warm-up crashed'))
+        : Promise.resolve({})
+    );
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles },
+      collectedStylesheetAssets: [],
+    });
+    const compiler = createFakeCompiler();
+    const plugin = new AngularRspackPlugin({
+      ...options,
+      skipTypeChecking: true,
+    } as never);
+    plugin.apply(compiler as never);
+
+    await runBuildStart(compiler);
+
+    const compilation = createFakeCompilation(compiler);
+    // emit must resolve (the callback fires) rather than leak the rejection
+    await fireAsyncTaps(compiler.hooks.emit, compilation);
+
+    expect(compilation.errors).toHaveLength(0);
+  });
+
+  it('should start the silent semantic warm-up pass without waiting for the surfaced diagnostics to resolve first', async () => {
+    let resolveSurfaced: (value: unknown) => void = () => undefined;
+    const diagnoseFiles = vi.fn().mockImplementation((modes: number) =>
+      // DiagnosticModes.All & ~DiagnosticModes.Semantic === 3
+      modes === 3
+        ? new Promise((resolve) => {
+            resolveSurfaced = resolve;
+          })
+        : Promise.resolve({})
+    );
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles },
+      collectedStylesheetAssets: [],
+    });
+    const compiler = createFakeCompiler();
+    const plugin = new AngularRspackPlugin({
+      ...options,
+      skipTypeChecking: true,
+    } as never);
+    plugin.apply(compiler as never);
+
+    // beforeRun/beforeCompile await buildAndAnalyze(), which only awaits up
+    // to starting (not resolving) the diagnostics promise, so this settles
+    // even while the surfaced call above is still pending.
+    await fireAsyncTaps(compiler.hooks.beforeRun, compiler);
+    await fireAsyncTaps(compiler.hooks.beforeCompile, {});
+
+    // both calls were already started - the semantic warm-up was not
+    // gated behind the surfaced diagnostics call resolving first
+    expect(diagnoseFiles).toHaveBeenCalledWith(3);
+    expect(diagnoseFiles).toHaveBeenCalledWith(4);
+
+    resolveSurfaced({});
+  });
+
   it('should not throw from afterDone when the run failed before producing stats', async () => {
     const compiler = applyPlugin();
 

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -339,7 +339,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       try {
         if (!this.#initializationError) {
           const { errors, warnings } = await (this.#diagnosticsPromise ??
-            this.#angularCompilation.diagnoseFiles(this.#diagnosticModes()));
+            this.#createDiagnosticsPromise());
           for (const error of errors ?? []) {
             compilation.errors.push({
               name: PLUGIN_NAME,
@@ -707,12 +707,54 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     }
   }
 
-  // Skipping type checking skips only the semantic pass; option and
-  // syntactic diagnostics still surface configuration and parse errors.
-  #diagnosticModes(): DiagnosticModes {
-    return this.#_options.skipTypeChecking
-      ? ((DiagnosticModes.All & ~DiagnosticModes.Semantic) as DiagnosticModes)
-      : DiagnosticModes.All;
+  // Starts diagnostics collection for this build.
+  #createDiagnosticsPromise(): ReturnType<AngularCompilation['diagnoseFiles']> {
+    if (!this.#_options.skipTypeChecking) {
+      return this.#angularCompilation.diagnoseFiles(DiagnosticModes.All);
+    }
+
+    // Surface everything except Semantic (type-checking) diagnostics.
+    const surfacedDiagnostics = this.#angularCompilation.diagnoseFiles(
+      (DiagnosticModes.All & ~DiagnosticModes.Semantic) as DiagnosticModes
+    );
+
+    // Still run the Semantic pass silently, purely for its side effect: it's
+    // the only thing that advances the compiler's incremental state to
+    // `Analyzed`, which is required for incremental rebuilds to skip
+    // re-emitting unchanged files. Its result is always discarded and must
+    // never surface or fail the build.
+    //
+    // - `collectDiagnostics()` only calls `getDiagnosticsForFile()` when
+    //   Semantic mode is requested:
+    //   https://github.com/angular/angular-cli/blob/60078fc914b35158598bd141f480e38d3455114e/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts#L282-L306
+    // - `getDiagnosticsForFile()`/`getDiagnostics()` are the only callers of
+    //   `ensureAnalyzed()`, which triggers `recordSuccessfulAnalysis()`:
+    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/core/src/compiler.ts#L616-L619
+    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/core/src/compiler.ts#L1243-L1245
+    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/core/src/compiler.ts#L1016-L1045
+    // - `recordSuccessfulAnalysis()` is the only place the incremental state
+    //   moves from `Fresh` to `Analyzed`:
+    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/incremental/src/incremental.ts#L247
+    // - Without that, `IncrementalCompilation.incremental()` always
+    //   short-circuits back to `.fresh()`, and `safeToSkipEmit()` always
+    //   returns `false` (`this.step === null`), forcing a full re-emit:
+    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/incremental/src/incremental.ts#L125-L128
+    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/incremental/src/incremental.ts#L376-L379
+    //
+    // Safe to run alongside the surfaced call above: it never requests
+    // Semantic mode, so it never touches the `diagnosticCache`/
+    // `getDiagnosticsForFile` path this call exercises, and both only ever
+    // read `affectedFiles`, never mutate it.
+    const silentSemanticWarmup = this.#angularCompilation
+      .diagnoseFiles(DiagnosticModes.Semantic)
+      .then(
+        () => undefined,
+        () => undefined
+      );
+
+    return Promise.all([surfacedDiagnostics, silentSemanticWarmup]).then(
+      ([result]) => result
+    );
   }
 
   private async buildAndAnalyze() {
@@ -737,9 +779,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     // worker-based compilation it runs off the main thread and the emit hook
     // only waits for what is left. Diagnostics still run after an emit
     // failure since they usually carry the root cause.
-    const diagnosticsPromise = this.#angularCompilation.diagnoseFiles(
-      this.#diagnosticModes()
-    );
+    const diagnosticsPromise = this.#createDiagnosticsPromise();
     // Failed builds skip the emit hook that reports the result; don't
     // leave the rejection unhandled.
     diagnosticsPromise.catch(() => {});

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -718,33 +718,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       (DiagnosticModes.All & ~DiagnosticModes.Semantic) as DiagnosticModes
     );
 
-    // Still run the Semantic pass silently, purely for its side effect: it's
-    // the only thing that advances the compiler's incremental state to
-    // `Analyzed`, which is required for incremental rebuilds to skip
-    // re-emitting unchanged files. Its result is always discarded and must
-    // never surface or fail the build.
-    //
-    // - `collectDiagnostics()` only calls `getDiagnosticsForFile()` when
-    //   Semantic mode is requested:
-    //   https://github.com/angular/angular-cli/blob/60078fc914b35158598bd141f480e38d3455114e/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts#L282-L306
-    // - `getDiagnosticsForFile()`/`getDiagnostics()` are the only callers of
-    //   `ensureAnalyzed()`, which triggers `recordSuccessfulAnalysis()`:
-    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/core/src/compiler.ts#L616-L619
-    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/core/src/compiler.ts#L1243-L1245
-    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/core/src/compiler.ts#L1016-L1045
-    // - `recordSuccessfulAnalysis()` is the only place the incremental state
-    //   moves from `Fresh` to `Analyzed`:
-    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/incremental/src/incremental.ts#L247
-    // - Without that, `IncrementalCompilation.incremental()` always
-    //   short-circuits back to `.fresh()`, and `safeToSkipEmit()` always
-    //   returns `false` (`this.step === null`), forcing a full re-emit:
-    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/incremental/src/incremental.ts#L125-L128
-    //   https://github.com/angular/angular/blob/7c15737f50c0f22b2f04e138f18ec862ac446d09/packages/compiler-cli/src/ngtsc/incremental/src/incremental.ts#L376-L379
-    //
-    // Safe to run alongside the surfaced call above: it never requests
-    // Semantic mode, so it never touches the `diagnosticCache`/
-    // `getDiagnosticsForFile` path this call exercises, and both only ever
-    // read `affectedFiles`, never mutate it.
+    // Angular records state needed for incremental emission during semantic diagnostics.
+    // Start both calls together, but discard the semantic result or rejection.
     const silentSemanticWarmup = this.#angularCompilation
       .diagnoseFiles(DiagnosticModes.Semantic)
       .then(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
With `skipTypeChecking: true` set on `@nx/angular-rspack`'s `AngularRspackPlugin`, every incremental rebuild re-emits the entire program instead of only the changed file(s), no matter how small the edit is. On a real-world app (~6000 source files) this makes single-file rebuilds take 20-55 seconds instead of the expected 1-3 seconds.

This happens because `skipTypeChecking: true` strips the `Semantic` diagnostic mode from what's passed to `AngularCompilation#diagnoseFiles()`. Semantic mode is the only path that reaches `NgCompiler#ensureAnalyzed()` → `recordSuccessfulAnalysis()`, which is the only place the compiler's incremental state advances from `Fresh` to `Analyzed`. Without that transition, `IncrementalCompilation#safeToSkipEmit()` always returns `false`, forcing a full re-emit on every rebuild.

See #36970 for the full root-cause trace with source references.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`skipTypeChecking: true` should only suppress *surfacing* Semantic (type-checking) diagnostics - it should not disable the Angular compiler's incremental-emit optimization. Incremental rebuilds should re-emit only the files actually affected by a change, same as when `skipTypeChecking` is `false`.

`#createDiagnosticsPromise()` now always fires a second, silent `diagnoseFiles(DiagnosticModes.Semantic)` call whenever `skipTypeChecking` is `true`, purely for its incremental-state side effect. Its result is fully discarded and can never surface or fail the build - the diagnostics actually surfaced to users (`Option`/`Syntactic`) are unchanged. Both calls run concurrently via `Promise.all`, verified safe since they touch disjoint internal state (the surfaced call never requests `Semantic`, so it never touches the `diagnosticCache`/`getDiagnosticsForFile` path the silent call exercises).

Validated against a real ~6000-file app: cold builds are unaffected (as expected), and every subsequent incremental rebuild dropped from 20-55s to 2-4s, with the correct "affected files" count reported.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #36970
