### PR TITLE
feat(js): cache TypeScript reference expansion during createNodes

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -2367,6 +2367,108 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         );
       });
 
+      it('should preserve shared external reference subtrees with cycles and missing configs', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'tsconfig.base.json': JSON.stringify({
+            compilerOptions: { strict: true },
+          }),
+          'apps/app-one/tsconfig.json': JSON.stringify({
+            references: [{ path: '../../libs/shared' }],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'apps/app-one/package.json': `{}`,
+          'apps/app-two/tsconfig.json': JSON.stringify({
+            references: [{ path: '../../libs/shared' }],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'apps/app-two/package.json': `{}`,
+          'libs/shared/tsconfig.json': JSON.stringify({
+            extends: '../../tsconfig.base.json',
+            references: [
+              { path: './tsconfig.lib.json' },
+              { path: './nested/tsconfig.json' },
+              { path: './missing/tsconfig.json' },
+            ],
+          }),
+          'libs/shared/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/shared/nested/tsconfig.json': JSON.stringify({
+            references: [{ path: '../tsconfig.json' }],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/shared/package.json': `{}`,
+        });
+
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        const expectedPatterns = [
+          '^{projectRoot}/tsconfig.json',
+          '^{projectRoot}/tsconfig.lib.json',
+          '^{projectRoot}/nested/tsconfig.json',
+        ];
+
+        for (const projectRoot of ['apps/app-one', 'apps/app-two']) {
+          expect(
+            result.projects[projectRoot].targets.typecheck.inputs.filter(
+              (input) =>
+                typeof input === 'string' && input.startsWith('^{projectRoot}/')
+            )
+          ).toEqual(expectedPatterns);
+        }
+      });
+
+      it('should not reuse reference expansions across invocations', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'apps/my-app/tsconfig.json': JSON.stringify({
+            references: [{ path: '../../libs/shared' }],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'apps/my-app/package.json': `{}`,
+          'libs/shared/tsconfig.json': JSON.stringify({
+            references: [{ path: './tsconfig.one.json' }],
+          }),
+          'libs/shared/tsconfig.one.json': JSON.stringify({
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/shared/tsconfig.two.json': JSON.stringify({
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/shared/package.json': `{}`,
+        });
+
+        const firstResult = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        expect(
+          firstResult.projects['apps/my-app'].targets.typecheck.inputs
+        ).toContain('^{projectRoot}/tsconfig.one.json');
+
+        await tempFs.createFiles({
+          'libs/shared/tsconfig.json': JSON.stringify({
+            references: [{ path: './tsconfig.two.json' }],
+          }),
+        });
+        setupWorkspaceContext(tempFs.tempDir);
+
+        const secondResult = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        expect(
+          secondResult.projects['apps/my-app'].targets.typecheck.inputs
+        ).toContain('^{projectRoot}/tsconfig.two.json');
+        expect(
+          secondResult.projects['apps/my-app'].targets.typecheck.inputs
+        ).not.toContain('^{projectRoot}/tsconfig.one.json');
+      });
+
       it('should normalize and add directories in `include` from internal project references', async () => {
         configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -1409,8 +1409,9 @@ function getExternalProjectReferenceTsconfigPatterns(
 }
 
 /**
- * Caches immediate edges only so the caller retains transitive traversal,
- * ordering, and root-local visited semantics.
+ * Returns a config's immediate `extends` and project-reference expansion for
+ * the current owner, caching it for reuse within this invocation. Transitive
+ * traversal, ordering, and visited checks remain with the caller.
  */
 function getReferenceExpansion(
   configPath: string,
@@ -1435,8 +1436,10 @@ function getReferenceExpansion(
   const tsConfigData = tsConfigCacheData[configKey]?.data;
 
   if (tsConfigData) {
-    // tsc reads extended configs while resolving project references.
-    // Workspace-root configs are covered by the local project's extends walk.
+    // Walk `extends` chains for the visited tsconfig. tsc reads extended
+    // configs while resolving project references, so the rel paths must be
+    // emitted as inputs. Workspace-root files (no owning project) are skipped
+    // — those are covered by the local project's own extends walk.
     for (const extended of tsConfigData.extendedConfigFiles ?? []) {
       if (!extended.filePath) {
         continue;
@@ -1496,7 +1499,6 @@ function getReferenceExpansion(
     }
   }
 
-  // Cache empty expansions too; tsconfig data is stable for this invocation.
   ownerCache ??= new Map();
   ownerCache.set(ownerKey, expansion);
   cache.referenceExpansionCache.set(configKey, ownerCache);

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -137,6 +137,19 @@ const TS_CONFIG_CACHE_PATH = join(
   workspaceDataDirectory,
   'tsconfig-files.hash'
 );
+type ReferenceExpansionEntry = {
+  configPath: string;
+  ownerProject: ProjectContext;
+  pattern?: string;
+};
+
+type ReferenceExpansion = {
+  extendedConfigs: Array<ReferenceExpansionEntry & { pattern: string }>;
+  projectReferences: ReferenceExpansionEntry[];
+};
+
+type ReferenceExpansionCache = Map<string, Map<string, ReferenceExpansion>>;
+
 type InvocationCache = {
   fileHashes: Record<string, string>;
   rawFiles: Record<string, string>;
@@ -145,6 +158,7 @@ type InvocationCache = {
   configOwners: Map<string, string>;
   projectContexts: Map<string, ProjectContext>;
   configContexts: Map<string, ConfigContext>;
+  referenceExpansionCache: ReferenceExpansionCache;
 };
 
 // Module-level cache store — each invocation gets a unique Symbol key
@@ -282,6 +296,7 @@ export const createNodesV2: CreateNodes<TscPluginOptions> = [
       configOwners: new Map(),
       projectContexts: new Map(),
       configContexts: new Map(),
+      referenceExpansionCache: new Map(),
     });
     const cache = cacheStore.get(cacheKey)!;
 
@@ -1346,82 +1361,34 @@ function getExternalProjectReferenceTsconfigPatterns(
     }
     visited.add(configPath);
 
-    const wsRelPath = posixRelative(workspaceRoot, configPath);
-    const tsConfigData = tsConfigCacheData[wsRelPath]?.data;
-    if (!tsConfigData) {
-      continue;
-    }
+    const expansion = getReferenceExpansion(
+      configPath,
+      ownerProject,
+      workspaceRoot,
+      cache
+    );
 
-    // Walk `extends` chains for the visited tsconfig. tsc reads extended
-    // configs while resolving project references, so the rel paths must be
-    // emitted as inputs. Workspace-root files (no owning project) are skipped
-    // — those are covered by the local project's own extends walk.
-    if (tsConfigData.extendedConfigFiles?.length) {
-      for (const extended of tsConfigData.extendedConfigFiles) {
-        if (!extended.filePath || visited.has(extended.filePath)) {
-          continue;
-        }
-        const extendedWsRelPath = posixRelative(
-          workspaceRoot,
-          extended.filePath
-        );
-        if (!tsConfigCacheData[extendedWsRelPath]) {
-          continue;
-        }
-        const extendedContext = getConfigContext(
-          extended.filePath,
-          workspaceRoot,
-          cache
-        );
-        if (
-          extendedContext.project.root &&
-          extendedContext.project.root !== '.'
-        ) {
-          uniqueRelPaths.add(
-            posixRelative(extendedContext.project.absolute, extended.filePath)
-          );
-          worklist.push({
-            configPath: extended.filePath,
-            ownerProject: extendedContext.project,
-          });
-        }
-      }
-    }
-
-    if (!tsConfigData.projectReferences?.length) {
-      continue;
-    }
-
-    for (const ref of tsConfigData.projectReferences) {
-      let refPath = ref.path;
-      if (!refPath.endsWith('.json')) {
-        refPath = join(refPath, 'tsconfig.json');
-      }
-
-      // Skip references not found in the tsconfig cache
-      const refWsRelPath = posixRelative(workspaceRoot, refPath);
-      if (!tsConfigCacheData[refWsRelPath]) {
+    for (const extended of expansion.extendedConfigs) {
+      if (visited.has(extended.configPath)) {
         continue;
       }
 
-      const refContext = getConfigContext(refPath, workspaceRoot, cache);
+      uniqueRelPaths.add(extended.pattern);
+      worklist.push({
+        configPath: extended.configPath,
+        ownerProject: extended.ownerProject,
+      });
+    }
 
-      // Collect paths for references within the same project
-      if (
-        !isExternalProjectReference(
-          refContext,
-          ownerProject,
-          workspaceRoot,
-          cache
-        )
-      ) {
-        uniqueRelPaths.add(posixRelative(ownerProject.absolute, refPath));
+    for (const ref of expansion.projectReferences) {
+      if (ref.pattern) {
+        uniqueRelPaths.add(ref.pattern);
       }
 
-      if (!visited.has(refPath)) {
+      if (!visited.has(ref.configPath)) {
         worklist.push({
-          configPath: refPath,
-          ownerProject: refContext.project,
+          configPath: ref.configPath,
+          ownerProject: ref.ownerProject,
         });
       }
     }
@@ -1430,6 +1397,92 @@ function getExternalProjectReferenceTsconfigPatterns(
   return Array.from(uniqueRelPaths).map(
     (relPath) => `^{projectRoot}/${relPath}`
   );
+}
+
+function getReferenceExpansion(
+  configPath: string,
+  ownerProject: ProjectContext,
+  workspaceRoot: string,
+  cache: InvocationCache
+): ReferenceExpansion {
+  const configKey = posixRelative(workspaceRoot, configPath);
+  const ownerKey = ownerProject.normalized;
+
+  let ownerCache = cache.referenceExpansionCache.get(configKey);
+  const cached = ownerCache?.get(ownerKey);
+  if (cached) {
+    return cached;
+  }
+
+  const expansion: ReferenceExpansion = {
+    extendedConfigs: [],
+    projectReferences: [],
+  };
+  const tsConfigData = tsConfigCacheData[configKey]?.data;
+
+  if (tsConfigData) {
+    for (const extended of tsConfigData.extendedConfigFiles ?? []) {
+      if (!extended.filePath) {
+        continue;
+      }
+
+      const extendedWsRelPath = posixRelative(workspaceRoot, extended.filePath);
+      if (!tsConfigCacheData[extendedWsRelPath]) {
+        continue;
+      }
+
+      const extendedContext = getConfigContext(
+        extended.filePath,
+        workspaceRoot,
+        cache
+      );
+      if (
+        extendedContext.project.root &&
+        extendedContext.project.root !== '.'
+      ) {
+        expansion.extendedConfigs.push({
+          configPath: extended.filePath,
+          ownerProject: extendedContext.project,
+          pattern: posixRelative(
+            extendedContext.project.absolute,
+            extended.filePath
+          ),
+        });
+      }
+    }
+
+    for (const ref of tsConfigData.projectReferences ?? []) {
+      let refPath = ref.path;
+      if (!refPath.endsWith('.json')) {
+        refPath = join(refPath, 'tsconfig.json');
+      }
+
+      const refWsRelPath = posixRelative(workspaceRoot, refPath);
+      if (!tsConfigCacheData[refWsRelPath]) {
+        continue;
+      }
+
+      const refContext = getConfigContext(refPath, workspaceRoot, cache);
+      expansion.projectReferences.push({
+        configPath: refPath,
+        ownerProject: refContext.project,
+        pattern: isExternalProjectReference(
+          refContext,
+          ownerProject,
+          workspaceRoot,
+          cache
+        )
+          ? undefined
+          : posixRelative(ownerProject.absolute, refPath),
+      });
+    }
+  }
+
+  ownerCache ??= new Map();
+  ownerCache.set(ownerKey, expansion);
+  cache.referenceExpansionCache.set(configKey, ownerCache);
+
+  return expansion;
 }
 
 function isExternalProjectReference(

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -1399,6 +1399,10 @@ function getExternalProjectReferenceTsconfigPatterns(
   );
 }
 
+/**
+ * Caches immediate edges only so the caller retains transitive traversal,
+ * ordering, and root-local visited semantics.
+ */
 function getReferenceExpansion(
   configPath: string,
   ownerProject: ProjectContext,
@@ -1406,6 +1410,7 @@ function getReferenceExpansion(
   cache: InvocationCache
 ): ReferenceExpansion {
   const configKey = posixRelative(workspaceRoot, configPath);
+  // Reference classification and relative patterns depend on the owner.
   const ownerKey = ownerProject.normalized;
 
   let ownerCache = cache.referenceExpansionCache.get(configKey);
@@ -1421,6 +1426,8 @@ function getReferenceExpansion(
   const tsConfigData = tsConfigCacheData[configKey]?.data;
 
   if (tsConfigData) {
+    // tsc reads extended configs while resolving project references.
+    // Workspace-root configs are covered by the local project's extends walk.
     for (const extended of tsConfigData.extendedConfigFiles ?? []) {
       if (!extended.filePath) {
         continue;
@@ -1466,6 +1473,7 @@ function getReferenceExpansion(
       expansion.projectReferences.push({
         configPath: refPath,
         ownerProject: refContext.project,
+        // Only references owned by this project contribute input patterns.
         pattern: isExternalProjectReference(
           refContext,
           ownerProject,

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -140,12 +140,19 @@ const TS_CONFIG_CACHE_PATH = join(
 type ReferenceExpansionEntry = {
   configPath: string;
   ownerProject: ProjectContext;
-  pattern?: string;
+};
+
+type ExtendedConfigExpansionEntry = ReferenceExpansionEntry & {
+  pattern: string;
+};
+
+type ProjectReferenceExpansionEntry = ReferenceExpansionEntry & {
+  pattern: string | undefined;
 };
 
 type ReferenceExpansion = {
-  extendedConfigs: Array<ReferenceExpansionEntry & { pattern: string }>;
-  projectReferences: ReferenceExpansionEntry[];
+  extendedConfigs: ExtendedConfigExpansionEntry[];
+  projectReferences: ProjectReferenceExpansionEntry[];
 };
 
 type ReferenceExpansionCache = Map<string, Map<string, ReferenceExpansion>>;
@@ -1368,6 +1375,7 @@ function getExternalProjectReferenceTsconfigPatterns(
       cache
     );
 
+    // Extended-config patterns follow the traversal's first-visit semantics.
     for (const extended of expansion.extendedConfigs) {
       if (visited.has(extended.configPath)) {
         continue;
@@ -1380,8 +1388,9 @@ function getExternalProjectReferenceTsconfigPatterns(
       });
     }
 
+    // Reference patterns are collected even when traversal already visited them.
     for (const ref of expansion.projectReferences) {
-      if (ref.pattern) {
+      if (ref.pattern !== undefined) {
         uniqueRelPaths.add(ref.pattern);
       }
 
@@ -1464,6 +1473,7 @@ function getReferenceExpansion(
         refPath = join(refPath, 'tsconfig.json');
       }
 
+      // References absent from the invocation's tsconfig data remain ignored.
       const refWsRelPath = posixRelative(workspaceRoot, refPath);
       if (!tsConfigCacheData[refWsRelPath]) {
         continue;
@@ -1486,6 +1496,7 @@ function getReferenceExpansion(
     }
   }
 
+  // Cache empty expansions too; tsconfig data is stable for this invocation.
   ownerCache ??= new Map();
   ownerCache.set(ownerKey, expansion);
   cache.referenceExpansionCache.set(configKey, ownerCache);


### PR DESCRIPTION
## Current Behavior

The `@nx/js/typescript` plugin generates inferred target inputs by traversing external TypeScript project references and their `extends` chains. This traversal currently repeats the same reference expansion for every project that reaches a shared dependency subtree.

In the reference-heavy workspace used to validate this change, the plugin processed 715 matched tsconfig files, 695 valid project configs, and 695 inferred typecheck targets. Across those targets:

| Work | Total evaluations | Unique | Repeated share |
|---|---:|---:|---:|
| Config visits | 109,187 | 647 | 99.41% |
| Config-and-owner contexts | 109,187 | 652 | 99.40% |
| Project-reference edges | 658,597 | 5,847 | 99.11% |
| Owner-aware reference edges | 658,597 | 5,849 | 99.11% |
| Extended-config edges | 109,181 | 646 | 99.41% |

Each project traversed an average of 157 configs, with a median of 108 and a maximum of 632. Despite that work, each inferred target emitted a median of one project-reference input pattern and a maximum of two.

Profiling showed that external project-reference pattern generation accounted for most of the cost:

| Phase | Representative median |
|---|---:|
| Generate inferred targets | 22.82 s |
| Generate target inputs | 17.30 s |
| Generate external project-reference patterns | 16.93 s |
| Walk project references | 13.45 s |
| Initialize the tsconfig cache | 3.20 s |

## Expected Behavior

Shared reference subtrees should be expanded once per relevant config-and-owner context during a `createNodes` invocation. Inferred target inputs and project graph output must remain unchanged.

## Implementation

This change adds an invocation-scoped cache for the immediate expansion of each TypeScript config.

The cache key contains:

- the config path relative to the workspace root;
- the normalized owner project root.

Each entry stores:

- valid non-root extended configs and their relative patterns;
- valid project references and their owning project;
- the internal-reference pattern when the reference belongs to the current owner.

Only immediate expansion is cached. The existing worklist continues to perform transitive traversal.

## Correctness

### Invocation isolation

The cache is part of the existing `InvocationCache`. It is created at the start of `createNodes` and becomes unreachable when the invocation's cache entry is deleted in the existing `finally` block. No cached expansion is reused by a later project-graph computation.

### Owner-sensitive classification

`isExternalProjectReference()` depends on the project from which a reference is evaluated. The cache therefore includes the normalized owner root in addition to the config path. A config reached in different ownership contexts cannot reuse an incompatible classification.

### Traversal and ordering

The cache stores immediate edges in the same order in which they appear in the parsed tsconfig data:

1. extended configs;
2. project references.

The existing worklist consumes those entries in the same order. Worklist seeding, final pattern materialization, and the root-local `visited` set are unchanged.

### Extended configs

The cached path preserves the existing behavior:

1. Entries without a resolved file path are ignored.
2. Configs absent from the invocation's tsconfig data are ignored.
3. Workspace-root extended configs are excluded from dependency-project patterns.
4. Valid project-owned configs contribute the same relative pattern.
5. The root traversal still decides whether an extended config has already been visited.

### Project references

The cached path preserves the existing behavior:

1. Directory references are normalized to `tsconfig.json`.
2. References absent from the invocation's tsconfig data are ignored.
3. Ownership is evaluated against the current owner project.
4. Only internal references contribute a relative pattern.
5. The root traversal still decides whether a referenced config is enqueued.

### Cycles

The cache does not compute or store transitive closures. Cycles continue to terminate through the existing root-local `visited` set, without partial cache entries or cycle-specific state.

### Cache stability

The tsconfig data and project ownership information used by the cache are stable for the duration of an invocation. Cached `ProjectContext` values are existing invocation-scoped objects and are not retained after completion.

## Performance

Three alternating standalone runs on the same workspace produced:

| Measurement | Before | After | Change |
|---|---:|---:|---:|
| Median standalone `createNodes` | 21.94 s | 10.85 s | 50.5% faster |
| Expansion-cache lookups | 109,187 misses | 108,535 hits / 652 misses | 99.40% hit rate |

The final implementation without profiling hooks completed three standalone runs in:

```text
10.50 s
12.96 s
10.60 s
```

Median: **10.60 seconds**.

## Output Equivalence

The complete `createNodes` result was canonicalized while preserving target input-array order:

| Property | Before | After |
|---|---:|---:|
| Matched tsconfigs | 715 | 715 |
| Project results | 695 | 695 |
| Inferred targets | 695 | 695 |
| SHA-256 | `293d99b00aa16a9735fb8eede1883b7da8114d104993a9fe9fa32a3ec66ac820` | `293d99b00aa16a9735fb8eede1883b7da8114d104993a9fe9fa32a3ec66ac820` |

The complete project graph was also canonicalized and compared:

| Property | Before | After |
|---|---:|---:|
| Projects | 703 | 703 |
| External nodes | 4,268 | 4,268 |
| Dependencies | 20,591 | 20,591 |
| SHA-256 | `100ba50922c572c6cae947621517a98e9ce14f5fb4d4ef5a4b501186bc1e1c81` | `100ba50922c572c6cae947621517a98e9ce14f5fb4d4ef5a4b501186bc1e1c81` |

Both comparisons were byte-for-byte identical.

## Memory

Heap usage was measured with garbage collection forced before the invocation and after target construction while the invocation cache remained reachable:

| Measurement | Before | After | Increase |
|---|---:|---:|---:|
| Median post-GC heap growth | 26.87 MB | 32.94 MB | 6.07 MB |

The cache held 652 config-and-owner entries, 5,849 project-reference records, and two non-root extended-config records. Its additional memory is proportional to unique contexts and immediate edges, rather than the hundreds of thousands of repeated evaluations, and is released after the invocation.

## Tests

The added regression coverage verifies:

- shared external reference subtrees produce stable input patterns for multiple projects;
- extended configs preserve their relative patterns;
- workspace-root extended configs remain excluded;
- missing referenced configs remain ignored;
- cyclic references terminate;
- a later invocation does not reuse expansion data from an earlier invocation.

Validation completed successfully:

- `pnpm nx test js --testPathPatterns=src/plugins/typescript/plugin.spec.ts --runInBand --skipNxCache` — 97 tests and 107 snapshots passed.
- `pnpm nx run-many -t test,build,lint -p js --skipNxCache`
- `pnpm nx affected -t build,test,lint --files=packages/js/src/plugins/typescript/plugin.ts,packages/js/src/plugins/typescript/plugin.spec.ts --skipNxCache` — 191 tasks passed across 49 affected projects.
- `pnpm nx prepush`

Affected e2e execution was attempted, but the local Colima Docker VM failed to start before the e2e targets ran.

## Related Issue(s)

Fixes #37002
