### PR TITLE
docs(misc): redirect /docs/extending-nx to kb index

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -314,6 +314,13 @@ to = "/docs/kb/what-is-a-monorepo"
 from = "/docs/concepts/typescript-project-linking"
 to = "/docs/kb/typescript-project-linking"
 
+# force = true so this wins over the hidden extending-nx/index.mdoc stub page.
+[[redirects]]
+from = "/docs/extending-nx"
+to = "/docs/kb/extending-nx"
+status = 301
+force = true
+
 [[redirects]]
 from = "/docs/extending-nx/compose-executors"
 to = "/docs/kb/compose-executors"


### PR DESCRIPTION
## Summary

- `https://nx.dev/docs/extending-nx` currently renders an empty section page ("No pages found in this section.")
- Adds a forced 301 in `astro-docs/netlify.toml` from `/docs/extending-nx` to `/docs/kb/extending-nx` (the 16-article KB index)
- Exact path only, so the existing `/docs/extending-nx/*` subpath redirects keep working
- Catches the ~40 older blog posts and any future links still pointing at `/docs/extending-nx`. The new Nx Plugin for AWS post (nrwl/nx-blog#73) now links to `/docs/kb/extending-nx` directly.

Reported in review on nrwl/nx-blog#73.

https://claude.ai/code/session_019RuEy4cEPi5xMKumSLot6A

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nx-aws-article-7f167e27">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->