### PR TITLE
fix(vitest): memoize ancestor tsconfig walks in createNodes

### DIFF
--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -686,6 +686,47 @@ function collectTsconfigInputsByProjectRoot(
 
   const rootTsConfigName = getRootTsConfigFileName();
 
+  // Memoize the ws-relative tsconfig paths discovered by walking a single
+  // directory's own tsconfig extends-chain. The set of files reached from a
+  // given directory depends only on that directory (and the on-disk tsconfig
+  // contents, stable within one graph build via `jsonCache`), never on which
+  // project triggered the walk. In a large monorepo the ancestor directories
+  // (e.g. `packages`, `packages/<product>`, `packages/<product>/libs`) are
+  // shared by hundreds of projects, so without memoization the same
+  // existsSync + walkTsconfigExtendsChain + JSON parse work is repeated once
+  // per project.
+  const dirChainCache = new Map<string, string[]>();
+  // Raw ws-relative tsconfig paths reachable from `dir`'s own tsconfig.json
+  // (its extends chain), unfiltered. `dir` is a ws-relative directory (POSIX
+  // separators), or '' for the workspace root.
+  const collectDirChain = (dir: string): string[] => {
+    const cached = dirChainCache.get(dir);
+    if (cached !== undefined) return cached;
+    const paths: string[] = [];
+    const localSeen = new Set<string>();
+    const tsconfigPath = dir
+      ? join(workspaceRoot, dir, 'tsconfig.json')
+      : join(workspaceRoot, 'tsconfig.json');
+    if (existsSync(tsconfigPath)) {
+      walkTsconfigExtendsChain(
+        tsconfigPath,
+        (absPath) => {
+          const wsRelative = relative(workspaceRoot, absPath)
+            .split(sep)
+            .join('/');
+          if (!localSeen.has(wsRelative)) {
+            localSeen.add(wsRelative);
+            paths.push(wsRelative);
+          }
+          return 'continue';
+        },
+        { jsonCache }
+      );
+    }
+    dirChainCache.set(dir, paths);
+    return paths;
+  };
+
   for (const projectRoot of projectRoots) {
     if (projectRoot === '.') continue;
 
@@ -693,10 +734,9 @@ function collectTsconfigInputsByProjectRoot(
     const seen = new Set<string>();
     const projectPrefix = `${projectRoot}/`;
 
-    const collect = (absolutePath: string) => {
-      const wsRelative = relative(workspaceRoot, absolutePath)
-        .split(sep)
-        .join('/');
+    // Applies the project-specific exclusions to an already-resolved
+    // ws-relative path. Cheap string work; safe to repeat per project.
+    const collectWsRelative = (wsRelative: string) => {
       if (seen.has(wsRelative)) return;
       seen.add(wsRelative);
       if (wsRelative.startsWith('../') || wsRelative === '..') return;
@@ -711,13 +751,17 @@ function collectTsconfigInputsByProjectRoot(
       outside.push(wsRelative);
     };
 
-    // 1. Walk the project tsconfig's extends chain
+    // 1. Walk the project tsconfig's extends chain. Project-specific (entry
+    //    directory is the project root), so not memoized.
     const projectTsconfig = join(workspaceRoot, projectRoot, 'tsconfig.json');
     if (existsSync(projectTsconfig)) {
       walkTsconfigExtendsChain(
         projectTsconfig,
         (absPath) => {
-          collect(absPath);
+          const wsRelative = relative(workspaceRoot, absPath)
+            .split(sep)
+            .join('/');
+          collectWsRelative(wsRelative);
           return 'continue';
         },
         { jsonCache }
@@ -725,19 +769,12 @@ function collectTsconfigInputsByProjectRoot(
     }
 
     // 2. Walk UP ancestor directories (esbuild reads every tsconfig.json
-    //    between the entry point and the filesystem root)
+    //    between the entry point and the filesystem root). Each ancestor
+    //    directory's own chain is memoized across projects.
     let dir = dirname(projectRoot);
     while (dir && dir !== '.') {
-      const ancestorTsconfig = join(workspaceRoot, dir, 'tsconfig.json');
-      if (existsSync(ancestorTsconfig)) {
-        walkTsconfigExtendsChain(
-          ancestorTsconfig,
-          (absPath) => {
-            collect(absPath);
-            return 'continue';
-          },
-          { jsonCache }
-        );
+      for (const wsRelative of collectDirChain(dir)) {
+        collectWsRelative(wsRelative);
       }
       const parent = dirname(dir);
       if (parent === dir) break;
@@ -745,16 +782,8 @@ function collectTsconfigInputsByProjectRoot(
     }
 
     // 3. Check the workspace root itself (dirname loop above stops at '.')
-    const rootTsconfig = join(workspaceRoot, 'tsconfig.json');
-    if (existsSync(rootTsconfig)) {
-      walkTsconfigExtendsChain(
-        rootTsconfig,
-        (absPath) => {
-          collect(absPath);
-          return 'continue';
-        },
-        { jsonCache }
-      );
+    for (const wsRelative of collectDirChain('')) {
+      collectWsRelative(wsRelative);
     }
 
     if (outside.length > 0) {


### PR DESCRIPTION
## Current Behavior

The `@nx/vitest` inference plugin collects the "outside" tsconfig files that Vite's esbuild config bundler reads (so they can be declared as task inputs). For each project, `collectTsconfigInputsByProjectRoot` walks the project's own `tsconfig.json` extends chain and every ancestor directory up to the workspace root, running `existsSync` + `walkTsconfigExtendsChain` + JSON parse for each directory.

Ancestor directories (e.g. `packages`, `packages/<area>`, `packages/<area>/libs`) are shared by many projects, so during cold project-graph construction the identical ancestor-directory walk is repeated once per project. In a large monorepo (hundreds of vitest/vite configs) this redundant work is a measurable share of `createNodes` time on a cold filesystem cache.

## Expected Behavior

Each ancestor directory's own extends-chain walk is memoized (keyed by directory) via a new `collectDirChain(dir)` helper, so a shared ancestor is walked once regardless of how many projects reach it. The project-specific exclusion filtering is factored into `collectWsRelative` and still runs per project.

The collected result is unchanged — this is a behavior-preserving optimization. Verified over 908 real project roots with 0 mismatches, order-preserving.

### Measured impact

Isolated `collectTsconfigInputsByProjectRoot` timing in a large monorepo (Nx 23.3.0-beta.0, 908 vite/vitest configs, 1027 projects, Windows, 16 cores):

| Filesystem cache | Before | After |
| --- | --- | --- |
| Cold | ~5.9s | ~4.0s |
| Warm | ~0.97s | ~0.80s |

This is a minor contributor to overall cold project-graph time (dominated by `calculateHashesForCreateNodes`, which is intentionally untouched), but it's a free, correctness-preserving win that scales with project count.

## Related Issue(s)

Fixes #
