### PR TITLE
fix(js): recover registry data when a package has no latest dist-tag

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
@@ -531,4 +531,133 @@ describe('release-publish executor', () => {
       );
     });
   });
+  describe('unresolvable version spec', () => {
+    function mockNextTag() {
+      mockParseRegistryOptions.mockResolvedValue({
+        registry: 'https://registry.npmjs.org/',
+        tag: 'next',
+        registryConfigKey: 'registry',
+      });
+    }
+
+    function mockPublishJsonData() {
+      jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
+        beforeJsonData: '',
+        jsonData: {
+          id: '@scope/test-package@1.0.0',
+          name: '@scope/test-package',
+          version: '1.0.0',
+          size: 100,
+          unpackedSize: 200,
+          shasum: 'abc123',
+          integrity: 'sha512-abc',
+          filename: 'test-package-1.0.0.tgz',
+          files: [],
+          entryCount: 1,
+          bundled: [],
+        },
+        afterJsonData: '',
+      } as any);
+    }
+
+    it('should retry against the release tag when npm view prints nothing', async () => {
+      mockNextTag();
+      mockExecSync
+        .mockReturnValueOnce(Buffer.from('')) // npm view, no `latest` dist-tag to resolve
+        .mockReturnValueOnce(
+          Buffer.from(
+            JSON.stringify({
+              versions: ['1.0.0'],
+              'dist-tags': { next: '1.0.0' },
+            })
+          )
+        ); // npm view --tag next
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(mockExecSync).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('--tag next'),
+        expect.anything()
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('already exists')
+      );
+      expect(mockExecSync).toHaveBeenCalledTimes(3);
+    });
+
+    it('should publish when the release tag does not resolve either', async () => {
+      mockNextTag();
+      mockPublishJsonData();
+      mockExecSync
+        .mockReturnValueOnce(Buffer.from('')) // npm view
+        .mockImplementationOnce(() => {
+          const error: any = new Error('npm view failed');
+          error.stdout = Buffer.from(
+            JSON.stringify({
+              error: {
+                code: 'E404',
+                summary: 'No match found for version next',
+              },
+            })
+          );
+          error.stderr = Buffer.from('');
+          throw error;
+        }) // npm view --tag next
+        .mockReturnValueOnce(Buffer.from('{}') as any); // npm publish
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(console.error).not.toHaveBeenCalled();
+      expect(mockExecSync).toHaveBeenCalledTimes(4);
+    });
+
+    it('should not retry when the release tag is latest', async () => {
+      mockPublishJsonData();
+      mockExecSync
+        .mockReturnValueOnce(Buffer.from('')) // npm view
+        .mockReturnValueOnce(Buffer.from('{}') as any); // npm publish
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(console.error).not.toHaveBeenCalled();
+      expect(mockExecSync).toHaveBeenCalledTimes(3);
+    });
+
+    it('should retry against the release tag when bun info reports no matching version', async () => {
+      mockDetectPackageManager.mockReturnValue('bun');
+      mockNextTag();
+      mockExecSync
+        .mockImplementationOnce(() => {
+          const error: any = new Error('bun info failed');
+          error.stdout = Buffer.from(
+            JSON.stringify({
+              error: 'No matching version found',
+              version: '@scope/test-package',
+            })
+          );
+          error.stderr = Buffer.from('');
+          throw error;
+        }) // bun info
+        .mockReturnValueOnce(
+          Buffer.from(JSON.stringify({ versions: ['1.0.0'] }))
+        ) // bun info @scope/test-package@next
+        .mockReturnValueOnce(Buffer.from('') as any); // npm dist-tag add
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(mockExecSync).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('@scope/test-package@next'),
+        expect.anything()
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Added the dist-tag next to v1.0.0')
+      );
+    });
+  });
 });

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -202,6 +202,21 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
       : [
           `npm view ${packageName} versions dist-tags --json --"${registryConfigKey}=${registry}"`,
         ];
+  /**
+   * Both commands above resolve the packument through a version spec that defaults to the
+   * `latest` dist-tag, so a package only ever published under a different tag looks like it has
+   * no data at all. Asking for the tag being published recovers it.
+   */
+  const npmViewForTagCommandSegments =
+    pm === 'bun'
+      ? [
+          'bun info',
+          `${packageName}@${tag}`,
+          `--json --"${registryConfigKey}=${registry}"`,
+        ]
+      : [
+          `npm view ${packageName} versions dist-tags --json --"${registryConfigKey}=${registry}" --tag ${tag}`,
+        ];
   const npmDistTagAddCommandSegments = [
     `npm dist-tag add ${packageName}@${packageJson.version} ${tag} --"${registryConfigKey}=${registry}"`,
   ];
@@ -216,15 +231,91 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
    */
   if (!isDryRun && !options.firstRelease) {
     const currentVersion = packageJson.version;
-    try {
-      const result = execSync(npmViewCommandSegments.join(' '), {
+    const runNpmView = (commandSegments: string[]) =>
+      execSync(commandSegments.join(' '), {
         env: processEnv(true),
         cwd: context.root,
         stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
-      });
+      })
+        .toString()
+        .trim();
 
-      const resultJson = JSON.parse(result.toString());
+    /**
+     * An unresolvable version spec is not an error here, it just means there is nothing to compare
+     * the local version against, so fall back to publishing. npm exits 0 printing nothing in that
+     * case, bun exits 1 reporting "No matching version found" on stdout.
+     */
+    const runNpmViewForTag = (): string | null => {
+      if (tag === 'latest') {
+        return null;
+      }
+      try {
+        return runNpmView(npmViewForTagCommandSegments) || null;
+      } catch {
+        return null;
+      }
+    };
+
+    let npmViewOutput: string | null = null;
+    try {
+      npmViewOutput = runNpmView(npmViewCommandSegments) || runNpmViewForTag();
+    } catch (err) {
+      if (err.stdout?.toString().includes('No matching version found')) {
+        npmViewOutput = runNpmViewForTag();
+      } else {
+        try {
+          const stdoutData = JSON.parse(err.stdout?.toString() || '{}');
+          // If the error is that the package doesn't exist, then we can ignore it because we will be publishing it for the first time in the next step
+          if (
+            !(
+              stdoutData.error?.code?.includes('E404') &&
+              stdoutData.error?.summary?.toLowerCase().includes('not found')
+            ) &&
+            !(
+              err.stderr?.toString().includes('E404') &&
+              err.stderr?.toString().toLowerCase().includes('not found')
+            ) &&
+            // bun uses plain '404' instead of 'E404'
+            !(
+              err.stderr?.toString().includes('404') &&
+              err.stderr?.toString().toLowerCase().includes('not found')
+            )
+          ) {
+            console.error(
+              `Something unexpected went wrong when checking for existing dist-tags.\n`,
+              err
+            );
+            return {
+              success: false,
+            };
+          }
+        } catch {
+          // JSON parse failed entirely - check stderr/stdout for plain 404
+          const stderrStr = err.stderr?.toString() || '';
+          const stdoutStr = err.stdout?.toString() || '';
+          if (
+            !(
+              (stderrStr.includes('404') &&
+                stderrStr.toLowerCase().includes('not found')) ||
+              (stdoutStr.includes('404') &&
+                stdoutStr.toLowerCase().includes('not found'))
+            )
+          ) {
+            console.error(
+              `Something unexpected went wrong when checking for existing dist-tags.\n`,
+              err
+            );
+            return {
+              success: false,
+            };
+          }
+        }
+      }
+    }
+
+    if (npmViewOutput) {
+      const resultJson = JSON.parse(npmViewOutput);
       const distTags = resultJson['dist-tags'] || {};
       if (distTags[tag] === currentVersion) {
         console.warn(
@@ -314,54 +405,6 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
               };
             }
           }
-        }
-      }
-    } catch (err) {
-      try {
-        const stdoutData = JSON.parse(err.stdout?.toString() || '{}');
-        // If the error is that the package doesn't exist, then we can ignore it because we will be publishing it for the first time in the next step
-        if (
-          !(
-            stdoutData.error?.code?.includes('E404') &&
-            stdoutData.error?.summary?.toLowerCase().includes('not found')
-          ) &&
-          !(
-            err.stderr?.toString().includes('E404') &&
-            err.stderr?.toString().toLowerCase().includes('not found')
-          ) &&
-          // bun uses plain '404' instead of 'E404'
-          !(
-            err.stderr?.toString().includes('404') &&
-            err.stderr?.toString().toLowerCase().includes('not found')
-          )
-        ) {
-          console.error(
-            `Something unexpected went wrong when checking for existing dist-tags.\n`,
-            err
-          );
-          return {
-            success: false,
-          };
-        }
-      } catch {
-        // JSON parse failed entirely — check stderr/stdout for plain 404
-        const stderrStr = err.stderr?.toString() || '';
-        const stdoutStr = err.stdout?.toString() || '';
-        if (
-          !(
-            (stderrStr.includes('404') &&
-              stderrStr.toLowerCase().includes('not found')) ||
-            (stdoutStr.includes('404') &&
-              stdoutStr.toLowerCase().includes('not found'))
-          )
-        ) {
-          console.error(
-            `Something unexpected went wrong when checking for existing dist-tags.\n`,
-            err
-          );
-          return {
-            success: false,
-          };
         }
       }
     }


### PR DESCRIPTION
## Current Behavior

`npm view <pkg> versions dist-tags --json` filters the packument through a version spec that defaults to `latest`. A package only ever published under another tag has no `latest`, so npm matches nothing, prints nothing, and exits 0. `JSON.parse('')` then throws inside the `execSync` try and lands in the exec-error catch with no stdout to inspect, so publish fails with "Something unexpected went wrong when checking for existing dist-tags". `bun info` hits the same case with "No matching version found".

## Expected Behavior

Retry the lookup against the tag being published, and publish anyway when that tag does not resolve either.

## Related Issue(s)

Fixes #36358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADB1XzzGVaM4G2bVbACb4F

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/active-falconet-c38d7086">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->