### PR TITLE
feat(nx): Improve graph initialization by 23% with an opt-in workspace import reordering

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1466,7 +1466,9 @@ describe('TargetProjectLocator', () => {
         'packages/source/index.ts'
       );
 
-      expect(packagesMetadata.ambiguousEntryPoints).toContain('@org/pkg1');
+      expect(
+        packagesMetadata.directlyResolvableWorkspaceEntryPoints
+      ).not.toContain('@org/pkg1');
       expect(result).toEqual('pkg2');
       expect(typescriptResolution).toHaveBeenCalledOnce();
       expect(requireResolution).toHaveBeenCalledOnce();
@@ -1500,12 +1502,39 @@ describe('TargetProjectLocator', () => {
       );
 
       expect(
-        packagesMetadata.entryPointsWithProjectBoundaryCrossings
-      ).toContain('@org/pkg1/feature');
+        packagesMetadata.directlyResolvableWorkspaceEntryPoints
+      ).not.toContain('@org/pkg1/feature');
       expect(result).toEqual('feature');
       expect(npmResolution).toHaveBeenCalledOnce();
       expect(typescriptResolution).toHaveBeenCalledOnce();
       expect(requireResolution).toHaveBeenCalledOnce();
+    });
+
+    it('should not requalify an entry point after one condition crosses a project boundary', () => {
+      const projects = {
+        pkg1: createWorkspaceProject('pkg1', {
+          packageExports: {
+            require: './feature/index.js',
+            default: './dist/index.js',
+          },
+        }),
+        feature: {
+          name: 'feature',
+          type: 'lib' as const,
+          data: {
+            root: 'packages/pkg1/feature',
+          },
+        },
+      };
+
+      const packagesMetadata = getWorkspacePackagesMetadata(projects);
+
+      expect(
+        packagesMetadata.directlyResolvableWorkspaceEntryPoints
+      ).not.toContain('@org/pkg1');
+      expect(
+        packagesMetadata.entryPointsToProjectMap['@org/pkg1'].name
+      ).toEqual('pkg1');
     });
 
     it('should bypass the fast path for wildcard entry points', () => {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -6,6 +6,7 @@ import {
   ProjectGraphExternalNode,
   ProjectGraphProjectNode,
 } from '../../../../config/project-graph';
+import { getWorkspacePackagesMetadata } from '../../utils/packages';
 import {
   TargetProjectLocator,
   isBuiltinModuleImport,
@@ -1217,6 +1218,298 @@ describe('TargetProjectLocator', () => {
       );
 
       expect(result).toEqual('npm:foo@0.0.1');
+    });
+  });
+
+  describe('workspace package import fast path', () => {
+    const fastPathEnv = 'NX_ENABLE_WORKSPACE_PACKAGE_IMPORT_FAST_PATH';
+    let originalFastPathEnv: string | undefined;
+
+    beforeEach(() => {
+      originalFastPathEnv = process.env[fastPathEnv];
+      delete process.env[fastPathEnv];
+      vol.reset();
+      vol.fromJSON(
+        {
+          './tsconfig.base.json': JSON.stringify({
+            compilerOptions: { paths: {} },
+          }),
+        },
+        '/root'
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vol.reset();
+      if (originalFastPathEnv === undefined) {
+        delete process.env[fastPathEnv];
+      } else {
+        process.env[fastPathEnv] = originalFastPathEnv;
+      }
+    });
+
+    function createWorkspaceProject(
+      name: string,
+      js: {
+        packageExports?: string | Record<string, string | null>;
+        packageMain?: string;
+      } = {}
+    ): ProjectGraphProjectNode {
+      const project = {
+        name,
+        type: 'lib',
+        data: {
+          root: `packages/${name}`,
+          metadata: {
+            js: {
+              packageName: '@org/pkg1',
+              packageVersion: '1.0.0',
+              packageExports: undefined,
+              packageMain: undefined,
+              isInPackageManagerWorkspaces: true,
+            },
+          },
+        },
+      } satisfies ProjectGraphProjectNode;
+      Object.assign(project.data.metadata.js, js);
+      return project;
+    }
+
+    function createLocator(
+      projects: Record<string, ProjectGraphProjectNode>
+    ): TargetProjectLocator {
+      return new TargetProjectLocator(projects, {}, new Map(), new Map());
+    }
+
+    function spyOnResolutionPaths(targetProjectLocator: TargetProjectLocator) {
+      const npmResolution = vi
+        .spyOn(targetProjectLocator, 'findNpmProjectFromImport')
+        .mockReturnValue(null);
+      const typescriptResolution = vi
+        .spyOn(targetProjectLocator as any, 'resolveImportWithTypescript')
+        .mockReturnValue(undefined);
+      const requireResolution = vi
+        .spyOn(targetProjectLocator as any, 'resolveImportWithRequire')
+        .mockImplementation(() => {
+          throw new Error('Module not found');
+        });
+
+      return {
+        npmResolution,
+        typescriptResolution,
+        requireResolution,
+      };
+    }
+
+    it('should remain disabled by default', () => {
+      const targetProjectLocator = createLocator({
+        pkg1: createWorkspaceProject('pkg1', {
+          packageExports: { '.': './dist/index.js' },
+        }),
+      });
+      const { typescriptResolution, requireResolution } =
+        spyOnResolutionPaths(targetProjectLocator);
+
+      const result = targetProjectLocator.findProjectFromImport(
+        '@org/pkg1',
+        'packages/source/index.ts'
+      );
+
+      expect(result).toEqual('pkg1');
+      expect(typescriptResolution).toHaveBeenCalledOnce();
+      expect(requireResolution).toHaveBeenCalledOnce();
+    });
+
+    it.each`
+      packageExports                                                | packageMain          | importPath
+      ${'./dist/index.js'}                                          | ${undefined}         | ${'@org/pkg1'}
+      ${{ '.': './dist/index.js' }}                                 | ${undefined}         | ${'@org/pkg1'}
+      ${{ './feature': './dist/feature.js' }}                       | ${undefined}         | ${'@org/pkg1/feature'}
+      ${{ import: './dist/index.mjs', default: './dist/index.js' }} | ${undefined}         | ${'@org/pkg1'}
+      ${undefined}                                                  | ${'./dist/index.js'} | ${'@org/pkg1'}
+    `(
+      'should resolve the exact workspace entry point "$importPath" before expensive resolution',
+      ({ packageExports, packageMain, importPath }) => {
+        process.env[fastPathEnv] = 'true';
+        const targetProjectLocator = createLocator({
+          pkg1: createWorkspaceProject('pkg1', {
+            packageExports,
+            packageMain,
+          }),
+        });
+        const { npmResolution, typescriptResolution, requireResolution } =
+          spyOnResolutionPaths(targetProjectLocator);
+
+        const result = targetProjectLocator.findProjectFromImport(
+          importPath,
+          'packages/source/index.ts'
+        );
+
+        expect(result).toEqual('pkg1');
+        expect(npmResolution).toHaveBeenCalledOnce();
+        expect(typescriptResolution).not.toHaveBeenCalled();
+        expect(requireResolution).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should preserve npm external project precedence', () => {
+      process.env[fastPathEnv] = 'true';
+      const targetProjectLocator = createLocator({
+        pkg1: createWorkspaceProject('pkg1', {
+          packageExports: { '.': './dist/index.js' },
+        }),
+      });
+      const { npmResolution, typescriptResolution, requireResolution } =
+        spyOnResolutionPaths(targetProjectLocator);
+      npmResolution.mockReturnValue('npm:@org/pkg1');
+
+      const result = targetProjectLocator.findProjectFromImport(
+        '@org/pkg1',
+        'packages/source/index.ts'
+      );
+
+      expect(result).toEqual('npm:@org/pkg1');
+      expect(typescriptResolution).not.toHaveBeenCalled();
+      expect(requireResolution).not.toHaveBeenCalled();
+    });
+
+    it('should preserve tsconfig path precedence', () => {
+      process.env[fastPathEnv] = 'true';
+      vol.fromJSON(
+        {
+          './tsconfig.base.json': JSON.stringify({
+            compilerOptions: {
+              paths: {
+                '@org/pkg1': ['packages/tsconfig-project'],
+              },
+            },
+          }),
+        },
+        '/root'
+      );
+      const targetProjectLocator = createLocator({
+        pkg1: createWorkspaceProject('pkg1', {
+          packageExports: { '.': './dist/index.js' },
+        }),
+        'tsconfig-project': {
+          name: 'tsconfig-project',
+          type: 'lib',
+          data: {
+            root: 'packages/tsconfig-project',
+          },
+        },
+      });
+      const { npmResolution, typescriptResolution, requireResolution } =
+        spyOnResolutionPaths(targetProjectLocator);
+
+      const result = targetProjectLocator.findProjectFromImport(
+        '@org/pkg1',
+        'packages/source/index.ts'
+      );
+
+      expect(result).toEqual('tsconfig-project');
+      expect(npmResolution).not.toHaveBeenCalled();
+      expect(typescriptResolution).not.toHaveBeenCalled();
+      expect(requireResolution).not.toHaveBeenCalled();
+    });
+
+    it('should bypass the fast path when a tsconfig path matched without resolving a project', () => {
+      process.env[fastPathEnv] = 'true';
+      vol.fromJSON(
+        {
+          './tsconfig.base.json': JSON.stringify({
+            compilerOptions: {
+              paths: {
+                '@org/pkg1': ['packages/missing'],
+              },
+            },
+          }),
+        },
+        '/root'
+      );
+      const targetProjectLocator = createLocator({
+        pkg1: createWorkspaceProject('pkg1', {
+          packageExports: { '.': './dist/index.js' },
+        }),
+      });
+      const { typescriptResolution, requireResolution } =
+        spyOnResolutionPaths(targetProjectLocator);
+
+      const result = targetProjectLocator.findProjectFromImport(
+        '@org/pkg1',
+        'packages/source/index.ts'
+      );
+
+      expect(result).toEqual('pkg1');
+      expect(typescriptResolution).toHaveBeenCalledOnce();
+      expect(requireResolution).toHaveBeenCalledOnce();
+    });
+
+    it('should bypass the fast path for ambiguous exact entry points', () => {
+      process.env[fastPathEnv] = 'true';
+      const projects = {
+        pkg1: createWorkspaceProject('pkg1', {
+          packageExports: { '.': './dist/index.js' },
+        }),
+        pkg2: createWorkspaceProject('pkg2', {
+          packageExports: { '.': './dist/index.js' },
+        }),
+      };
+      const packagesMetadata = getWorkspacePackagesMetadata(projects);
+      const targetProjectLocator = createLocator(projects);
+      const { typescriptResolution, requireResolution } =
+        spyOnResolutionPaths(targetProjectLocator);
+
+      const result = targetProjectLocator.findProjectFromImport(
+        '@org/pkg1',
+        'packages/source/index.ts'
+      );
+
+      expect(packagesMetadata.ambiguousEntryPoints).toContain('@org/pkg1');
+      expect(result).toEqual('pkg2');
+      expect(typescriptResolution).toHaveBeenCalledOnce();
+      expect(requireResolution).toHaveBeenCalledOnce();
+    });
+
+    it('should bypass the fast path for wildcard entry points', () => {
+      process.env[fastPathEnv] = 'true';
+      const targetProjectLocator = createLocator({
+        pkg1: createWorkspaceProject('pkg1', {
+          packageExports: { './*': './dist/*.js' },
+        }),
+      });
+      const { typescriptResolution, requireResolution } =
+        spyOnResolutionPaths(targetProjectLocator);
+
+      const result = targetProjectLocator.findProjectFromImport(
+        '@org/pkg1/feature',
+        'packages/source/index.ts'
+      );
+
+      expect(result).toEqual('pkg1');
+      expect(typescriptResolution).toHaveBeenCalledOnce();
+      expect(requireResolution).toHaveBeenCalledOnce();
+    });
+
+    it('should not resolve restricted entry points', () => {
+      process.env[fastPathEnv] = 'true';
+      const targetProjectLocator = createLocator({
+        pkg1: createWorkspaceProject('pkg1', {
+          packageExports: { './internal': null },
+        }),
+      });
+      const { typescriptResolution, requireResolution } =
+        spyOnResolutionPaths(targetProjectLocator);
+
+      const result = targetProjectLocator.findProjectFromImport(
+        '@org/pkg1/internal',
+        'packages/source/index.ts'
+      );
+
+      expect(result).toBeNull();
+      expect(typescriptResolution).toHaveBeenCalledOnce();
+      expect(requireResolution).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1472,6 +1472,42 @@ describe('TargetProjectLocator', () => {
       expect(requireResolution).toHaveBeenCalledOnce();
     });
 
+    it('should bypass the fast path when an exact export targets a nested project', () => {
+      process.env[fastPathEnv] = 'true';
+      const projects = {
+        pkg1: createWorkspaceProject('pkg1', {
+          packageExports: {
+            './feature': './feature/index.js',
+          },
+        }),
+        feature: {
+          name: 'feature',
+          type: 'lib' as const,
+          data: {
+            root: 'packages/pkg1/feature',
+          },
+        },
+      };
+      const packagesMetadata = getWorkspacePackagesMetadata(projects);
+      const targetProjectLocator = createLocator(projects);
+      const { npmResolution, typescriptResolution, requireResolution } =
+        spyOnResolutionPaths(targetProjectLocator);
+      requireResolution.mockReturnValue('packages/pkg1/feature/index.js');
+
+      const result = targetProjectLocator.findProjectFromImport(
+        '@org/pkg1/feature',
+        'packages/source/index.ts'
+      );
+
+      expect(
+        packagesMetadata.entryPointsWithProjectBoundaryCrossings
+      ).toContain('@org/pkg1/feature');
+      expect(result).toEqual('feature');
+      expect(npmResolution).toHaveBeenCalledOnce();
+      expect(typescriptResolution).toHaveBeenCalledOnce();
+      expect(requireResolution).toHaveBeenCalledOnce();
+    });
+
     it('should bypass the fast path for wildcard entry points', () => {
       process.env[fastPathEnv] = 'true';
       const targetProjectLocator = createLocator({

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -366,7 +366,12 @@ export class TargetProjectLocator {
   ): string | null {
     this.packagesMetadata ??= getWorkspacePackagesMetadata(this.nodes);
 
-    if (this.packagesMetadata.ambiguousEntryPoints.has(importPath)) {
+    if (
+      this.packagesMetadata.ambiguousEntryPoints.has(importPath) ||
+      this.packagesMetadata.entryPointsWithProjectBoundaryCrossings.has(
+        importPath
+      )
+    ) {
       return null;
     }
 

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -69,11 +69,11 @@ export class TargetProjectLocator {
   private paths = this.tsConfig.config?.compilerOptions?.paths;
   private parsedPathPatterns: ParsedPatterns | undefined;
   private typescriptResolutionCache = new Map<string, string | null>();
-  private packagesMetadata: {
-    entryPointsToProjectMap: Record<string, ProjectGraphProjectNode>;
-    wildcardEntryPointsToProjectMap: Record<string, ProjectGraphProjectNode>;
-    packageToProjectMap: Record<string, ProjectGraphProjectNode>;
-  };
+  private packagesMetadata: ReturnType<
+    typeof getWorkspacePackagesMetadata<ProjectGraphProjectNode>
+  >;
+  private readonly useWorkspacePackageImportFastPath =
+    process.env.NX_ENABLE_WORKSPACE_PACKAGE_IMPORT_FAST_PATH === 'true';
 
   constructor(
     private readonly nodes: Record<string, ProjectGraphProjectNode>,
@@ -156,6 +156,14 @@ export class TargetProjectLocator {
     const externalProject = this.findNpmProjectFromImport(importExpr, filePath);
     if (externalProject) {
       return externalProject;
+    }
+
+    if (this.useWorkspacePackageImportFastPath && !results) {
+      const workspaceProject =
+        this.findExactImportInWorkspaceProjects(importExpr);
+      if (workspaceProject) {
+        return workspaceProject;
+      }
     }
 
     if (this.tsConfig.config) {
@@ -351,6 +359,20 @@ export class TargetProjectLocator {
     );
 
     return project?.name;
+  }
+
+  private findExactImportInWorkspaceProjects(
+    importPath: string
+  ): string | null {
+    this.packagesMetadata ??= getWorkspacePackagesMetadata(this.nodes);
+
+    if (this.packagesMetadata.ambiguousEntryPoints.has(importPath)) {
+      return null;
+    }
+
+    return (
+      this.packagesMetadata.entryPointsToProjectMap[importPath]?.name ?? null
+    );
   }
 
   findDependencyInWorkspaceProjects(

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -367,8 +367,7 @@ export class TargetProjectLocator {
     this.packagesMetadata ??= getWorkspacePackagesMetadata(this.nodes);
 
     if (
-      this.packagesMetadata.ambiguousEntryPoints.has(importPath) ||
-      this.packagesMetadata.entryPointsWithProjectBoundaryCrossings.has(
+      !this.packagesMetadata.directlyResolvableWorkspaceEntryPoints.has(
         importPath
       )
     ) {

--- a/packages/nx/src/plugins/js/utils/packages.ts
+++ b/packages/nx/src/plugins/js/utils/packages.ts
@@ -3,6 +3,19 @@ import type { ProjectGraphProjectNode } from '../../../config/project-graph';
 import type { ProjectConfiguration } from '../../../config/workspace-json-project-json';
 import type { PackageJsonProjectMetadata } from '../../../utils/package-json';
 
+function getPackageTargets(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap(getPackageTargets);
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).flatMap(getPackageTargets);
+  }
+  return [];
+}
+
 export function getWorkspacePackagesMetadata<
   T extends ProjectGraphProjectNode | ProjectConfiguration,
 >(
@@ -12,15 +25,45 @@ export function getWorkspacePackagesMetadata<
   wildcardEntryPointsToProjectMap: Record<string, T>;
   packageToProjectMap: Record<string, T>;
   ambiguousEntryPoints: Set<string>;
+  entryPointsWithProjectBoundaryCrossings: Set<string>;
 } {
   const entryPointsToProjectMap: Record<string, T> = {};
   const wildcardEntryPointsToProjectMap: Record<string, T> = {};
   const packageToProjectMap: Record<string, T> = {};
   const ambiguousEntryPoints = new Set<string>();
-  const addEntryPoint = (entryPoint: string, project: T): void => {
+  const entryPointsWithProjectBoundaryCrossings = new Set<string>();
+  const projectRoots = Object.values(projects)
+    .map((project) => ({
+      project,
+      root: join('data' in project ? project.data.root : project.root),
+    }))
+    .sort((a, b) => b.root.length - a.root.length);
+  const projectRootByProject = new Map(
+    projectRoots.map(({ project, root }) => [project, root])
+  );
+  const addEntryPoint = (
+    entryPoint: string,
+    project: T,
+    packageTargets: string[]
+  ): void => {
     const existingProject = entryPointsToProjectMap[entryPoint];
     if (existingProject && existingProject !== project) {
       ambiguousEntryPoints.add(entryPoint);
+    }
+    const projectRoot = projectRootByProject.get(project)!;
+    if (
+      packageTargets.some((target) => {
+        const targetPath = join(projectRoot, target);
+        const targetProject = projectRoots.find(
+          (candidate) =>
+            candidate.root === '.' ||
+            targetPath === candidate.root ||
+            targetPath.startsWith(`${candidate.root}/`)
+        );
+        return targetProject && targetProject.project !== project;
+      })
+    ) {
+      entryPointsWithProjectBoundaryCrossings.add(entryPoint);
     }
     entryPointsToProjectMap[entryPoint] = project;
   };
@@ -53,7 +96,7 @@ export function getWorkspacePackagesMetadata<
       if (typeof packageExports === 'string') {
         // it points to a file, which would be the equivalent of an '.' export,
         // in which case the package name is the entry point
-        addEntryPoint(packageName, project);
+        addEntryPoint(packageName, project, [packageExports]);
       } else {
         for (const entryPoint of Object.keys(packageExports)) {
           if (packageExports[entryPoint] === null) {
@@ -67,19 +110,27 @@ export function getWorkspacePackagesMetadata<
               wildcardEntryPointsToProjectMap[join(packageName, entryPoint)] =
                 project;
             } else {
-              addEntryPoint(join(packageName, entryPoint), project);
+              addEntryPoint(
+                join(packageName, entryPoint),
+                project,
+                getPackageTargets(packageExports[entryPoint])
+              );
             }
           } else {
             // it's a conditional export, so we use the package name as the entry point
             // https://nodejs.org/api/packages.html#conditional-exports
-            addEntryPoint(packageName, project);
+            addEntryPoint(
+              packageName,
+              project,
+              getPackageTargets(packageExports[entryPoint])
+            );
           }
         }
       }
     } else if (packageMain) {
       // if there is no exports, but there is a main, the package name is the
       // entry point
-      addEntryPoint(packageName, project);
+      addEntryPoint(packageName, project, [packageMain]);
     }
   }
 
@@ -88,6 +139,7 @@ export function getWorkspacePackagesMetadata<
     wildcardEntryPointsToProjectMap,
     packageToProjectMap,
     ambiguousEntryPoints,
+    entryPointsWithProjectBoundaryCrossings,
   };
 }
 

--- a/packages/nx/src/plugins/js/utils/packages.ts
+++ b/packages/nx/src/plugins/js/utils/packages.ts
@@ -80,6 +80,9 @@ export function getWorkspacePackagesMetadata<
       packageTargets
     );
 
+    // Directly resolvable entry points have one owning project and all declared
+    // targets remain within that project's boundary. Duplicate ownership or a
+    // cross-project target removes the entry because its project is not definitive.
     if (!hasExistingEntryPoint) {
       if (targetsAreOwnedByProject) {
         directlyResolvableWorkspaceEntryPoints.add(entryPoint);

--- a/packages/nx/src/plugins/js/utils/packages.ts
+++ b/packages/nx/src/plugins/js/utils/packages.ts
@@ -11,10 +11,20 @@ export function getWorkspacePackagesMetadata<
   entryPointsToProjectMap: Record<string, T>;
   wildcardEntryPointsToProjectMap: Record<string, T>;
   packageToProjectMap: Record<string, T>;
+  ambiguousEntryPoints: Set<string>;
 } {
   const entryPointsToProjectMap: Record<string, T> = {};
   const wildcardEntryPointsToProjectMap: Record<string, T> = {};
   const packageToProjectMap: Record<string, T> = {};
+  const ambiguousEntryPoints = new Set<string>();
+  const addEntryPoint = (entryPoint: string, project: T): void => {
+    const existingProject = entryPointsToProjectMap[entryPoint];
+    if (existingProject && existingProject !== project) {
+      ambiguousEntryPoints.add(entryPoint);
+    }
+    entryPointsToProjectMap[entryPoint] = project;
+  };
+
   for (const project of Object.values(projects)) {
     const metadata = (
       'data' in project ? project.data.metadata : project.metadata
@@ -43,7 +53,7 @@ export function getWorkspacePackagesMetadata<
       if (typeof packageExports === 'string') {
         // it points to a file, which would be the equivalent of an '.' export,
         // in which case the package name is the entry point
-        entryPointsToProjectMap[packageName] = project;
+        addEntryPoint(packageName, project);
       } else {
         for (const entryPoint of Object.keys(packageExports)) {
           if (packageExports[entryPoint] === null) {
@@ -57,19 +67,19 @@ export function getWorkspacePackagesMetadata<
               wildcardEntryPointsToProjectMap[join(packageName, entryPoint)] =
                 project;
             } else {
-              entryPointsToProjectMap[join(packageName, entryPoint)] = project;
+              addEntryPoint(join(packageName, entryPoint), project);
             }
           } else {
             // it's a conditional export, so we use the package name as the entry point
             // https://nodejs.org/api/packages.html#conditional-exports
-            entryPointsToProjectMap[packageName] = project;
+            addEntryPoint(packageName, project);
           }
         }
       }
     } else if (packageMain) {
       // if there is no exports, but there is a main, the package name is the
       // entry point
-      entryPointsToProjectMap[packageName] = project;
+      addEntryPoint(packageName, project);
     }
   }
 
@@ -77,6 +87,7 @@ export function getWorkspacePackagesMetadata<
     entryPointsToProjectMap,
     wildcardEntryPointsToProjectMap,
     packageToProjectMap,
+    ambiguousEntryPoints,
   };
 }
 

--- a/packages/nx/src/plugins/js/utils/packages.ts
+++ b/packages/nx/src/plugins/js/utils/packages.ts
@@ -1,6 +1,11 @@
 import { join } from 'node:path/posix';
 import type { ProjectGraphProjectNode } from '../../../config/project-graph';
 import type { ProjectConfiguration } from '../../../config/workspace-json-project-json';
+import {
+  findProjectForPath,
+  normalizeProjectRoot,
+  type ProjectRootMappings,
+} from '../../../project-graph/utils/find-project-for-path';
 import type { PackageJsonProjectMetadata } from '../../../utils/package-json';
 
 function getPackageTargets(value: unknown): string[] {
@@ -24,47 +29,65 @@ export function getWorkspacePackagesMetadata<
   entryPointsToProjectMap: Record<string, T>;
   wildcardEntryPointsToProjectMap: Record<string, T>;
   packageToProjectMap: Record<string, T>;
-  ambiguousEntryPoints: Set<string>;
-  entryPointsWithProjectBoundaryCrossings: Set<string>;
+  directlyResolvableWorkspaceEntryPoints: Set<string>;
 } {
   const entryPointsToProjectMap: Record<string, T> = {};
   const wildcardEntryPointsToProjectMap: Record<string, T> = {};
   const packageToProjectMap: Record<string, T> = {};
-  const ambiguousEntryPoints = new Set<string>();
-  const entryPointsWithProjectBoundaryCrossings = new Set<string>();
-  const projectRoots = Object.values(projects)
-    .map((project) => ({
-      project,
-      root: join('data' in project ? project.data.root : project.root),
-    }))
-    .sort((a, b) => b.root.length - a.root.length);
-  const projectRootByProject = new Map(
-    projectRoots.map(({ project, root }) => [project, root])
-  );
+  const directlyResolvableWorkspaceEntryPoints = new Set<string>();
+  const projectRootMappings: ProjectRootMappings = new Map();
+  const projectIdentityByProject = new Map<T, { name: string; root: string }>();
+
+  for (const [projectName, project] of Object.entries(projects)) {
+    const root = normalizeProjectRoot(
+      'data' in project ? project.data.root : project.root
+    );
+    const name = project.name ?? projectName;
+    projectRootMappings.set(root, name);
+    projectIdentityByProject.set(project, { name, root });
+  }
+
+  const targetsRemainInProject = (
+    project: T,
+    packageTargets: string[]
+  ): boolean => {
+    if (packageTargets.length === 0) {
+      return false;
+    }
+
+    const { name: projectName, root: projectRoot } =
+      projectIdentityByProject.get(project)!;
+
+    return packageTargets.every(
+      (target) =>
+        findProjectForPath(join(projectRoot, target), projectRootMappings) ===
+        projectName
+    );
+  };
+
   const addEntryPoint = (
     entryPoint: string,
     project: T,
     packageTargets: string[]
   ): void => {
+    const hasExistingEntryPoint = Object.hasOwn(
+      entryPointsToProjectMap,
+      entryPoint
+    );
     const existingProject = entryPointsToProjectMap[entryPoint];
-    if (existingProject && existingProject !== project) {
-      ambiguousEntryPoints.add(entryPoint);
+    const targetsAreOwnedByProject = targetsRemainInProject(
+      project,
+      packageTargets
+    );
+
+    if (!hasExistingEntryPoint) {
+      if (targetsAreOwnedByProject) {
+        directlyResolvableWorkspaceEntryPoints.add(entryPoint);
+      }
+    } else if (existingProject !== project || !targetsAreOwnedByProject) {
+      directlyResolvableWorkspaceEntryPoints.delete(entryPoint);
     }
-    const projectRoot = projectRootByProject.get(project)!;
-    if (
-      packageTargets.some((target) => {
-        const targetPath = join(projectRoot, target);
-        const targetProject = projectRoots.find(
-          (candidate) =>
-            candidate.root === '.' ||
-            targetPath === candidate.root ||
-            targetPath.startsWith(`${candidate.root}/`)
-        );
-        return targetProject && targetProject.project !== project;
-      })
-    ) {
-      entryPointsWithProjectBoundaryCrossings.add(entryPoint);
-    }
+
     entryPointsToProjectMap[entryPoint] = project;
   };
 
@@ -138,8 +161,7 @@ export function getWorkspacePackagesMetadata<
     entryPointsToProjectMap,
     wildcardEntryPointsToProjectMap,
     packageToProjectMap,
-    ambiguousEntryPoints,
-    entryPointsWithProjectBoundaryCrossings,
+    directlyResolvableWorkspaceEntryPoints,
   };
 }
 


### PR DESCRIPTION
## Current Behavior

Workspace package metadata is consulted only after npm resolution, TypeScript module resolution, and `require.resolve()`. In large package-based workspaces, imports that ultimately resolve through workspace metadata repeatedly pay for the more expensive resolver paths first.

See #37000 for the complete profile, impact, and resolution-consistency findings.

## Expected Behavior

When `NX_ENABLE_WORKSPACE_PACKAGE_IMPORT_FAST_PATH=true`, exact workspace entry points that have a definitive project identity resolve after npm/external resolution and before TypeScript and `require.resolve()`.

All other imports retain the existing resolver order and workspace fallback behavior. The feature remains disabled by default.

## Implementation

`getWorkspacePackagesMetadata()` now exposes `directlyResolvableWorkspaceEntryPoints`, a set containing exact entry points that:

- have one owning workspace project;
- have declared targets owned by that same Nx project;
- are not wildcard or restricted exports.

Eligibility is monotonic. An entry is added only when its declaration is safe and is removed if another project declares the same entry point or any conditional target crosses a project boundary. The existing `entryPointsToProjectMap` remains unchanged for plugin resolution and the final last-write-wins workspace fallback.

`TargetProjectLocator` checks this set after built-in and npm/external resolution. It also bypasses the direct lookup whenever a tsconfig path pattern matched, including patterns that did not identify a project.

The lookup adds no per-import filesystem work. Package targets and project ownership are evaluated once when workspace package metadata is created, using Nx's existing `findProjectForPath()` semantics.

## Resolution order when enabled

```text
relative import
→ tsconfig paths
→ built-in module
→ npm/external package
→ directly resolvable exact workspace entry point
→ TypeScript module resolution
→ require.resolve()
→ existing workspace package fallback
→ unresolved
```

## Measured performance

In the representative 703-project workspace described in #37000, the initial exact-entry implementation handled 26,130 imports.

| Measurement | Baseline | Enabled | Reduction |
|---|---:|---:|---:|
| Import-to-project resolution | 131.9 seconds | 40.2 seconds | 69.5% |
| TypeScript dependency construction | 146.8 seconds | 53.5 seconds | 63.5% |
| Complete graph initialization | 216.1 seconds | 165.0 seconds | 23.7% |

The import-to-project measurement is the primary performance signal. Complete graph initialization includes unrelated project inference and plugin startup.

These measurements predate the additional project-boundary eligibility guard. That guard only removes entries that cannot safely bypass legacy resolution, but the performance profile should be repeated before considering the feature for default enablement.

## Graph parity

The prototype graph was generated with the daemon and graph cache disabled, canonicalized by sorting node keys and dependency arrays, and compared before and after enabling the exact-entry lookup:

| Graph property | Baseline | Enabled |
|---|---:|---:|
| Projects | 703 | 703 |
| External nodes | 4,268 | 4,268 |
| Dependencies | 20,591 | 20,591 |
| Canonical SHA-256 | `100ba50922c572c6cae947621517a98e9ce14f5fb4d4ef5a4b501186bc1e1c81` | `100ba50922c572c6cae947621517a98e9ce14f5fb4d4ef5a4b501186bc1e1c81` |

The serialized graphs were byte-for-byte identical.

## Correctness safeguards

The focused coverage verifies:

- default-off behavior;
- exact root, subpath, `main`, and conditional exports;
- npm external-node precedence;
- successful and unresolved tsconfig path matches;
- duplicate exact entry points;
- wildcard and restricted exports;
- nested-project export targets;
- mixed conditional targets cannot requalify an entry after it becomes unsafe;
- existing workspace fallback behavior.

## Validation

- `pnpm nx run nx:test --args='src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts --run' --excludeTaskDependencies --skipNxCache`
  - All 212 tests passed.
- `NX_ENABLE_WORKSPACE_PACKAGE_IMPORT_FAST_PATH=true pnpm nx run nx:test --args='src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts --run' --excludeTaskDependencies --skipNxCache`
  - All 212 tests passed with the feature globally enabled.
- `pnpm exec eslint --no-ignore packages/nx/src/plugins/js/utils/packages.ts packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts --max-warnings=0`
- `pnpm nx prepush`
- `pnpm exec oxfmt --check packages/nx/src/plugins/js/utils/packages.ts packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts`

The complete `nx:test` dependency chain also runs native tests. Two unrelated environment-sensitive native tests failed locally: AI-agent detection observed the Copilot environment, and a native performance assertion measured 17.8 ms against a 10 ms threshold.

## Related Issue(s)

Fixes #37000
