### PR TITLE
fix(core): don't replay continuous task output in the tui summary on interrupt

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.spec.ts
@@ -337,9 +337,6 @@ describe('getTuiTerminalSummaryLifeCycle', () => {
 
       expect(lines.join('\n')).toMatchInlineSnapshot(`
         "
-        > nx run test:dev
-
-        I was a happy dev server
         ———————————————————————————————————————————————————————————————————————————————
 
          NX   Cancelled running target dev for project test (37w)
@@ -443,15 +440,122 @@ describe('getTuiTerminalSummaryLifeCycle', () => {
       // Should show success, not cancelled, because the discrete task (e2e) is the initiating task
       expect(lines.join('\n')).toMatchInlineSnapshot(`
         "
-        > nx run test:serve
-
-        Server running on port 4200
         > nx run test:e2e
 
         All tests passed
         ———————————————————————————————————————————————————————————————————————————————
 
          NX   Successfully ran target e2e for project test and 1 task it depends on (37w)
+        "
+      `);
+    });
+
+    it('should replay a stopped continuous dependency output when the dependent task failed', async () => {
+      // Same shape as the test above, but the e2e task fails. The summary is then the surface the
+      // failure is debugged from, so the stopped dev server's log is replayed in full.
+      const devServer = {
+        id: 'test:serve',
+        continuous: true,
+        target: {
+          target: 'serve',
+          project: 'test',
+        },
+      } as Partial<Task> as Task;
+
+      const e2eTest = {
+        id: 'test:e2e',
+        continuous: false,
+        target: {
+          target: 'e2e',
+          project: 'test',
+        },
+      } as Partial<Task> as Task;
+
+      const { lifeCycle, printSummary } = getTuiTerminalSummaryLifeCycle({
+        args: {
+          targets: ['e2e'],
+        },
+        initiatingProject: 'test',
+        initiatingTasks: [e2eTest],
+        taskGraph: {
+          tasks: { [devServer.id]: devServer, [e2eTest.id]: e2eTest },
+          dependencies: {
+            [devServer.id]: [],
+            [e2eTest.id]: [devServer.id],
+          },
+          continuousDependencies: {
+            [e2eTest.id]: [devServer.id],
+          },
+          roots: [devServer.id],
+        },
+        overrides: {},
+        projectNames: ['test'],
+        tasks: [devServer, e2eTest],
+        resolveRenderIsDonePromise: vi.fn().mockResolvedValue(null),
+      });
+
+      lifeCycle.startTasks?.([devServer], null as unknown as TaskMetadata);
+      lifeCycle.appendTaskOutput?.(
+        devServer.id,
+        'Server running on port 4200',
+        true
+      );
+
+      lifeCycle.startTasks?.([e2eTest], null as unknown as TaskMetadata);
+      lifeCycle.appendTaskOutput?.(e2eTest.id, '1 of 3 specs failed', true);
+      lifeCycle.endTasks?.(
+        [
+          {
+            code: 1,
+            status: 'failure',
+            task: e2eTest,
+            terminalOutput: '1 of 3 specs failed',
+          },
+        ],
+        null as unknown as TaskMetadata
+      );
+      lifeCycle.printTaskTerminalOutput?.(
+        e2eTest,
+        'failure',
+        '1 of 3 specs failed'
+      );
+
+      lifeCycle.endTasks?.(
+        [
+          {
+            code: 0,
+            status: 'success',
+            task: devServer,
+            terminalOutput: 'Server running on port 4200',
+          },
+        ],
+        null as unknown as TaskMetadata
+      );
+      lifeCycle.setTaskStatus?.(devServer.id, NativeTaskStatus.Stopped);
+      lifeCycle.printTaskTerminalOutput?.(
+        devServer,
+        'success',
+        'Server running on port 4200'
+      );
+
+      lifeCycle.endCommand?.();
+
+      const lines = getOutputLines(printSummary);
+
+      expect(lines.join('\n')).toMatchInlineSnapshot(`
+        "
+        > nx run test:serve
+
+        Server running on port 4200
+        > nx run test:e2e
+
+        1 of 3 specs failed
+        ———————————————————————————————————————————————————————————————————————————————
+
+         NX   Ran target e2e for project test and 1 task(s) they depend on (37w)
+
+           ✖  1/2 failed
+           ✔  1/2 succeeded [0 read from cache]
         "
       `);
     });
@@ -715,10 +819,6 @@ describe('getTuiTerminalSummaryLifeCycle', () => {
       expect(lines.join('\n')).toMatchInlineSnapshot(`
         "
 
-        > nx run test:serve
-
-        Server running on port 4200
-
            ◼  nx run test:serve
            ✔  nx run test:e2e
 
@@ -727,6 +827,194 @@ describe('getTuiTerminalSummaryLifeCycle', () => {
          NX   Successfully ran target e2e for project test and 1 task it depends on (37w)
         "
       `);
+    });
+
+    it('should replay a stopped continuous task output when a task in the run failed', async () => {
+      // Same shape as the test above, but the e2e task fails. A run with a failure replays every
+      // task's output, so the stopped dev server's log is still printed above the summary.
+      const devServer = {
+        id: 'test:serve',
+        continuous: true,
+        target: {
+          target: 'serve',
+          project: 'test',
+        },
+      } as Partial<Task> as Task;
+
+      const e2eTest = {
+        id: 'test:e2e',
+        continuous: false,
+        target: {
+          target: 'e2e',
+          project: 'test',
+        },
+      } as Partial<Task> as Task;
+
+      const { lifeCycle, printSummary } = getTuiTerminalSummaryLifeCycle({
+        args: {
+          targets: ['e2e'],
+        },
+        initiatingProject: '',
+        initiatingTasks: [e2eTest],
+        taskGraph: {
+          tasks: { [devServer.id]: devServer, [e2eTest.id]: e2eTest },
+          dependencies: {
+            [devServer.id]: [],
+            [e2eTest.id]: [devServer.id],
+          },
+          continuousDependencies: {
+            [e2eTest.id]: [devServer.id],
+          },
+          roots: [devServer.id],
+        },
+        overrides: {},
+        projectNames: ['test'],
+        tasks: [devServer, e2eTest],
+        resolveRenderIsDonePromise: vi.fn().mockResolvedValue(null),
+      });
+
+      lifeCycle.startTasks?.([devServer], null as unknown as TaskMetadata);
+      lifeCycle.appendTaskOutput?.(
+        devServer.id,
+        'Server running on port 4200',
+        true
+      );
+
+      lifeCycle.startTasks?.([e2eTest], null as unknown as TaskMetadata);
+      lifeCycle.appendTaskOutput?.(e2eTest.id, '1 of 3 specs failed', true);
+      lifeCycle.endTasks?.(
+        [
+          {
+            code: 1,
+            status: 'failure',
+            task: e2eTest,
+            terminalOutput: '1 of 3 specs failed',
+          },
+        ],
+        null as unknown as TaskMetadata
+      );
+      lifeCycle.printTaskTerminalOutput?.(
+        e2eTest,
+        'failure',
+        '1 of 3 specs failed'
+      );
+
+      lifeCycle.endTasks?.(
+        [
+          {
+            code: 0,
+            status: 'success',
+            task: devServer,
+            terminalOutput: 'Server running on port 4200',
+          },
+        ],
+        null as unknown as TaskMetadata
+      );
+      lifeCycle.setTaskStatus?.(devServer.id, NativeTaskStatus.Stopped);
+      lifeCycle.printTaskTerminalOutput?.(
+        devServer,
+        'success',
+        'Server running on port 4200'
+      );
+
+      lifeCycle.endCommand?.();
+
+      const lines = getOutputLines(printSummary);
+
+      expect(lines.join('\n')).toMatchInlineSnapshot(`
+        "
+
+        > nx run test:serve
+
+        Server running on port 4200
+
+        > nx run test:e2e
+
+        1 of 3 specs failed
+
+           ◼  nx run test:serve
+           ✖  nx run test:e2e
+
+        ———————————————————————————————————————————————————————————————————————————————
+
+         NX   Ran target e2e for project test and 1 task it depends on (37w)
+
+           ✔  1/2 succeeded [0 read from cache]
+
+           ✖  1/2 targets failed, including the following:
+
+              - nx run test:e2e
+
+        "
+      `);
+    });
+
+    it('should not replay task output when a run of continuous tasks is interrupted', async () => {
+      // `nx run-many -t serve` quit with Ctrl-C: every task is stopped and nothing failed, so
+      // replaying each task's buffered scrollback would bury the terminal in output the TUI has
+      // already shown live. The tasks are still listed.
+      const backend = {
+        id: 'backend:serve',
+        continuous: true,
+        target: { target: 'serve', project: 'backend' },
+      } as Partial<Task> as Task;
+      const frontend = {
+        id: 'frontend:serve',
+        continuous: true,
+        target: { target: 'serve', project: 'frontend' },
+      } as Partial<Task> as Task;
+
+      const { lifeCycle, printSummary } = getTuiTerminalSummaryLifeCycle({
+        args: { targets: ['serve'] },
+        initiatingProject: '',
+        initiatingTasks: [],
+        taskGraph: {
+          tasks: { [backend.id]: backend, [frontend.id]: frontend },
+          dependencies: { [backend.id]: [], [frontend.id]: [] },
+          continuousDependencies: { [backend.id]: [], [frontend.id]: [] },
+          roots: [backend.id, frontend.id],
+        },
+        overrides: {},
+        projectNames: ['backend', 'frontend'],
+        tasks: [backend, frontend],
+        resolveRenderIsDonePromise: vi.fn().mockResolvedValue(null),
+      });
+
+      lifeCycle.startTasks?.([backend, frontend], null as unknown as TaskMetadata);
+      lifeCycle.appendTaskOutput?.(
+        backend.id,
+        'Nest application successfully started',
+        true
+      );
+      lifeCycle.appendTaskOutput?.(frontend.id, 'VITE ready in 412 ms', true);
+      lifeCycle.setTaskStatus?.(backend.id, NativeTaskStatus.Stopped);
+      lifeCycle.setTaskStatus?.(frontend.id, NativeTaskStatus.Stopped);
+      lifeCycle.endTasks?.(
+        [
+          {
+            code: 0,
+            status: 'stopped',
+            task: backend,
+            terminalOutput: 'Nest application successfully started',
+          },
+          {
+            code: 0,
+            status: 'stopped',
+            task: frontend,
+            terminalOutput: 'VITE ready in 412 ms',
+          },
+        ],
+        null as unknown as TaskMetadata
+      );
+      lifeCycle.endCommand?.();
+
+      const summary = getOutputLines(printSummary).join('\n');
+
+      expect(summary).not.toContain('Nest application successfully started');
+      expect(summary).not.toContain('VITE ready in 412 ms');
+      expect(summary).toContain('◼  nx run backend:serve');
+      expect(summary).toContain('◼  nx run frontend:serve');
+      expect(summary).toContain('Cancelled while running');
     });
 
     it('should handle successful run-many tasks', async () => {

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -65,6 +65,29 @@ export function getTuiTerminalSummaryLifeCycle({
   const getTerminalOutput = (taskId: string): string =>
     tasksToTerminalOutputs[taskId] ?? taskOutputChunks[taskId]?.join('') ?? '';
 
+  // A task that was stopped, or was still running when the run ended, did not fail — it was
+  // interrupted.
+  const wasInterrupted = (taskId: string): boolean =>
+    displayStoppedTasks.has(taskId) ||
+    tasksToTaskStatus[taskId] === 'stopped' ||
+    inProgressTasks.has(taskId);
+
+  // Whether to leave a task out of the output replayed above the summary.
+  //
+  // A continuous task's buffered output is unbounded and the TUI has already shown it live, so
+  // replaying it on a clean interrupt buries the terminal for no gain: `nx run-many -t serve`
+  // quit with Ctrl-C stops every task, and the summary reprints every dev server's entire
+  // scrollback. Those tasks are still listed in the checklist, just not replayed.
+  //
+  // Two cases deliberately keep today's behaviour. A run containing a failure replays
+  // everything, because there the summary is the debugging surface and a stopped dev server's
+  // log is the context you need. And an interrupted *discrete* task still replays, since its
+  // partial output is bounded and shows how far it got.
+  const skipReplayingOutput = (taskId: string): boolean =>
+    totalFailedTasks === 0 &&
+    taskGraph.tasks[taskId]?.continuous === true &&
+    wasInterrupted(taskId);
+
   lifeCycle.startTasks = (tasks) => {
     for (let t of tasks) {
       taskOutputChunks[t.id] ??= [];
@@ -190,6 +213,10 @@ export function getTuiTerminalSummaryLifeCycle({
       const taskStatus = tasksToTaskStatus[taskId];
       // Skipped tasks never ran; don't print a misleading `> nx run` header.
       if (taskStatus === 'skipped') {
+        continue;
+      }
+      // Nothing to replay, so don't print an empty `> nx run` block either.
+      if (skipReplayingOutput(taskId)) {
         continue;
       }
       const terminalOutput = getTerminalOutput(taskId);
@@ -339,8 +366,11 @@ export function getTuiTerminalSummaryLifeCycle({
       const taskStatus = tasksToTaskStatus[taskId];
       const terminalOutput = getTerminalOutput(taskId);
       if (displayStoppedTasks.has(taskId) || !taskStatus) {
-        output.logCommandOutput(taskId, taskStatus, terminalOutput);
-        output.addNewline();
+        // The checklist below still lists the task; only the replay is skipped.
+        if (!skipReplayingOutput(taskId)) {
+          output.logCommandOutput(taskId, taskStatus, terminalOutput);
+          output.addNewline();
+        }
         checklistLines.push(
           `${LEFT_PAD}${output.colors.cyan(
             figures.squareSmallFilled


### PR DESCRIPTION
## Current Behavior

With the TUI enabled, the tui summary life cycle accumulates every chunk of every task's output and
replays it all when the run ends. Quitting a `run-many` of continuous tasks with Ctrl-C ends every
task as `stopped`, so `printRunManySummary` reprints each task's entire buffered scrollback —
output the TUI has already shown live in its panes. With several dev servers that have been up for
a while this is tens of thousands of lines, and it buries the terminal (and the user's scrollback)
right at the moment they are trying to get their prompt back. `taskOutputChunks` has no cap, so the
longer the session ran the bigger the dump.

There is currently no way to keep the TUI and opt out of the replay: `nx.json` → `tui` takes only
`enabled` / `autoExit` / `suppressHints`, and `printSummary` is called unconditionally.

## Expected Behavior

A **continuous** task that was interrupted — ended as `stopped`, or still running when the run
ended — is left out of the output replayed above the summary. It still appears in the checklist
with its `◼` icon and in the cancelled footer.

Two cases deliberately keep today's behaviour:

- **A run containing a failure replays everything.** That is where the summary is the debugging
  surface, and where a stopped dev server's log is the context you need. `nx e2e` with a stopped
  dev-server dependency still prints the dev server's log when the e2e task fails.
- **An interrupted discrete task still replays.** Its output is bounded and shows how far it got.

Implementation is two predicates next to `getTerminalOutput` and a guard at the two print sites in
`printRunOneSummary` / `printRunManySummary`.

## Related Issue(s)

Fixes #36996

---

## Notes for reviewers

- **Three existing snapshots change, and each loses exactly the block that is no longer printed** —
  the `> nx run <project>:<continuous target>` header and its body. The scenarios are the ones with
  an interrupted continuous task and no failure:
  - `runOne` → `should display cancelled for single continuous task`
  - `runOne` → `should display success for discrete task with stopped continuous dependency`
  - `runMany` → `should display stopped icon for stopped continuous task in run-many`
- **No other snapshot moves.** In particular `should handle canceled run-one tasks` and `should
  handle canceled run-many tasks` are untouched: their interrupted tasks are discrete, so they
  still replay.
- **The output that disappears from those three is asserted in two new tests**, which are the same
  scenarios with the dependent task failing — so the full replay stays covered byte-for-byte:
  - `runOne` → `should replay a stopped continuous dependency output when the dependent task failed`
  - `runMany` → `should replay a stopped continuous task output when a task in the run failed`
- **One more new test** covers the reported case directly, with explicit assertions rather than a
  snapshot so the absence is unmissable: `runMany` → `should not replay task output when a run of
  continuous tasks is interrupted`.
- Not addressed here, but worth a separate look: `appendTaskOutput` accumulates into
  `taskOutputChunks` without any cap, so a long-lived `run-many -t serve` retains every log line
  every service has emitted for the lifetime of the process. Capping it would bound that memory and
  also shrink the replay for the failure case; it seemed like a separate decision from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
