### PR TITLE
fix(dotnet): ship the ci-workflow templates and detect Microsoft.Testing.Platform projects

### DIFF
--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -133,6 +133,37 @@ Run it once before `build`.
 The files it writes to `obj` are excluded from the outputs of `build`, `publish`, and `pack`, so a
 cache hit never replaces a machine's own restore.
 
+### Test project detection
+
+A project gets a `test` target, and loses its `pack` target, when either MSBuild property is `true`:
+
+- `IsTestProject`, which `Microsoft.NET.Test.Sdk` sets.
+- `IsTestingPlatformApplication`, which [Microsoft.Testing.Platform](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro) sets.
+  The xunit.v3 and TUnit runners set this one, and may leave `IsTestProject` unset.
+
+These are the two properties the .NET SDK itself checks before it will run a project.
+Nx therefore agrees with `dotnet test` about what a test project is.
+Referencing a framework such as xunit or NUnit is not enough on its own, which is what lets a
+library expose test helpers and keep its `pack` target.
+`publish` and `run` depend only on `OutputType`, so a runner built as an executable keeps both.
+
+Both properties arrive with a restored package, so neither has a value before the project has
+been restored.
+Until then Nx falls back to a `Microsoft.NET.Test.Sdk` or `Microsoft.Testing.*` package
+reference, which it reads straight from the project file.
+Restore writes its imports under `obj`, which Nx doesn't watch, so run `nx reset` once
+afterwards to pick the properties up.
+
+Set `IsTestProject` yourself to settle it and skip all of the above.
+`IsTestingPlatformApplication` is not read this way, because it describes the runner rather than
+the project, and MSTest.Sdk sets it to `false` on a project it has already marked as a test:
+
+```xml
+<PropertyGroup>
+  <IsTestProject>false</IsTestProject>
+</PropertyGroup>
+```
+
 ### Test results
 
 `dotnet test` writes nothing to disk on its own.

--- a/e2e/dotnet/src/dotnet.test.ts
+++ b/e2e/dotnet/src/dotnet.test.ts
@@ -164,6 +164,21 @@ describe('.NET Plugin', () => {
     });
   });
 
+  describe('Generators', () => {
+    // The templates are copied assets rather than compiled output, so they
+    // reach the installed package only if assets.json ships them.
+    it.each(['github', 'circleci'] as const)(
+      'should generate a %s workflow from the installed package',
+      (ci) => {
+        runCLI(`generate @nx/dotnet:ci-workflow --ci=${ci} --name=ci`);
+
+        checkFilesExist(
+          ci === 'github' ? '.github/workflows/ci.yml' : '.circleci/config.yml'
+        );
+      }
+    );
+  });
+
   describe('Project Graph', () => {
     beforeAll(() => {
       createSimpleDotNetWorkspace();

--- a/nx.json
+++ b/nx.json
@@ -488,6 +488,9 @@
         "rule": "./tools/workspace-plugin/dist/src/conformance-rules/migration-markdown-assets"
       },
       {
+        "rule": "./tools/workspace-plugin/dist/src/conformance-rules/generator-template-assets"
+      },
+      {
         "rule": "./tools/workspace-plugin/dist/src/conformance-rules/no-ignored-tracked-files"
       },
       {

--- a/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
+++ b/packages/dotnet/analyzer.Tests/AnalyzerSmokeTests.cs
@@ -182,6 +182,53 @@ public class AnalyzerSmokeTests : IDisposable
     }
 
     [Fact]
+    public void TestingPlatformApplication_GetsATestTarget()
+    {
+        // Set directly rather than restoring a real MTP package, which would
+        // need the network. The property is what the analyzer reads either way.
+        var targets = Analyze(WriteProject("MyTests", """
+            <OutputType>Exe</OutputType>
+            <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+            """));
+
+        Assert.Contains("test", targets.Keys);
+    }
+
+    [Fact]
+    public void PlainExecutable_GetsNoTestTarget()
+    {
+        var targets = Analyze(WriteProject("MyApp", "<OutputType>Exe</OutputType>"));
+
+        Assert.DoesNotContain("test", targets.Keys);
+        Assert.Contains("run", targets.Keys);
+    }
+
+    [Fact]
+    public void LibraryReferencingATestFramework_KeepsPackAndGetsNoTestTarget()
+    {
+        // A helper library referencing xunit is not runnable by `dotnet test`,
+        // and pack is gated on the project not being a test project, so a wrong
+        // answer here costs it the pack target.
+        var projectFile = WriteProject("MyHelpers", "<IsTestProject>false</IsTestProject>");
+        File.WriteAllText(projectFile, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <IsTestProject>false</IsTestProject>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        var targets = Analyze(projectFile);
+
+        Assert.DoesNotContain("test", targets.Keys);
+        Assert.Contains("pack", targets.Keys);
+    }
+
+    [Fact]
     public void EvaluatedImportsAndLinkedFiles_AreInputsOnBuild()
     {
         Directory.CreateDirectory(Path.Combine(_workspaceRoot, "build"));

--- a/packages/dotnet/analyzer.Tests/TestProjectDetectionTests.cs
+++ b/packages/dotnet/analyzer.Tests/TestProjectDetectionTests.cs
@@ -1,0 +1,161 @@
+using MsbuildAnalyzer.Models;
+using MsbuildAnalyzer.Utilities;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// What makes a project a test project, and so which projects get a <c>test</c>
+/// target and lose <c>pack</c>. <c>publish</c> and <c>run</c> are decided by
+/// OutputType alone, so an MTP runner keeps both.
+///
+/// The expectations here mirror the SDK's own gate in
+/// <c>Microsoft.TestPlatform.ImportAfter.targets</c>:
+/// <c>IsTestProject == 'true' OR IsTestingPlatformApplication == 'true'</c>.
+/// Measured against real MSBuild evaluation: a plain library leaves both empty,
+/// xunit.v3 sets IsTestProject=true and IsTestingPlatformApplication=True, and
+/// xunit.v3.mtp-v2 sets only IsTestingPlatformApplication=true. All three
+/// values appear only after a restore.
+/// </summary>
+public class TestProjectDetectionTests
+{
+    private static bool IsTestProject(
+        Dictionary<string, string>? properties = null,
+        params string[] packages)
+    {
+        return ProjectUtilities.IsTestProject(
+            new Dictionary<string, string>(
+                properties ?? [],
+                StringComparer.OrdinalIgnoreCase),
+            [.. packages.Select(p => new PackageReference { Include = p })]);
+    }
+
+    private static Dictionary<string, string> Property(string name, string value) =>
+        new() { [name] = value };
+
+    [Fact]
+    public void NoSignals_IsNotATestProject()
+    {
+        Assert.False(IsTestProject());
+    }
+
+    [Fact]
+    public void OrdinaryLibrary_IsNotATestProject()
+    {
+        Assert.False(IsTestProject(properties: null, "Newtonsoft.Json", "Serilog"));
+    }
+
+    [Theory]
+    [InlineData("IsTestProject")]
+    // Microsoft.Testing.Platform sets this instead of IsTestProject, and it is
+    // the only property xunit.v3.mtp-v2 sets. NXC-4963.
+    [InlineData("IsTestingPlatformApplication")]
+    public void TestProperty_IsATestProject(string property)
+    {
+        Assert.True(IsTestProject(Property(property, "true")));
+    }
+
+    // MSBuild compares booleans case-insensitively, and xunit.v3 really does
+    // evaluate IsTestingPlatformApplication to "True".
+    [Theory]
+    [InlineData("IsTestProject", "True")]
+    [InlineData("IsTestProject", "TRUE")]
+    [InlineData("IsTestingPlatformApplication", "True")]
+    public void TestProperty_IsCaseInsensitive(string property, string value)
+    {
+        Assert.True(IsTestProject(Property(property, value)));
+    }
+
+    [Theory]
+    [InlineData("IsTestProject")]
+    [InlineData("IsTestingPlatformApplication")]
+    public void TestPropertySetFalse_IsNotATestProject(string property)
+    {
+        Assert.False(IsTestProject(Property(property, "false")));
+    }
+
+    // The escape hatch. A library that references a test framework so it can
+    // expose helpers is not itself runnable by `dotnet test`, and saying so in
+    // the project file has to win over anything inferred from packages.
+    [Fact]
+    public void IsTestProjectSetFalse_OverridesTheTestPackages()
+    {
+        Assert.False(IsTestProject(
+            Property("IsTestProject", "false"),
+            "Microsoft.NET.Test.Sdk",
+            "Microsoft.Testing.Platform"));
+    }
+
+    // Only IsTestProject carries that meaning. MSTest.Sdk evaluates
+    // IsTestingPlatformApplication to "false" on a project it has already marked
+    // with IsTestProject=true, so that property saying false describes the runner
+    // kind and cannot be read as "not a test project".
+    [Fact]
+    public void MSTestSdkShape_IsATestProject()
+    {
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["IsTestProject"] = "true",
+            ["IsTestingPlatformApplication"] = "false",
+        };
+
+        Assert.True(ProjectUtilities.IsTestProject(properties, []));
+    }
+
+    [Fact]
+    public void TestingPlatformApplicationSetFalse_DoesNotSuppressTheTestPackages()
+    {
+        Assert.True(IsTestProject(
+            Property("IsTestingPlatformApplication", "false"),
+            "Microsoft.NET.Test.Sdk"));
+    }
+
+    // Both properties come from a restored package, so before the first restore
+    // a reference to the test SDK is the only evidence there is.
+    [Theory]
+    [InlineData("Microsoft.NET.Test.Sdk")]
+    [InlineData("microsoft.net.test.sdk")]
+    [InlineData("Microsoft.Testing.Platform")]
+    [InlineData("Microsoft.Testing.Extensions.CodeCoverage")]
+    public void TestSdkPackageWithNoProperties_IsATestProject(string package)
+    {
+        Assert.True(IsTestProject(packages: package));
+    }
+
+    [Fact]
+    public void TestSdkPackageAmongOthers_IsATestProject()
+    {
+        Assert.True(IsTestProject(
+            properties: null,
+            "Newtonsoft.Json",
+            "Microsoft.NET.Test.Sdk",
+            "Moq"));
+    }
+
+    // A framework reference is not evidence of runnability on its own. xunit,
+    // NUnit, MSTest and TUnit projects are detected from the properties their
+    // packages set once restored, which is also what keeps a helper library
+    // that references one from losing its pack target.
+    [Theory]
+    [InlineData("xunit")]
+    [InlineData("xunit.v3")]
+    [InlineData("xunit.v3.mtp-v2")]
+    [InlineData("xunit.abstractions")]
+    [InlineData("xunit.extensibility.core")]
+    [InlineData("NUnit")]
+    [InlineData("NUnit3TestAdapter")]
+    [InlineData("NUnit.Analyzers")]
+    [InlineData("MSTest.TestFramework")]
+    [InlineData("TUnit")]
+    public void FrameworkPackageAlone_IsNotATestProject(string package)
+    {
+        Assert.False(IsTestProject(packages: package));
+    }
+
+    // A name that merely starts with a family name is not in that family.
+    [Fact]
+    public void PackageNamedLikeTheTestingPrefix_IsNotATestProject()
+    {
+        Assert.False(IsTestProject(packages: "Microsoft.TestingHelpers"));
+    }
+}

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -173,7 +173,7 @@ public static class Analyzer
                     var properties = CollectProperties(primaryNode.ProjectInstance!);
 
                     // Determine project type
-                    var isTest = IsTestProject(properties, packageRefs);
+                    var isTest = ProjectUtilities.IsTestProject(properties, packageRefs);
                     var isExe = properties.IsExecutable;
 
                     // Build targets
@@ -342,13 +342,5 @@ public static class Analyzer
         }
 
         return properties;
-    }
-
-    private static bool IsTestProject(
-        EvaluatedProperties properties,
-        List<PackageReference> packageRefs)
-    {
-        return properties.IsTestProject ||
-               packageRefs.Any(p => p.Include == "Microsoft.NET.Test.Sdk" || p.Include.StartsWith("Microsoft.Testing"));
     }
 }

--- a/packages/dotnet/analyzer/Models/EvaluatedProperties.cs
+++ b/packages/dotnet/analyzer/Models/EvaluatedProperties.cs
@@ -83,11 +83,26 @@ public sealed class EvaluatedProperties
     // Interpreted values. Each derives from a raw member above or, like
     // IsTestProject, carries the MSBuild name itself; either way the name comes
     // from a `nameof`.
-    public bool IsTestProject => Get(nameof(IsTestProject)) == "true";
-    public bool UsesArtifactsOutput =>
-        string.Equals(UseArtifactsOutput, "true", StringComparison.OrdinalIgnoreCase);
+    public bool IsTestProject => IsTrue(nameof(IsTestProject));
+
+    /// <summary>
+    /// Microsoft.Testing.Platform's marker for a runner project. Some runners
+    /// set it and leave <see cref="IsTestProject"/> unset, so neither property
+    /// implies the other. MTP imports its targets from a restored package, so
+    /// the value exists only once the project has been restored.
+    /// </summary>
+    public bool IsTestingPlatformApplication => IsTrue(nameof(IsTestingPlatformApplication));
+
+    public bool UsesArtifactsOutput => IsTrue(nameof(UseArtifactsOutput));
     public bool IsExecutable =>
         string.Equals(OutputType, "Exe", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// MSBuild compares booleans case-insensitively, so a project that writes
+    /// <c>True</c> means the same thing as one that writes <c>true</c>.
+    /// </summary>
+    private bool IsTrue(string name) =>
+        string.Equals(Get(name), "true", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// The directory NuGet writes its restore-generated imports into.

--- a/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
+++ b/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
@@ -1,4 +1,5 @@
 using Microsoft.Build.Execution;
+using MsbuildAnalyzer.Models;
 
 namespace MsbuildAnalyzer.Utilities;
 
@@ -261,5 +262,50 @@ public static class ProjectUtilities
 
 
         return techs;
+    }
+
+    /// <summary>
+    /// The test SDK packages that mark a project before it has been restored.
+    /// Matched case-insensitively because NuGet ids are.
+    /// </summary>
+    private const string TestSdkPackage = "Microsoft.NET.Test.Sdk";
+    private const string TestingPlatformPackagePrefix = "Microsoft.Testing.";
+
+    /// <summary>
+    /// Whether the project gets a <c>test</c> target.
+    ///
+    /// The property pair is the SDK's own gate, from
+    /// <c>Microsoft.TestPlatform.ImportAfter.targets</c>:
+    /// <c>IsTestProject == 'true' OR IsTestingPlatformApplication == 'true'</c>.
+    /// A framework reference is deliberately not a signal, since a library can
+    /// reference xunit or NUnit to expose helpers without being runnable.
+    /// </summary>
+    public static bool IsTestProject(
+        EvaluatedProperties properties,
+        IEnumerable<PackageReference> packageRefs)
+    {
+        if (properties.IsTestProject || properties.IsTestingPlatformApplication)
+        {
+            return true;
+        }
+
+        // A non-true IsTestProject is the project's own answer and settles it.
+        // MSBuild leaves the property empty when nothing assigns it, so an
+        // explicit `false` is distinguishable from an absent value.
+        //
+        // IsTestingPlatformApplication is deliberately not read this way. It
+        // describes the runner kind rather than the project kind, and MSTest.Sdk
+        // evaluates it to `false` on a project it has already marked with
+        // IsTestProject=true.
+        if (properties.Get(nameof(EvaluatedProperties.IsTestProject)) is not null)
+        {
+            return false;
+        }
+
+        // Both properties arrive with a restored package, so a reference to the
+        // test SDK is the only evidence available before the first restore.
+        return packageRefs.Any(p =>
+            p.Include.Equals(TestSdkPackage, StringComparison.OrdinalIgnoreCase) ||
+            p.Include.StartsWith(TestingPlatformPackagePrefix, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/packages/dotnet/assets.json
+++ b/packages/dotnet/assets.json
@@ -4,6 +4,7 @@
     {
       "glob": "*.md"
     },
+    { "glob": "**/files/**", "input": "packages/dotnet/src" },
     { "glob": "**/schema.json", "input": "packages/dotnet/src" },
     { "glob": "**/schema.d.ts", "input": "packages/dotnet/src" },
     {

--- a/tools/workspace-plugin/src/conformance-rules/generator-template-assets/index.spec.ts
+++ b/tools/workspace-plugin/src/conformance-rules/generator-template-assets/index.spec.ts
@@ -1,0 +1,143 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { validateGeneratorTemplateAssets } from './index';
+import type { BuildLayout } from '../utils/copied-assets';
+
+describe('generator-template-assets', () => {
+  let rootDir: string;
+  const projectRoot = 'packages/acme';
+  const flatLayout: BuildLayout = { sourceDir: 'src', outDir: 'dist' };
+  const nestedLayout: BuildLayout = { sourceDir: '.', outDir: 'dist' };
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'generator-template-assets-'));
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  function writeFile(path: string, content = 'template') {
+    const file = join(rootDir, path);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, content);
+  }
+
+  function validate(assets: any[], buildLayout: BuildLayout = flatLayout) {
+    return validateGeneratorTemplateAssets({
+      assetsJson: { outDir: `${projectRoot}/dist`, assets },
+      buildLayout,
+      projectRoot,
+      sourceProject: 'acme',
+      assetsPath: join(rootDir, projectRoot, 'assets.json'),
+      rootDir,
+    });
+  }
+
+  it('should return no violations when an asset glob copies the templates into the build output', () => {
+    writeFile('packages/acme/src/generators/app/files/src/index.ts.template');
+
+    expect(
+      validate([{ glob: '**/files/**', input: 'packages/acme/src' }])
+    ).toEqual([]);
+  });
+
+  it('should return a violation when no asset glob copies the templates', () => {
+    writeFile('packages/acme/src/generators/app/files/src/index.ts.template');
+
+    const violations = validate([{ glob: 'src/**/schema.json' }]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain(
+      'src/generators/app/files/src/index.ts.template'
+    );
+    expect(violations[0].sourceProject).toBe('acme');
+  });
+
+  // A glob whose input is the package root mirrors `src/` into the output, so
+  // under this layout the templates land a directory below where the compiled
+  // generator looks for them.
+  it('should return a violation when the glob copies the templates beside the build output rather than into it', () => {
+    writeFile('packages/acme/src/generators/app/files/src/index.ts.template');
+
+    const violations = validate([{ glob: '**/files/**' }]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain(
+      'packages/acme/dist/generators/app/files/src/index.ts.template'
+    );
+  });
+
+  it('should accept a package-root glob when the package compiles from its own root', () => {
+    writeFile('packages/acme/src/generators/app/files/src/index.ts.template');
+
+    expect(validate([{ glob: '**/files/**' }], nestedLayout)).toEqual([]);
+  });
+
+  it('should return a violation when the glob copies the templates elsewhere in the build output', () => {
+    writeFile('packages/acme/src/generators/app/files/src/index.ts.template');
+
+    expect(
+      validate([
+        {
+          glob: '**/files/**',
+          input: 'packages/acme/src',
+          output: '/templates',
+        },
+      ])
+    ).toHaveLength(1);
+  });
+
+  // The ci-workflow generators template whole dot directories, and a glob that
+  // does not opt into dotfiles skips every one of them.
+  it('should check templates nested under a dot directory', () => {
+    writeFile(
+      'packages/acme/src/generators/ci-workflow/files/github/.github/workflows/ci.yml.template'
+    );
+
+    expect(validate([{ glob: 'src/**/schema.json' }])).toHaveLength(1);
+    expect(
+      validate([{ glob: '**/files/**', input: 'packages/acme/src' }])
+    ).toEqual([]);
+  });
+
+  it('should check suffixed template directories', () => {
+    writeFile(
+      'packages/acme/src/generators/app/files-angular/src/app.ts.template'
+    );
+
+    expect(
+      validate([{ glob: '**/files/**', input: 'packages/acme/src' }])
+    ).toHaveLength(1);
+    expect(
+      validate([
+        { glob: '**/@(files|files-angular)/**', input: 'packages/acme/src' },
+      ])
+    ).toEqual([]);
+  });
+
+  // A package that compiles from its own root has its build output and its
+  // installed dependencies inside the walked tree. Templates the build already
+  // copied are not sources, and a dependency's templates are not this package's.
+  it('should ignore templates inside the build output', () => {
+    writeFile('packages/acme/src/generators/app/files/index.ts.template');
+    writeFile('packages/acme/dist/src/generators/app/files/index.ts.template');
+
+    expect(validate([{ glob: '**/files/**' }], nestedLayout)).toEqual([]);
+  });
+
+  it('should ignore templates inside node_modules', () => {
+    writeFile(
+      'packages/acme/node_modules/dep/src/generators/x/files/a.template'
+    );
+
+    expect(validate([{ glob: '**/files/**' }], nestedLayout)).toEqual([]);
+  });
+
+  it('should return no violations when the package has no template directories', () => {
+    writeFile('packages/acme/src/generators/app/generator.ts', 'export {};');
+
+    expect(validate([{ glob: 'src/**/schema.json' }])).toEqual([]);
+  });
+});

--- a/tools/workspace-plugin/src/conformance-rules/generator-template-assets/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/generator-template-assets/index.ts
@@ -1,0 +1,126 @@
+import {
+  createConformanceRule,
+  type ConformanceViolation,
+} from '@nx/conformance';
+import { readJsonFile, workspaceRoot } from '@nx/devkit';
+import { existsSync, readdirSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import type { AssetsJson } from '../../plugins/copy-assets-plugin.js';
+import {
+  collectCopiedFiles,
+  readBuildLayout,
+  type BuildLayout,
+} from '../utils/copied-assets.js';
+
+export default createConformanceRule({
+  name: 'generator-template-assets',
+  category: 'consistency',
+  description:
+    'Ensures the EJS templates a generator reads with generateFiles are copied into the built package, so the published generator finds them next to its own compiled file',
+  implementation: async ({ projectGraph }) => {
+    const violations: ConformanceViolation[] = [];
+
+    for (const project of Object.values(projectGraph.nodes)) {
+      const projectRoot = project.data.root;
+      const assetsPath = join(workspaceRoot, projectRoot, 'assets.json');
+      if (!existsSync(assetsPath)) continue;
+
+      const buildLayout = readBuildLayout(projectRoot, workspaceRoot);
+      if (!buildLayout) continue;
+
+      violations.push(
+        ...validateGeneratorTemplateAssets({
+          assetsJson: readJsonFile<AssetsJson>(assetsPath),
+          buildLayout,
+          projectRoot,
+          sourceProject: project.name,
+          assetsPath,
+          rootDir: workspaceRoot,
+        })
+      );
+    }
+
+    return {
+      severity: 'high',
+      details: {
+        violations,
+      },
+    };
+  },
+});
+
+export function validateGeneratorTemplateAssets(opts: {
+  assetsJson: AssetsJson;
+  buildLayout: BuildLayout;
+  projectRoot: string;
+  sourceProject: string;
+  assetsPath: string;
+  rootDir: string;
+}): ConformanceViolation[] {
+  const { assetsJson, buildLayout, projectRoot, rootDir } = opts;
+  const packageDir = join(rootDir, projectRoot);
+  const sourceDir = resolve(packageDir, buildLayout.sourceDir);
+  const outputDir = resolve(packageDir, buildLayout.outDir);
+
+  const templates = collectTemplateFiles(sourceDir, outputDir);
+  if (!templates.length) return [];
+
+  const copied = collectCopiedFiles(assetsJson, projectRoot, rootDir);
+
+  const violations: ConformanceViolation[] = [];
+  for (const template of templates) {
+    // generateFiles resolves its directory from the generator's own __dirname,
+    // so a template has to land at the path tsc's rootDir/outDir mapping gives
+    // it. Copied anywhere else it is published but unreachable.
+    const expected = join(outputDir, relative(sourceDir, template));
+    if (copied.has(expected)) continue;
+
+    violations.push({
+      message: `The generator template "${relative(
+        packageDir,
+        template
+      )}" is not copied to "${relative(
+        rootDir,
+        expected
+      )}", so generateFiles cannot read it from the published package. Add an assets.json glob that copies the template directory.`,
+      sourceProject: opts.sourceProject,
+      file: opts.assetsPath,
+    });
+  }
+
+  return violations;
+}
+
+/**
+ * Every file below a template directory. `files` and its suffixed variants
+ * (`files-angular`, `files-integrated-repo`) are the workspace convention for a
+ * generateFiles directory, and everything under one is a template whatever its
+ * extension.
+ *
+ * A package that compiles from its own root has `outputDir` and `node_modules`
+ * inside `sourceDir`. Templates a build already copied would otherwise be read
+ * back as sources and checked for a second copy one directory deeper.
+ */
+function collectTemplateFiles(sourceDir: string, outputDir: string): string[] {
+  if (!existsSync(sourceDir)) return [];
+
+  const templates: string[] = [];
+  const walk = (dir: string, insideTemplate: boolean) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (path === outputDir || entry.name === 'node_modules') continue;
+        walk(path, insideTemplate || isTemplateDirectory(entry.name));
+      } else if (insideTemplate && entry.isFile()) {
+        templates.push(path);
+      }
+    }
+  };
+  walk(sourceDir, false);
+
+  return templates;
+}
+
+function isTemplateDirectory(name: string): boolean {
+  return name === 'files' || name.startsWith('files-');
+}

--- a/tools/workspace-plugin/src/conformance-rules/generator-template-assets/schema.json
+++ b/tools/workspace-plugin/src/conformance-rules/generator-template-assets/schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "generator-template-assets",
+  "title": "generator-template-assets rule configuration",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
@@ -3,13 +3,15 @@ import {
   type ConformanceViolation,
 } from '@nx/conformance';
 import { readJsonFile, workspaceRoot } from '@nx/devkit';
-import { CopyAssetsHandler } from '@nx/js/src/utils/assets/copy-assets-handler';
 import { existsSync } from 'node:fs';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
+import type { AssetsJson } from '../../plugins/copy-assets-plugin.js';
 import {
-  toExecutorAssets,
-  type AssetsJson,
-} from '../../plugins/copy-assets-plugin.js';
+  collectCopiedFiles,
+  isInside,
+  readBuildLayout,
+  type BuildLayout,
+} from '../utils/copied-assets.js';
 
 const REFERENCE_KEYS = ['prompt', 'documentation'] as const;
 
@@ -115,32 +117,6 @@ export function validateMigrationMarkdownAssets(opts: {
   return violations;
 }
 
-type BuildLayout = { sourceDir: string; outDir: string };
-
-/**
- * Reads the `rootDir`/`outDir` the package builds with. Returns null when
- * neither tsconfig declares both, so a package whose layout cannot be
- * determined is left unchecked rather than checked against a guess.
- */
-function readBuildLayout(
-  projectRoot: string,
-  rootDir: string
-): BuildLayout | null {
-  for (const tsconfig of ['tsconfig.lib.json', 'tsconfig.json']) {
-    const tsconfigPath = join(rootDir, projectRoot, tsconfig);
-    if (!existsSync(tsconfigPath)) continue;
-    const compilerOptions = readJsonFile(tsconfigPath).compilerOptions ?? {};
-    if (compilerOptions.rootDir && compilerOptions.outDir) {
-      return {
-        sourceDir: compilerOptions.rootDir,
-        outDir: compilerOptions.outDir,
-      };
-    }
-  }
-
-  return null;
-}
-
 /**
  * Implementations are tsc outputs rather than copied assets, so the assets
  * pipeline cannot vouch for them. Map the published path back through the
@@ -187,33 +163,4 @@ function validateImplementationPath(
   }
 
   return null;
-}
-
-/**
- * Drives the real copy-assets pipeline over the working tree with a collecting
- * callback in place of the copying one, so the resulting paths are the ones a
- * build would produce, without writing any of them.
- */
-function collectCopiedFiles(
-  assetsJson: AssetsJson,
-  projectRoot: string,
-  rootDir: string
-): Set<string> {
-  const copied = new Set<string>();
-  new CopyAssetsHandler({
-    rootDir,
-    projectDir: join(rootDir, projectRoot),
-    outputDir: resolve(rootDir, assetsJson.outDir),
-    assets: toExecutorAssets(assetsJson, projectRoot),
-    callback: (events) => {
-      for (const event of events) copied.add(event.dest);
-    },
-  }).processAllAssetsOnceSync();
-
-  return copied;
-}
-
-function isInside(dir: string, file: string): boolean {
-  const rel = relative(dir, file);
-  return !!rel && !rel.startsWith('..') && !isAbsolute(rel);
 }

--- a/tools/workspace-plugin/src/conformance-rules/utils/copied-assets.ts
+++ b/tools/workspace-plugin/src/conformance-rules/utils/copied-assets.ts
@@ -1,0 +1,64 @@
+import { CopyAssetsHandler } from '@nx/js/src/utils/assets/copy-assets-handler';
+import { existsSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import { readJsonFile } from '@nx/devkit';
+import {
+  toExecutorAssets,
+  type AssetsJson,
+} from '../../plugins/copy-assets-plugin.js';
+
+/**
+ * Drives the real copy-assets pipeline over the working tree with a collecting
+ * callback in place of the copying one, so the resulting paths are the ones a
+ * build would produce, without writing any of them.
+ */
+export function collectCopiedFiles(
+  assetsJson: AssetsJson,
+  projectRoot: string,
+  rootDir: string
+): Set<string> {
+  const copied = new Set<string>();
+  new CopyAssetsHandler({
+    rootDir,
+    projectDir: join(rootDir, projectRoot),
+    outputDir: resolve(rootDir, assetsJson.outDir),
+    assets: toExecutorAssets(assetsJson, projectRoot),
+    callback: (events) => {
+      for (const event of events) copied.add(event.dest);
+    },
+  }).processAllAssetsOnceSync();
+
+  return copied;
+}
+
+export function isInside(dir: string, file: string): boolean {
+  const rel = relative(dir, file);
+  return !!rel && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+/** The source and output directories a package builds with, relative to it. */
+export type BuildLayout = { sourceDir: string; outDir: string };
+
+/**
+ * Reads the `rootDir`/`outDir` the package builds with. Returns null when
+ * neither tsconfig declares both, so a package whose layout cannot be
+ * determined is left unchecked rather than checked against a guess.
+ */
+export function readBuildLayout(
+  projectRoot: string,
+  rootDir: string
+): BuildLayout | null {
+  for (const tsconfig of ['tsconfig.lib.json', 'tsconfig.json']) {
+    const tsconfigPath = join(rootDir, projectRoot, tsconfig);
+    if (!existsSync(tsconfigPath)) continue;
+    const compilerOptions = readJsonFile(tsconfigPath).compilerOptions ?? {};
+    if (compilerOptions.rootDir && compilerOptions.outDir) {
+      return {
+        sourceDir: compilerOptions.rootDir,
+        outDir: compilerOptions.outDir,
+      };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

Stacked on #36958. The last two commits are the new work.

## Current Behavior

<!-- This is the behavior we have today -->

`packages/dotnet/assets.json` has no `files` glob, so the ci-workflow templates never reach `dist`. Running the generator from the published package fails with `generateFiles: No files found in ".../dist/generators/ci-workflow/files/github"`.

Test detection accepts only `IsTestProject` or a reference to `Microsoft.NET.Test.Sdk`/`Microsoft.Testing.*`. Microsoft.Testing.Platform marks a runner with `IsTestingPlatformApplication` instead, and `xunit.v3.mtp-v2` sets only that one, leaving `IsTestProject` unset. OrchardCore's test projects reference it with `OutputType=Exe`, so they get publish and run targets but no `test`.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

The templates ship, and MTP runners get a `test` target.

Detection mirrors the SDK's own gate, from `Microsoft.TestPlatform.ImportAfter.targets`: `IsTestProject == 'true' OR IsTestingPlatformApplication == 'true'`. So Nx agrees with `dotnet test` about what a test project is. A framework reference is deliberately not a signal, which keeps a library that references xunit to expose helpers from losing its `pack` target. Setting `IsTestProject` yourself settles it. `IsTestingPlatformApplication` is not read that way, since MSTest.Sdk evaluates it to `false` on a project it has already marked as a test.

The glob has to be rooted at `packages/dotnet/src` because this package compiles with `rootDir: "src"`. The bare `**/files/**` that gradle and workspace use lands one directory too deep here. A new `generator-template-assets` conformance rule now checks that mapping for every package.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

No GitHub issue. Tracked in Linear.

Fixes NXC-4962
Fixes NXC-4963

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-dotnet-ci-workflow-assets--MTP-test-detection-NXC-4962-NXC-4963-5d6bec51">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->