### PR TITLE
fix(core): give plugin workers a minute to receive the load message

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -65,6 +65,10 @@ if (!socketPath || !expectedPluginName || !hostWorkspaceRoot) {
 }
 
 const CONNECT_TIMEOUT_MS = 30_000;
+// Runs in this worker's own loop from the moment it accepts, while the host is
+// loading every plugin at once and may sit in a synchronous workspace walk for
+// over ten seconds. A host that has died closes the socket; 'end' covers that.
+const LOAD_TIMEOUT_MS = 60_000;
 
 let connectErrorTimeout = setErrorTimeout(
   CONNECT_TIMEOUT_MS,
@@ -88,8 +92,8 @@ const server = createServer((socket) => {
   // after the worker connected but before the worker was
   // instructed to load the plugin.
   let loadErrorTimeout = setErrorTimeout(
-    10_000,
-    `Plugin Worker for ${expectedPluginName} is exiting as it did not receive a load message within 10 seconds of connecting. ` +
+    LOAD_TIMEOUT_MS,
+    `Plugin Worker for ${expectedPluginName} is exiting as it did not receive a load message within ${LOAD_TIMEOUT_MS / 1000} seconds of connecting. ` +
       'This likely indicates that the host process was terminated before the worker could be instructed to load the plugin. ' +
       'If you are seeing this issue, please report it to the Nx team at https://github.com/nrwl/nx/issues.'
   );


### PR DESCRIPTION
## Current Behavior

A plugin worker gives the host ten seconds to send `load` after it accepts the connection. The clock runs in the worker's own event loop, so it measures the host's responsiveness, not whether the host is alive.

The host is at its busiest at exactly that moment. `loadSpecifiedNxPlugins` loads every plugin concurrently, and resolving a workspace-local plugin goes through `retrieveProjectConfigurationsWithoutPluginInference`, whose native `multiGlob` waits synchronously for the workspace walk to finish. On a large repo with a cold hash archive that walk runs past ten seconds, and the host cannot run its connect callback or send `load` until it returns. Any worker whose accept landed early in that window exits 1 with `did not receive a load message within 10 seconds`, and the host reports `Plugin worker "X" exited unexpectedly (exit code 1)`.

Ocean CI hit this on the migration to 23.3.0-beta.0. The host printed nothing at all from `19:24:40.62` to `19:24:50.94`, then flushed every worker's buffered output in one burst, with gradle's timeout message among it and the host's own `connected to worker for "@nx/gradle"` line stamped after the worker had already died. Which plugin gets named is whichever one was unlucky: gradle there, playwright in a local sighting, jest in NXC-3211.

## Expected Behavior

The worker waits sixty seconds for `load`. The timeout exists for a host that died before sending it, but a dead host closes the socket and the `end` handler already exits on that, so the only case sixty seconds gives up is a host that hangs without dying, and that one is not worth racing a slow walk for.

The message derives its wording from the constant, so the two cannot drift.

Nothing else changes. The synchronous walk during plugin loading is a separate problem and the reason the host goes dark at all; this only stops the worker from treating that as a death.

## Related Issue(s)

NXC-4932. Follow-up to #36894, which is what made the cause visible.
