### PR TITLE
fix(release): honor conventional-commits severity on prerelease versions

### DIFF
--- a/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.spec.ts
+++ b/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.spec.ts
@@ -1,0 +1,194 @@
+const mocks = {
+  resolveSemverSpecifierFromConventionalCommits: vi.fn(),
+  getLatestGitTagForPattern: vi.fn(),
+  getFirstGitCommit: vi.fn(),
+  getFirstProjectCommit: vi.fn(),
+};
+
+vi.mock('../utils/resolve-semver-specifier', () => ({
+  resolveSemverSpecifierFromConventionalCommits: (...args: any[]) =>
+    mocks.resolveSemverSpecifierFromConventionalCommits(...args),
+}));
+
+vi.mock('../utils/git', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    getLatestGitTagForPattern: (...args: any[]) =>
+      mocks.getLatestGitTagForPattern(...args),
+    getFirstGitCommit: (...args: any[]) => mocks.getFirstGitCommit(...args),
+    getFirstProjectCommit: (...args: any[]) =>
+      mocks.getFirstProjectCommit(...args),
+  };
+});
+
+import type {
+  ProjectGraph,
+  ProjectGraphProjectNode,
+} from '../../../config/project-graph';
+import type { NxReleaseConfig } from '../config/config';
+import type { ReleaseGroupWithName } from '../config/filter-release-groups';
+import type { ReleaseGraph } from '../utils/release-graph';
+import { SemverSpecifier } from '../utils/semver';
+import { deriveSpecifierFromConventionalCommits } from './derive-specifier-from-conventional-commits';
+import { ProjectLogger } from './project-logger';
+
+describe('deriveSpecifierFromConventionalCommits', () => {
+  const projectName = 'my-lib';
+  const projectGraphNode = {
+    name: projectName,
+    data: { root: 'libs/my-lib' },
+  } as ProjectGraphProjectNode;
+  const releaseGroup = {
+    name: '__default__',
+    projects: [projectName],
+    projectsRelationship: 'fixed',
+    releaseTag: {
+      pattern: 'v{version}',
+      checkAllBranchesWhen: undefined,
+      requireSemver: true,
+      strictPreid: true,
+    },
+  } as ReleaseGroupWithName;
+  const projectLogger = new ProjectLogger(projectName);
+  const releaseGraph = {
+    resolveRepositoryTags: vi.fn(),
+  } as unknown as ReleaseGraph;
+
+  const derive = ({
+    currentVersion,
+    derivedSpecifier,
+    latestMatchingGitTag = {
+      tag: `v${currentVersion}`,
+      extractedVersion: currentVersion,
+    },
+    latestStableGitTag = null,
+    preid,
+  }: {
+    currentVersion: string;
+    derivedSpecifier: SemverSpecifier | null;
+    latestMatchingGitTag?: { tag: string; extractedVersion: string } | null;
+    latestStableGitTag?: { tag: string; extractedVersion: string } | null;
+    preid?: string;
+  }) => {
+    mocks.resolveSemverSpecifierFromConventionalCommits.mockResolvedValue(
+      new Map([[projectName, derivedSpecifier]])
+    );
+    mocks.getLatestGitTagForPattern.mockResolvedValue(latestStableGitTag);
+    return deriveSpecifierFromConventionalCommits(
+      {} as NxReleaseConfig,
+      {} as ProjectGraph,
+      projectLogger,
+      releaseGroup,
+      projectGraphNode,
+      currentVersion,
+      latestMatchingGitTag,
+      releaseGraph,
+      undefined,
+      preid
+    );
+  };
+
+  it('should resolve the derived specifier for a stable current version', async () => {
+    await expect(
+      derive({
+        currentVersion: '2.1.9',
+        derivedSpecifier: SemverSpecifier.MAJOR,
+      })
+    ).resolves.toBe('major');
+    await expect(
+      derive({
+        currentVersion: '2.1.9',
+        derivedSpecifier: SemverSpecifier.MINOR,
+      })
+    ).resolves.toBe('minor');
+    await expect(
+      derive({
+        currentVersion: '2.1.9',
+        derivedSpecifier: SemverSpecifier.PATCH,
+      })
+    ).resolves.toBe('patch');
+  });
+
+  it('should combine the derived specifier with a preid for a stable current version', async () => {
+    await expect(
+      derive({
+        currentVersion: '2.1.9',
+        derivedSpecifier: SemverSpecifier.MAJOR,
+        preid: 'rc',
+      })
+    ).resolves.toBe('premajor');
+  });
+
+  it('should return "none" when no changes are detected', async () => {
+    await expect(
+      derive({ currentVersion: '2.2.0-rc.0', derivedSpecifier: null })
+    ).resolves.toBe('none');
+  });
+
+  it('should resolve "prerelease" when the derived severity does not exceed the bump the current prerelease encodes', async () => {
+    const latestStableGitTag = { tag: 'v2.1.9', extractedVersion: '2.1.9' };
+    // 2.2.0-rc.0 already encodes a minor bump over 2.1.9
+    await expect(
+      derive({
+        currentVersion: '2.2.0-rc.0',
+        derivedSpecifier: SemverSpecifier.PATCH,
+        latestStableGitTag,
+        preid: 'rc',
+      })
+    ).resolves.toBe('prerelease');
+    await expect(
+      derive({
+        currentVersion: '2.2.0-rc.0',
+        derivedSpecifier: SemverSpecifier.MINOR,
+        latestStableGitTag,
+        preid: 'rc',
+      })
+    ).resolves.toBe('prerelease');
+  });
+
+  it('should escalate to a higher prerelease base when the derived severity exceeds the encoded bump', async () => {
+    const latestStableGitTag = { tag: 'v2.1.9', extractedVersion: '2.1.9' };
+    // 2.2.0-rc.0 encodes minor; a breaking change must produce 3.0.0-rc.0
+    await expect(
+      derive({
+        currentVersion: '2.2.0-rc.0',
+        derivedSpecifier: SemverSpecifier.MAJOR,
+        latestStableGitTag,
+        preid: 'rc',
+      })
+    ).resolves.toBe('premajor');
+    // 2.1.10-rc.0 encodes patch; a feature must produce 2.2.0-rc.0
+    await expect(
+      derive({
+        currentVersion: '2.1.10-rc.0',
+        derivedSpecifier: SemverSpecifier.MINOR,
+        latestStableGitTag,
+        preid: 'rc',
+      })
+    ).resolves.toBe('preminor');
+  });
+
+  it('should stay on "prerelease" when the derived severity matches the encoded bump', async () => {
+    // 3.0.0-rc.0 already encodes a major bump over 2.1.9
+    await expect(
+      derive({
+        currentVersion: '3.0.0-rc.0',
+        derivedSpecifier: SemverSpecifier.MAJOR,
+        latestStableGitTag: { tag: 'v2.1.9', extractedVersion: '2.1.9' },
+        preid: 'rc',
+      })
+    ).resolves.toBe('prerelease');
+  });
+
+  it('should stay on "prerelease" when no stable tag can be resolved', async () => {
+    await expect(
+      derive({
+        currentVersion: '1.0.0-beta.0',
+        derivedSpecifier: SemverSpecifier.MAJOR,
+        latestStableGitTag: null,
+        preid: 'beta',
+      })
+    ).resolves.toBe('prerelease');
+  });
+});

--- a/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.ts
+++ b/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.ts
@@ -1,3 +1,10 @@
+import {
+  coerce as semverCoerce,
+  gt as semverGt,
+  inc as semverInc,
+  prerelease,
+  type ReleaseType,
+} from 'semver';
 import type {
   ProjectGraph,
   ProjectGraphProjectNode,
@@ -8,6 +15,7 @@ import {
   getFirstGitCommit,
   getFirstProjectCommit,
   getLatestGitTagForPattern,
+  sanitizeProjectNameForGitTag,
 } from '../utils/git';
 import { ReleaseGraph } from '../utils/release-graph';
 import { resolveSemverSpecifierFromConventionalCommits } from '../utils/resolve-semver-specifier';
@@ -21,12 +29,7 @@ export async function deriveSpecifierFromConventionalCommits(
   projectLogger: ProjectLogger,
   releaseGroup: ReleaseGroupWithName,
   projectGraphNode: ProjectGraphProjectNode,
-  // NOTE: This TODO was carried over from the original version generator.
-  //
-  // TODO: reevaluate this prerelease logic/workflow for independent projects
-  // Always assume that if the current version is a prerelease, then the next version should be a prerelease.
-  // Users must manually graduate from a prerelease to a release by providing an explicit specifier.
-  isPrerelease: boolean,
+  currentVersion: string,
   latestMatchingGitTag:
     | Awaited<ReturnType<typeof getLatestGitTagForPattern>>
     | undefined,
@@ -94,11 +97,44 @@ export async function deriveSpecifierFromConventionalCommits(
 
   // NOTE: This TODO was carried over from the original version generator.
   // TODO: reevaluate this prerelease logic/workflow for independent projects
-  if (isPrerelease) {
-    specifier = 'prerelease';
-    projectLogger.buffer(
-      `📄 Resolved the specifier as "${specifier}" since the current version is a prerelease`
-    );
+  if (prerelease(currentVersion)) {
+    // A prerelease version's base already encodes a severity relative to the
+    // latest stable release (e.g. 2.2.0-rc.0 encodes a minor bump over 2.1.x).
+    // Escalate to a higher base only when the derived severity exceeds it.
+    const currentBaseVersion = semverCoerce(currentVersion)?.version;
+    const latestStableVersion = currentBaseVersion
+      ? (
+          await getLatestGitTagForPattern(
+            releaseGroup.releaseTag.pattern,
+            {
+              projectName: sanitizeProjectNameForGitTag(projectGraphNode.name),
+              releaseGroupName: releaseGroup.name,
+            },
+            releaseGraph.resolveRepositoryTags.bind(releaseGraph),
+            {
+              checkAllBranchesWhen:
+                releaseGroup.releaseTag.checkAllBranchesWhen,
+              requireSemver: releaseGroup.releaseTag.requireSemver,
+              strictPreid: true,
+            }
+          )
+        )?.extractedVersion
+      : undefined;
+    const nextBaseVersion =
+      latestStableVersion && currentBaseVersion
+        ? semverInc(latestStableVersion, specifier as ReleaseType)
+        : null;
+    if (nextBaseVersion && semverGt(nextBaseVersion, currentBaseVersion)) {
+      specifier = `pre${specifier}`;
+      projectLogger.buffer(
+        `📄 Resolved the specifier as "${specifier}" since the derived change severity exceeds the bump encoded by the current prerelease version`
+      );
+    } else {
+      specifier = 'prerelease';
+      projectLogger.buffer(
+        `📄 Resolved the specifier as "${specifier}" since the current version is a prerelease`
+      );
+    }
   } else {
     let extraText = '';
     if (preid && !specifier.startsWith('pre')) {

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -628,7 +628,7 @@ export class ReleaseGroupProcessor {
         projectLogger,
         releaseGroup,
         projectGraphNode,
-        !!semver.prerelease(currentVersion ?? ''),
+        currentVersion ?? '',
         this.releaseGraph.cachedLatestMatchingGitTag.get(projectName),
         this.releaseGraph,
         cachedFinalConfigForProject.fallbackCurrentVersionResolver,


### PR DESCRIPTION
## Current Behavior

<!-- This is the behavior we have today -->

When `release.version.conventionalCommits` is enabled and `--preid` is supplied, the specifier derived from git history is discarded whenever the current version is already a prerelease — it is unconditionally replaced with `prerelease`. This means a `BREAKING CHANGE` committed on top of `2.2.0-rc.0` produces `2.2.0-rc.1` instead of `3.0.0-rc.0`:

```text
2.2.0-rc.0 + BREAKING CHANGE + --preid=rc → 2.2.0-rc.1   (current)
2.2.0-rc.0 + BREAKING CHANGE + --preid=rc → 3.0.0-rc.0   (expected)
```

The breaking change ships under an RC counter bump with nothing in the version to signal it.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

A prerelease version's base already encodes a severity relative to the latest stable release (e.g. `2.2.0-rc.0` encodes a `minor` bump over `2.1.9`). When the severity derived from conventional commits exceeds that encoded bump, the prerelease should be cut from the higher base — `pre<severity>` — instead of bumping the counter:

- `2.2.0-rc.0` + breaking → `premajor` → `3.0.0-rc.0`
- `2.2.0-rc.0` + feature/fix → `prerelease` → `2.2.0-rc.1` (unchanged)
- `3.0.0-rc.0` + breaking → `prerelease` → `3.0.0-rc.1` (base already encodes `major`)

### Implementation

`deriveSpecifierFromConventionalCommits` now receives `currentVersion` instead of an `isPrerelease` flag. When the current version is a prerelease, it resolves the latest **stable** tag (via `getLatestGitTagForPattern` with `strictPreid: true` and no `preid`, using the already-cached repository tag list), computes the base that applying the derived specifier to that stable version would produce, and escalates to `pre<severity>` only when it is ahead of the current prerelease's base version. Otherwise it keeps the existing `prerelease` behavior. Stable starting versions are unaffected, and the `'none'` no-change detection still scans commits from the latest matching tag.

Verified end-to-end with the reproduction from the issue on a patched install of `nx@23.1.2`:

```text
2.1.9 → feat → 2.2.0-rc.0 → feat! → 3.0.0-rc.0 → fix → 3.0.0-rc.1
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #37004

---

<sub>This fix was implemented with AI assistance (Devin) and verified with unit tests plus an end-to-end reproduction.</sub>
