### PR TITLE
fix(core): traverse past module-format package.json stubs when locating npm dependencies

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -34,6 +34,12 @@ vi.mock('nx/src/plugins/js/utils/resolve-relative-to-dir', () => ({
     if (pathOrPackage === '@json2csv/plainjs/package.json') {
       return '/root/node_modules/@json2csv/plainjs/dist/cjs/package.json';
     }
+    // A wildcard export ("./*": "./dist/cjs/*") reroutes package.json to a
+    // module-format stub. Unlike @json2csv/plainjs above, this package has NO
+    // unversioned `npm:@rerouted/pkg` node to fall back on.
+    if (pathOrPackage === '@rerouted/pkg/package.json') {
+      return '/root/node_modules/@rerouted/pkg/dist/cjs/package.json';
+    }
     return join(
       '/root',
       'node_modules',
@@ -768,6 +774,16 @@ describe('TargetProjectLocator', () => {
           JSON.stringify({
             type: 'commonjs',
           }),
+        // @rerouted/pkg models the same reroute, but its only graph node is
+        // versioned (it is not a dependency of the root package.json), so the
+        // locator must traverse up to the real manifest to find the version.
+        './node_modules/@rerouted/pkg/package.json': JSON.stringify({
+          name: '@rerouted/pkg',
+          version: '2.0.0',
+        }),
+        './node_modules/@rerouted/pkg/dist/cjs/package.json': JSON.stringify({
+          type: 'commonjs',
+        }),
       };
       vol.fromJSON(fsJson, '/root');
 
@@ -972,6 +988,19 @@ describe('TargetProjectLocator', () => {
             hash: 'sha512-4Md7RPDCSYpmW1HWIpWBOqCd4vWfIqm53S3e/uzQ62iGi7L3r34fK/8nhOMEe+/eVfCx8+gdSCt1d74SlacQHw==',
           },
         },
+        /**
+         * @rerouted/pkg also reroutes package.json to a module-format stub, but
+         * only exists as a VERSIONED node (no root-level `npm:@rerouted/pkg`).
+         */
+        'npm:@rerouted/pkg@2.0.0': {
+          type: 'npm',
+          name: 'npm:@rerouted/pkg@2.0.0',
+          data: {
+            version: '2.0.0',
+            packageName: '@rerouted/pkg',
+            hash: 'sha512-4Md7RPDCSYpmW1HWIpWBOqCd4vWfIqm53S3e/uzQ62iGi7L3r34fK/8nhOMEe+/eVfCx8+gdSCt1d74SlacQHw==',
+          },
+        },
       };
 
       targetProjectLocator = new TargetProjectLocator(projects, npmProjects);
@@ -1138,6 +1167,19 @@ describe('TargetProjectLocator', () => {
         'libs/proj/index.ts'
       );
       expect(result).toEqual('npm:@json2csv/plainjs');
+    });
+
+    it('should resolve a rerouted package.json to its versioned node when no root-level node exists', () => {
+      // With a wildcard export the directly resolvable package.json is a
+      // module-format stub without name/version. The locator must keep
+      // traversing to the real manifest instead of returning null, otherwise
+      // the import can only be matched through the unversioned fallback node,
+      // which exists solely for packages declared by the root package.json.
+      const result = targetProjectLocator.findProjectFromImport(
+        '@rerouted/pkg/some/subpath',
+        'libs/proj/index.ts'
+      );
+      expect(result).toEqual('npm:@rerouted/pkg@2.0.0');
     });
   });
 

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -606,10 +606,12 @@ export class TargetProjectLocator {
       if (parsedPackageJson.name && parsedPackageJson.version) {
         this.packageJsonResolutionCache.set(packageJsonPath, parsedPackageJson);
         return parsedPackageJson;
-      } else {
-        this.packageJsonResolutionCache.set(packageJsonPath, null);
-        return null;
       }
+      // A wildcard export such as `"./*": "./dist/cjs/*"` reroutes
+      // `<package>/package.json` to a module-format stub (`{"type":"commonjs"}`)
+      // that carries no name or version. That stub is not the package manifest,
+      // so fall through and traverse upwards from it, exactly as we do when the
+      // package.json is not directly resolvable at all.
     }
 
     try {
@@ -621,23 +623,28 @@ export class TargetProjectLocator {
       while (dir !== dirname(dir)) {
         const packageJsonPath = join(dir, 'package.json');
         if (this.packageJsonResolutionCache.has(packageJsonPath)) {
-          return this.packageJsonResolutionCache.get(packageJsonPath);
-        }
-        try {
-          const parsedPackageJson = readJsonFile(packageJsonPath);
-          // Ensure the package.json contains the "name" and "version" fields
-          if (parsedPackageJson.name && parsedPackageJson.version) {
-            this.packageJsonResolutionCache.set(
-              packageJsonPath,
-              parsedPackageJson
-            );
-            return parsedPackageJson;
-          } else {
-            this.packageJsonResolutionCache.set(packageJsonPath, null);
-            return null;
+          const cached = this.packageJsonResolutionCache.get(packageJsonPath);
+          if (cached) {
+            return cached;
           }
-        } catch {
-          // Package.json is invalid, keep traversing
+          // A cached null marks a module-format stub; keep traversing.
+        } else {
+          try {
+            const parsedPackageJson = readJsonFile(packageJsonPath);
+            // Ensure the package.json contains the "name" and "version" fields
+            if (parsedPackageJson.name && parsedPackageJson.version) {
+              this.packageJsonResolutionCache.set(
+                packageJsonPath,
+                parsedPackageJson
+              );
+              return parsedPackageJson;
+            }
+            // A module-format stub without name/version: remember it and keep
+            // traversing towards the real manifest.
+            this.packageJsonResolutionCache.set(packageJsonPath, null);
+          } catch {
+            // Package.json is invalid, keep traversing
+          }
         }
         dir = dirname(dir);
       }


### PR DESCRIPTION
## Current Behavior

`TargetProjectLocator.readPackageJson` returns `null` when the directly resolvable `<pkg>/package.json` is a module-format stub (`{"type":"commonjs"}`) without `name`/`version`, and again at the first such stub during the upward traversal. A wildcard export (`"./*": "./dist/cjs/*"`) with no explicit `./package.json` export produces exactly that stub (e.g. `@modelcontextprotocol/sdk`, `react-router-dom`, `recharts`, `react-markdown`).

The import then only matches through the unversioned `npm:<name>` node, which exists solely for the hoisted (root-level) version. When the package is declared by projects but not by the root `package.json`, and more than one version exists, the project loses its edge to the package: `nx graph` shows none, and `@nx/dependency-checks` reports the dependency as unused (its `--fix` then deletes a real dependency).

## Expected Behavior

As the method's JSDoc already states: keep traversing past a stub until a package.json with `name` and `version` is found, then match the versioned node (`npm:@modelcontextprotocol/sdk@1.28.0`).

## Related Issue(s)

Fixes #36984

Related: #30342 (fixed by #30511, which added the traversal and its comment but kept both early returns).

## Changes

- `readPackageJson`: the directly-resolvable branch falls through to the traversal when the manifest lacks `name`/`version`; the traversal caches a stub as `null` and continues upward instead of returning.
- Spec: new case `@rerouted/pkg` with a rerouted `package.json` and a **versioned-only** external node (`npm:@rerouted/pkg@2.0.0`). The existing `@json2csv/plainjs` case is unchanged; it passes through the unversioned fallback node and never reached the traversal.

## Verification

- Minimal pnpm workspace (two libs on `@modelcontextprotocol/sdk` 1.28.0 and 1.29.0, root does not declare it): before, both projects have no edge; after, `npm:@modelcontextprotocol/sdk@1.28.0` and `@1.29.0` respectively.
- Applied as a pnpm patch to `nx@23.1.0` in a 119-project workspace: `@nx/dependency-checks` false positive gone, and the project graph keeps every project-to-package edge it had while the root manifest still hoisted everything.
