### PR TITLE
fix(core): deduplicate external inputs before hash plan allocation

### DIFF
--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -275,7 +275,7 @@ impl HashPlanner {
                 // todo)) @Cammisuli: we need to gather the project's inputs and its dep inputs similar to how we do it in `self_and_deps_inputs`
                 return Ok(None);
             };
-            let mut external_deps: Vec<&'a String> = vec![];
+            let mut external_deps = hashbrown::HashSet::new();
             trace!(
                 "Add External Instruction for executor {existing_package}: {}",
                 target.executor.as_ref().unwrap()
@@ -284,7 +284,7 @@ impl HashPlanner {
                 "Add External Instructions for dependencies of executor {existing_package}: {:?}",
                 &external_deps_map[existing_package]
             );
-            external_deps.push(existing_package);
+            external_deps.insert(existing_package);
             external_deps.extend(&external_deps_map[existing_package]);
             Ok(Some(
                 external_deps
@@ -293,7 +293,7 @@ impl HashPlanner {
                     .collect(),
             ))
         } else {
-            let mut external_deps: Vec<&'a String> = vec![];
+            let mut external_deps = hashbrown::HashSet::new();
             let mut has_external_deps = false;
             for input in self_inputs {
                 match input {
@@ -328,7 +328,7 @@ impl HashPlanner {
                                 "Add External Instructions for dependencies of External Input {external_node_name}: {:?}",
                                 &external_deps_map[external_node_name]
                             );
-                            external_deps.push(external_node_name);
+                            external_deps.insert(external_node_name);
                             external_deps.extend(&external_deps_map[external_node_name]);
                         }
                     }
@@ -492,6 +492,9 @@ impl HashPlanner {
             .map(|instruction| pool.intern(instruction))
             .collect();
 
+        // Deduplicate borrowed names before allocating or interning instructions.
+        // Keep each memo entry self-contained so cache hits retain its externals.
+        let mut external_inputs = hashbrown::HashSet::new();
         if let Some(child_input) = dep_inputs.deps_inputs.first() {
             for child in &self.project_graph.dependencies[dep] {
                 if self.project_graph.nodes.contains_key(child) {
@@ -500,16 +503,17 @@ impl HashPlanner {
                     needs_legacy |= sub.needs_legacy;
                     ids.extend_from_slice(&sub.ids);
                 } else if let Some(external_deps) = external_deps_mapped.get(child) {
-                    ids.push(pool.intern(HashInstruction::External(child.to_string())));
-                    ids.extend(
-                        external_deps
-                            .iter()
-                            .map(|s| pool.intern(HashInstruction::External(s.to_string()))),
-                    );
+                    external_inputs.insert(child);
+                    external_inputs.extend(external_deps);
                 }
             }
         }
 
+        ids.extend(
+            external_inputs
+                .into_iter()
+                .map(|s| pool.intern(HashInstruction::External(s.to_string()))),
+        );
         ids.sort_unstable();
         ids.dedup();
 
@@ -570,6 +574,9 @@ impl HashPlanner {
         let pool = &self.instruction_pool;
         let memo_enabled = self.dependency_memo_enabled();
         let mut deps_inputs: Vec<u32> = Vec::with_capacity(project_deps.len());
+        // External membership is separate from project cycle detection, whose
+        // scopes must still be rolled back independently for sibling inputs.
+        let mut external_inputs = hashbrown::HashSet::new();
 
         for dep in project_deps {
             if !visited.insert(dep.as_str()) {
@@ -606,16 +613,17 @@ impl HashPlanner {
             } else {
                 // todo(jcammisuli): add a check to skip this when the new task hasher is ready, and when `AllExternalDependencies` is used
                 if let Some(external_deps) = external_deps_mapped.get(dep) {
-                    deps_inputs.push(pool.intern(HashInstruction::External(dep.to_string())));
-                    deps_inputs.extend(
-                        external_deps
-                            .iter()
-                            .map(|s| pool.intern(HashInstruction::External(s.to_string()))),
-                    );
+                    external_inputs.insert(dep);
+                    external_inputs.extend(external_deps);
                 }
             }
         }
 
+        deps_inputs.extend(
+            external_inputs
+                .into_iter()
+                .map(|s| pool.intern(HashInstruction::External(s.to_string()))),
+        );
         Ok(deps_inputs)
     }
 
@@ -795,7 +803,8 @@ fn find_external_dependency_node_name<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::VisitedTracker;
+    use super::*;
+    use crate::native::project_graph::types::{ExternalNode, Project, Target};
 
     #[test]
     fn insert_reports_first_insertion_only() {
@@ -819,5 +828,75 @@ mod tests {
         assert!(visited.insert("inner1"));
         assert!(!visited.insert("outer"));
         assert!(!visited.insert("seed"));
+    }
+
+    #[test]
+    fn overlapping_external_closures_retain_capacity_proportional_to_unique_inputs() {
+        let direct_count = 50;
+        let shared_count = 100;
+        let direct: Vec<String> = (0..direct_count)
+            .map(|i| format!("npm:direct-{i}"))
+            .collect();
+        let shared: Vec<String> = (0..shared_count)
+            .map(|i| format!("npm:shared-{i}"))
+            .collect();
+        let mut dependencies = HashMap::from([("app".to_string(), direct.clone())]);
+        for dep in &direct {
+            dependencies.insert(dep.clone(), shared.clone());
+        }
+        let graph = ProjectGraph {
+            nodes: HashMap::from([(
+                "app".to_string(),
+                Project {
+                    root: "app".to_string(),
+                    targets: HashMap::from([("build".to_string(), Target::default())]),
+                    ..Default::default()
+                },
+            )]),
+            dependencies,
+            external_nodes: direct
+                .into_iter()
+                .chain(shared)
+                .map(|name| {
+                    (
+                        name,
+                        ExternalNode {
+                            package_name: None,
+                            version: "1.0.0".to_string(),
+                            hash: None,
+                        },
+                    )
+                })
+                .collect(),
+        };
+        let planner = HashPlanner::new(
+            NxJson { named_inputs: None },
+            &External::new(Arc::new(graph)),
+        );
+        let task = Task::new("app", "build");
+        let task_graph = TaskGraph {
+            roots: vec![task.id.clone()],
+            tasks: HashMap::from([(task.id.clone(), task)]),
+            dependencies: HashMap::new(),
+            continuous_dependencies: HashMap::new(),
+        };
+        let plans = planner
+            .get_plans_internal(vec!["app:build"], task_graph)
+            .unwrap();
+        let plan = &plans.plans["app:build"];
+        assert_eq!(
+            plan.iter()
+                .filter(|id| matches!(plans.pool.get(**id).value(), HashInstruction::External(_)))
+                .count(),
+            direct_count + shared_count
+        );
+        // Vec::dedup alone leaves storage for all 5,050 external occurrences.
+        // Bound retained storage without depending on exact allocator growth.
+        assert!(
+            plan.capacity() <= plan.len() * 2,
+            "{} unique instructions retained {} slots",
+            plan.len(),
+            plan.capacity()
+        );
     }
 }

--- a/packages/nx/src/native/tests/__snapshots__/planner.spec.ts.snap
+++ b/packages/nx/src/native/tests/__snapshots__/planner.spec.ts.snap
@@ -61,6 +61,125 @@ exports[`task planner > should build plans where the project graph has circular 
 }
 `;
 
+exports[`task planner > should deduplicate overlapping external closures for all inputs without losing sibling project inputs > overlapping external all hash 1`] = `
+{
+  "details": {
+    "AllExternalDependencies": "13071596994106544840",
+    "app:ProjectConfiguration": "17530813657774869408",
+    "app:TsConfig": "1389868326933519382",
+    "app:apps/app/**/*": "3244421341483603138",
+    "child:ProjectConfiguration": "14397347420239404290",
+    "child:TsConfig": "1389868326933519382",
+    "child:libs/child/prod.ts": "13546527163958192884",
+    "child:libs/child/test.ts": "17746510544300185116",
+    "env:NX_CLOUD_ENCRYPTION_KEY": "3244421341483603138",
+    "npm:@nx/left": "11507288172457604164",
+    "npm:leaf": "11507288172457604164",
+    "npm:right": "11507288172457604164",
+    "npm:shared": "11507288172457604164",
+    "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "9198976360534335893",
+  },
+  "inputs": {
+    "depOutputs": [],
+    "environment": [
+      "NX_CLOUD_ENCRYPTION_KEY",
+    ],
+    "external": [
+      "AllExternalDependencies",
+      "npm:@nx/left",
+      "npm:leaf",
+      "npm:right",
+      "npm:shared",
+    ],
+    "files": [
+      "libs/child/prod.ts",
+      "libs/child/test.ts",
+      "nx.json",
+    ],
+    "runtime": [],
+  },
+  "value": "6233822002282478864",
+}
+`;
+
+exports[`task planner > should deduplicate overlapping external closures for executor inputs without losing sibling project inputs > overlapping external executor hash 1`] = `
+{
+  "details": {
+    "app:ProjectConfiguration": "16742437351803050589",
+    "app:TsConfig": "1389868326933519382",
+    "app:apps/app/**/*": "3244421341483603138",
+    "child:ProjectConfiguration": "14397347420239404290",
+    "child:TsConfig": "1389868326933519382",
+    "child:libs/child/prod.ts": "13546527163958192884",
+    "child:libs/child/test.ts": "17746510544300185116",
+    "env:NX_CLOUD_ENCRYPTION_KEY": "3244421341483603138",
+    "npm:@nx/left": "11507288172457604164",
+    "npm:leaf": "11507288172457604164",
+    "npm:right": "11507288172457604164",
+    "npm:shared": "11507288172457604164",
+    "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "9198976360534335893",
+  },
+  "inputs": {
+    "depOutputs": [],
+    "environment": [
+      "NX_CLOUD_ENCRYPTION_KEY",
+    ],
+    "external": [
+      "npm:@nx/left",
+      "npm:leaf",
+      "npm:right",
+      "npm:shared",
+    ],
+    "files": [
+      "libs/child/prod.ts",
+      "libs/child/test.ts",
+      "nx.json",
+    ],
+    "runtime": [],
+  },
+  "value": "235537722388302509",
+}
+`;
+
+exports[`task planner > should deduplicate overlapping external closures for explicit inputs without losing sibling project inputs > overlapping external explicit hash 1`] = `
+{
+  "details": {
+    "app:ProjectConfiguration": "17530813657774869408",
+    "app:TsConfig": "1389868326933519382",
+    "app:apps/app/**/*": "3244421341483603138",
+    "child:ProjectConfiguration": "14397347420239404290",
+    "child:TsConfig": "1389868326933519382",
+    "child:libs/child/prod.ts": "13546527163958192884",
+    "child:libs/child/test.ts": "17746510544300185116",
+    "env:NX_CLOUD_ENCRYPTION_KEY": "3244421341483603138",
+    "npm:@nx/left": "11507288172457604164",
+    "npm:leaf": "11507288172457604164",
+    "npm:right": "11507288172457604164",
+    "npm:shared": "11507288172457604164",
+    "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "9198976360534335893",
+  },
+  "inputs": {
+    "depOutputs": [],
+    "environment": [
+      "NX_CLOUD_ENCRYPTION_KEY",
+    ],
+    "external": [
+      "npm:@nx/left",
+      "npm:leaf",
+      "npm:right",
+      "npm:shared",
+    ],
+    "files": [
+      "libs/child/prod.ts",
+      "libs/child/test.ts",
+      "nx.json",
+    ],
+    "runtime": [],
+  },
+  "value": "17658889447241127891",
+}
+`;
+
 exports[`task planner > should hash executors 1`] = `
 {
   "proj:lint": [

--- a/packages/nx/src/native/tests/planner.spec.ts
+++ b/packages/nx/src/native/tests/planner.spec.ts
@@ -1,5 +1,10 @@
 import { TempFs } from '../../internal-testing-utils/temp-fs';
-import { HashPlanner, transferProjectGraph } from '../index';
+import {
+  HashPlanner,
+  TaskHasher,
+  testOnlyTransferFileMap,
+  transferProjectGraph,
+} from '../index';
 import { withEnvironmentVariables } from '../../internal-testing-utils/with-environment';
 import { ProjectGraphBuilder } from '../../project-graph/project-graph-builder';
 import { createTaskGraph } from '../../tasks-runner/create-task-graph';
@@ -806,6 +811,174 @@ describe('task planner', () => {
     const plans = planner.getPlans(['app:build'], taskGraph);
     expect(plans).toMatchSnapshot();
   });
+
+  it.each(['explicit', 'executor', 'all'])(
+    'should deduplicate overlapping external closures for %s inputs without losing sibling project inputs',
+    (mode) => {
+      const builder = new ProjectGraphBuilder();
+      builder.addNode({
+        name: 'app',
+        type: 'app',
+        data: {
+          root: 'apps/app',
+          targets: {
+            build: {
+              executor:
+                mode === 'executor' ? '@nx/left:build' : 'nx:run-commands',
+              inputs: [
+                'default',
+                '^prod',
+                '^test',
+                ...(mode === 'explicit'
+                  ? [
+                      {
+                        externalDependencies: ['@nx/left', 'right', '@nx/left'],
+                      },
+                    ]
+                  : []),
+              ],
+            },
+          },
+        },
+      });
+      builder.addNode({
+        name: 'child',
+        type: 'lib',
+        data: {
+          root: 'libs/child',
+          namedInputs: {
+            prod: ['{projectRoot}/prod.ts'],
+            test: ['{projectRoot}/test.ts'],
+          },
+          targets: {},
+        },
+      });
+      for (const packageName of ['@nx/left', 'right', 'shared', 'leaf']) {
+        builder.addExternalNode({
+          name: `npm:${packageName}`,
+          type: 'npm',
+          data: { packageName, version: '1.0.0' },
+        });
+      }
+      builder.addImplicitDependency('app', 'child');
+      builder.addImplicitDependency('child', 'app');
+      builder.addImplicitDependency('app', 'npm:@nx/left');
+      builder.addImplicitDependency('child', 'npm:@nx/left');
+      builder.addImplicitDependency('child', 'npm:right');
+      builder.addStaticDependency('npm:@nx/left', 'npm:shared');
+      builder.addStaticDependency('npm:right', 'npm:shared');
+      builder.addStaticDependency('npm:shared', 'npm:leaf');
+      builder.addStaticDependency('npm:leaf', 'npm:shared');
+      const graph = builder.getUpdatedProjectGraph();
+      const tasks = createTaskGraph(
+        graph,
+        {},
+        ['app'],
+        ['build'],
+        undefined,
+        {}
+      );
+      const planner = new HashPlanner(
+        {},
+        transferProjectGraph(transformProjectGraphForRust(graph))
+      );
+      const plan = planner.getPlans(['app:build'], tasks)['app:build'];
+      expect(
+        plan.filter((instruction) => instruction.startsWith('npm:'))
+      ).toEqual(['npm:@nx/left', 'npm:leaf', 'npm:right', 'npm:shared']);
+      expect(plan).toContain('child:libs/child/prod.ts');
+      expect(plan).toContain('child:libs/child/test.ts');
+      expect(plan.includes('AllExternalDependencies')).toBe(mode === 'all');
+      const hashGraph = (
+        reverse: boolean,
+        changes: {
+          leafVersion?: string;
+          prodHash?: string;
+          ignoredHash?: string;
+          acyclic?: boolean;
+        } = {}
+      ) => {
+        const files = testOnlyTransferFileMap(
+          {
+            app: [],
+            child: [
+              {
+                file: 'libs/child/prod.ts',
+                hash: changes.prodHash ?? 'prod-hash',
+              },
+              { file: 'libs/child/test.ts', hash: 'test-hash' },
+              {
+                file: 'libs/child/ignored.ts',
+                hash: changes.ignoredHash ?? 'ignored-hash',
+              },
+            ],
+          },
+          [{ file: 'nx.json', hash: 'nx-json-hash' }]
+        );
+        const transformed = transformProjectGraphForRust(graph);
+        if (changes.acyclic) {
+          transformed.dependencies.child =
+            transformed.dependencies.child.filter((dep) => dep !== 'app');
+        }
+        if (changes.leafVersion)
+          transformed.externalNodes['npm:leaf'].version = changes.leafVersion;
+        if (reverse) {
+          transformed.nodes = Object.fromEntries(
+            Object.entries(transformed.nodes).reverse()
+          );
+          transformed.externalNodes = Object.fromEntries(
+            Object.entries(transformed.externalNodes).reverse()
+          );
+          transformed.dependencies = Object.fromEntries(
+            Object.entries(transformed.dependencies)
+              .reverse()
+              .map(([name, deps]) => [name, [...deps].reverse()])
+          );
+        }
+        const ref = transferProjectGraph(transformed);
+        const reorderedPlanner = new HashPlanner({}, ref);
+        expect(
+          reorderedPlanner.getPlans(['app:build'], tasks)['app:build']
+        ).toEqual(plan);
+        const hasher = new TaskHasher(
+          tempFs.tempDir,
+          ref,
+          files.projectFiles,
+          files.allWorkspaceFiles,
+          Buffer.from('{}'),
+          {},
+          undefined,
+          { selectivelyHashTsConfig: false }
+        );
+        return hasher.hashPlans(
+          reorderedPlanner.getPlansReference(['app:build'], tasks),
+          { 'app:build': {} },
+          tempFs.tempDir,
+          true
+        )['app:build'];
+      };
+      const hash = hashGraph(false);
+      expect(hash).toMatchSnapshot(`overlapping external ${mode} hash`);
+      expect(hashGraph(true)).toEqual(hash);
+      expect(hashGraph(false, { leafVersion: '2.0.0' }).value).not.toBe(
+        hash.value
+      );
+      expect(hashGraph(false, { prodHash: 'changed' }).value).not.toBe(
+        hash.value
+      );
+      expect(hashGraph(false, { ignoredHash: 'changed' })).toEqual(hash);
+      // Removing the back-edge enables subtree memoization. The same inputs
+      // must survive both the initial plan and the subsequent cached call.
+      expect(hashGraph(false, { acyclic: true })).toEqual(hash);
+      expect(hashGraph(true, { acyclic: true })).toEqual(hash);
+      expect(
+        hashGraph(false, { acyclic: true, leafVersion: '2.0.0' }).value
+      ).not.toBe(hash.value);
+      expect(
+        hashGraph(false, { acyclic: true, prodHash: 'changed' }).value
+      ).not.toBe(hash.value);
+    }
+  );
 
   it('should interpolate {projectRoot} and {projectName} in {workspaceRoot} input patterns', async () => {
     let projectFileMap = {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

#36994 is stacked on this branch.

## Current Behavior

The hash planner turns each external dependency name into an owned `External` instruction and interns it as it walks. Projects that share an npm closure hit the same names repeatedly, so the planner allocates and interns duplicates, and the id vector retains capacity for them until the later sort and dedup.

## Expected Behavior

Borrowed names are collected in a set first, so each unique external is interned once. Plans and hashes are unchanged.

Measured on a synthetic fixture of 600 projects sharing one closure of 100 packages, medians of seven interleaved rounds against current master:

| Measure             | master | this PR |
| ------------------- | -----: | ------: |
| `hashMultipleTasks` | 746 ms |  646 ms |
| tasks peak RSS      | 380 MB |  351 MB |

Graph construction does not move, and all 600 task hashes are identical to master.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
