### PR TITLE
docs(misc): add github actions pricing and ci cost comparison guide

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/index.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/index.mdoc
@@ -71,6 +71,10 @@ On the Hobby plan, Nx Cloud features turn off once the monthly credits are gone 
 
 The Team plan has no such cap, and usage beyond the $29 of included credit is billed at $5.50 per 10,000 credits. See [credit pricing](/docs/reference/nx-cloud/credits-pricing) for what each operation costs.
 
+### Is Nx Cloud cheaper than running CI on GitHub Actions alone?
+
+It depends on how many machine-minutes your pipeline burns today. Each run costs one CI pipeline execution, worth about 46 minutes on a standard GitHub runner, so the cache has to avoid more than that to pay for itself. Pipelines that already spread work across a job matrix or larger runners clear that bar comfortably. See [GitHub Actions pricing and how to cut your CI bill](/docs/kb/github-actions-pricing) for the rate tables and the break-even math at 50% and 70% cache hit rates.
+
 ### Do unused credits carry over?
 
 No. Your allowance resets at the start of each billing cycle.

--- a/astro-docs/src/content/docs/features/CI Features/index.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/index.mdoc
@@ -73,7 +73,7 @@ The Team plan has no such cap, and usage beyond the $29 of included credit is bi
 
 ### Is Nx Cloud cheaper than running CI on GitHub Actions alone?
 
-It depends on how many machine-minutes your pipeline burns today. Each run costs one CI pipeline execution, worth about 46 minutes on a standard GitHub runner, so the cache has to avoid more than that to pay for itself. Pipelines that already spread work across a job matrix or larger runners clear that bar comfortably. See [GitHub Actions pricing and how to cut your CI bill](/docs/kb/github-actions-pricing) for the rate tables and the break-even math at 50% and 70% cache hit rates.
+At a 70% cache hit rate, eight jobs on 8-core runners come in 47% cheaper with PR feedback down from 20 minutes to 9. A four-job matrix on standard runners saves 22% and cuts feedback by 60%. The savings scale with how many machine-minutes your pipeline burns today, so [GitHub Actions pricing and how to cut your CI bill](/docs/kb/github-actions-pricing) has the rate tables, the break-even math at 50% and 70% hit rates, and the small pipelines where the trade buys speed rather than savings.
 
 ### Do unused credits carry over?
 

--- a/astro-docs/src/content/docs/features/CI Features/index.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/index.mdoc
@@ -73,7 +73,7 @@ The Team plan has no such cap, and usage beyond the $29 of included credit is bi
 
 ### Is Nx Cloud cheaper than running CI on GitHub Actions alone?
 
-At a 70% cache hit rate, eight jobs on 8-core runners come in 47% cheaper with PR feedback down from 20 minutes to 9. A four-job matrix on standard runners saves 22% and cuts feedback by 60%. The savings scale with how many machine-minutes your pipeline burns today, so [GitHub Actions pricing and how to cut your CI bill](/docs/kb/github-actions-pricing) has the rate tables, the break-even math at 50% and 70% hit rates, and the small pipelines where the trade buys speed rather than savings.
+At a 70% cache hit rate, pipeline times roughly halve and GitHub spend drops 22% to 47%, depending on how many machine-minutes the pipeline burns today. See [GitHub Actions pricing and how to cut your CI bill](/docs/kb/github-actions-pricing) for the rate tables and the break-even math.
 
 ### Do unused credits carry over?
 

--- a/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
+++ b/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
@@ -106,41 +106,11 @@ other.
 The more expensive the runner, the sooner the cache pays for itself, because every minute it skips
 is worth more.
 
-### Run it on your own numbers
-
-Per run, with the jobs still on GitHub runners:
-
-```plaintext
-savings  = J * r * (w * h - c) - 0.275
-wall_clock = s + c + w * (1 - h)
-```
-
-- `J` jobs per run
-- `r` runner rate in dollars per minute, from the rate card above
-- `s` setup minutes per job, meaning checkout and install
-- `w` task minutes per job today, not counting setup
-- `h` cache hit rate, between 0 and 1
-- `c` minutes to restore the cache, about 1
-
-Nx Cloud is cheaper whenever `savings` is positive.
-The four-job example below has `J=4`, `r=0.006`, `s=3`, `w=27`, and `c=1`, so at `h=0.5` it saves
-`4 * 0.006 * (27 * 0.5 - 1) - 0.275`, or $0.025 per run and $12.50 across 500 runs.
-
-The arithmetic assumes:
-
-- Jobs stay on GitHub runners. Moving them to Nx Agents replaces `r` with the agent rate.
-- Setup is never cached, so `s` is the same with and without Nx Cloud.
-- The hit rate applies evenly across task time. A pipeline whose slowest task always misses saves
-  less than `h` suggests.
-- Jobs are balanced and run in parallel, so the wall clock is one job's time.
-- `0.275` is the Team plan price of one CI pipeline execution.
-- GitHub's round-up to the whole minute is ignored, which understates the plain GitHub Actions cost
-  a little.
-
 {% aside type="note" %}
 The examples below are illustrations, not benchmarks.
 Real costs and times depend on your task mix, how well tasks parallelize, how often inputs change,
-and your own cache hit rate, so run the numbers against your own workspace.
+and your own cache hit rate, so
+[run the numbers](#appendix-run-it-on-your-own-numbers) against your own workspace.
 {% /aside %}
 
 ## Example: four-job matrix on standard runners
@@ -224,3 +194,34 @@ runner sits partly idle.
 Nx Agents also take over the job matrix you maintain by hand.
 One `distribute-on` line in the [CI configuration file](/docs/reference/nx-cloud/ci-config) sets how
 many machines a run uses, and raising it leaves the workflow file alone.
+
+## Appendix: run it on your own numbers
+
+Per run, with the jobs still on GitHub runners:
+
+```plaintext
+savings  = J * r * (w * h - c) - 0.275
+wall_clock = s + c + w * (1 - h)
+```
+
+- `J` jobs per run
+- `r` runner rate in dollars per minute, from the rate card above
+- `s` setup minutes per job, meaning checkout and install
+- `w` task minutes per job today, not counting setup
+- `h` cache hit rate, between 0 and 1
+- `c` minutes to restore the cache, about 1
+
+Nx Cloud is cheaper whenever `savings` is positive.
+The four-job example above has `J=4`, `r=0.006`, `s=3`, `w=27`, and `c=1`, so at `h=0.5` it saves
+`4 * 0.006 * (27 * 0.5 - 1) - 0.275`, or $0.025 per run and $12.50 across 500 runs.
+
+The arithmetic assumes:
+
+- Jobs stay on GitHub runners. Moving them to Nx Agents replaces `r` with the agent rate.
+- Setup is never cached, so `s` is the same with and without Nx Cloud.
+- The hit rate applies evenly across task time. A pipeline whose slowest task always misses saves
+  less than `h` suggests.
+- Jobs are balanced and run in parallel, so the wall clock is one job's time.
+- `0.275` is the Team plan price of one CI pipeline execution.
+- GitHub's round-up to the whole minute is ignored, which understates the plain GitHub Actions cost
+  a little.

--- a/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
+++ b/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
@@ -15,6 +15,7 @@ A 25-minute pipeline split across four parallel jobs burns 100 machine-minutes a
 a 100-minute pipeline on a single runner.
 Cutting that bill means running fewer minutes, not buying cheaper ones, and a remote cache plus
 `nx affected` is how you stop paying twice for the same work.
+It also replaces the job matrix you maintain by hand with a single line of configuration.
 
 ## GitHub Actions pricing for private repositories
 
@@ -86,7 +87,7 @@ minutes you never buy:
   A hand-written matrix pays full checkout, install, and idle time on every job in the matrix,
   whether or not that job had anything to do.
 
-## Break-even: how much the cache has to save
+## Caching and cost savings
 
 Nx Cloud comes out cheaper than plain GitHub Actions when the minutes the cache avoids, minus about
 1 minute per job to restore it, are worth more than the $0.275 pipeline fee.
@@ -116,46 +117,53 @@ for each other.
 The more expensive the runner, the sooner the cache pays for itself, because every minute it skips
 is worth more.
 
+{% aside type="note" %}
+The examples below are illustrations, not benchmarks.
+Real costs and times depend on your task mix, how well tasks parallelize, project graph shape, how
+often inputs change, runner availability, and your own cache hit rate.
+Use them to see which lever moves your bill, then run the numbers against your workspace.
+{% /aside %}
+
 ## Example: four-job matrix on standard runners
 
-A workspace runs 400 CI pipelines a month.
+A workspace runs 500 CI pipelines a month.
 To keep PR feedback near 30 minutes it splits lint, test, build, and e2e across a four-job matrix on
 standard 2-core Linux runners.
 Each job takes about 30 minutes, 3 of them checkout and install, for 120 machine-minutes per run.
 
-| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 400 runs | PR feedback |
+| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 500 runs | PR feedback |
 | ------------------------ | --------------- | -------------- | ---------------- | ------------- | -------- | ----------- |
-| Plain GitHub Actions     | 120             | $0.72          | None             | $0.72         | $288     | 30 min      |
-| Nx Cloud, 50% cache hits | 70              | $0.42          | $0.275           | $0.695        | $278     | 17.5 min    |
-| Nx Cloud, 70% cache hits | 48.4            | $0.29          | $0.275           | $0.565        | $226     | 12.1 min    |
+| Plain GitHub Actions     | 120             | $0.72          | None             | $0.72         | $360     | 30 min      |
+| Nx Cloud, 50% cache hits | 70              | $0.42          | $0.275           | $0.695        | $348     | 17.5 min    |
+| Nx Cloud, 70% cache hits | 48.4            | $0.29          | $0.275           | $0.565        | $283     | 12.1 min    |
 
 At 50% the jobs stay on GitHub runners and each one pays 3 minutes of setup, 1 minute to restore the
 cache, then half of its remaining 27 minutes of work.
-The month comes in 3% cheaper and PR feedback drops by 12.5 minutes, or about 83 hours of waiting
-across 400 runs.
+The month comes in 3% cheaper and PR feedback drops by 12.5 minutes, or about 104 hours of waiting
+across 500 runs.
 At 70% the same pipeline runs in 12.1 minutes and the bill falls 22%.
 
 ## Example: eight-job matrix on 8-core runners
 
-A larger workspace runs 600 pipelines a month across eight jobs on 8-core runners, 20 minutes each,
-for 160 machine-minutes per run.
+A larger workspace runs the same 500 pipelines a month across eight jobs on 8-core runners,
+20 minutes each, for 160 machine-minutes per run.
 That baseline is well above the 65-minute break-even, so the cache is cheaper at either hit rate.
 
-| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 600 runs | PR feedback |
+| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 500 runs | PR feedback |
 | ------------------------ | --------------- | -------------- | ---------------- | ------------- | -------- | ----------- |
-| Plain GitHub Actions     | 160             | $3.52          | None             | $3.52         | $2,112   | 20 min      |
-| Nx Cloud, 50% cache hits | 100             | $2.20          | $0.275           | $2.475        | $1,485   | 12.5 min    |
-| Nx Cloud, 70% cache hits | 72.8            | $1.60          | $0.275           | $1.877        | $1,126   | 9.1 min     |
+| Plain GitHub Actions     | 160             | $3.52          | None             | $3.52         | $1,760   | 20 min      |
+| Nx Cloud, 50% cache hits | 100             | $2.20          | $0.275           | $2.475        | $1,238   | 12.5 min    |
+| Nx Cloud, 70% cache hits | 72.8            | $1.60          | $0.275           | $1.877        | $938     | 9.1 min     |
 
 That is 30% off the bill at 50% hits and 47% off at 70%, with PR feedback down to 12.5 and 9.1
 minutes.
 This is the shape the break-even table points at: a pipeline already on large runners, where each
 skipped minute is worth almost four times what it is on a standard runner.
-The Nx Cloud share is 600 pipeline executions, $165 a month, and the Team plan covers the first $29
+The Nx Cloud share is 500 pipeline executions, $138 a month, and the Team plan covers the first $29
 of it.
 
 A small single-job pipeline is the case where Nx Cloud doesn't pay for itself on compute.
-A 30-minute job on one 2-core runner costs $72 a month at 400 runs, and about $152 with Nx Cloud.
+A 30-minute job on one 2-core runner costs $90 a month at 500 runs, and about $190 with Nx Cloud.
 It finishes in 17.5 minutes instead of 30, which many teams will take, but that's speed rather than
 a lower bill.
 
@@ -167,13 +175,13 @@ GitHub prices cores close to linearly, so work that scales perfectly costs about
 Checkout and install don't scale, and those 3 fixed minutes per job are what tip it.
 Taking the four-job pipeline from the first example:
 
-| Option                            | PR feedback | Cost per run | 400 runs |
+| Option                            | PR feedback | Cost per run | 500 runs |
 | --------------------------------- | ----------- | ------------ | -------- |
-| Four 2-core jobs, as-is           | 30 min      | $0.72        | $288     |
-| Four 8-core jobs                  | 9.8 min     | $0.86        | $343     |
-| Four 2-core jobs, Nx Cloud at 50% | 17.5 min    | $0.695       | $278     |
-| Four 2-core jobs, Nx Cloud at 70% | 12.1 min    | $0.565       | $226     |
-| Four 8-core jobs, Nx Cloud at 70% | 6 min       | $0.805       | $322     |
+| Four 2-core jobs, as-is           | 30 min      | $0.72        | $360     |
+| Four 8-core jobs                  | 9.8 min     | $0.86        | $429     |
+| Four 2-core jobs, Nx Cloud at 50% | 17.5 min    | $0.695       | $348     |
+| Four 2-core jobs, Nx Cloud at 70% | 12.1 min    | $0.565       | $283     |
+| Four 8-core jobs, Nx Cloud at 70% | 6 min       | $0.805       | $403     |
 
 Both 8-core rows assume tasks scale perfectly with cores, which is the optimistic end, so the real
 premium is larger than shown.
@@ -182,63 +190,6 @@ gives the fastest pipeline for less than big runners alone.
 
 Extra cores need `--parallel` raised to match.
 Nx runs 3 tasks at a time by default, so an 8-core runner sits partly idle until you ask for more.
-
-## Simpler configuration
-
-Splitting work by hand on GitHub Actions means choosing the bins yourself and rebalancing them as
-projects are added:
-
-```yaml
-// .github/workflows/ci.yml
-jobs:
-  ci:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [lint, test, build, e2e]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'npm'
-      - run: npm ci
-      - run: npx nx run-many -t ${{ matrix.target }}
-```
-
-Every job in that matrix re-runs checkout and install, and a slow target holds up the run while the
-other three sit idle.
-With Nx Cloud the pipeline is a single job, and how many machines it uses is one line of
-configuration:
-
-```yaml
-// .nx/ci-config.yaml
-dte:
-  distribute-on: 8 linux-medium-js
-```
-
-```yaml
-// .github/workflows/ci.yml
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          filter: tree:0
-          fetch-depth: 0
-      - run: npx nx-cloud start-nx-agents
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'npm'
-      - run: npm ci
-      - uses: nrwl/nx-set-shas@v5
-      - run: npx nx affected -t lint test build e2e
-```
-
-Changing `distribute-on` from `8` to `16` doubles the machines without touching the workflow file.
-The full setup, including the other CI providers, is in [setting up CI for Nx Cloud](/docs/kb/setup-ci).
 
 ## How to cut your GitHub Actions bill
 
@@ -257,3 +208,7 @@ The full setup, including the other CI providers, is in [setting up CI for Nx Cl
   Skip the division if you run with `--parallel=1`.
 - Track total minutes, since rate shopping between GitHub runners and Nx Agents moves the bill by
   single-digit percentages while the cache hit rate moves it by tens.
+
+Beyond the time and the money, Nx Agents take over the job matrix you maintain by hand.
+One `distribute-on` line in the [CI configuration file](/docs/reference/nx-cloud/ci-config) sets how
+many machines a run uses, and raising it leaves the workflow file alone.

--- a/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
+++ b/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
@@ -1,0 +1,259 @@
+---
+title: 'GitHub Actions Pricing and How to Cut Your CI Bill'
+description: 'GitHub Actions per-minute rates for private repositories, how Nx Cloud credits convert into those minutes, and the break-even math at 50% and 70% cache hit rates.'
+sidebar:
+  label: GitHub Actions pricing
+filter: 'type:Guides'
+topics:
+  - 'Continuous integration'
+  - 'Nx Cloud'
+---
+
+GitHub Actions bills private repositories by the minute, and the bill follows total machine-minutes
+rather than how long a pipeline takes on the wall clock.
+A 25-minute pipeline split across four parallel jobs burns 100 machine-minutes and costs the same as
+a 100-minute pipeline on a single runner.
+Cutting that bill means running fewer minutes, not buying cheaper ones, and a remote cache plus
+`nx affected` is how you stop paying twice for the same work.
+
+## GitHub Actions pricing for private repositories
+
+Per-minute rates for GitHub-hosted runners:
+
+| Runner                      | USD per minute |
+| --------------------------- | -------------- |
+| Linux x64, 2 core, standard | $0.006         |
+| Linux x64, 4 core           | $0.012         |
+| Linux x64, 8 core           | $0.022         |
+| Linux x64, 16 core          | $0.042         |
+| Linux arm64, 2 core         | $0.005         |
+| Windows x64, 2 core         | $0.010         |
+| macOS, 3 to 4 core          | $0.062         |
+
+GitHub rounds each job up to the next whole minute, so a pipeline made of many short jobs costs more
+than its runtime suggests.
+[Included minutes per month](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+for private repositories are 2,000 on Free, 3,000 on Pro and Team, and 50,000 on Enterprise Cloud.
+Public repositories run on standard runners at no charge.
+See the [GitHub Actions runner pricing reference](https://docs.github.com/en/billing/reference/actions-runner-pricing)
+for the full rate card.
+
+## What Nx Cloud costs in GitHub Actions minutes
+
+Nx Cloud bills in credits.
+On the Team plan they cost $5.50 per 10,000, or $0.00055 each, so 10,000 credits buy about 917
+minutes on a standard 2-core GitHub runner.
+
+Every CI run connected to Nx Cloud is one CI pipeline execution: 500 credits, $0.275, or about 46
+standard GitHub minutes.
+That fee is the only fixed cost, and the cache has to earn it back.
+
+If you also move work onto [Nx Agents](/docs/features/ci-features/distribute-task-execution) instead
+of GitHub runners, the compute rates line up like this:
+
+| Nx Agents resource class | Credits per minute | USD per minute | Comparable GitHub runner | GitHub USD per minute |
+| ------------------------ | ------------------ | -------------- | ------------------------ | --------------------- |
+| Linux medium, 2 vCPU     | 10                 | $0.0055        | Linux x64, 2 core        | $0.006                |
+| Linux XL, 8 vCPU         | 40                 | $0.022         | Linux x64, 8 core        | $0.022                |
+
+Linux x64 agents run about 8% below the equivalent GitHub runner at 2 cores and match it at 8.
+The GitHub arm64 and Windows runners are cheaper than the matching Nx Agents classes, so price those
+workloads separately.
+Full rates are in the [Nx Cloud credit pricing reference](/docs/reference/nx-cloud/credits-pricing).
+
+### Free tiers compared
+
+| Plan           | Included per month | Value at the 2-core GitHub rate | What it covers                                                |
+| -------------- | ------------------ | ------------------------------- | ------------------------------------------------------------- |
+| Nx Cloud Hobby | 50,000 credits     | $27.50                          | 100 pipeline executions, 5,000 medium-agent minutes, or a mix |
+| GitHub Free    | 2,000 minutes      | $12.00                          | 2,000 standard 2-core minutes                                 |
+| GitHub Team    | 3,000 minutes      | $18.00                          | 3,000 standard 2-core minutes                                 |
+
+In compute-equivalent value the Hobby allowance is about 2.3 times GitHub Free and about 1.5 times
+GitHub Team, and it covers remote caching and Nx Agents rather than runner minutes alone.
+
+## Where the savings come from
+
+The per-minute rates are close enough that switching runners isn't where the money is.
+The difference between running Nx on plain GitHub Actions and running it with Nx Cloud is the
+minutes you never buy:
+
+- A task that hits the [remote cache](/docs/features/ci-features/remote-cache) costs a few seconds of
+  download instead of its full runtime, and the cache is shared across every PR and every machine.
+- `nx affected` builds and tests only the projects a change touches.
+  This works without Nx Cloud, and the shared cache is what makes the work that remains cheap.
+- Nx Agents pack tasks onto machines and shut them down when the work is done.
+  A hand-written matrix pays full checkout, install, and idle time on every job in the matrix,
+  whether or not that job had anything to do.
+
+## Break-even: how much the cache has to save
+
+Nx Cloud comes out cheaper than plain GitHub Actions when the minutes the cache avoids, minus about
+1 minute per job to restore it, are worth more than the $0.275 pipeline fee.
+On a standard 2-core runner that is roughly 46 net minutes per run, and on an 8-core runner 12.5.
+
+The table below converts that into the baseline you need today, in machine-minutes per run, before
+the cache pays for itself.
+It assumes 3 minutes of checkout and install per job and 1 minute to restore the cache.
+Each row holds the runner fixed and compares a pipeline against itself, so the rows are not one
+workload moved between runner sizes.
+Above these numbers Nx Cloud is faster and cheaper.
+Below them it is faster and costs slightly more.
+
+| Runner                | Jobs per run | Break-even at 50% hits | Break-even at 70% hits |
+| --------------------- | ------------ | ---------------------- | ---------------------- |
+| Linux 2-core ($0.006) | 1            | 97 machine-minutes     | 70 machine-minutes     |
+| Linux 2-core ($0.006) | 4            | 112 machine-minutes    | 83 machine-minutes     |
+| Linux 8-core ($0.022) | 1            | 30 machine-minutes     | 22 machine-minutes     |
+| Linux 8-core ($0.022) | 4            | 45 machine-minutes     | 36 machine-minutes     |
+| Linux 8-core ($0.022) | 8            | 65 machine-minutes     | 53 machine-minutes     |
+
+Two cache hit rates run through every example here.
+Plan on 50% for a workspace that has connected Nx Cloud and left the default inputs alone, and on
+70% once [inputs](/docs/kb/configure-inputs) are tuned and PR branches start populating the cache
+for each other.
+
+The more expensive the runner, the sooner the cache pays for itself, because every minute it skips
+is worth more.
+
+## Example: four-job matrix on standard runners
+
+A workspace runs 400 CI pipelines a month.
+To keep PR feedback near 30 minutes it splits lint, test, build, and e2e across a four-job matrix on
+standard 2-core Linux runners.
+Each job takes about 30 minutes, 3 of them checkout and install, for 120 machine-minutes per run.
+
+| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 400 runs | PR feedback |
+| ------------------------ | --------------- | -------------- | ---------------- | ------------- | -------- | ----------- |
+| Plain GitHub Actions     | 120             | $0.72          | None             | $0.72         | $288     | 30 min      |
+| Nx Cloud, 50% cache hits | 70              | $0.42          | $0.275           | $0.695        | $278     | 17.5 min    |
+| Nx Cloud, 70% cache hits | 48.4            | $0.29          | $0.275           | $0.565        | $226     | 12.1 min    |
+
+At 50% the jobs stay on GitHub runners and each one pays 3 minutes of setup, 1 minute to restore the
+cache, then half of its remaining 27 minutes of work.
+The month comes in 3% cheaper and PR feedback drops by 12.5 minutes, or about 83 hours of waiting
+across 400 runs.
+At 70% the same pipeline runs in 12.1 minutes and the bill falls 22%.
+
+## Example: eight-job matrix on 8-core runners
+
+A larger workspace runs 600 pipelines a month across eight jobs on 8-core runners, 20 minutes each,
+for 160 machine-minutes per run.
+That baseline is well above the 65-minute break-even, so the cache is cheaper at either hit rate.
+
+| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 600 runs | PR feedback |
+| ------------------------ | --------------- | -------------- | ---------------- | ------------- | -------- | ----------- |
+| Plain GitHub Actions     | 160             | $3.52          | None             | $3.52         | $2,112   | 20 min      |
+| Nx Cloud, 50% cache hits | 100             | $2.20          | $0.275           | $2.475        | $1,485   | 12.5 min    |
+| Nx Cloud, 70% cache hits | 72.8            | $1.60          | $0.275           | $1.877        | $1,126   | 9.1 min     |
+
+That is 30% off the bill at 50% hits and 47% off at 70%, with PR feedback down to 12.5 and 9.1
+minutes.
+This is the shape the break-even table points at: a pipeline already on large runners, where each
+skipped minute is worth almost four times what it is on a standard runner.
+The Nx Cloud share is 600 pipeline executions, $165 a month, and the Team plan covers the first $29
+of it.
+
+A small single-job pipeline is the case where Nx Cloud doesn't pay for itself on compute.
+A 30-minute job on one 2-core runner costs $72 a month at 400 runs, and about $152 with Nx Cloud.
+It finishes in 17.5 minutes instead of 30, which many teams will take, but that's speed rather than
+a lower bill.
+
+## Larger runners cost more for the same work
+
+Moving the same jobs onto bigger runners is the other lever, and it does buy real time.
+GitHub prices cores close to linearly, so work that scales perfectly costs about the same on an
+8-core runner as on a 2-core one and finishes in a quarter of the time.
+Checkout and install don't scale, and those 3 fixed minutes per job are what tip it.
+Taking the four-job pipeline from the first example:
+
+| Option                            | PR feedback | Cost per run | 400 runs |
+| --------------------------------- | ----------- | ------------ | -------- |
+| Four 2-core jobs, as-is           | 30 min      | $0.72        | $288     |
+| Four 8-core jobs                  | 9.8 min     | $0.86        | $343     |
+| Four 2-core jobs, Nx Cloud at 50% | 17.5 min    | $0.695       | $278     |
+| Four 2-core jobs, Nx Cloud at 70% | 12.1 min    | $0.565       | $226     |
+| Four 8-core jobs, Nx Cloud at 70% | 6 min       | $0.805       | $322     |
+
+Both 8-core rows assume tasks scale perfectly with cores, which is the optimistic end, so the real
+premium is larger than shown.
+Bigger runners cut the time and raise the bill, while the cache cuts both, and stacking the two
+gives the fastest pipeline for less than big runners alone.
+
+Extra cores need `--parallel` raised to match.
+Nx runs 3 tasks at a time by default, so an 8-core runner sits partly idle until you ask for more.
+
+## Simpler configuration
+
+Splitting work by hand on GitHub Actions means choosing the bins yourself and rebalancing them as
+projects are added:
+
+```yaml
+// .github/workflows/ci.yml
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [lint, test, build, e2e]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+      - run: npm ci
+      - run: npx nx run-many -t ${{ matrix.target }}
+```
+
+Every job in that matrix re-runs checkout and install, and a slow target holds up the run while the
+other three sit idle.
+With Nx Cloud the pipeline is a single job, and how many machines it uses is one line of
+configuration:
+
+```yaml
+// .nx/ci-config.yaml
+dte:
+  distribute-on: 8 linux-medium-js
+```
+
+```yaml
+// .github/workflows/ci.yml
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: tree:0
+          fetch-depth: 0
+      - run: npx nx-cloud start-nx-agents
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+      - run: npm ci
+      - uses: nrwl/nx-set-shas@v5
+      - run: npx nx affected -t lint test build e2e
+```
+
+Changing `distribute-on` from `8` to `16` doubles the machines without touching the workflow file.
+The full setup, including the other CI providers, is in [setting up CI for Nx Cloud](/docs/kb/setup-ci).
+
+## How to cut your GitHub Actions bill
+
+- Count machine-minutes, not wall-clock minutes.
+  Matrix jobs and larger runners multiply the baseline, and those are the pipelines where caching is
+  cheaper as well as faster.
+- Connect the pipelines already on large runners first.
+  An 8-core job breaks even after 30 machine-minutes, a 2-core job after 97.
+- Reach for a bigger runner when you want wall-clock time and are willing to pay for it.
+  It doesn't reduce the work, so the bill goes up.
+- Check the cache hit rate in the Nx Cloud workspace overview after two weeks.
+  Under 50% is usually an `inputs` and `namedInputs` problem, not a compute problem.
+- To put a dollar figure on the "computation time saved" that Nx Cloud reports, divide the saved
+  task-minutes by two for a 2-core runner running two tasks at once, then multiply by the runner
+  rate.
+  Skip the division if you run with `--parallel=1`.
+- Track total minutes, since rate shopping between GitHub runners and Nx Agents moves the bill by
+  single-digit percentages while the cache hit rate moves it by tens.

--- a/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
+++ b/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
@@ -71,8 +71,8 @@ remote caching and Nx Agents rather than runner minutes alone.
 
 ## Where the savings come from
 
-The per-minute rates are close enough that switching runners isn't where the money is.
-The difference is the minutes you never buy:
+The per-minute rates are close enough that switching runners barely changes the bill.
+The difference is in machine-minutes:
 
 - A task that hits the [remote cache](/docs/features/ci-features/remote-cache) costs a few seconds of
   download instead of its full runtime, and the cache is shared across every PR and every machine.

--- a/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
+++ b/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
@@ -87,24 +87,55 @@ Nx Cloud comes out cheaper than plain GitHub Actions when the minutes the cache 
 1 minute per job to restore it, are worth more than the $0.275 pipeline fee.
 On a standard 2-core runner that is roughly 46 net minutes per run, and on an 8-core runner 12.5.
 
-The table below is the baseline you need today, in machine-minutes per run, before the cache pays
-for itself, assuming 3 minutes of checkout and install per job and 1 minute to restore the cache.
+The table below is the baseline a single-job pipeline needs today, in machine-minutes per run,
+before the cache pays for itself.
 Each row holds the runner fixed and compares a pipeline against itself.
 Above these numbers Nx Cloud is faster and cheaper, below them it is faster and costs slightly more.
 
-| Runner                | Jobs per run | Break-even at 50% hits | Break-even at 70% hits |
-| --------------------- | ------------ | ---------------------- | ---------------------- |
-| Linux 2-core ($0.006) | 1            | 97 machine-minutes     | 70 machine-minutes     |
-| Linux 2-core ($0.006) | 4            | 112 machine-minutes    | 83 machine-minutes     |
-| Linux 8-core ($0.022) | 1            | 30 machine-minutes     | 22 machine-minutes     |
-| Linux 8-core ($0.022) | 4            | 45 machine-minutes     | 36 machine-minutes     |
-| Linux 8-core ($0.022) | 8            | 65 machine-minutes     | 53 machine-minutes     |
+| Runner                | Break-even at 50% hits | Break-even at 70% hits |
+| --------------------- | ---------------------- | ---------------------- |
+| Linux 2-core ($0.006) | 97 machine-minutes     | 70 machine-minutes     |
+| Linux 8-core ($0.022) | 30 machine-minutes     | 22 machine-minutes     |
+
+Splitting across a matrix raises the bar, because every job pays its own cache restore.
+At 50% hits, four 2-core jobs break even at 112 machine-minutes and eight 8-core jobs at 65.
 
 Plan on 50% for a workspace that has connected Nx Cloud and left the default inputs alone, and 70%
 once [inputs](/docs/kb/configure-inputs) are tuned and PR branches populate the cache for each
 other.
 The more expensive the runner, the sooner the cache pays for itself, because every minute it skips
 is worth more.
+
+### Run it on your own numbers
+
+Per run, with the jobs still on GitHub runners:
+
+```plaintext
+savings  = J * r * (w * h - c) - 0.275
+feedback = s + c + w * (1 - h)
+```
+
+- `J` jobs per run
+- `r` runner rate in dollars per minute, from the rate card above
+- `s` setup minutes per job, meaning checkout and install
+- `w` task minutes per job today, not counting setup
+- `h` cache hit rate, between 0 and 1
+- `c` minutes to restore the cache, about 1
+
+Nx Cloud is cheaper whenever `savings` is positive.
+The four-job example below has `J=4`, `r=0.006`, `s=3`, `w=27`, and `c=1`, so at `h=0.5` it saves
+`4 * 0.006 * (27 * 0.5 - 1) - 0.275`, or $0.025 per run and $12.50 across 500 runs.
+
+The arithmetic assumes:
+
+- Jobs stay on GitHub runners. Moving them to Nx Agents replaces `r` with the agent rate.
+- Setup is never cached, so `s` is the same with and without Nx Cloud.
+- The hit rate applies evenly across task time. A pipeline whose slowest task always misses saves
+  less than `h` suggests.
+- Jobs are balanced and run in parallel, so wall-clock feedback is one job's time.
+- `0.275` is the Team plan price of one CI pipeline execution.
+- GitHub's round-up to the whole minute is ignored, which understates the plain GitHub Actions cost
+  a little.
 
 {% aside type="note" %}
 The examples below are illustrations, not benchmarks.

--- a/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
+++ b/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
@@ -13,13 +13,13 @@ GitHub Actions bills private repositories by the minute, and the bill follows to
 rather than how long a pipeline takes on the wall clock.
 A 25-minute pipeline split across four parallel jobs burns 100 machine-minutes and costs the same as
 a 100-minute pipeline on a single runner.
-Cutting that bill means running fewer minutes, not buying cheaper ones, and a remote cache plus
-`nx affected` is how you stop paying twice for the same work.
-It also replaces the job matrix you maintain by hand with a single line of configuration.
+A remote cache plus `nx affected` is how you cut that bill, and it replaces the job matrix you
+maintain by hand with a single line of configuration.
 
 ## GitHub Actions pricing for private repositories
 
-Per-minute rates for GitHub-hosted runners:
+Per-minute rates for
+[GitHub-hosted runners](https://docs.github.com/en/billing/reference/actions-runner-pricing):
 
 | Runner                      | USD per minute |
 | --------------------------- | -------------- |
@@ -36,21 +36,17 @@ than its runtime suggests.
 [Included minutes per month](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
 for private repositories are 2,000 on Free, 3,000 on Pro and Team, and 50,000 on Enterprise Cloud.
 Public repositories run on standard runners at no charge.
-See the [GitHub Actions runner pricing reference](https://docs.github.com/en/billing/reference/actions-runner-pricing)
-for the full rate card.
 
 ## What Nx Cloud costs in GitHub Actions minutes
 
-Nx Cloud bills in credits.
-On the Team plan they cost $5.50 per 10,000, or $0.00055 each, so 10,000 credits buy about 917
+Nx Cloud bills in credits, $5.50 per 10,000 on the Team plan, so 10,000 credits buy about 917
 minutes on a standard 2-core GitHub runner.
 
-Every CI run connected to Nx Cloud is one CI pipeline execution: 500 credits, $0.275, or about 46
-standard GitHub minutes.
-That fee is the only fixed cost, and the cache has to earn it back.
+Every CI run connected to Nx Cloud costs one CI pipeline execution, 500 credits or $0.275.
+That is the only fixed cost, and the cache has to earn it back.
 
-If you also move work onto [Nx Agents](/docs/features/ci-features/distribute-task-execution) instead
-of GitHub runners, the compute rates line up like this:
+Moving work onto [Nx Agents](/docs/features/ci-features/distribute-task-execution) instead of GitHub
+runners prices out like this:
 
 | Nx Agents resource class | Credits per minute | USD per minute | Comparable GitHub runner | GitHub USD per minute |
 | ------------------------ | ------------------ | -------------- | ------------------------ | --------------------- |
@@ -60,7 +56,7 @@ of GitHub runners, the compute rates line up like this:
 Linux x64 agents run about 8% below the equivalent GitHub runner at 2 cores and match it at 8.
 The GitHub arm64 and Windows runners are cheaper than the matching Nx Agents classes, so price those
 workloads separately.
-Full rates are in the [Nx Cloud credit pricing reference](/docs/reference/nx-cloud/credits-pricing).
+Full rates are in the [credit pricing reference](/docs/reference/nx-cloud/credits-pricing).
 
 ### Free tiers compared
 
@@ -70,22 +66,20 @@ Full rates are in the [Nx Cloud credit pricing reference](/docs/reference/nx-clo
 | GitHub Free    | 2,000 minutes      | $12.00                          | 2,000 standard 2-core minutes                                 |
 | GitHub Team    | 3,000 minutes      | $18.00                          | 3,000 standard 2-core minutes                                 |
 
-In compute-equivalent value the Hobby allowance is about 2.3 times GitHub Free and about 1.5 times
-GitHub Team, and it covers remote caching and Nx Agents rather than runner minutes alone.
+The Hobby allowance is worth about 2.3 times GitHub Free and 1.5 times GitHub Team, and it covers
+remote caching and Nx Agents rather than runner minutes alone.
 
 ## Where the savings come from
 
 The per-minute rates are close enough that switching runners isn't where the money is.
-The difference between running Nx on plain GitHub Actions and running it with Nx Cloud is the
-minutes you never buy:
+The difference is the minutes you never buy:
 
 - A task that hits the [remote cache](/docs/features/ci-features/remote-cache) costs a few seconds of
   download instead of its full runtime, and the cache is shared across every PR and every machine.
-- `nx affected` builds and tests only the projects a change touches.
-  This works without Nx Cloud, and the shared cache is what makes the work that remains cheap.
-- Nx Agents pack tasks onto machines and shut them down when the work is done.
-  A hand-written matrix pays full checkout, install, and idle time on every job in the matrix,
-  whether or not that job had anything to do.
+- `nx affected` builds and tests only the projects a change touches, with or without Nx Cloud.
+- Nx Agents pack tasks onto machines and shut them down when the work is done, where a hand-written
+  matrix pays full checkout, install, and idle time on every job whether or not it had anything
+  to do.
 
 ## Caching and cost savings
 
@@ -93,13 +87,10 @@ Nx Cloud comes out cheaper than plain GitHub Actions when the minutes the cache 
 1 minute per job to restore it, are worth more than the $0.275 pipeline fee.
 On a standard 2-core runner that is roughly 46 net minutes per run, and on an 8-core runner 12.5.
 
-The table below converts that into the baseline you need today, in machine-minutes per run, before
-the cache pays for itself.
-It assumes 3 minutes of checkout and install per job and 1 minute to restore the cache.
-Each row holds the runner fixed and compares a pipeline against itself, so the rows are not one
-workload moved between runner sizes.
-Above these numbers Nx Cloud is faster and cheaper.
-Below them it is faster and costs slightly more.
+The table below is the baseline you need today, in machine-minutes per run, before the cache pays
+for itself, assuming 3 minutes of checkout and install per job and 1 minute to restore the cache.
+Each row holds the runner fixed and compares a pipeline against itself.
+Above these numbers Nx Cloud is faster and cheaper, below them it is faster and costs slightly more.
 
 | Runner                | Jobs per run | Break-even at 50% hits | Break-even at 70% hits |
 | --------------------- | ------------ | ---------------------- | ---------------------- |
@@ -109,19 +100,16 @@ Below them it is faster and costs slightly more.
 | Linux 8-core ($0.022) | 4            | 45 machine-minutes     | 36 machine-minutes     |
 | Linux 8-core ($0.022) | 8            | 65 machine-minutes     | 53 machine-minutes     |
 
-Two cache hit rates run through every example here.
-Plan on 50% for a workspace that has connected Nx Cloud and left the default inputs alone, and on
-70% once [inputs](/docs/kb/configure-inputs) are tuned and PR branches start populating the cache
-for each other.
-
+Plan on 50% for a workspace that has connected Nx Cloud and left the default inputs alone, and 70%
+once [inputs](/docs/kb/configure-inputs) are tuned and PR branches populate the cache for each
+other.
 The more expensive the runner, the sooner the cache pays for itself, because every minute it skips
 is worth more.
 
 {% aside type="note" %}
 The examples below are illustrations, not benchmarks.
-Real costs and times depend on your task mix, how well tasks parallelize, project graph shape, how
-often inputs change, runner availability, and your own cache hit rate.
-Use them to see which lever moves your bill, then run the numbers against your workspace.
+Real costs and times depend on your task mix, how well tasks parallelize, how often inputs change,
+and your own cache hit rate, so run the numbers against your own workspace.
 {% /aside %}
 
 ## Example: four-job matrix on standard runners
@@ -137,11 +125,11 @@ Each job takes about 30 minutes, 3 of them checkout and install, for 120 machine
 | Nx Cloud, 50% cache hits | 70              | $0.42          | $0.275           | $0.695        | $348     | 17.5 min    |
 | Nx Cloud, 70% cache hits | 48.4            | $0.29          | $0.275           | $0.565        | $283     | 12.1 min    |
 
-At 50% the jobs stay on GitHub runners and each one pays 3 minutes of setup, 1 minute to restore the
-cache, then half of its remaining 27 minutes of work.
-The month comes in 3% cheaper and PR feedback drops by 12.5 minutes, or about 104 hours of waiting
-across 500 runs.
-At 70% the same pipeline runs in 12.1 minutes and the bill falls 22%.
+At 50% each job pays 3 minutes of setup, 1 minute to restore the cache, then half of its remaining
+27 minutes of work.
+The month comes in 3% cheaper with 12.5 minutes off every PR, about 104 hours of waiting across 500
+runs.
+At 70% the pipeline runs in 12.1 minutes and the bill falls 22%.
 
 ## Example: eight-job matrix on 8-core runners
 
@@ -157,22 +145,20 @@ That baseline is well above the 65-minute break-even, so the cache is cheaper at
 
 That is 30% off the bill at 50% hits and 47% off at 70%, with PR feedback down to 12.5 and 9.1
 minutes.
-This is the shape the break-even table points at: a pipeline already on large runners, where each
-skipped minute is worth almost four times what it is on a standard runner.
+On large runners each skipped minute is worth almost four times what it is on a standard one.
 The Nx Cloud share is 500 pipeline executions, $138 a month, and the Team plan covers the first $29
 of it.
 
-A small single-job pipeline is the case where Nx Cloud doesn't pay for itself on compute.
-A 30-minute job on one 2-core runner costs $90 a month at 500 runs, and about $190 with Nx Cloud.
-It finishes in 17.5 minutes instead of 30, which many teams will take, but that's speed rather than
-a lower bill.
+A small single-job pipeline is where Nx Cloud doesn't pay for itself on compute.
+A 30-minute job on one 2-core runner costs $90 a month at 500 runs and about $190 with Nx Cloud.
+It finishes in 17.5 minutes instead of 30, so that is speed rather than a lower bill.
 
 ## Larger runners cost more for the same work
 
 Moving the same jobs onto bigger runners is the other lever, and it does buy real time.
 GitHub prices cores close to linearly, so work that scales perfectly costs about the same on an
 8-core runner as on a 2-core one and finishes in a quarter of the time.
-Checkout and install don't scale, and those 3 fixed minutes per job are what tip it.
+Checkout and install don't scale, and those 3 fixed minutes per job tip the balance.
 Taking the four-job pipeline from the first example:
 
 | Option                            | PR feedback | Cost per run | 500 runs |
@@ -183,13 +169,12 @@ Taking the four-job pipeline from the first example:
 | Four 2-core jobs, Nx Cloud at 70% | 12.1 min    | $0.565       | $283     |
 | Four 8-core jobs, Nx Cloud at 70% | 6 min       | $0.805       | $403     |
 
-Both 8-core rows assume tasks scale perfectly with cores, which is the optimistic end, so the real
-premium is larger than shown.
+Both 8-core rows assume perfect scaling with cores, so the real premium is larger than shown.
 Bigger runners cut the time and raise the bill, while the cache cuts both, and stacking the two
 gives the fastest pipeline for less than big runners alone.
 
-Extra cores need `--parallel` raised to match.
-Nx runs 3 tasks at a time by default, so an 8-core runner sits partly idle until you ask for more.
+Nx runs 3 tasks at a time by default, so raise `--parallel` to match the extra cores or an 8-core
+runner sits partly idle.
 
 ## How to cut your GitHub Actions bill
 
@@ -198,17 +183,13 @@ Nx runs 3 tasks at a time by default, so an 8-core runner sits partly idle until
   cheaper as well as faster.
 - Connect the pipelines already on large runners first.
   An 8-core job breaks even after 30 machine-minutes, a 2-core job after 97.
-- Reach for a bigger runner when you want wall-clock time and are willing to pay for it.
-  It doesn't reduce the work, so the bill goes up.
 - Check the cache hit rate in the Nx Cloud workspace overview after two weeks.
-  Under 50% is usually an `inputs` and `namedInputs` problem, not a compute problem.
+  Under 50% usually means `inputs` and `namedInputs` need tuning.
 - To put a dollar figure on the "computation time saved" that Nx Cloud reports, divide the saved
   task-minutes by two for a 2-core runner running two tasks at once, then multiply by the runner
   rate.
   Skip the division if you run with `--parallel=1`.
-- Track total minutes, since rate shopping between GitHub runners and Nx Agents moves the bill by
-  single-digit percentages while the cache hit rate moves it by tens.
 
-Beyond the time and the money, Nx Agents take over the job matrix you maintain by hand.
+Nx Agents also take over the job matrix you maintain by hand.
 One `distribute-on` line in the [CI configuration file](/docs/reference/nx-cloud/ci-config) sets how
 many machines a run uses, and raising it leaves the workflow file alone.

--- a/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
+++ b/astro-docs/src/content/docs/kb/github-actions-pricing.mdoc
@@ -112,7 +112,7 @@ Per run, with the jobs still on GitHub runners:
 
 ```plaintext
 savings  = J * r * (w * h - c) - 0.275
-feedback = s + c + w * (1 - h)
+wall_clock = s + c + w * (1 - h)
 ```
 
 - `J` jobs per run
@@ -132,7 +132,7 @@ The arithmetic assumes:
 - Setup is never cached, so `s` is the same with and without Nx Cloud.
 - The hit rate applies evenly across task time. A pipeline whose slowest task always misses saves
   less than `h` suggests.
-- Jobs are balanced and run in parallel, so wall-clock feedback is one job's time.
+- Jobs are balanced and run in parallel, so the wall clock is one job's time.
 - `0.275` is the Team plan price of one CI pipeline execution.
 - GitHub's round-up to the whole minute is ignored, which understates the plain GitHub Actions cost
   a little.
@@ -146,15 +146,15 @@ and your own cache hit rate, so run the numbers against your own workspace.
 ## Example: four-job matrix on standard runners
 
 A workspace runs 500 CI pipelines a month.
-To keep PR feedback near 30 minutes it splits lint, test, build, and e2e across a four-job matrix on
+To keep the wall clock near 30 minutes it splits lint, test, build, and e2e across a four-job matrix on
 standard 2-core Linux runners.
 Each job takes about 30 minutes, 3 of them checkout and install, for 120 machine-minutes per run.
 
-| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 500 runs | PR feedback |
-| ------------------------ | --------------- | -------------- | ---------------- | ------------- | -------- | ----------- |
-| Plain GitHub Actions     | 120             | $0.72          | None             | $0.72         | $360     | 30 min      |
-| Nx Cloud, 50% cache hits | 70              | $0.42          | $0.275           | $0.695        | $348     | 17.5 min    |
-| Nx Cloud, 70% cache hits | 48.4            | $0.29          | $0.275           | $0.565        | $283     | 12.1 min    |
+| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 500 runs | Wall clock |
+| ------------------------ | --------------- | -------------- | ---------------- | ------------- | -------- | ---------- |
+| Plain GitHub Actions     | 120             | $0.72          | None             | $0.72         | $360     | 30 min     |
+| Nx Cloud, 50% cache hits | 70              | $0.42          | $0.275           | $0.695        | $348     | 17.5 min   |
+| Nx Cloud, 70% cache hits | 48.4            | $0.29          | $0.275           | $0.565        | $283     | 12.1 min   |
 
 At 50% each job pays 3 minutes of setup, 1 minute to restore the cache, then half of its remaining
 27 minutes of work.
@@ -168,13 +168,13 @@ A larger workspace runs the same 500 pipelines a month across eight jobs on 8-co
 20 minutes each, for 160 machine-minutes per run.
 That baseline is well above the 65-minute break-even, so the cache is cheaper at either hit rate.
 
-| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 500 runs | PR feedback |
-| ------------------------ | --------------- | -------------- | ---------------- | ------------- | -------- | ----------- |
-| Plain GitHub Actions     | 160             | $3.52          | None             | $3.52         | $1,760   | 20 min      |
-| Nx Cloud, 50% cache hits | 100             | $2.20          | $0.275           | $2.475        | $1,238   | 12.5 min    |
-| Nx Cloud, 70% cache hits | 72.8            | $1.60          | $0.275           | $1.877        | $938     | 9.1 min     |
+| Setup                    | Machine-minutes | GitHub per run | Nx Cloud per run | Total per run | 500 runs | Wall clock |
+| ------------------------ | --------------- | -------------- | ---------------- | ------------- | -------- | ---------- |
+| Plain GitHub Actions     | 160             | $3.52          | None             | $3.52         | $1,760   | 20 min     |
+| Nx Cloud, 50% cache hits | 100             | $2.20          | $0.275           | $2.475        | $1,238   | 12.5 min   |
+| Nx Cloud, 70% cache hits | 72.8            | $1.60          | $0.275           | $1.877        | $938     | 9.1 min    |
 
-That is 30% off the bill at 50% hits and 47% off at 70%, with PR feedback down to 12.5 and 9.1
+That is 30% off the bill at 50% hits and 47% off at 70%, with the wall clock down to 12.5 and 9.1
 minutes.
 On large runners each skipped minute is worth almost four times what it is on a standard one.
 The Nx Cloud share is 500 pipeline executions, $138 a month, and the Team plan covers the first $29
@@ -192,13 +192,13 @@ GitHub prices cores close to linearly, so work that scales perfectly costs about
 Checkout and install don't scale, and those 3 fixed minutes per job tip the balance.
 Taking the four-job pipeline from the first example:
 
-| Option                            | PR feedback | Cost per run | 500 runs |
-| --------------------------------- | ----------- | ------------ | -------- |
-| Four 2-core jobs, as-is           | 30 min      | $0.72        | $360     |
-| Four 8-core jobs                  | 9.8 min     | $0.86        | $429     |
-| Four 2-core jobs, Nx Cloud at 50% | 17.5 min    | $0.695       | $348     |
-| Four 2-core jobs, Nx Cloud at 70% | 12.1 min    | $0.565       | $283     |
-| Four 8-core jobs, Nx Cloud at 70% | 6 min       | $0.805       | $403     |
+| Option                            | Wall clock | Cost per run | 500 runs |
+| --------------------------------- | ---------- | ------------ | -------- |
+| Four 2-core jobs, as-is           | 30 min     | $0.72        | $360     |
+| Four 8-core jobs                  | 9.8 min    | $0.86        | $429     |
+| Four 2-core jobs, Nx Cloud at 50% | 17.5 min   | $0.695       | $348     |
+| Four 2-core jobs, Nx Cloud at 70% | 12.1 min   | $0.565       | $283     |
+| Four 8-core jobs, Nx Cloud at 70% | 6 min      | $0.805       | $403     |
 
 Both 8-core rows assume perfect scaling with cores, so the real premium is larger than shown.
 Bigger runners cut the time and raise the bill, while the cache cuts both, and stacking the two


### PR DESCRIPTION
## Current Behavior

No docs page covers GitHub Actions pricing or what CI costs, so there is nothing to rank for "github actions pricing" or "cut my CI bill" searches.

## Expected Behavior

New KB guide at `/docs/kb/github-actions-pricing` with the GitHub runner rate card, credit-to-minute conversion, break-even math at 50% and 70% cache hit rates, and two worked examples at 500 runs a month. Analysis uses Linux 2-core and 8-core runners. An FAQ entry on the CI features page links to it.

## Preview

- https://deploy-preview-37014--nx-docs.netlify.app/docs/kb/github-actions-pricing
- https://deploy-preview-37014--nx-docs.netlify.app/docs/features/ci-features (new FAQ entry only)

## Related Issue(s)

DOC-665

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUoTwxvt86w81J9AxqezzC
