### PR TITLE
docs(misc): add setup and guides pointer to reference index pages

### DIFF
--- a/astro-docs/src/content/docs/reference/Nx Cloud/index.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/index.mdoc
@@ -6,4 +6,6 @@ description: API references, commands, and configuration documentation for Nx Cl
 pagefind: false
 ---
 
+For setup and guides, see [Setting Up CI for Nx Cloud](/docs/kb/setup-ci). The pages below are the API reference.
+
 {% index_page_cards path="reference/nx-cloud" /%}

--- a/astro-docs/src/content/docs/reference/Owners/index.mdoc
+++ b/astro-docs/src/content/docs/reference/Owners/index.mdoc
@@ -6,4 +6,6 @@ description: Managing code ownership
 pagefind: false
 ---
 
+For setup and guides, see [Define Code Ownership at the Project Level](/docs/enterprise/owners). The pages below are the API reference.
+
 {% index_page_cards path="reference/owners" /%}


### PR DESCRIPTION
## Current Behavior

Reference index pages using `{% sidebar_group_cards %}` carry a "For setup and guides" pointer line. The `{% index_page_cards %}` ones do not.

## Expected Behavior

Owners and Nx Cloud get the same line. Benchmarks, Deprecated and the top-level reference index are left alone - no meaningful setup destination.

## Preview

- [Owners reference index](https://deploy-preview-37010--nx-docs.netlify.app/docs/reference/owners) -> links [Define Code Ownership at the Project Level](https://deploy-preview-37010--nx-docs.netlify.app/docs/enterprise/owners)
- [Nx Cloud reference index](https://deploy-preview-37010--nx-docs.netlify.app/docs/reference/nx-cloud) -> links [Setting Up CI for Nx Cloud](https://deploy-preview-37010--nx-docs.netlify.app/docs/kb/setup-ci)

One line added per page, above the cards tag.

## Related Issue(s)

DOC-653
