### PR TITLE
fix(angular): acknowledge pnpm 11 build-script dependencies

### DIFF
--- a/e2e/workspace-create/src/create-nx-workspace-angular.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-angular.test.ts
@@ -5,6 +5,7 @@ import {
   expectCodeIsFormatted,
   getSelectedPackageManager,
   readJson,
+  runNxCommandAsync,
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e-utils';
@@ -13,6 +14,42 @@ describe('create-nx-workspace --preset=angular', () => {
   const packageManager = getSelectedPackageManager() || 'pnpm';
 
   afterEach(() => cleanupProject());
+
+  (packageManager === 'pnpm' ? it : it.skip)(
+    'should create and build an Angular app with strict pnpm build approvals',
+    async () => {
+      const strictDepBuilds = process.env.pnpm_config_strict_dep_builds;
+      const codexThreadId = process.env.CODEX_THREAD_ID;
+      try {
+        // Keep the real preset flow and pnpm 11's default strict behavior,
+        // even when the surrounding e2e environment relaxes build approvals.
+        process.env.pnpm_config_strict_dep_builds = 'true';
+        delete process.env.CODEX_THREAD_ID;
+        runCreateWorkspace(uniq('angular-pnpm'), {
+          preset: 'angular-monorepo',
+          appName: 'sample-app',
+          style: 'css',
+          packageManager: 'pnpm',
+          formatter: 'prettier',
+          e2eTestRunner: 'playwright',
+          ssr: false,
+          extraArgs: '--bundler=esbuild --zoneless=true',
+        });
+
+        await runNxCommandAsync('build sample-app');
+        await runNxCommandAsync('test sample-app');
+      } finally {
+        if (strictDepBuilds === undefined) {
+          delete process.env.pnpm_config_strict_dep_builds;
+        } else {
+          process.env.pnpm_config_strict_dep_builds = strictDepBuilds;
+        }
+        if (codexThreadId !== undefined) {
+          process.env.CODEX_THREAD_ID = codexThreadId;
+        }
+      }
+    }
+  );
 
   it('should create a workspace with a single angular app at the root without routing', () => {
     const wsName = uniq('angular');

--- a/e2e/workspace-create/src/create-nx-workspace-angular.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-angular.test.ts
@@ -5,7 +5,7 @@ import {
   expectCodeIsFormatted,
   getSelectedPackageManager,
   readJson,
-  runNxCommandAsync,
+  runCLIAsync,
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e-utils';
@@ -36,8 +36,8 @@ describe('create-nx-workspace --preset=angular', () => {
           extraArgs: '--bundler=esbuild --zoneless=true',
         });
 
-        await runNxCommandAsync('build sample-app');
-        await runNxCommandAsync('test sample-app');
+        await runCLIAsync('build sample-app');
+        await runCLIAsync('test sample-app');
       } finally {
         if (strictDepBuilds === undefined) {
           delete process.env.pnpm_config_strict_dep_builds;

--- a/packages/angular/src/generators/utils/ensure-angular-dependencies.spec.ts
+++ b/packages/angular/src/generators/utils/ensure-angular-dependencies.spec.ts
@@ -1,5 +1,7 @@
 import { readJson, updateJson, type Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import * as devkit from '@nx/devkit';
+import { parse } from 'yaml';
 import { angularDevkitVersion, angularVersion } from '../../utils/versions';
 import { ensureAngularDependencies } from './ensure-angular-dependencies';
 
@@ -8,6 +10,52 @@ describe('ensureAngularDependencies', () => {
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('pnpm build scripts', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('should record decisions before installation and preserve user choices', () => {
+      jest.spyOn(devkit, 'detectPackageManager').mockReturnValue('pnpm');
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        packageManager: 'pnpm@11.21.0',
+      }));
+      tree.write(
+        'pnpm-workspace.yaml',
+        'allowBuilds:\n  nx: true\n  esbuild: true\n  lmdb: false\n  "@parcel/watcher": set this to true or false\n'
+      );
+
+      ensureAngularDependencies(tree, true);
+
+      expect(
+        parse(tree.read('pnpm-workspace.yaml', 'utf-8')).allowBuilds
+      ).toEqual({
+        nx: true,
+        '@parcel/watcher': false,
+        esbuild: true,
+        lmdb: false,
+        'msgpackr-extract': false,
+        less: false,
+      });
+    });
+
+    it.each(['pnpm@10.6.0', 'npm@10.9.8'])(
+      'should not change build settings for %s',
+      (packageManager) => {
+        jest
+          .spyOn(devkit, 'detectPackageManager')
+          .mockReturnValue(packageManager.startsWith('pnpm') ? 'pnpm' : 'npm');
+        updateJson(tree, 'package.json', (json) => ({
+          ...json,
+          packageManager,
+        }));
+
+        ensureAngularDependencies(tree, true);
+
+        expect(tree.exists('pnpm-workspace.yaml')).toBe(false);
+      }
+    );
   });
 
   it('should add angular dependencies when not installed', () => {

--- a/packages/angular/src/generators/utils/ensure-angular-dependencies.ts
+++ b/packages/angular/src/generators/utils/ensure-angular-dependencies.ts
@@ -1,17 +1,29 @@
 import {
   addDependenciesToPackageJson,
+  detectPackageManager,
   getDependencyVersionFromPackageJson,
   readJson,
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
 import { getInstalledAngularDevkitVersion, versions } from './version-utils';
-import { type PackageJson } from '@nx/devkit/internal';
+import { acknowledgeBuildScripts, type PackageJson } from '@nx/devkit/internal';
 
 export function ensureAngularDependencies(
   tree: Tree,
   zoneless: boolean
 ): GeneratorCallback {
+  // Angular's tooling ships native binaries as optional dependencies. Its
+  // install scripts only provide source-build fallbacks; less's postinstall
+  // is for its own development environment. Match pnpm 10's skip behavior.
+  acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
+    '@parcel/watcher': false,
+    esbuild: false,
+    lmdb: false,
+    'msgpackr-extract': false,
+    less: false,
+  });
+
   const dependencies: Record<string, string> = {};
   const devDependencies: Record<string, string> = {};
   const pkgVersions = versions(tree);

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@nx/devkit';
 import { createTree } from '@nx/devkit/testing';
 import Ajv from 'ajv';
+import { parse } from 'yaml';
 import { Preset } from '../utils/presets';
 import { generateWorkspaceFiles } from './generate-workspace-files';
 
@@ -427,4 +428,28 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
     `);
     expect(tree.exists('proj/.npmrc')).toBeFalsy();
   });
+
+  it.each([Preset.AngularMonorepo, Preset.AngularStandalone])(
+    'should acknowledge bootstrap dependencies before installing %s with pnpm 11',
+    async (preset) => {
+      jest.spyOn(devkit, 'getPackageManagerVersion').mockReturnValue('11.21.0');
+
+      await generateWorkspaceFiles(tree, {
+        name: 'proj',
+        directory: 'proj',
+        preset,
+        defaultBase: 'main',
+        packageManager: 'pnpm',
+        isCustomPreset: false,
+      });
+
+      expect(
+        parse(tree.read('proj/pnpm-workspace.yaml', 'utf-8')).allowBuilds
+      ).toEqual({
+        nx: true,
+        '@parcel/watcher': false,
+        less: false,
+      });
+    }
+  );
 });

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -344,9 +344,20 @@ function addPnpmSettings(
   options: NormalizedSchema,
   packageManagerVersion: string
 ) {
-  const buildAllowlist = gte(packageManagerVersion, '11.0.0')
+  let buildAllowlist = gte(packageManagerVersion, '11.0.0')
     ? `allowBuilds:\n  nx: true`
     : `onlyBuiltDependencies:\n  - nx`;
+
+  // The Angular plugin is installed before its generators can acknowledge
+  // build scripts. These can be pulled in by its dependencies/auto-installed
+  // peers: watcher ships prebuilt binaries and less's script is development-only.
+  if (
+    gte(packageManagerVersion, '11.0.0') &&
+    (options.preset === Preset.AngularMonorepo ||
+      options.preset === Preset.AngularStandalone)
+  ) {
+    buildAllowlist += `\n  '@parcel/watcher': false\n  less: false`;
+  }
 
   tree.write(
     join(options.directory, 'pnpm-workspace.yaml'),


### PR DESCRIPTION
## Summary

Angular workspace creation with pnpm 11 fails with `ERR_PNPM_IGNORED_BUILDS` because dependency install scripts have no `allowBuilds` decision. Record skip decisions for Angular tooling through `acknowledgeBuildScripts`, preserving existing user choices, and seed watcher/less decisions before the initial preset install.

Adds unit coverage and a workspace-creation regression with strict pnpm checks enabled. 192 focused tests, builds, lint and prepush checks passed. Built-package validation on Node 22.23.2 and pnpm 11.21.0 passed installation and generated-app build/tests. The full creation regression remains unverified locally because the local registry release setup failed before tests.

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/Fix-Angular-pnpm-11-build-script-approvals-05742052">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->