### PR TITLE
fix(core): let the client env override the daemon's logging settings

### DIFF
--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -237,12 +237,34 @@ describe('daemon environment', () => {
     it('should apply the required and overridable daemon settings', () => {
       process.env.NX_PROJECT_GLOB_CACHE = 'true';
       delete process.env.NX_VERBOSE_LOGGING;
+      delete process.env.NX_PERF_LOGGING;
+      delete process.env.NX_NATIVE_LOGGING;
 
       const env = getDaemonEnv();
 
       expect(env.NX_PROJECT_GLOB_CACHE).toBe('false');
       expect(env.NX_CACHE_PROJECTS_CONFIG).toBe('false');
       expect(env.NX_VERBOSE_LOGGING).toBe('true');
+      expect(env.NX_PERF_LOGGING).toBe('true');
+      expect(env.NX_NATIVE_LOGGING).toBe('nx=debug');
+    });
+
+    it('should let the client env override the overridable daemon settings', () => {
+      process.env.NX_VERBOSE_LOGGING = 'false';
+      process.env.NX_PERF_LOGGING = 'false';
+      process.env.NX_NATIVE_LOGGING = 'off';
+
+      const env = getDaemonEnv();
+
+      expect(env.NX_VERBOSE_LOGGING).toBe('false');
+      expect(env.NX_PERF_LOGGING).toBe('false');
+      expect(env.NX_NATIVE_LOGGING).toBe('off');
+    });
+
+    it('should not let the client env override the required daemon settings', () => {
+      process.env.NX_CACHE_PROJECTS_CONFIG = 'true';
+
+      expect(getDaemonEnv().NX_CACHE_PROJECTS_CONFIG).toBe('false');
     });
   });
 
@@ -368,13 +390,16 @@ describe('daemon environment', () => {
       expect(process.env.NX_CACHE_PROJECTS_CONFIG).toBe('false');
     });
 
-    it('should turn on the overridable logging settings on the daemon', () => {
+    it("should carry the client's overridable logging settings to the daemon", () => {
       process.env.NX_VERBOSE_LOGGING = 'false';
+      const payload = getDaemonEnv();
+      process.env.NX_VERBOSE_LOGGING = 'true';
+      applyDaemonEnvFromClient({ ...process.env });
 
-      const changed = applyDaemonEnvFromClient(getDaemonEnv());
+      const changed = applyDaemonEnvFromClient(payload);
 
       expect(changed).toContain('NX_VERBOSE_LOGGING');
-      expect(process.env.NX_VERBOSE_LOGGING).toBe('true');
+      expect(process.env.NX_VERBOSE_LOGGING).toBe('false');
     });
 
     it('should apply and delete the Nx Cloud auth tokens like any forwarded var', () => {
@@ -563,11 +588,16 @@ describe('daemon environment', () => {
     });
 
     // Pins that the overridable settings need no dedicated skip like the
-    // required ones above: they are already in the exclusion set.
+    // required ones above: they are already in the exclusion set. Without
+    // this, `--verbose` alone would discard the daemon's cached graph.
     it('is stable when an overridable daemon setting changes', () => {
       delete process.env.NX_VERBOSE_LOGGING;
+      delete process.env.NX_PERF_LOGGING;
+      delete process.env.NX_NATIVE_LOGGING;
       const base = hashDaemonClientEnv();
       process.env.NX_VERBOSE_LOGGING = 'true';
+      process.env.NX_PERF_LOGGING = 'false';
+      process.env.NX_NATIVE_LOGGING = 'off';
       expect(hashDaemonClientEnv()).toEqual(base);
     });
   });

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -5,6 +5,14 @@ const DAEMON_ENV_REQUIRED_SETTINGS = {
   NX_CACHE_PROJECTS_CONFIG: 'false',
 };
 
+/**
+ * Logging defaults the daemon runs with when the client's env says nothing,
+ * so `daemon.log` is useful without the user opting in. They are listed in
+ * `DAEMON_ENV_VARS_EXCLUSIONS` to keep them out of the graph identity digest
+ * (`--verbose` alone would otherwise discard the cached graph), so the
+ * reflection loop skips them and `getDaemonEnv` applies the client's value
+ * for them separately.
+ */
 const DAEMON_ENV_OVERRIDABLE_SETTINGS = {
   NX_VERBOSE_LOGGING: 'true',
   NX_PERF_LOGGING: 'true',
@@ -14,7 +22,9 @@ const DAEMON_ENV_OVERRIDABLE_SETTINGS = {
 /**
  * Env vars that should NOT be sent to the daemon because they cannot affect
  * the project graph. Only vars that can actually affect the project graph
- * (e.g. PATH, JAVA_HOME, GRADLE_HOME) should be allowed through.
+ * (e.g. PATH, JAVA_HOME, GRADLE_HOME) should be allowed through. The
+ * `DAEMON_ENV_OVERRIDABLE_SETTINGS` keys are the exception: they are listed
+ * for the digest's sake and still reach the daemon, see `getDaemonEnv`.
  */
 const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   // Nx task-scoped vars
@@ -293,6 +303,13 @@ export function getDaemonEnv() {
   const env: NodeJS.ProcessEnv = { ...DAEMON_ENV_OVERRIDABLE_SETTINGS };
   for (const key in process.env) {
     if (!isExcludedEnvVar(key)) {
+      env[key] = process.env[key];
+    }
+  }
+  // Excluded from the loop above for the graph identity digest, so the
+  // client's value for them is applied here instead of being dropped.
+  for (const key of Object.keys(DAEMON_ENV_OVERRIDABLE_SETTINGS)) {
+    if (process.env[key] !== undefined) {
       env[key] = process.env[key];
     }
   }


### PR DESCRIPTION
## Current Behavior

`getDaemonEnv` seeds the daemon env with `DAEMON_ENV_OVERRIDABLE_SETTINGS` and then reflects the caller's `process.env` over it, so a user's own environment can override those defaults. But the reflection loop is gated on `isExcludedEnvVar`, and all three overridable keys are listed in `DAEMON_ENV_VARS_EXCLUSIONS`:

```ts
export function getDaemonEnv() {
  const env: NodeJS.ProcessEnv = { ...DAEMON_ENV_OVERRIDABLE_SETTINGS }; // NX_NATIVE_LOGGING: 'nx=debug', ...
  for (const key in process.env) {
    if (!isExcludedEnvVar(key)) {  // false for exactly these three keys
      env[key] = process.env[key];
    }
  }
  ...
```

The loop therefore skips precisely the keys the seed is meant to make overridable. The daemon is pinned at `NX_NATIVE_LOGGING=nx=debug`, `NX_PERF_LOGGING=true` and `NX_VERBOSE_LOGGING=true`, and no env var or flag turns any of them off — only `NX_DAEMON=false`, which disables the daemon outright.

In practice a long enough daemon round trip (one waiting on a plugin's `preTasksExecution` hook doing real async work, for instance) surfaces raw `DEBUG nx::native::...` lines and `Time taken for '... round trip'` timings in the user's terminal, with no way to silence them.

This is a regression of #34324, which built the env as `{...OVERRIDABLE, ...process.env, ...REQUIRED}` — a raw spread with no guard, so the caller's value did land. Replacing that spread with the guarded reflection loop silently undid it.

## Expected Behavior

Setting `NX_NATIVE_LOGGING=off`, `NX_PERF_LOGGING=false` or `NX_VERBOSE_LOGGING=false` in the invoking shell takes effect for the daemon, matching what the name `DAEMON_ENV_OVERRIDABLE_SETTINGS` implies. When the client sets nothing, the existing defaults still apply, so `daemon.log` stays useful without opting in.

### Why not just drop the three keys from the exclusion set

That fixes the override but also folds them into `hashDaemonClientEnv`. `withVerbose` stamps `process.env.NX_VERBOSE_LOGGING = args.verbose.toString()` on nearly every invocation, so `nx build --verbose` would then produce a different env digest and discard the daemon's cached graph.

Instead the keys stay excluded — out of the graph identity digest — and `getDaemonEnv` applies the client's value for them separately. This keeps the split #36565 introduced between daemon runtime env and graph identity.

### Note for reviewers

Because of the `withVerbose` stamp above, most `nx run`-family invocations now send an explicit `NX_VERBOSE_LOGGING=false` to the daemon. That restores what #34324 shipped, but it does walk back the verbose-by-default `daemon.log` that #31948 added. Flagging it as a deliberate consequence rather than an oversight — happy to gate it differently if you'd rather keep the daemon verbose by default.

Also worth noting: because an env var can't express "override with nothing", *unsetting* a var still yields the default. Turning a setting off requires an explicit `off` / `false`.

## Related Issue(s)

Fixes #36995

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Q9DgEQgg3nn4zU9NMk7QV
