### PR TITLE
fix(core): release per-run process listeners and task history results

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -32,6 +32,8 @@ export class ForkedProcessTaskRunner {
 
   private readonly verbose = process.env.NX_VERBOSE_LOGGING === 'true';
   private processes = new Set<RunningTask | BatchProcess>();
+  private processMessageHandler: (message: Serializable) => void;
+  private processExitHandler: () => void;
   private finishedProcesses = new Set<BatchProcess>();
   private pseudoTerminals = new Set<PseudoTerminal>();
 
@@ -415,7 +417,7 @@ export class ForkedProcessTaskRunner {
   }
 
   private setupProcessEventListeners() {
-    const messageHandler = (message: Serializable) => {
+    this.processMessageHandler = (message: Serializable) => {
       this.pseudoTerminals.forEach((p) => {
         p.sendMessageToChildren(message);
       });
@@ -426,15 +428,25 @@ export class ForkedProcessTaskRunner {
         }
       });
     };
+    this.processExitHandler = () => {
+      this.cleanup();
+      process.off('message', this.processMessageHandler);
+    };
 
     // When the nx process gets a message, it will be sent into the task's process
-    process.on('message', messageHandler);
+    process.on('message', this.processMessageHandler);
 
     // Terminate any task processes on exit
-    process.once('exit', () => {
-      this.cleanup();
-      process.off('message', messageHandler);
-    });
+    process.once('exit', this.processExitHandler);
     // Signal handlers removed - TaskOrchestrator owns signal handling
+  }
+
+  // Long-lived processes (Nx Cloud agents) create a runner per invocation;
+  // without this each instance stays reachable from `process` forever.
+  // Call only after cleanup(): the exit handler is the last-resort child
+  // kill, so it must not be removed while children may still be alive.
+  removeProcessEventListeners() {
+    process.off('message', this.processMessageHandler);
+    process.off('exit', this.processExitHandler);
   }
 }

--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -19,6 +19,7 @@ import { createTaskHasher } from '../hasher/create-task-hasher';
 import type { ProjectGraph } from '../config/project-graph';
 import { daemonClient } from '../daemon/client/client';
 import { RunningTask } from './running-tasks/running-task';
+import { SharedRunningTask } from './running-tasks/shared-running-task';
 import { TaskResultsLifeCycle } from './life-cycles/task-results-life-cycle';
 
 /**
@@ -162,6 +163,12 @@ async function createOrchestrator(
   return orchestrator;
 }
 
+// Nothing awaits the dispose chains below, so an unhandled rejection would take
+// down a long-lived agent process.
+function logDisposeFailure(e: unknown) {
+  console.error('Failed to dispose the task orchestrator:', e);
+}
+
 export async function runDiscreteTasks(
   tasks: Task[],
   projectGraph: ProjectGraph,
@@ -216,7 +223,16 @@ export async function runDiscreteTasks(
     }
   );
 
-  return [...batchResults, ...taskResults];
+  const results = [...batchResults, ...taskResults];
+  // Callers like Nx Cloud agents create an orchestrator per invocation in a
+  // long-lived process; release its process-level listeners once all tasks
+  // settle, otherwise every invocation's orchestrator stays reachable forever.
+  // Not awaited, so callers keep consuming handles as they settle; the forked
+  // runner's exit handler still reaps children until dispose() runs.
+  Promise.allSettled(results)
+    .then(() => orchestrator.dispose())
+    .catch(logDisposeFailure);
+  return results;
 }
 
 export async function runContinuousTasks(
@@ -233,11 +249,28 @@ export async function runContinuousTasks(
     nxJson,
     lifeCycle
   );
-  return tasks.reduce(
+  const runningTasks = tasks.reduce(
     (current, task, index) => {
       current[task.id] = orchestrator.startContinuousTask(task, index);
       return current;
     },
     {} as Record<string, Promise<RunningTask>>
   );
+  // Unlike runDiscreteTasks, this must resolve at task start: callers keep
+  // the RunningTask handles to kill later, so disposal has to be deferred
+  // until every task actually exits.
+  Promise.allSettled(
+    Object.entries(runningTasks).map(async ([taskId, promise]) => {
+      const runningTask = await promise;
+      // A shared task is owned by another nx process; this orchestrator has
+      // no child to protect for it, so disposal does not wait on it.
+      if (runningTask instanceof SharedRunningTask) {
+        return;
+      }
+      await orchestrator.waitForContinuousTaskExit(taskId);
+    })
+  )
+    .then(() => orchestrator.dispose())
+    .catch(logDisposeFailure);
+  return runningTasks;
 }

--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.spec.ts
@@ -1,0 +1,89 @@
+import { Task } from '../../config/task-graph';
+import { TaskResult } from '../life-cycle';
+import { TaskHistoryLifeCycle } from './task-history-life-cycle';
+
+jest.mock('../is-tui-enabled', () => ({ isTuiEnabled: () => false }));
+
+describe('TaskHistoryLifeCycle', () => {
+  function createTask(id: string): Task {
+    const [project, target] = id.split(':');
+    return {
+      id,
+      target: { project, target },
+      overrides: {},
+      outputs: [],
+      hash: `hash-${id}`,
+      startTime: 1,
+      endTime: 2,
+      cache: true,
+      parallelism: true,
+    } as Task;
+  }
+
+  // Bypass the constructor — it enforces a process-wide singleton and its
+  // field initializer opens the task history db.
+  function createLifeCycle(taskHistory: object | null = null) {
+    const lifeCycle: any = Object.create(TaskHistoryLifeCycle.prototype);
+    lifeCycle.startTimings = {};
+    lifeCycle.pendingResults = new Map();
+    lifeCycle.taskRuns = new Map();
+    lifeCycle.taskHistory = taskHistory ?? {
+      recordTaskRuns: jest.fn(async () => {}),
+      getFlakyTasks: jest.fn(async () => []),
+    };
+    return lifeCycle;
+  }
+
+  it('should not retain terminalOutput on pending results', async () => {
+    const lifeCycle = createLifeCycle();
+    const task = createTask('proj:build');
+    const result: TaskResult = {
+      task,
+      status: 'success',
+      code: 0,
+      terminalOutput: 'x'.repeat(1024),
+    };
+
+    await lifeCycle.endTasks([result]);
+
+    const pending = Array.from(lifeCycle.pendingResults.values());
+    expect(pending).toEqual([{ task, code: 0, status: 'success' }]);
+    expect(pending[0]).not.toHaveProperty('terminalOutput');
+  });
+
+  it('should record runs and release per-task state on endCommand', async () => {
+    const lifeCycle = createLifeCycle();
+    const task = createTask('proj:build');
+    lifeCycle.startTasks([task]);
+    await lifeCycle.endTasks([
+      { task, status: 'success', code: 0, terminalOutput: 'out' },
+    ]);
+
+    await lifeCycle.endCommand();
+
+    expect(lifeCycle.taskHistory.recordTaskRuns).toHaveBeenCalledWith([
+      expect.objectContaining({
+        hash: 'hash-proj:build',
+        status: 'success',
+        code: 0,
+      }),
+    ]);
+    // A long-lived process (Nx Cloud agent) runs many commands; per-task
+    // state must not accumulate across them.
+    expect(lifeCycle.pendingResults.size).toBe(0);
+    expect(lifeCycle.startTimings).toEqual({});
+  });
+
+  it('should release pending results on endCommand even without task history', async () => {
+    const lifeCycle = createLifeCycle();
+    lifeCycle.taskHistory = null;
+    const task = createTask('proj:build');
+    await lifeCycle.endTasks([
+      { task, status: 'success', code: 0, terminalOutput: 'out' },
+    ]);
+
+    await lifeCycle.endCommand();
+
+    expect(lifeCycle.pendingResults.size).toBe(0);
+  });
+});

--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
@@ -30,7 +30,12 @@ export function getTasksHistoryLifeCycle():
 
 export class TaskHistoryLifeCycle implements LifeCycle {
   private startTimings: Record<string, number> = {};
-  private pendingResults = new Map<string, TaskResult>();
+  // Holds no terminalOutput: this singleton outlives every run in the
+  // process, and agents complete thousands of tasks in one process.
+  private pendingResults = new Map<
+    string,
+    Pick<TaskResult, 'task' | 'code' | 'status'>
+  >();
   private taskRuns = new Map<string, TaskRun>();
   private taskHistory: TaskHistory | null = getTaskHistory();
   private flakyTasks: string[];
@@ -51,28 +56,31 @@ export class TaskHistoryLifeCycle implements LifeCycle {
   }
 
   async endTasks(taskResults: TaskResult[]) {
-    for (const taskResult of taskResults) {
-      this.pendingResults.set(taskResult.task.id, taskResult);
+    for (const { task, code, status } of taskResults) {
+      this.pendingResults.set(task.id, { task, code, status });
     }
   }
 
   async endCommand() {
+    const pendingResults = Array.from(this.pendingResults.values());
+    this.pendingResults.clear();
+
     if (!this.taskHistory) {
       return;
     }
 
     // Build TaskRun objects now — task.hash is guaranteed to be set by this point
-    for (const [, taskResult] of this.pendingResults) {
-      this.taskRuns.set(taskResult.task.hash, {
-        hash: taskResult.task.hash,
-        target: taskResult.task.target,
-        code: taskResult.code,
-        status: taskResult.status,
-        start:
-          taskResult.task.startTime ?? this.startTimings[taskResult.task.id],
-        end: taskResult.task.endTime ?? Date.now(),
-        cacheable: taskResult.task.cache === true,
+    for (const { task, code, status } of pendingResults) {
+      this.taskRuns.set(task.hash, {
+        hash: task.hash,
+        target: task.target,
+        code,
+        status,
+        start: task.startTime ?? this.startTimings[task.id],
+        end: task.endTime ?? Date.now(),
+        cacheable: task.cache === true,
       });
+      delete this.startTimings[task.id];
     }
 
     const runs = [];

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -101,6 +101,9 @@ export class BatchProcess {
     this.outputCallbacks.push(cb);
   }
 
+  // Resolves on the CompleteBatchExecution message, not process exit: the
+  // child can outlive its results (open handles keep it alive), so callers
+  // must not treat a settled batch as an exited process.
   async getResults(): Promise<BatchResults> {
     return Promise.race<BatchResults>([
       new Promise((_, rej) => {

--- a/packages/nx/src/tasks-runner/running-tasks/shared-running-task.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/shared-running-task.spec.ts
@@ -1,0 +1,47 @@
+import { SharedRunningTask } from './shared-running-task';
+
+describe('SharedRunningTask', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should fire exit callbacks once when the owning process finishes the task', async () => {
+    const service = { getRunningTasks: jest.fn(() => ['t1']) };
+    const task = new SharedRunningTask(service as any, 't1');
+    const exits: number[] = [];
+    task.onExit((code) => exits.push(code));
+
+    await jest.advanceTimersByTimeAsync(300);
+    expect(exits).toEqual([]);
+
+    service.getRunningTasks.mockReturnValue([]);
+    await jest.advanceTimersByTimeAsync(200);
+    expect(exits).toEqual([0]);
+  });
+
+  it('should stop watching the db and not re-fire exit callbacks after kill()', async () => {
+    const service = { getRunningTasks: jest.fn(() => ['t1']) };
+    const task = new SharedRunningTask(service as any, 't1');
+    const exits: number[] = [];
+    task.onExit((code) => exits.push(code));
+
+    await jest.advanceTimersByTimeAsync(500);
+    const pollsBeforeKill = service.getRunningTasks.mock.calls.length;
+    expect(pollsBeforeKill).toBeGreaterThan(0);
+
+    task.kill();
+    expect(exits).toEqual([0]);
+
+    // The watcher previously kept polling (and re-fired callbacks) until the
+    // owning process finished, pinning the caller's object graph.
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(service.getRunningTasks.mock.calls.length).toBe(pollsBeforeKill);
+    expect(exits).toEqual([0]);
+
+    task.kill();
+    expect(exits).toEqual([0]);
+  });
+});

--- a/packages/nx/src/tasks-runner/running-tasks/shared-running-task.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/shared-running-task.ts
@@ -3,12 +3,16 @@ import { RunningTasksService } from '../../native';
 
 export class SharedRunningTask implements RunningTask {
   private exitCallbacks: ((code: number) => void)[] = [];
+  private detached = false;
 
   constructor(
     private runningTasksService: RunningTasksService,
     taskId: string
   ) {
     this.waitForTaskToFinish(taskId).then(() => {
+      if (this.detached) {
+        return;
+      }
       // notify exit callbacks
       this.exitCallbacks.forEach((cb) => cb(0));
     });
@@ -18,8 +22,14 @@ export class SharedRunningTask implements RunningTask {
     throw new Error('Results cannot be retrieved from a shared task');
   }
 
+  // Detaches from the shared task; the owning process keeps running it.
   kill(): void {
+    if (this.detached) {
+      return;
+    }
+    this.detached = true;
     this.exitCallbacks.forEach((cb) => cb(0));
+    this.exitCallbacks = [];
   }
 
   onExit(cb: (code: number) => void): void {
@@ -31,6 +41,9 @@ export class SharedRunningTask implements RunningTask {
     // wait for the running task to finish
     do {
       await new Promise((resolve) => setTimeout(resolve, 100));
-    } while (this.runningTasksService.getRunningTasks([taskId]).length);
+    } while (
+      !this.detached &&
+      this.runningTasksService.getRunningTasks([taskId]).length
+    );
   }
 }

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -1,0 +1,70 @@
+import { TaskOrchestrator } from './task-orchestrator';
+
+describe('TaskOrchestrator', () => {
+  describe('process listener lifecycle', () => {
+    it('should remove on dispose() every process listener registered by setupSignalHandlers', async () => {
+      const orchestrator: any = Object.create(TaskOrchestrator.prototype);
+      orchestrator.signalHandlers = [];
+      orchestrator.forkedProcessTaskRunner = {
+        cleanup: jest.fn(async () => {}),
+        removeProcessEventListeners: jest.fn(),
+      };
+      const signals = ['SIGINT', 'SIGTERM', 'SIGHUP'] as const;
+      const before = Object.fromEntries(
+        signals.map((s) => [s, process.listenerCount(s)])
+      );
+
+      orchestrator.setupSignalHandlers();
+      for (const s of signals) {
+        expect(process.listenerCount(s)).toBe(before[s] + 1);
+      }
+
+      await orchestrator.dispose();
+      for (const s of signals) {
+        expect(process.listenerCount(s)).toBe(before[s]);
+      }
+      expect(
+        orchestrator.forkedProcessTaskRunner.removeProcessEventListeners
+      ).toHaveBeenCalled();
+    });
+
+    it('should reap child processes before removing the last-resort exit handler', async () => {
+      const orchestrator: any = Object.create(TaskOrchestrator.prototype);
+      orchestrator.signalHandlers = [];
+      const order: string[] = [];
+      orchestrator.forkedProcessTaskRunner = {
+        // cleanup() dispatches the child kills and the exit handler is the
+        // last-resort kill, so the handler must not be removed first. The
+        // push happens after a real async hop so that dropping the await in
+        // dispose() flips the recorded order and fails this test.
+        cleanup: jest.fn(async () => {
+          await new Promise((r) => setImmediate(r));
+          order.push('cleanup');
+        }),
+        removeProcessEventListeners: jest.fn(() => {
+          order.push('removeProcessEventListeners');
+        }),
+      };
+
+      await orchestrator.dispose();
+
+      expect(order).toEqual(['cleanup', 'removeProcessEventListeners']);
+    });
+
+    it('should resolve waitForContinuousTaskExit even for an exit that already happened', async () => {
+      const orchestrator: any = Object.create(TaskOrchestrator.prototype);
+      const exitHandled = Promise.resolve();
+      orchestrator.continuousTaskExitHandled = new Map([
+        ['proj:serve', exitHandled],
+      ]);
+
+      // The creation-time promise is returned as-is; an unknown id (task
+      // never started, or already fully handled) resolves immediately
+      // rather than hanging disposal.
+      expect(orchestrator.waitForContinuousTaskExit('proj:serve')).toBe(
+        exitHandled
+      );
+      await orchestrator.waitForContinuousTaskExit('proj:unknown');
+    });
+  });
+});

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -152,6 +152,7 @@ export class TaskOrchestrator {
   private discreteTaskExitHandled = new Map<string, Promise<void>>();
   private continuousTaskExitHandled = new Map<string, Promise<void>>();
   private cleanupPromise: Promise<void> | null = null;
+  private signalHandlers: Array<[NodeJS.Signals, () => void]> = [];
   // endregion internal state
 
   constructor(
@@ -243,6 +244,7 @@ export class TaskOrchestrator {
       this.cache.removeOldCacheRecords();
     }
     await this.cleanup();
+    await this.dispose();
 
     // Public API (defaultTasksRunner) returns a plain object keyed by
     // task id. Internal state is a Map for faster lookup.
@@ -1763,7 +1765,7 @@ export class TaskOrchestrator {
   }
 
   private setupSignalHandlers() {
-    process.once('SIGINT', () => {
+    const sigintHandler = () => {
       this.stopRequested = true;
       if (!this.tuiEnabled) {
         // Synchronously remove DB entries before async cleanup to prevent
@@ -1793,23 +1795,57 @@ export class TaskOrchestrator {
           process.exit(signalToCode('SIGINT'));
         }
       });
-    });
-    process.once('SIGTERM', () => {
+    };
+    const sigtermHandler = () => {
       this.stopRequested = true;
       this.cleanup().finally(() => {
         if (this.resolveStopPromise) {
           this.resolveStopPromise();
         }
       });
-    });
-    process.once('SIGHUP', () => {
+    };
+    const sighupHandler = () => {
       this.stopRequested = true;
       this.cleanup().finally(() => {
         if (this.resolveStopPromise) {
           this.resolveStopPromise();
         }
       });
-    });
+    };
+
+    for (const [signal, handler] of [
+      ['SIGINT', sigintHandler],
+      ['SIGTERM', sigtermHandler],
+      ['SIGHUP', sighupHandler],
+    ] as const) {
+      this.signalHandlers.push([signal, handler]);
+      process.once(signal, handler);
+    }
+  }
+
+  // Registered at child creation, so unlike subscribing to RunningTask.onExit
+  // after the fact it cannot miss an exit that already happened.
+  waitForContinuousTaskExit(taskId: string): Promise<void> {
+    return this.continuousTaskExitHandled.get(taskId) ?? Promise.resolve();
+  }
+
+  // Releases the process-level listeners registered by setupSignalHandlers.
+  // Each closes over `this`, so a long-lived caller (an Nx Cloud agent creates
+  // an orchestrator per invocation) leaks whole orchestrators until they run.
+  async dispose() {
+    // The forked runner's exit handler is the last-resort kill for child
+    // processes, and a batch child can outlive its results message. Signal the
+    // children first so removing that handler cannot orphan a live one.
+    try {
+      await this.forkedProcessTaskRunner.cleanup();
+    } catch (e) {
+      console.error('Failed to clean up child processes on dispose:', e);
+    }
+    for (const [signal, handler] of this.signalHandlers) {
+      process.off(signal, handler);
+    }
+    this.signalHandlers = [];
+    this.forkedProcessTaskRunner.removeProcessEventListeners();
   }
 
   private cleanUpUnneededContinuousTasks() {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

Backport of #36866 to 22.7.x. The leak goes back to at least 22.5, so agents on this line still grow unbounded.

The port differs from the original in three places, since 22.7.x still has separate signal handlers, a synchronous `ForkedProcessTaskRunner.cleanup()`, and jest rather than vitest. The commit message covers each.

## Current Behavior
<!-- This is the behavior we have today -->

Every `runDiscreteTasks` call registers SIGINT/SIGTERM/SIGHUP handlers that are never removed. Each closes over its orchestrator, so an Nx Cloud agent retains every orchestrator it ever created, along with its task hasher and every task result. `TaskHistoryLifeCycle.pendingResults` keeps every `TaskResult` for the life of the process too.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Listeners are released once a run completes, and agent memory stays flat across assignment batches.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
