### PR TITLE
fix(core): accept pr and canary releases in the migrate provenance check

### DIFF
--- a/packages/nx/src/utils/provenance.spec.ts
+++ b/packages/nx/src/utils/provenance.spec.ts
@@ -154,4 +154,99 @@ describe('ensurePackageHasProvenance', () => {
       'This could indicate a security risk'
     );
   });
+
+  /**
+   * A PR release is published by the same workflow running on master, so it
+   * carries real provenance but no tag. Rejecting it told anyone testing one to
+   * disable a security check, which is the wrong habit to teach.
+   */
+  describe('which ref is allowed to have built the package', () => {
+    // A full attestation, so these reach the ref check rather than stopping at
+    // the fetch like the cases above.
+    function attestationFor(version: string, ref: string) {
+      const payload = {
+        predicate: {
+          buildDefinition: {
+            externalParameters: {
+              workflow: {
+                repository: 'https://github.com/nrwl/nx',
+                path: '.github/workflows/publish.yml',
+                ref,
+              },
+            },
+          },
+        },
+        subject: [
+          {
+            digest: {
+              sha512: Buffer.from(version, 'base64').toString('hex'),
+            },
+          },
+        ],
+      };
+      return {
+        ok: true,
+        json: async () => ({
+          attestations: [
+            {
+              predicateType: 'https://slsa.dev/provenance/v1',
+              bundle: {
+                dsseEnvelope: {
+                  payload: Buffer.from(JSON.stringify(payload)).toString(
+                    'base64'
+                  ),
+                },
+              },
+            },
+          ],
+        }),
+      };
+    }
+
+    function arrange(version: string, ref: string) {
+      packageRegistryViewSpy.mockResolvedValue(
+        JSON.stringify(packument(version))
+      );
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          attestationFor(version, ref)
+        ) as unknown as typeof fetch;
+    }
+
+    it('accepts a tagged release built from its own tag', async () => {
+      arrange('1.0.0', 'refs/tags/1.0.0');
+      await expect(
+        ensurePackageHasProvenance('nx', '1.0.0')
+      ).resolves.toBeUndefined();
+    });
+
+    it('accepts a pr release built from master', async () => {
+      arrange('23.3.0-pr.36841.f66e88b', 'refs/heads/master');
+      await expect(
+        ensurePackageHasProvenance('nx', '23.3.0-pr.36841.f66e88b')
+      ).resolves.toBeUndefined();
+    });
+
+    it('accepts a canary release built from master', async () => {
+      arrange('23.2.0-canary.20260908-89f02c1', 'refs/heads/master');
+      await expect(
+        ensurePackageHasProvenance('nx', '23.2.0-canary.20260908-89f02c1')
+      ).resolves.toBeUndefined();
+    });
+
+    it('still rejects a tagged release built from master', async () => {
+      arrange('1.0.0', 'refs/heads/master');
+      await expect(ensurePackageHasProvenance('nx', '1.0.0')).rejects.toThrow(
+        'Version ref does not match refs/tags/1.0.0'
+      );
+    });
+
+    it('does not treat an ordinary prerelease as a pr release', async () => {
+      arrange('1.0.0-preview.1', 'refs/heads/master');
+      await expect(
+        ensurePackageHasProvenance('nx', '1.0.0-preview.1')
+      ).rejects.toThrow('Version ref does not match refs/tags/1.0.0-preview.1');
+    });
+  });
 });

--- a/packages/nx/src/utils/provenance.ts
+++ b/packages/nx/src/utils/provenance.ts
@@ -14,6 +14,16 @@ import {
  *
  * Will throw if the package does not have valid provenance.
  */
+/**
+ * A build the publish workflow cuts from master rather than from a tag:
+ * `23.3.0-pr.36841.f66e88b` from a pull request, `23.2.0-canary.20260908-89f02c1`
+ * from the nightly. Each segment is matched with its leading digits so an
+ * ordinary prerelease like `1.0.0-preview.1` does not qualify.
+ */
+function isPublishedFromMaster(version: string): boolean {
+  return /-pr\.\d+\./.test(version) || /-canary\.\d/.test(version);
+}
+
 export async function ensurePackageHasProvenance(
   packageName: string,
   packageVersion: string
@@ -106,11 +116,18 @@ export async function ensurePackageHasProvenance(
         'Publishing workflow does not match .github/workflows/publish.yml'
       );
     }
-    if (workflowParameters.ref !== `refs/tags/${npmViewResult.version}`) {
+    // PR and canary releases are published by this same workflow running on
+    // master, so a tag for them does not exist and never will. Repository,
+    // workflow path and the artifact digest are still checked, so this only
+    // widens which ref of nrwl/nx is allowed to have built it.
+    const allowedRefs = isPublishedFromMaster(npmViewResult.version)
+      ? [`refs/tags/${npmViewResult.version}`, 'refs/heads/master']
+      : [`refs/tags/${npmViewResult.version}`];
+    if (!allowedRefs.includes(workflowParameters.ref)) {
       throw new ProvenanceError(
         packageName,
         packageVersion,
-        `Version ref does not match refs/tags/${npmViewResult.version}`
+        `Version ref does not match ${allowedRefs.join(' or ')}`
       );
     }
 


### PR DESCRIPTION
## Current Behavior

`nx migrate` rejects every PR release and every canary:

```
> nx migrate 23.3.0-pr.36841.f66e88b

 NX   An error occurred while checking the provenance of nx@23.3.0-pr.36841.f66e88b.
 This could indicate a security risk. [...] To disable this check at your own risk,
 you can set the NX_SKIP_PROVENANCE_CHECK environment variable to true.

 Error: Version ref does not match refs/tags/23.3.0-pr.36841.f66e88b
```

Nothing is wrong with the package. Its attestation is signed and says:

```
predicateType : https://slsa.dev/provenance/v1
repository    : https://github.com/nrwl/nx
path          : .github/workflows/publish.yml
ref           : refs/heads/master
```

A canary reports the same three values. Both are published by that workflow running on master, so there is no tag for the version and there never will be. The check compared `workflowParameters.ref` against `refs/tags/${version}`, so it failed by construction on both.

The cost is not just a blocked command. Anyone testing a PR release or pinning a canary is shown a supply-chain warning and told to turn off a security check to continue, which is the wrong habit to teach for what is really "this was published from a branch, as these always are".

## Expected Behavior

`refs/heads/master` is accepted when the version's prerelease segment is `-pr.<n>` or `-canary.<digits>`, the two shapes that workflow publishes from a branch. Both refs were read off real attestations rather than assumed.

The repository, the workflow path and the artifact digest are all still verified, so this widens which ref of `nrwl/nx` is allowed to have built the package and nothing else. A tagged release built from master is still rejected, and an ordinary prerelease such as `1.0.0-preview.1` does not qualify.

Five tests cover the ref rule, which had none: they build a full attestation instead of stopping at the fetch like the existing cases.

The check only ever runs for nx's own package group, `nx` plus the `@nx/*` entries in its `nx-migrations.packageGroup`, so no community plugin is held to this tagging convention.

## Related Issue(s)

Found while testing #36841 via #36975.
