### PR TITLE
docs(misc): add redirects for three indexed docs urls returning 404

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -1170,6 +1170,16 @@ to = "/docs/technologies/module-federation/introduction"
 from = "/docs/concepts/decisions"
 to = "/docs/kb/monorepo-vs-polyrepo"
 
+# DOC-660: bare /docs/<slug> forms of these kb pages are indexed and ranking,
+# but only the old deep paths were redirected.
+[[redirects]]
+from = "/docs/what-is-a-monorepo"
+to = "/docs/kb/what-is-a-monorepo"
+
+[[redirects]]
+from = "/docs/angular-nx-version-matrix"
+to = "/docs/kb/angular-nx-version-matrix"
+
 # Rewrite for base path handling (keeps URL the same)
 [[redirects]]
 from = "/docs/*"

--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -343,6 +343,9 @@ export const config = {
     // Exact paths only, so the proxies keep serving everything else.
     '/blog/2024-05-08-nx-19-release',
     '/blog/evolving-nx',
+    // DOC-660: excludedPath matching is case-sensitive, so the '/docs/*' entry
+    // above does not cover this indexed mixed-case URL.
+    '/Docs/Knowledge',
     '/cypress/overview',
     '/jest/overview',
     '/more-concepts/monorepo-nx-enterprise',

--- a/nx-dev/nx-dev/_redirects
+++ b/nx-dev/nx-dev/_redirects
@@ -1360,3 +1360,6 @@
 /nx/reset /docs/reference/nx-commands#nx-reset 301
 /core-concepts/computation-caching /docs/features/cache-task-results 301
 /nx-community /docs/getting-started/intro 301
+
+# --- DOC-660: indexed mixed-case legacy URL ---
+/Docs/Knowledge /docs/kb 301


### PR DESCRIPTION
## Current Behavior

`/docs/what-is-a-monorepo`, `/docs/angular-nx-version-matrix` and `/Docs/Knowledge` all 404, despite being indexed and ranking. Only the old deep paths were redirected.

## Expected Behavior

All three 301 to their live `/docs/kb/` equivalents.

The first two are plain `astro-docs/netlify.toml` rules. `/Docs/Knowledge` needed two more: the Framer edge proxy answers it first (`x-nx-edge-function: framer-proxy` live) because `excludedPath` matching is case-sensitive, so `/docs/*` misses it. Excluding the exact path drops it to `_redirects`, which does the 301.

## Preview

Verified on the deploy previews - each 301s and the target returns 200.

- [/docs/what-is-a-monorepo](https://deploy-preview-37009--nx-docs.netlify.app/docs/what-is-a-monorepo) -> `/docs/kb/what-is-a-monorepo`
- [/docs/angular-nx-version-matrix](https://deploy-preview-37009--nx-docs.netlify.app/docs/angular-nx-version-matrix) -> `/docs/kb/angular-nx-version-matrix`
- [/Docs/Knowledge](https://deploy-preview-37009--nx-dev.netlify.app/Docs/Knowledge) -> `/docs/kb` (nx-dev preview, since the edge function and `_redirects` live there)

The last one is the interesting check: on the preview the answering layer is `x-nx-edge-function: track-page-requests`, versus `framer-proxy` on production. That flip is the fix.

## Related Issue(s)

DOC-660
