### PR TITLE
feat(core): add support for --exclude-files and --include-files to `nx watch`

### DIFF
--- a/astro-docs/src/content/docs/kb/workspace-watching.mdoc
+++ b/astro-docs/src/content/docs/kb/workspace-watching.mdoc
@@ -176,3 +176,31 @@ nx watch --projects=my-app --includeDependencies -- nx run-many -t build -p \$NX
 ```
 
 `--includeDependencies` ensures that any changes to projects your application depends on trigger a rebuild, while `--exclude=my-app` skips rebuilding the app itself since it's already being served by the development server.
+
+{% callout type="note" title="That `--exclude` belongs to `run-many`" %}
+Everything after `--` is the command being run, so the `--exclude=my-app` above is `run-many`'s project filter. `nx watch` has its own `--exclude`, which takes file globs rather than project names — see [Filtering which file changes trigger the command](#filtering-which-file-changes-trigger-the-command) below.
+{% /callout %}
+
+### Filtering which file changes trigger the command
+
+By default any change inside a watched project re-runs the command. `--include` and `--exclude` narrow that down to the files you actually care about:
+
+```shell
+nx watch --projects=my-app --include "**/*.ts" "**/*.html" -- nx run my-app:build
+```
+
+```shell
+nx watch --all --exclude "**/*.spec.ts" "**/*.md" -- nx affected -t test
+```
+
+Both flags take one or more globs, either space-delimited after a single flag as above, or by repeating the flag. Each value is one whole glob, so a brace glob such as `**/*.{ts,tsx}` stays intact — the values are never split on commas, and `--include "**/*.ts,**/*.js"` is a single pattern that matches nothing.
+
+Things worth knowing:
+
+- **Patterns are anchored at the workspace root** and matched against workspace-root-relative paths. `**/*.ts` matches TypeScript files anywhere; `*.ts` matches only the ones directly in the workspace root; a leading `./` is ignored.
+- **`--exclude` wins over `--include`.** A file matching both is skipped.
+- **`--exclude` here filters files, not projects.** Use `--projects` to choose which projects are watched.
+- **Negated patterns are rejected.** `!**/*.spec.ts` errors rather than being accepted with surprising semantics; use the other flag instead.
+- **Filtering happens after the daemon has already processed the change**, so these flags decide whether your command re-runs — they don't reduce the daemon's own work.
+
+If a filter drops every changed file, `nx watch` tells you once in the terminal instead of silently doing nothing.

--- a/astro-docs/src/content/docs/kb/workspace-watching.mdoc
+++ b/astro-docs/src/content/docs/kb/workspace-watching.mdoc
@@ -178,28 +178,28 @@ nx watch --projects=my-app --includeDependencies -- nx run-many -t build -p \$NX
 `--includeDependencies` ensures that any changes to projects your application depends on trigger a rebuild, while `--exclude=my-app` skips rebuilding the app itself since it's already being served by the development server.
 
 {% callout type="note" title="That `--exclude` belongs to `run-many`" %}
-Everything after `--` is the command being run, so the `--exclude=my-app` above is `run-many`'s project filter. `nx watch` has its own `--exclude`, which takes file globs rather than project names — see [Filtering which file changes trigger the command](#filtering-which-file-changes-trigger-the-command) below.
+Everything after `--` is the command being run, so the `--exclude=my-app` above is `run-many`'s project filter. `nx watch` has no `--exclude` of its own — its file filters are spelled [`--includeFiles` and `--excludeFiles`](#filtering-which-file-changes-trigger-the-command) precisely so the two can't be confused.
 {% /callout %}
 
 ### Filtering which file changes trigger the command
 
-By default any change inside a watched project re-runs the command. `--include` and `--exclude` narrow that down to the files you actually care about:
+By default any change inside a watched project re-runs the command. `--includeFiles` and `--excludeFiles` narrow that down to the files you actually care about:
 
 ```shell
-nx watch --projects=my-app --include "**/*.ts" "**/*.html" -- nx run my-app:build
+nx watch --projects=my-app --includeFiles "**/*.ts" "**/*.html" -- nx run my-app:build
 ```
 
 ```shell
-nx watch --all --exclude "**/*.spec.ts" "**/*.md" -- nx affected -t test
+nx watch --all --excludeFiles "**/*.spec.ts" "**/*.md" -- nx affected -t test
 ```
 
-Both flags take one or more globs, either space-delimited after a single flag as above, or by repeating the flag. Each value is one whole glob, so a brace glob such as `**/*.{ts,tsx}` stays intact — the values are never split on commas, and `--include "**/*.ts,**/*.js"` is a single pattern that matches nothing.
+Both flags take one or more globs, either space-delimited after a single flag as above, or by repeating the flag. Each value is one whole glob, so a brace glob such as `**/*.{ts,tsx}` stays intact — the values are never split on commas, and `--includeFiles "**/*.ts,**/*.js"` is a single pattern that matches nothing.
 
 Things worth knowing:
 
 - **Patterns are anchored at the workspace root** and matched against workspace-root-relative paths. `**/*.ts` matches TypeScript files anywhere; `*.ts` matches only the ones directly in the workspace root; a leading `./` is ignored.
-- **`--exclude` wins over `--include`.** A file matching both is skipped.
-- **`--exclude` here filters files, not projects.** Use `--projects` to choose which projects are watched.
+- **`--excludeFiles` wins over `--includeFiles`.** A file matching both is skipped.
+- **These take file globs, not project names.** Use `--projects` to choose which projects are watched. (This is why they aren't spelled `--include`/`--exclude`, which elsewhere in Nx select projects.)
 - **Negated patterns are rejected.** `!**/*.spec.ts` errors rather than being accepted with surprising semantics; use the other flag instead.
 - **Filtering happens after the daemon has already processed the change**, so these flags decide whether your command re-runs — they don't reduce the daemon's own work.
 

--- a/packages/nx/src/command-line/watch/command-object.spec.ts
+++ b/packages/nx/src/command-line/watch/command-object.spec.ts
@@ -1,0 +1,92 @@
+import yargs = require('yargs');
+import { yargsWatchCommand } from './command-object';
+
+describe('watch command-object argument parsing', () => {
+  // Run the real command builder (parserConfiguration, checks, and the
+  // `--`->command middleware) but capture the parsed argv instead of importing
+  // and running watch.js, so we exercise the actual parse pipeline.
+  function parse(args: string[]): Record<string, any> {
+    let parsed: any;
+    yargs(args)
+      .command({
+        ...yargsWatchCommand,
+        handler: (a) => {
+          parsed = a;
+        },
+      })
+      .parse();
+    return parsed;
+  }
+
+  it('collects space-delimited --include values into an array', () => {
+    const parsed = parse([
+      'watch',
+      '--all',
+      '--include',
+      'a',
+      'b',
+      '--',
+      'echo',
+      'hi',
+    ]);
+    expect(parsed.include).toEqual(['a', 'b']);
+  });
+
+  it('collects repeated --include flags into an array', () => {
+    const parsed = parse([
+      'watch',
+      '--all',
+      '--include',
+      'a',
+      '--include',
+      'b',
+      '--',
+      'echo',
+      'hi',
+    ]);
+    expect(parsed.include).toEqual(['a', 'b']);
+  });
+
+  it('collects space-delimited --exclude values into an array', () => {
+    const parsed = parse([
+      'watch',
+      '--all',
+      '--exclude',
+      'a',
+      'b',
+      '--',
+      'echo',
+      'hi',
+    ]);
+    expect(parsed.exclude).toEqual(['a', 'b']);
+  });
+
+  it('keeps a brace glob intact without splitting on the comma', () => {
+    const parsed = parse([
+      'watch',
+      '--all',
+      '--include',
+      '**/*.{ts,tsx}',
+      '--',
+      'echo',
+      'hi',
+    ]);
+    expect(parsed.include).toEqual(['**/*.{ts,tsx}']);
+  });
+
+  it('does not swallow the trailing -- command into the include array', () => {
+    const parsed = parse([
+      'watch',
+      '--all',
+      '--include',
+      '**/*.ts',
+      '--',
+      'nx',
+      'build',
+    ]);
+    // The trailing command lands in `command` (via the `--` middleware), not in
+    // the include array — proving the array flag stops at `--`.
+    expect(parsed.include).toEqual(['**/*.ts']);
+    expect(parsed.command).toBe('nx build');
+  });
+});

--- a/packages/nx/src/command-line/watch/command-object.spec.ts
+++ b/packages/nx/src/command-line/watch/command-object.spec.ts
@@ -1,4 +1,5 @@
 import yargs = require('yargs');
+import { rewriteTargetsAndProjects } from '../../../bin/init-local';
 import { yargsWatchCommand } from './command-object';
 
 describe('watch command-object argument parsing', () => {
@@ -18,27 +19,46 @@ describe('watch command-object argument parsing', () => {
     return parsed;
   }
 
-  it('collects space-delimited --include values into an array', () => {
+  it('collects space-delimited --includeFiles values into an array', () => {
     const parsed = parse([
       'watch',
       '--all',
-      '--include',
+      '--includeFiles',
       'a',
       'b',
       '--',
       'echo',
       'hi',
     ]);
-    expect(parsed.include).toEqual(['a', 'b']);
+    expect(parsed.includeFiles).toEqual(['a', 'b']);
   });
 
-  it('collects repeated --include flags into an array of strings', () => {
+  it('accepts the kebab-case --include-files spelling', () => {
+    // The option is declared camelCase, like its `includeGlobalWorkspaceFiles`
+    // and `includeDependencies` siblings, and yargs' camel-case expansion is
+    // what makes the kebab spelling work. `strip-dashed` then drops the
+    // dashed key, so only `includeFiles` reaches the handler either way.
     const parsed = parse([
       'watch',
       '--all',
-      '--include',
+      '--include-files',
+      'a',
+      'b',
+      '--',
+      'echo',
+      'hi',
+    ]);
+    expect(parsed.includeFiles).toEqual(['a', 'b']);
+    expect(parsed['include-files']).toBeUndefined();
+  });
+
+  it('collects repeated --includeFiles flags into an array of strings', () => {
+    const parsed = parse([
+      'watch',
+      '--all',
+      '--includeFiles',
       '2024',
-      '--include',
+      '--includeFiles',
       'b',
       '--',
       'echo',
@@ -49,49 +69,118 @@ describe('watch command-object argument parsing', () => {
     // would pass with the option declaration deleted. `string: true` is what
     // keeps `2024` from arriving as the number 2024 and blowing up in
     // `new Minimatch`.
-    expect(parsed.include).toEqual(['2024', 'b']);
+    expect(parsed.includeFiles).toEqual(['2024', 'b']);
   });
 
-  it('collects space-delimited --exclude values into an array', () => {
+  it('collects space-delimited --excludeFiles values into an array', () => {
     const parsed = parse([
       'watch',
       '--all',
-      '--exclude',
+      '--excludeFiles',
       'a',
       'b',
       '--',
       'echo',
       'hi',
     ]);
-    expect(parsed.exclude).toEqual(['a', 'b']);
+    expect(parsed.excludeFiles).toEqual(['a', 'b']);
+  });
+
+  it('accepts the kebab-case --exclude-files spelling', () => {
+    const parsed = parse([
+      'watch',
+      '--all',
+      '--exclude-files',
+      'a',
+      'b',
+      '--',
+      'echo',
+      'hi',
+    ]);
+    expect(parsed.excludeFiles).toEqual(['a', 'b']);
+    expect(parsed['exclude-files']).toBeUndefined();
+  });
+
+  it('does not bind bare --include/--exclude to the file filters', () => {
+    // `nx watch` deliberately does not spell these `--include`/`--exclude`:
+    // the workspace-wide `--exclude` that `run-many`/`affected` take is a
+    // comma-separated list of *project names*, so the same spelling here
+    // would read as that and silently filter nothing. They are undeclared,
+    // so yargs leaves them as loose values that never reach the glob filter.
+    const parsed = parse([
+      'watch',
+      '--all',
+      '--include',
+      'a',
+      '--exclude',
+      'b',
+      '--',
+      'echo',
+      'hi',
+    ]);
+    expect(parsed.includeFiles).toBeUndefined();
+    expect(parsed.excludeFiles).toBeUndefined();
   });
 
   it('keeps a brace glob intact without splitting on the comma', () => {
     const parsed = parse([
       'watch',
       '--all',
-      '--include',
+      '--includeFiles',
       '**/*.{ts,tsx}',
       '--',
       'echo',
       'hi',
     ]);
-    expect(parsed.include).toEqual(['**/*.{ts,tsx}']);
+    expect(parsed.includeFiles).toEqual(['**/*.{ts,tsx}']);
   });
 
-  it('does not swallow the trailing -- command into the include array', () => {
+  it('does not swallow the trailing -- command into the includeFiles array', () => {
     const parsed = parse([
       'watch',
       '--all',
-      '--include',
+      '--includeFiles',
       '**/*.ts',
       '--',
       'nx',
       'build',
     ]);
     // The trailing command lands in `command` (via the `--` middleware), not in
-    // the include array — proving the array flag stops at `--`.
-    expect(parsed.include).toEqual(['**/*.ts']);
+    // the includeFiles array — proving the array flag stops at `--`.
+    expect(parsed.includeFiles).toEqual(['**/*.ts']);
     expect(parsed.command).toBe('nx build');
+  });
+
+  // The specs above hand argv straight to yargs. The real `nx` binary does not:
+  // it runs argv through `rewriteTargetsAndProjects` first, which collapses the
+  // space-delimited values of `--projects`/`--exclude`/`--files`/`--target(s)`
+  // into one comma-joined value for `run-many`/`affected`. It keys off the flag
+  // spelling alone, for every command, so a `nx watch --exclude a b` would have
+  // arrived as the single pattern `a,b` — a glob that matches nothing. The
+  // `Files` suffix is what keeps these flags out of that rewrite.
+  it('survives the arg rewriter that collapses run-many-style list flags', () => {
+    const argv = (flag: string) => [
+      'node',
+      'nx',
+      'watch',
+      '--all',
+      flag,
+      '**/*.spec.ts',
+      '**/*.md',
+      '--',
+      'echo',
+      'hi',
+    ];
+
+    expect(rewriteTargetsAndProjects(argv('--excludeFiles'))).toContain(
+      '**/*.md'
+    );
+    expect(rewriteTargetsAndProjects(argv('--includeFiles'))).toContain(
+      '**/*.md'
+    );
+    // The spelling this PR deliberately avoids, for contrast.
+    expect(rewriteTargetsAndProjects(argv('--exclude'))).toContain(
+      '**/*.spec.ts,**/*.md'
+    );
   });
 });

--- a/packages/nx/src/command-line/watch/command-object.spec.ts
+++ b/packages/nx/src/command-line/watch/command-object.spec.ts
@@ -32,19 +32,24 @@ describe('watch command-object argument parsing', () => {
     expect(parsed.include).toEqual(['a', 'b']);
   });
 
-  it('collects repeated --include flags into an array', () => {
+  it('collects repeated --include flags into an array of strings', () => {
     const parsed = parse([
       'watch',
       '--all',
       '--include',
-      'a',
+      '2024',
       '--include',
       'b',
       '--',
       'echo',
       'hi',
     ]);
-    expect(parsed.include).toEqual(['a', 'b']);
+    // The numeric-looking value is what makes this a real guard: yargs collects
+    // repeated flags into an array all on its own, so the array part alone
+    // would pass with the option declaration deleted. `string: true` is what
+    // keeps `2024` from arriving as the number 2024 and blowing up in
+    // `new Minimatch`.
+    expect(parsed.include).toEqual(['2024', 'b']);
   });
 
   it('collects space-delimited --exclude values into an array', () => {

--- a/packages/nx/src/command-line/watch/command-object.ts
+++ b/packages/nx/src/command-line/watch/command-object.ts
@@ -53,16 +53,16 @@ function withWatchOptions(yargs: Argv) {
         hidden: true,
       })
       .option('include', {
-        type: 'string',
-        coerce: parseCSV,
+        type: 'array',
+        string: true,
         description:
-          'Glob patterns (comma/space delimited) for file paths that should re-trigger the watched command. A changed file must match at least one pattern to count. When omitted, all changed files are included.',
+          'Glob pattern for workspace-relative file paths that should re-trigger the watched command. A changed file must match at least one --include pattern to count. Pass multiple patterns space-delimited after one flag (e.g. `--include "**/*.ts" "**/*.html"`) or by repeating the flag; each value is one whole glob, so brace globs like `**/*.{ts,tsx}` are kept intact. When omitted, all changed files are included.',
       })
       .option('exclude', {
-        type: 'string',
-        coerce: parseCSV,
+        type: 'array',
+        string: true,
         description:
-          'Glob patterns (comma/space delimited) for file paths that should never re-trigger the watched command. A file matching any exclude pattern is always skipped, even if it also matched --include.',
+          'Glob pattern for workspace-relative file paths that should never re-trigger the watched command. A file matching any --exclude pattern is always skipped, even if it also matched --include. Pass multiple patterns space-delimited after one flag (e.g. `--exclude "**/*.spec.ts" "**/*.md"`) or by repeating the flag; each value is one whole glob.',
       })
       .option('command', { type: 'string', hidden: true })
       .option('verbose', {

--- a/packages/nx/src/command-line/watch/command-object.ts
+++ b/packages/nx/src/command-line/watch/command-object.ts
@@ -52,6 +52,18 @@ function withWatchOptions(yargs: Argv) {
         alias: 'g',
         hidden: true,
       })
+      .option('include', {
+        type: 'string',
+        coerce: parseCSV,
+        description:
+          'Glob patterns (comma/space delimited) for file paths that should re-trigger the watched command. A changed file must match at least one pattern to count. When omitted, all changed files are included.',
+      })
+      .option('exclude', {
+        type: 'string',
+        coerce: parseCSV,
+        description:
+          'Glob patterns (comma/space delimited) for file paths that should never re-trigger the watched command. A file matching any exclude pattern is always skipped, even if it also matched --include.',
+      })
       .option('command', { type: 'string', hidden: true })
       .option('verbose', {
         type: 'boolean',

--- a/packages/nx/src/command-line/watch/command-object.ts
+++ b/packages/nx/src/command-line/watch/command-object.ts
@@ -56,13 +56,13 @@ function withWatchOptions(yargs: Argv) {
         type: 'array',
         string: true,
         description:
-          'Glob pattern for workspace-relative file paths that should re-trigger the watched command. A changed file must match at least one --include pattern to count. Pass multiple patterns space-delimited after one flag (e.g. `--include "**/*.ts" "**/*.html"`) or by repeating the flag; each value is one whole glob, so brace globs like `**/*.{ts,tsx}` are kept intact. When omitted, all changed files are included.',
+          'Only re-trigger the command for changed files matching one of these globs (space-delimited, anchored at the workspace root — use `**/*.ts`, not `*.ts`).',
       })
       .option('exclude', {
         type: 'array',
         string: true,
         description:
-          'Glob pattern for workspace-relative file paths that should never re-trigger the watched command. A file matching any --exclude pattern is always skipped, even if it also matched --include. Pass multiple patterns space-delimited after one flag (e.g. `--exclude "**/*.spec.ts" "**/*.md"`) or by repeating the flag; each value is one whole glob.',
+          'Never re-trigger the command for changed files matching one of these globs (space-delimited, anchored at the workspace root). Wins over --include.',
       })
       .option('command', { type: 'string', hidden: true })
       .option('verbose', {

--- a/packages/nx/src/command-line/watch/command-object.ts
+++ b/packages/nx/src/command-line/watch/command-object.ts
@@ -52,17 +52,17 @@ function withWatchOptions(yargs: Argv) {
         alias: 'g',
         hidden: true,
       })
-      .option('include', {
+      .option('includeFiles', {
         type: 'array',
         string: true,
         description:
           'Only re-trigger the command for changed files matching one of these globs (space-delimited, anchored at the workspace root — use `**/*.ts`, not `*.ts`).',
       })
-      .option('exclude', {
+      .option('excludeFiles', {
         type: 'array',
         string: true,
         description:
-          'Never re-trigger the command for changed files matching one of these globs (space-delimited, anchored at the workspace root). Wins over --include.',
+          'Never re-trigger the command for changed files matching one of these globs (space-delimited, anchored at the workspace root). Wins over --includeFiles.',
       })
       .option('command', { type: 'string', hidden: true })
       .option('verbose', {

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -5,6 +5,7 @@ import {
   WatcherFailedError,
 } from '../../daemon/client/client';
 import { VersionMismatchError } from '../../daemon/client/daemon-socket-messenger';
+import { normalizeWatchGlobs } from '../../daemon/server/file-watching/glob-filter';
 import { output } from '../../utils/output';
 
 export interface WatchArguments {
@@ -24,12 +25,22 @@ export interface WatchArguments {
    * Glob patterns for changed file paths that should re-trigger the watched
    * command. A changed file must match at least one include pattern to count.
    * When omitted, all files are included.
+   *
+   * Patterns are anchored at the workspace root and matched against
+   * workspace-root-relative paths, so `**\/*.ts` matches anywhere while
+   * `*.ts` only matches the workspace root itself. Negated (`!`) patterns are
+   * rejected — use {@link WatchArguments.exclude} instead.
    */
   include?: string[];
   /**
    * Glob patterns for changed file paths that should never re-trigger the
    * watched command. A file matching any exclude pattern is always ignored,
    * even if it matched an include pattern.
+   *
+   * These are file globs, not project names — use
+   * {@link WatchArguments.projects} to choose which projects are watched.
+   * Anchoring and negation follow the same rules as
+   * {@link WatchArguments.include}.
    */
   exclude?: string[];
   verbose?: boolean;
@@ -204,6 +215,16 @@ export async function watch(args: WatchArguments) {
     process.exit(1);
   }
 
+  let include: string[] | undefined;
+  let exclude: string[] | undefined;
+  try {
+    include = normalizeWatchGlobs(args.include, '--include');
+    exclude = normalizeWatchGlobs(args.exclude, '--exclude');
+  } catch (e) {
+    output.error({ title: e.message });
+    process.exit(1);
+  }
+
   args.verbose &&
     output.logSingleLine('running with args: ' + JSON.stringify(args));
   args.verbose && output.logSingleLine('starting watch process');
@@ -228,14 +249,34 @@ export async function watch(args: WatchArguments) {
     await batchQueue.enqueue(initialProjects, []);
   }
 
+  // Echoed unconditionally, not behind --verbose: when a pattern matches
+  // nothing the command simply never runs, and the terminal is otherwise
+  // silent forever. Seeing the patterns as the daemon received them, next to
+  // the anchoring rule, is what turns "nx watch is hung" into "I typed
+  // `*.ts`".
+  if (include?.length || exclude?.length) {
+    output.note({
+      title: 'Watching with file filters',
+      bodyLines: [
+        ...(include?.length
+          ? [`include: ${include.map((p) => `"${p}"`).join(' ')}`]
+          : []),
+        ...(exclude?.length
+          ? [`exclude: ${exclude.map((p) => `"${p}"`).join(' ')}`]
+          : []),
+        'Patterns are matched against workspace-root-relative paths, so use "**/*.ts" rather than "*.ts" to match nested files.',
+      ],
+    });
+  }
+
   await daemonClient.registerFileWatcher(
     {
       watchProjects: whatToWatch,
       includeDependencies:
         args.includeDependencies ?? args.includeDependentProjects,
       includeGlobalWorkspaceFiles: args.includeGlobalWorkspaceFiles,
-      include: args.include,
-      exclude: args.exclude,
+      include,
+      exclude,
     },
     async (err, data) => {
       if (err === 'reconnecting') {

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -29,9 +29,9 @@ export interface WatchArguments {
    * Patterns are anchored at the workspace root and matched against
    * workspace-root-relative paths, so `**\/*.ts` matches anywhere while
    * `*.ts` only matches the workspace root itself. Negated (`!`) patterns are
-   * rejected — use {@link WatchArguments.exclude} instead.
+   * rejected — use {@link WatchArguments.excludeFiles} instead.
    */
-  include?: string[];
+  includeFiles?: string[];
   /**
    * Glob patterns for changed file paths that should never re-trigger the
    * watched command. A file matching any exclude pattern is always ignored,
@@ -40,9 +40,9 @@ export interface WatchArguments {
    * These are file globs, not project names — use
    * {@link WatchArguments.projects} to choose which projects are watched.
    * Anchoring and negation follow the same rules as
-   * {@link WatchArguments.include}.
+   * {@link WatchArguments.includeFiles}.
    */
-  exclude?: string[];
+  excludeFiles?: string[];
   verbose?: boolean;
   command?: string;
   initialRun?: boolean;
@@ -215,11 +215,11 @@ export async function watch(args: WatchArguments) {
     process.exit(1);
   }
 
-  let include: string[] | undefined;
-  let exclude: string[] | undefined;
+  let includeFiles: string[] | undefined;
+  let excludeFiles: string[] | undefined;
   try {
-    include = normalizeWatchGlobs(args.include, '--include');
-    exclude = normalizeWatchGlobs(args.exclude, '--exclude');
+    includeFiles = normalizeWatchGlobs(args.includeFiles, '--includeFiles');
+    excludeFiles = normalizeWatchGlobs(args.excludeFiles, '--excludeFiles');
   } catch (e) {
     output.error({ title: e.message });
     process.exit(1);
@@ -254,15 +254,15 @@ export async function watch(args: WatchArguments) {
   // silent forever. Seeing the patterns as the daemon received them, next to
   // the anchoring rule, is what turns "nx watch is hung" into "I typed
   // `*.ts`".
-  if (include?.length || exclude?.length) {
+  if (includeFiles?.length || excludeFiles?.length) {
     output.note({
       title: 'Watching with file filters',
       bodyLines: [
-        ...(include?.length
-          ? [`include: ${include.map((p) => `"${p}"`).join(' ')}`]
+        ...(includeFiles?.length
+          ? [`includeFiles: ${includeFiles.map((p) => `"${p}"`).join(' ')}`]
           : []),
-        ...(exclude?.length
-          ? [`exclude: ${exclude.map((p) => `"${p}"`).join(' ')}`]
+        ...(excludeFiles?.length
+          ? [`excludeFiles: ${excludeFiles.map((p) => `"${p}"`).join(' ')}`]
           : []),
         'Patterns are matched against workspace-root-relative paths, so use "**/*.ts" rather than "*.ts" to match nested files.',
       ],
@@ -275,8 +275,8 @@ export async function watch(args: WatchArguments) {
       includeDependencies:
         args.includeDependencies ?? args.includeDependentProjects,
       includeGlobalWorkspaceFiles: args.includeGlobalWorkspaceFiles,
-      include,
-      exclude,
+      includeFiles,
+      excludeFiles,
     },
     async (err, data) => {
       if (err === 'reconnecting') {

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -20,6 +20,18 @@ export interface WatchArguments {
   // TODO(v24): remove this property
   includeDependentProjects?: boolean;
   includeGlobalWorkspaceFiles?: boolean;
+  /**
+   * Glob patterns for changed file paths that should re-trigger the watched
+   * command. A changed file must match at least one include pattern to count.
+   * When omitted, all files are included.
+   */
+  include?: string[];
+  /**
+   * Glob patterns for changed file paths that should never re-trigger the
+   * watched command. A file matching any exclude pattern is always ignored,
+   * even if it matched an include pattern.
+   */
+  exclude?: string[];
   verbose?: boolean;
   command?: string;
   initialRun?: boolean;
@@ -222,6 +234,8 @@ export async function watch(args: WatchArguments) {
       includeDependencies:
         args.includeDependencies ?? args.includeDependentProjects,
       includeGlobalWorkspaceFiles: args.includeGlobalWorkspaceFiles,
+      include: args.include,
+      exclude: args.exclude,
     },
     async (err, data) => {
       if (err === 'reconnecting') {

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -228,8 +228,8 @@ export class DaemonClient {
       includeGlobalWorkspaceFiles?: boolean;
       includeDependencies?: boolean;
       allowPartialGraph?: boolean;
-      include?: string[];
-      exclude?: string[];
+      includeFiles?: string[];
+      excludeFiles?: string[];
     }
   > = new Map();
 
@@ -409,8 +409,8 @@ export class DaemonClient {
       includeGlobalWorkspaceFiles?: boolean;
       includeDependencies?: boolean;
       allowPartialGraph?: boolean;
-      include?: string[];
-      exclude?: string[];
+      includeFiles?: string[];
+      excludeFiles?: string[];
     },
     callback: (
       error: Error | null | 'reconnecting' | 'reconnected' | 'closed',

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -459,11 +459,7 @@ export class DaemonClient {
             const parsedMessage = parseMessage<any>(message);
             // A delivered message means the stream is healthy again.
             this.fileWatcherFramingFailures = 0;
-            if (parsedMessage?.watcherError) {
-              const error = new WatcherFailedError(parsedMessage.watcherError);
-              for (const cb of this.fileWatcherCallbacks.values()) {
-                cb(error, null);
-              }
+            if (this.handleFileWatcherSideChannelMessage(parsedMessage)) {
               return;
             }
             // Notify all callbacks
@@ -522,6 +518,47 @@ export class DaemonClient {
         this.fileWatcherMessenger = undefined;
       }
     };
+  }
+
+  /**
+   * Handles the messages that can arrive on a watch socket without being a
+   * file-change notification, and reports whether the message was one of them.
+   *
+   * The watch socket carries three kinds of traffic: the FILE-WATCH-CHANGED
+   * notifications the callbacks exist for, log lines the daemon wants shown in
+   * this terminal (e.g. "your filter dropped every changed file"), and an
+   * error response when registration itself failed. Only the first is a
+   * `data` payload — handing either of the others to the callbacks would have
+   * them read `changedProjects` off the wrong shape.
+   */
+  private handleFileWatcherSideChannelMessage(parsedMessage: any): boolean {
+    if (isEmitLogMessage(parsedMessage)) {
+      console[parsedMessage.level](parsedMessage.message);
+      return true;
+    }
+
+    if (parsedMessage?.watcherError) {
+      const error = new WatcherFailedError(parsedMessage.watcherError);
+      for (const cb of this.fileWatcherCallbacks.values()) {
+        cb(error, null);
+      }
+      return true;
+    }
+
+    if (parsedMessage?.error) {
+      const error =
+        parsedMessage.error instanceof Error
+          ? parsedMessage.error
+          : new Error(
+              parsedMessage.error.message ?? String(parsedMessage.error)
+            );
+      for (const cb of this.fileWatcherCallbacks.values()) {
+        cb(error, null);
+      }
+      return true;
+    }
+
+    return false;
   }
 
   private async reconnectFileWatcher() {
@@ -596,6 +633,9 @@ export class DaemonClient {
             const parsedMessage = parseMessage<any>(message);
             // A delivered message means the stream is healthy again.
             this.fileWatcherFramingFailures = 0;
+            if (this.handleFileWatcherSideChannelMessage(parsedMessage)) {
+              return;
+            }
             for (const cb of this.fileWatcherCallbacks.values()) {
               cb(null, parsedMessage);
             }

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -228,6 +228,8 @@ export class DaemonClient {
       includeGlobalWorkspaceFiles?: boolean;
       includeDependencies?: boolean;
       allowPartialGraph?: boolean;
+      include?: string[];
+      exclude?: string[];
     }
   > = new Map();
 
@@ -407,6 +409,8 @@ export class DaemonClient {
       includeGlobalWorkspaceFiles?: boolean;
       includeDependencies?: boolean;
       allowPartialGraph?: boolean;
+      include?: string[];
+      exclude?: string[];
     },
     callback: (
       error: Error | null | 'reconnecting' | 'reconnected' | 'closed',

--- a/packages/nx/src/daemon/server/client-socket-context.ts
+++ b/packages/nx/src/daemon/server/client-socket-context.ts
@@ -117,3 +117,23 @@ export function sendEmitLogMessageToTopic(
     writeStreamingMessage(socket, payload, 'emit log message to ' + topic);
   }
 }
+
+/**
+ * Sends a log line to one specific client socket, so it surfaces in that
+ * client's terminal instead of being lost to the daemon log file.
+ *
+ * Use this instead of a {@link ProgressTopic} broadcast when the daemon
+ * already knows exactly which client the message is about — a topic would fan
+ * the message out to every other subscribed client as well.
+ *
+ * Must only be invoked from inside the Nx daemon process.
+ */
+export function sendEmitLogMessageToSocket(
+  socket: Socket,
+  message: string,
+  level: EmitLogLevel
+): void {
+  assertOnDaemon('sendEmitLogMessageToSocket');
+  const payload: EmitLogMessage = { type: EMIT_LOG, message, level };
+  writeStreamingMessage(socket, payload, 'emit log message to socket');
+}

--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
@@ -21,8 +21,8 @@ export interface RegisteredFileWatcherConfig {
   watchProjects: string[] | 'all';
   includeGlobalWorkspaceFiles: boolean;
   includeDependencies: boolean;
-  include?: string[];
-  exclude?: string[];
+  includeFiles?: string[];
+  excludeFiles?: string[];
 }
 
 interface RegisteredFileWatcherSocket {
@@ -52,8 +52,14 @@ export function registerFileWatcherSocket(watcher: {
   registeredFileWatcherSockets.push({
     socket: watcher.socket,
     config: watcher.config,
-    includeMatchers: compileGlobs(watcher.config.include ?? [], '--include'),
-    excludeMatchers: compileGlobs(watcher.config.exclude ?? [], '--exclude'),
+    includeMatchers: compileGlobs(
+      watcher.config.includeFiles ?? [],
+      '--includeFiles'
+    ),
+    excludeMatchers: compileGlobs(
+      watcher.config.excludeFiles ?? [],
+      '--excludeFiles'
+    ),
     warnedAboutDroppedBatch: false,
   });
 }
@@ -220,11 +226,11 @@ function reportFilterDroppedEntireBatch(
   consideredFileCount: number
 ) {
   const details =
-    `include=${JSON.stringify(watcher.config.include ?? [])} ` +
-    `exclude=${JSON.stringify(watcher.config.exclude ?? [])}`;
+    `includeFiles=${JSON.stringify(watcher.config.includeFiles ?? [])} ` +
+    `excludeFiles=${JSON.stringify(watcher.config.excludeFiles ?? [])}`;
 
   serverLogger.watcherLog(
-    `Include/exclude filter dropped all ${consideredFileCount} changed file(s); no command will run. ${details}`
+    `File filter dropped all ${consideredFileCount} changed file(s); no command will run. ${details}`
   );
 
   if (watcher.warnedAboutDroppedBatch) {
@@ -234,7 +240,7 @@ function reportFilterDroppedEntireBatch(
 
   sendEmitLogMessageToSocket(
     watcher.socket,
-    `nx watch: the --include/--exclude filter dropped all ${consideredFileCount} changed file(s), so the command did not run. ${details}. ` +
+    `nx watch: the --includeFiles/--excludeFiles filter dropped all ${consideredFileCount} changed file(s), so the command did not run. ${details}. ` +
       `Patterns are matched against workspace-root-relative paths, so use "**/*.ts" rather than "*.ts" to match nested files. ` +
       `(Only reported once per watch.)`,
     'warn'

--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
@@ -5,6 +5,7 @@ import { PromisedBasedQueue } from '../../../utils/promised-based-queue';
 import { currentProjectGraph } from '../project-graph-incremental-recomputation';
 import { handleResult } from '../server';
 import { getProjectsAndGlobalChanges } from './changed-projects';
+import { filterChangedFiles } from './glob-filter';
 
 const queue = new PromisedBasedQueue();
 
@@ -14,6 +15,8 @@ export let registeredFileWatcherSockets: {
     watchProjects: string[] | 'all';
     includeGlobalWorkspaceFiles: boolean;
     includeDependencies: boolean;
+    include?: string[];
+    exclude?: string[];
   };
 }[] = [];
 
@@ -72,14 +75,24 @@ export function notifyFileWatcherSockets(
 
     await Promise.all(
       registeredFileWatcherSockets.map(({ socket, config }) => {
+        const include = config.include ?? [];
+        const exclude = config.exclude ?? [];
+
         const changedProjects = [];
         const changedFiles = [];
         if (config.watchProjects === 'all') {
           for (const [projectName, projectFiles] of Object.entries(
             projectAndGlobalChanges.projects
           )) {
-            changedProjects.push(projectName);
-            changedFiles.push(...projectFiles);
+            const filteredFiles = filterChangedFiles(
+              projectFiles,
+              include,
+              exclude
+            );
+            if (filteredFiles.length > 0) {
+              changedProjects.push(projectName);
+              changedFiles.push(...filteredFiles);
+            }
           }
         } else {
           const watchedProjects = new Set<string>(
@@ -102,17 +115,26 @@ export function notifyFileWatcherSockets(
 
           for (const watchedProject of watchedProjects) {
             if (!!projectAndGlobalChanges.projects[watchedProject]) {
-              changedProjects.push(watchedProject);
-
-              changedFiles.push(
-                ...projectAndGlobalChanges.projects[watchedProject]
+              const filteredFiles = filterChangedFiles(
+                projectAndGlobalChanges.projects[watchedProject],
+                include,
+                exclude
               );
+              if (filteredFiles.length > 0) {
+                changedProjects.push(watchedProject);
+                changedFiles.push(...filteredFiles);
+              }
             }
           }
         }
 
         if (config.includeGlobalWorkspaceFiles) {
-          changedFiles.push(...projectAndGlobalChanges.globalFiles);
+          const filteredGlobalFiles = filterChangedFiles(
+            projectAndGlobalChanges.globalFiles,
+            include,
+            exclude
+          );
+          changedFiles.push(...filteredGlobalFiles);
         }
 
         if (changedProjects.length > 0 || changedFiles.length > 0) {

--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
@@ -1,24 +1,48 @@
 import { Socket } from 'net';
+import type { Minimatch } from 'minimatch';
 import { findMatchingProjects } from '../../../utils/find-matching-projects';
 import { findAllProjectNodeDependencies } from '../../../utils/project-graph-utils';
 import { PromisedBasedQueue } from '../../../utils/promised-based-queue';
+import { serverLogger } from '../../logger';
 import { currentProjectGraph } from '../project-graph-incremental-recomputation';
 import { handleResult } from '../server';
-import { getProjectsAndGlobalChanges } from './changed-projects';
-import { filterChangedFiles } from './glob-filter';
+import { ChangedFile, getProjectsAndGlobalChanges } from './changed-projects';
+import {
+  compileGlobs,
+  filterChangedFiles,
+  selectChangedProjectsAndFiles,
+} from './glob-filter';
 
 const queue = new PromisedBasedQueue();
 
+export interface RegisteredFileWatcherConfig {
+  watchProjects: string[] | 'all';
+  includeGlobalWorkspaceFiles: boolean;
+  includeDependencies: boolean;
+  include?: string[];
+  exclude?: string[];
+}
+
 export let registeredFileWatcherSockets: {
   socket: Socket;
-  config: {
-    watchProjects: string[] | 'all';
-    includeGlobalWorkspaceFiles: boolean;
-    includeDependencies: boolean;
-    include?: string[];
-    exclude?: string[];
-  };
+  config: RegisteredFileWatcherConfig;
+  // Include/exclude patterns are invariant for the life of the subscription, so
+  // they are compiled once here rather than on every file-change batch.
+  includeMatchers: Minimatch[];
+  excludeMatchers: Minimatch[];
 }[] = [];
+
+export function registerFileWatcherSocket(watcher: {
+  socket: Socket;
+  config: RegisteredFileWatcherConfig;
+}) {
+  registeredFileWatcherSockets.push({
+    socket: watcher.socket,
+    config: watcher.config,
+    includeMatchers: compileGlobs(watcher.config.include ?? []),
+    excludeMatchers: compileGlobs(watcher.config.exclude ?? []),
+  });
+}
 
 export function removeRegisteredFileWatcherSocket(socket: Socket) {
   registeredFileWatcherSockets = registeredFileWatcherSockets.filter(
@@ -74,85 +98,96 @@ export function notifyFileWatcherSockets(
     );
 
     await Promise.all(
-      registeredFileWatcherSockets.map(({ socket, config }) => {
-        const include = config.include ?? [];
-        const exclude = config.exclude ?? [];
+      registeredFileWatcherSockets.map(
+        ({ socket, config, includeMatchers, excludeMatchers }) => {
+          const hasFilters =
+            includeMatchers.length > 0 || excludeMatchers.length > 0;
 
-        const changedProjects = [];
-        const changedFiles = [];
-        if (config.watchProjects === 'all') {
-          for (const [projectName, projectFiles] of Object.entries(
-            projectAndGlobalChanges.projects
-          )) {
-            const filteredFiles = filterChangedFiles(
-              projectFiles,
-              include,
-              exclude
+          const changedProjects = [];
+          const changedFiles = [];
+          let consideredFileCount = 0;
+          if (config.watchProjects === 'all') {
+            const selected = selectChangedProjectsAndFiles(
+              projectAndGlobalChanges.projects,
+              includeMatchers,
+              excludeMatchers
             );
-            if (filteredFiles.length > 0) {
-              changedProjects.push(projectName);
-              changedFiles.push(...filteredFiles);
-            }
-          }
-        } else {
-          const watchedProjects = new Set<string>(
-            findMatchingProjects(
-              config.watchProjects,
-              currentProjectGraph.nodes
-            )
-          );
+            changedProjects.push(...selected.changedProjects);
+            changedFiles.push(...selected.changedFiles);
+            consideredFileCount += selected.consideredFileCount;
+          } else {
+            const watchedProjects = new Set<string>(
+              findMatchingProjects(
+                config.watchProjects,
+                currentProjectGraph.nodes
+              )
+            );
 
-          if (config.includeDependencies) {
-            for (const project of watchedProjects) {
-              for (const dep of findAllProjectNodeDependencies(
-                project,
-                currentProjectGraph
-              )) {
-                watchedProjects.add(dep);
+            if (config.includeDependencies) {
+              for (const project of watchedProjects) {
+                for (const dep of findAllProjectNodeDependencies(
+                  project,
+                  currentProjectGraph
+                )) {
+                  watchedProjects.add(dep);
+                }
               }
             }
-          }
 
-          for (const watchedProject of watchedProjects) {
-            if (!!projectAndGlobalChanges.projects[watchedProject]) {
-              const filteredFiles = filterChangedFiles(
-                projectAndGlobalChanges.projects[watchedProject],
-                include,
-                exclude
-              );
-              if (filteredFiles.length > 0) {
-                changedProjects.push(watchedProject);
-                changedFiles.push(...filteredFiles);
+            const watchedProjectFiles: Record<string, ChangedFile[]> = {};
+            for (const watchedProject of watchedProjects) {
+              if (projectAndGlobalChanges.projects[watchedProject]) {
+                watchedProjectFiles[watchedProject] =
+                  projectAndGlobalChanges.projects[watchedProject];
               }
             }
+
+            const selected = selectChangedProjectsAndFiles(
+              watchedProjectFiles,
+              includeMatchers,
+              excludeMatchers
+            );
+            changedProjects.push(...selected.changedProjects);
+            changedFiles.push(...selected.changedFiles);
+            consideredFileCount += selected.consideredFileCount;
           }
-        }
 
-        if (config.includeGlobalWorkspaceFiles) {
-          const filteredGlobalFiles = filterChangedFiles(
-            projectAndGlobalChanges.globalFiles,
-            include,
-            exclude
-          );
-          changedFiles.push(...filteredGlobalFiles);
-        }
+          if (config.includeGlobalWorkspaceFiles) {
+            consideredFileCount += projectAndGlobalChanges.globalFiles.length;
+            const filteredGlobalFiles = filterChangedFiles(
+              projectAndGlobalChanges.globalFiles,
+              includeMatchers,
+              excludeMatchers
+            );
+            changedFiles.push(...filteredGlobalFiles);
+          }
 
-        if (changedProjects.length > 0 || changedFiles.length > 0) {
-          return handleResult(
-            socket,
-            'FILE-WATCH-CHANGED',
-            () =>
-              Promise.resolve({
-                description: 'File watch changed',
-                response: JSON.stringify({
-                  changedProjects,
-                  changedFiles,
+          if (changedProjects.length > 0 || changedFiles.length > 0) {
+            return handleResult(
+              socket,
+              'FILE-WATCH-CHANGED',
+              () =>
+                Promise.resolve({
+                  description: 'File watch changed',
+                  response: JSON.stringify({
+                    changedProjects,
+                    changedFiles,
+                  }),
                 }),
-              }),
-            'json'
-          );
+              'json'
+            );
+          } else if (hasFilters && consideredFileCount > 0) {
+            // Files changed but the include/exclude filter dropped the entire
+            // batch, so no command runs. Log it so a misconfigured pattern is
+            // debuggable. Patterns match workspace-relative paths.
+            serverLogger.watcherLog(
+              `Include/exclude filter dropped all ${consideredFileCount} changed file(s); no command will run. include=${JSON.stringify(
+                config.include ?? []
+              )} exclude=${JSON.stringify(config.exclude ?? [])}`
+            );
+          }
         }
-      })
+      )
     );
   });
 }

--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
@@ -4,9 +4,11 @@ import { findMatchingProjects } from '../../../utils/find-matching-projects';
 import { findAllProjectNodeDependencies } from '../../../utils/project-graph-utils';
 import { PromisedBasedQueue } from '../../../utils/promised-based-queue';
 import { serverLogger } from '../../logger';
+import { sendEmitLogMessageToSocket } from '../client-socket-context';
 import { currentProjectGraph } from '../project-graph-incremental-recomputation';
 import { handleResult } from '../server';
-import { ChangedFile, getProjectsAndGlobalChanges } from './changed-projects';
+import type { ChangedFile } from './changed-projects';
+import { getProjectsAndGlobalChanges } from './changed-projects';
 import {
   compileGlobs,
   filterChangedFiles,
@@ -23,15 +25,26 @@ export interface RegisteredFileWatcherConfig {
   exclude?: string[];
 }
 
-export let registeredFileWatcherSockets: {
+interface RegisteredFileWatcherSocket {
   socket: Socket;
   config: RegisteredFileWatcherConfig;
   // Include/exclude patterns are invariant for the life of the subscription, so
   // they are compiled once here rather than on every file-change batch.
   includeMatchers: Minimatch[];
   excludeMatchers: Minimatch[];
-}[] = [];
+  // Whether this subscription has already been told, in its own terminal, that
+  // its filter dropped a whole batch. The condition repeats on every keystroke
+  // in an excluded file, so it is only worth saying once per subscription.
+  warnedAboutDroppedBatch: boolean;
+}
 
+export let registeredFileWatcherSockets: RegisteredFileWatcherSocket[] = [];
+
+/**
+ * Registers a watch subscription. Throws when a pattern is invalid — see
+ * {@link compileGlobs} — so the caller in `handleMessage` must report the
+ * failure back over the socket rather than letting it reject unhandled.
+ */
 export function registerFileWatcherSocket(watcher: {
   socket: Socket;
   config: RegisteredFileWatcherConfig;
@@ -39,8 +52,9 @@ export function registerFileWatcherSocket(watcher: {
   registeredFileWatcherSockets.push({
     socket: watcher.socket,
     config: watcher.config,
-    includeMatchers: compileGlobs(watcher.config.include ?? []),
-    excludeMatchers: compileGlobs(watcher.config.exclude ?? []),
+    includeMatchers: compileGlobs(watcher.config.include ?? [], '--include'),
+    excludeMatchers: compileGlobs(watcher.config.exclude ?? [], '--exclude'),
+    warnedAboutDroppedBatch: false,
   });
 }
 
@@ -98,96 +112,131 @@ export function notifyFileWatcherSockets(
     );
 
     await Promise.all(
-      registeredFileWatcherSockets.map(
-        ({ socket, config, includeMatchers, excludeMatchers }) => {
-          const hasFilters =
-            includeMatchers.length > 0 || excludeMatchers.length > 0;
+      registeredFileWatcherSockets.map((watcher) => {
+        const { socket, config, includeMatchers, excludeMatchers } = watcher;
+        const hasFilters =
+          includeMatchers.length > 0 || excludeMatchers.length > 0;
 
-          const changedProjects = [];
-          const changedFiles = [];
-          let consideredFileCount = 0;
-          if (config.watchProjects === 'all') {
-            const selected = selectChangedProjectsAndFiles(
-              projectAndGlobalChanges.projects,
-              includeMatchers,
-              excludeMatchers
-            );
-            changedProjects.push(...selected.changedProjects);
-            changedFiles.push(...selected.changedFiles);
-            consideredFileCount += selected.consideredFileCount;
-          } else {
-            const watchedProjects = new Set<string>(
-              findMatchingProjects(
-                config.watchProjects,
-                currentProjectGraph.nodes
-              )
-            );
+        const changedProjects = [];
+        const changedFiles = [];
+        let consideredFileCount = 0;
+        if (config.watchProjects === 'all') {
+          const selected = selectChangedProjectsAndFiles(
+            Object.entries(projectAndGlobalChanges.projects),
+            includeMatchers,
+            excludeMatchers
+          );
+          changedProjects.push(...selected.changedProjects);
+          changedFiles.push(...selected.changedFiles);
+          consideredFileCount += selected.consideredFileCount;
+        } else {
+          const watchedProjects = new Set<string>(
+            findMatchingProjects(
+              config.watchProjects,
+              currentProjectGraph.nodes
+            )
+          );
 
-            if (config.includeDependencies) {
-              for (const project of watchedProjects) {
-                for (const dep of findAllProjectNodeDependencies(
-                  project,
-                  currentProjectGraph
-                )) {
-                  watchedProjects.add(dep);
-                }
+          if (config.includeDependencies) {
+            for (const project of watchedProjects) {
+              for (const dep of findAllProjectNodeDependencies(
+                project,
+                currentProjectGraph
+              )) {
+                watchedProjects.add(dep);
               }
             }
+          }
 
-            const watchedProjectFiles: Record<string, ChangedFile[]> = {};
-            for (const watchedProject of watchedProjects) {
-              if (projectAndGlobalChanges.projects[watchedProject]) {
-                watchedProjectFiles[watchedProject] =
-                  projectAndGlobalChanges.projects[watchedProject];
-              }
+          // A Map, not a plain object: integer-like object keys are hoisted to
+          // the front on iteration, which would reorder a project named e.g.
+          // `2024` relative to the order the projects were matched in.
+          const watchedProjectFiles = new Map<string, ChangedFile[]>();
+          for (const watchedProject of watchedProjects) {
+            if (projectAndGlobalChanges.projects[watchedProject]) {
+              watchedProjectFiles.set(
+                watchedProject,
+                projectAndGlobalChanges.projects[watchedProject]
+              );
             }
-
-            const selected = selectChangedProjectsAndFiles(
-              watchedProjectFiles,
-              includeMatchers,
-              excludeMatchers
-            );
-            changedProjects.push(...selected.changedProjects);
-            changedFiles.push(...selected.changedFiles);
-            consideredFileCount += selected.consideredFileCount;
           }
 
-          if (config.includeGlobalWorkspaceFiles) {
-            consideredFileCount += projectAndGlobalChanges.globalFiles.length;
-            const filteredGlobalFiles = filterChangedFiles(
-              projectAndGlobalChanges.globalFiles,
-              includeMatchers,
-              excludeMatchers
-            );
-            changedFiles.push(...filteredGlobalFiles);
-          }
-
-          if (changedProjects.length > 0 || changedFiles.length > 0) {
-            return handleResult(
-              socket,
-              'FILE-WATCH-CHANGED',
-              () =>
-                Promise.resolve({
-                  description: 'File watch changed',
-                  response: JSON.stringify({
-                    changedProjects,
-                    changedFiles,
-                  }),
-                }),
-              'json'
-            );
-          } else if (hasFilters && consideredFileCount > 0) {
-            // Files changed but the include/exclude filter dropped the entire
-            // batch, so no command runs. Log it so a misconfigured pattern is
-            // debuggable. Patterns match workspace-relative paths.
-            serverLogger.watcherLog(
-              `Include/exclude filter dropped all ${consideredFileCount} changed file(s); no command will run. include=${JSON.stringify(
-                config.include ?? []
-              )} exclude=${JSON.stringify(config.exclude ?? [])}`
-            );
-          }
+          const selected = selectChangedProjectsAndFiles(
+            watchedProjectFiles,
+            includeMatchers,
+            excludeMatchers
+          );
+          changedProjects.push(...selected.changedProjects);
+          changedFiles.push(...selected.changedFiles);
+          consideredFileCount += selected.consideredFileCount;
         }
-      )
+
+        if (config.includeGlobalWorkspaceFiles) {
+          consideredFileCount += projectAndGlobalChanges.globalFiles.length;
+          const filteredGlobalFiles = filterChangedFiles(
+            projectAndGlobalChanges.globalFiles,
+            includeMatchers,
+            excludeMatchers
+          );
+          changedFiles.push(...filteredGlobalFiles);
+        }
+
+        if (changedProjects.length > 0 || changedFiles.length > 0) {
+          return handleResult(
+            socket,
+            'FILE-WATCH-CHANGED',
+            () =>
+              Promise.resolve({
+                description: 'File watch changed',
+                response: JSON.stringify({
+                  changedProjects,
+                  changedFiles,
+                }),
+              }),
+            'json'
+          );
+        }
+
+        if (hasFilters && consideredFileCount > 0) {
+          reportFilterDroppedEntireBatch(watcher, consideredFileCount);
+        }
+      })
     );
   });
+}
+
+/**
+ * Files changed but the include/exclude filter dropped the whole batch, so no
+ * command runs and `nx watch` looks hung. The daemon log alone can't tell the
+ * person who typed the pattern anything, so this goes to their terminal over
+ * their own watch socket, and the daemon log keeps the full record.
+ *
+ * Only the first drop per subscription is sent to the terminal — the condition
+ * repeats on every save in an excluded file, and a filter that is doing its job
+ * hits this constantly.
+ */
+function reportFilterDroppedEntireBatch(
+  watcher: RegisteredFileWatcherSocket,
+  consideredFileCount: number
+) {
+  const details =
+    `include=${JSON.stringify(watcher.config.include ?? [])} ` +
+    `exclude=${JSON.stringify(watcher.config.exclude ?? [])}`;
+
+  serverLogger.watcherLog(
+    `Include/exclude filter dropped all ${consideredFileCount} changed file(s); no command will run. ${details}`
+  );
+
+  if (watcher.warnedAboutDroppedBatch) {
+    return;
+  }
+  watcher.warnedAboutDroppedBatch = true;
+
+  sendEmitLogMessageToSocket(
+    watcher.socket,
+    `nx watch: the --include/--exclude filter dropped all ${consideredFileCount} changed file(s), so the command did not run. ${details}. ` +
+      `Patterns are matched against workspace-root-relative paths, so use "**/*.ts" rather than "*.ts" to match nested files. ` +
+      `(Only reported once per watch.)`,
+    'warn'
+  );
 }

--- a/packages/nx/src/daemon/server/file-watching/glob-filter.spec.ts
+++ b/packages/nx/src/daemon/server/file-watching/glob-filter.spec.ts
@@ -1,5 +1,15 @@
-import { fileMatchesGlobFilter, filterChangedFiles } from './glob-filter';
+import {
+  compileGlobs,
+  fileMatchesGlobFilter,
+  filterChangedFiles,
+  selectChangedProjectsAndFiles,
+} from './glob-filter';
 import type { ChangedFile } from './changed-projects';
+
+// Convenience: the filter helpers take precompiled matchers, so tests compile
+// their raw patterns up front (mirroring how the daemon compiles once at
+// registration).
+const globs = (patterns: string[]) => compileGlobs(patterns);
 
 describe('fileMatchesGlobFilter', () => {
   describe('no filters (empty include and exclude)', () => {
@@ -11,34 +21,53 @@ describe('fileMatchesGlobFilter', () => {
 
   describe('include only', () => {
     it('accepts files matching an include pattern', () => {
-      expect(fileMatchesGlobFilter('src/app/main.ts', ['**/*.ts'], [])).toBe(
-        true
-      );
+      expect(
+        fileMatchesGlobFilter('src/app/main.ts', globs(['**/*.ts']), [])
+      ).toBe(true);
     });
 
     it('rejects files not matching any include pattern', () => {
-      expect(fileMatchesGlobFilter('src/app/styles.css', ['**/*.ts'], [])).toBe(
-        false
-      );
+      expect(
+        fileMatchesGlobFilter('src/app/styles.css', globs(['**/*.ts']), [])
+      ).toBe(false);
     });
 
     it('accepts a file matching any one of multiple include patterns', () => {
       expect(
-        fileMatchesGlobFilter('src/app/main.ts', ['**/*.ts', '**/*.tsx'], [])
+        fileMatchesGlobFilter(
+          'src/app/main.ts',
+          globs(['**/*.ts', '**/*.tsx']),
+          []
+        )
       ).toBe(true);
+    });
+
+    it('supports brace-expansion globs (passed through intact)', () => {
+      const matchers = globs(['**/*.{ts,tsx}']);
+      expect(fileMatchesGlobFilter('src/app/main.tsx', matchers, [])).toBe(
+        true
+      );
+      expect(fileMatchesGlobFilter('src/app/main.ts', matchers, [])).toBe(true);
+      expect(fileMatchesGlobFilter('src/app/main.css', matchers, [])).toBe(
+        false
+      );
     });
   });
 
   describe('exclude only', () => {
     it('rejects files matching an exclude pattern', () => {
       expect(
-        fileMatchesGlobFilter('src/app/main.spec.ts', [], ['**/*.spec.ts'])
+        fileMatchesGlobFilter(
+          'src/app/main.spec.ts',
+          [],
+          globs(['**/*.spec.ts'])
+        )
       ).toBe(false);
     });
 
     it('accepts files not matching any exclude pattern', () => {
       expect(
-        fileMatchesGlobFilter('src/app/main.ts', [], ['**/*.spec.ts'])
+        fileMatchesGlobFilter('src/app/main.ts', [], globs(['**/*.spec.ts']))
       ).toBe(true);
     });
   });
@@ -46,7 +75,11 @@ describe('fileMatchesGlobFilter', () => {
   describe('include and exclude combined', () => {
     it('accepts a file matching include but not exclude', () => {
       expect(
-        fileMatchesGlobFilter('src/app/main.ts', ['**/*.ts'], ['**/*.spec.ts'])
+        fileMatchesGlobFilter(
+          'src/app/main.ts',
+          globs(['**/*.ts']),
+          globs(['**/*.spec.ts'])
+        )
       ).toBe(true);
     });
 
@@ -54,8 +87,8 @@ describe('fileMatchesGlobFilter', () => {
       expect(
         fileMatchesGlobFilter(
           'src/app/main.spec.ts',
-          ['**/*.ts'],
-          ['**/*.spec.ts']
+          globs(['**/*.ts']),
+          globs(['**/*.spec.ts'])
         )
       ).toBe(false);
     });
@@ -64,16 +97,22 @@ describe('fileMatchesGlobFilter', () => {
       expect(
         fileMatchesGlobFilter(
           'src/app/styles.css',
-          ['**/*.ts'],
-          ['**/*.spec.ts']
+          globs(['**/*.ts']),
+          globs(['**/*.spec.ts'])
         )
       ).toBe(false);
     });
   });
 
   describe('dot files', () => {
-    it('matches dot files when the pattern uses dot:true semantics', () => {
-      expect(fileMatchesGlobFilter('.env', ['**/.env'], [])).toBe(true);
+    it('traverses a dot-prefixed directory (load-bearing: needs dot:true)', () => {
+      // `**/*.ts` only reaches a file inside `.config/` because compileGlobs
+      // uses `dot: true`. Removing `dot: true` makes this assertion fail, which
+      // is what makes it a real guard for the option (unlike a pattern with a
+      // literal leading dot, which matches either way).
+      expect(
+        fileMatchesGlobFilter('.config/settings.ts', globs(['**/*.ts']), [])
+      ).toBe(true);
     });
 
     it('includes dot files when no filter is set', () => {
@@ -85,14 +124,14 @@ describe('fileMatchesGlobFilter', () => {
 describe('filterChangedFiles', () => {
   const makeFile = (path: string): ChangedFile => ({ path, type: 'update' });
 
-  it('returns the original array when both filters are empty', () => {
+  it('returns the original array by reference when both filters are empty', () => {
     const files = [makeFile('a.ts'), makeFile('b.ts')];
     expect(filterChangedFiles(files, [], [])).toBe(files); // same reference
   });
 
   it('keeps only files matching the include pattern', () => {
     const files = [makeFile('a.ts'), makeFile('b.css'), makeFile('c.ts')];
-    const result = filterChangedFiles(files, ['**/*.ts'], []);
+    const result = filterChangedFiles(files, globs(['**/*.ts']), []);
     expect(result.map((f) => f.path)).toEqual(['a.ts', 'c.ts']);
   });
 
@@ -102,14 +141,17 @@ describe('filterChangedFiles', () => {
       makeFile('a.spec.ts'),
       makeFile('b.spec.ts'),
     ];
-    const result = filterChangedFiles(files, [], ['**/*.spec.ts']);
+    const result = filterChangedFiles(files, [], globs(['**/*.spec.ts']));
     expect(result.map((f) => f.path)).toEqual(['a.ts']);
   });
 
-  it('drops a project when all its files are filtered out', () => {
-    // Simulate: only spec files changed → all filtered → empty result
+  it('drops all files when every one is filtered out', () => {
     const files = [makeFile('src/a.spec.ts'), makeFile('src/b.spec.ts')];
-    const result = filterChangedFiles(files, ['**/*.ts'], ['**/*.spec.ts']);
+    const result = filterChangedFiles(
+      files,
+      globs(['**/*.ts']),
+      globs(['**/*.spec.ts'])
+    );
     expect(result).toHaveLength(0);
   });
 
@@ -118,7 +160,65 @@ describe('filterChangedFiles', () => {
       { path: 'src/a.ts', type: 'create' },
       { path: 'src/b.ts', type: 'delete' },
     ];
-    const result = filterChangedFiles(files, ['**/*.ts'], []);
+    const result = filterChangedFiles(files, globs(['**/*.ts']), []);
     expect(result).toEqual(files);
+  });
+});
+
+describe('selectChangedProjectsAndFiles (project-drop gate)', () => {
+  const makeFile = (path: string): ChangedFile => ({ path, type: 'update' });
+
+  it('drops a project when all of its changed files are filtered out', () => {
+    // proj-a only changed spec files (all excluded) → the whole project is
+    // dropped. proj-b has a surviving file → it is kept.
+    const projects = {
+      'proj-a': [makeFile('proj-a/x.spec.ts'), makeFile('proj-a/y.spec.ts')],
+      'proj-b': [makeFile('proj-b/z.ts')],
+    };
+
+    const { changedProjects, changedFiles, consideredFileCount } =
+      selectChangedProjectsAndFiles(
+        projects,
+        globs(['**/*.ts']),
+        globs(['**/*.spec.ts'])
+      );
+
+    expect(changedProjects).toEqual(['proj-b']);
+    expect(changedFiles.map((f) => f.path)).toEqual(['proj-b/z.ts']);
+    // Both projects' files were considered before filtering.
+    expect(consideredFileCount).toBe(3);
+  });
+
+  it('keeps every project when there are no filters', () => {
+    const projects = {
+      'proj-a': [makeFile('proj-a/x.ts')],
+      'proj-b': [makeFile('proj-b/y.css')],
+    };
+
+    const { changedProjects, changedFiles, consideredFileCount } =
+      selectChangedProjectsAndFiles(projects, [], []);
+
+    expect(changedProjects).toEqual(['proj-a', 'proj-b']);
+    expect(changedFiles.map((f) => f.path)).toEqual([
+      'proj-a/x.ts',
+      'proj-b/y.css',
+    ]);
+    expect(consideredFileCount).toBe(2);
+  });
+
+  it('drops every project when the filter excludes all files', () => {
+    const projects = {
+      'proj-a': [makeFile('proj-a/x.spec.ts')],
+      'proj-b': [makeFile('proj-b/y.spec.ts')],
+    };
+
+    const { changedProjects, changedFiles, consideredFileCount } =
+      selectChangedProjectsAndFiles(projects, [], globs(['**/*.spec.ts']));
+
+    expect(changedProjects).toEqual([]);
+    expect(changedFiles).toEqual([]);
+    // Nothing survived, but two files were considered — the caller uses this to
+    // tell "entire batch filtered out" apart from "nothing changed".
+    expect(consideredFileCount).toBe(2);
   });
 });

--- a/packages/nx/src/daemon/server/file-watching/glob-filter.spec.ts
+++ b/packages/nx/src/daemon/server/file-watching/glob-filter.spec.ts
@@ -1,0 +1,124 @@
+import { fileMatchesGlobFilter, filterChangedFiles } from './glob-filter';
+import type { ChangedFile } from './changed-projects';
+
+describe('fileMatchesGlobFilter', () => {
+  describe('no filters (empty include and exclude)', () => {
+    it('accepts any file', () => {
+      expect(fileMatchesGlobFilter('src/index.ts', [], [])).toBe(true);
+      expect(fileMatchesGlobFilter('some/random/path.json', [], [])).toBe(true);
+    });
+  });
+
+  describe('include only', () => {
+    it('accepts files matching an include pattern', () => {
+      expect(fileMatchesGlobFilter('src/app/main.ts', ['**/*.ts'], [])).toBe(
+        true
+      );
+    });
+
+    it('rejects files not matching any include pattern', () => {
+      expect(fileMatchesGlobFilter('src/app/styles.css', ['**/*.ts'], [])).toBe(
+        false
+      );
+    });
+
+    it('accepts a file matching any one of multiple include patterns', () => {
+      expect(
+        fileMatchesGlobFilter('src/app/main.ts', ['**/*.ts', '**/*.tsx'], [])
+      ).toBe(true);
+    });
+  });
+
+  describe('exclude only', () => {
+    it('rejects files matching an exclude pattern', () => {
+      expect(
+        fileMatchesGlobFilter('src/app/main.spec.ts', [], ['**/*.spec.ts'])
+      ).toBe(false);
+    });
+
+    it('accepts files not matching any exclude pattern', () => {
+      expect(
+        fileMatchesGlobFilter('src/app/main.ts', [], ['**/*.spec.ts'])
+      ).toBe(true);
+    });
+  });
+
+  describe('include and exclude combined', () => {
+    it('accepts a file matching include but not exclude', () => {
+      expect(
+        fileMatchesGlobFilter('src/app/main.ts', ['**/*.ts'], ['**/*.spec.ts'])
+      ).toBe(true);
+    });
+
+    it('rejects a file matching both include and exclude (exclude wins)', () => {
+      expect(
+        fileMatchesGlobFilter(
+          'src/app/main.spec.ts',
+          ['**/*.ts'],
+          ['**/*.spec.ts']
+        )
+      ).toBe(false);
+    });
+
+    it('rejects a file not matching include', () => {
+      expect(
+        fileMatchesGlobFilter(
+          'src/app/styles.css',
+          ['**/*.ts'],
+          ['**/*.spec.ts']
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('dot files', () => {
+    it('matches dot files when the pattern uses dot:true semantics', () => {
+      expect(fileMatchesGlobFilter('.env', ['**/.env'], [])).toBe(true);
+    });
+
+    it('includes dot files when no filter is set', () => {
+      expect(fileMatchesGlobFilter('.gitignore', [], [])).toBe(true);
+    });
+  });
+});
+
+describe('filterChangedFiles', () => {
+  const makeFile = (path: string): ChangedFile => ({ path, type: 'update' });
+
+  it('returns the original array when both filters are empty', () => {
+    const files = [makeFile('a.ts'), makeFile('b.ts')];
+    expect(filterChangedFiles(files, [], [])).toBe(files); // same reference
+  });
+
+  it('keeps only files matching the include pattern', () => {
+    const files = [makeFile('a.ts'), makeFile('b.css'), makeFile('c.ts')];
+    const result = filterChangedFiles(files, ['**/*.ts'], []);
+    expect(result.map((f) => f.path)).toEqual(['a.ts', 'c.ts']);
+  });
+
+  it('removes files matching the exclude pattern', () => {
+    const files = [
+      makeFile('a.ts'),
+      makeFile('a.spec.ts'),
+      makeFile('b.spec.ts'),
+    ];
+    const result = filterChangedFiles(files, [], ['**/*.spec.ts']);
+    expect(result.map((f) => f.path)).toEqual(['a.ts']);
+  });
+
+  it('drops a project when all its files are filtered out', () => {
+    // Simulate: only spec files changed → all filtered → empty result
+    const files = [makeFile('src/a.spec.ts'), makeFile('src/b.spec.ts')];
+    const result = filterChangedFiles(files, ['**/*.ts'], ['**/*.spec.ts']);
+    expect(result).toHaveLength(0);
+  });
+
+  it('preserves the ChangedFile shape (path + type)', () => {
+    const files: ChangedFile[] = [
+      { path: 'src/a.ts', type: 'create' },
+      { path: 'src/b.ts', type: 'delete' },
+    ];
+    const result = filterChangedFiles(files, ['**/*.ts'], []);
+    expect(result).toEqual(files);
+  });
+});

--- a/packages/nx/src/daemon/server/file-watching/glob-filter.spec.ts
+++ b/packages/nx/src/daemon/server/file-watching/glob-filter.spec.ts
@@ -2,6 +2,7 @@ import {
   compileGlobs,
   fileMatchesGlobFilter,
   filterChangedFiles,
+  normalizeWatchGlobs,
   selectChangedProjectsAndFiles,
 } from './glob-filter';
 import type { ChangedFile } from './changed-projects';
@@ -9,7 +10,68 @@ import type { ChangedFile } from './changed-projects';
 // Convenience: the filter helpers take precompiled matchers, so tests compile
 // their raw patterns up front (mirroring how the daemon compiles once at
 // registration).
-const globs = (patterns: string[]) => compileGlobs(patterns);
+const globs = (patterns: string[]) => compileGlobs(patterns, '--include');
+
+describe('compileGlobs', () => {
+  // A negated pattern used to be compiled and handed straight to minimatch,
+  // where it inverted its own result inside an OR-list — so
+  // `--include "**/*.ts" "!**/*.spec.ts"` *kept* spec files and
+  // `--exclude "!**/*.spec.ts"` dropped everything that was not a spec. Both
+  // read as the exact opposite of what they did, so they are rejected.
+  it('rejects a negated pattern and points at the other flag', () => {
+    expect(() => compileGlobs(['!**/*.spec.ts'], '--include')).toThrow(
+      /negated patterns are not supported.*--exclude/s
+    );
+    expect(() => compileGlobs(['!**/*.spec.ts'], '--exclude')).toThrow(
+      /negated patterns are not supported.*--include/s
+    );
+  });
+
+  it('rejects an empty pattern (what an unset shell variable expands to)', () => {
+    expect(() => compileGlobs([''], '--include')).toThrow(
+      /the pattern is empty/
+    );
+    expect(() => compileGlobs(['   '], '--exclude')).toThrow(
+      /the pattern is empty/
+    );
+  });
+
+  it('strips a leading ./ so a tsconfig-style pattern still matches', () => {
+    const matchers = compileGlobs(['./src/**/*.ts'], '--include');
+    expect(fileMatchesGlobFilter('src/app/main.ts', matchers, [])).toBe(true);
+  });
+
+  it('leaves a valid pattern untouched', () => {
+    const matchers = compileGlobs(['**/*.ts'], '--include');
+    expect(fileMatchesGlobFilter('src/app/main.ts', matchers, [])).toBe(true);
+    expect(fileMatchesGlobFilter('src/app/main.css', matchers, [])).toBe(false);
+  });
+});
+
+describe('normalizeWatchGlobs', () => {
+  it('passes undefined through (the flag was not used)', () => {
+    expect(normalizeWatchGlobs(undefined, '--include')).toBeUndefined();
+  });
+
+  it('rejects a flag passed with no patterns, which would disable the filter', () => {
+    expect(() => normalizeWatchGlobs([], '--include')).toThrow(
+      /--include was passed without any glob patterns/
+    );
+  });
+
+  it('normalizes each pattern', () => {
+    expect(normalizeWatchGlobs(['./src/**', '**/*.ts'], '--include')).toEqual([
+      'src/**',
+      '**/*.ts',
+    ]);
+  });
+
+  it('rejects a negated pattern', () => {
+    expect(() => normalizeWatchGlobs(['!**/*.spec.ts'], '--exclude')).toThrow(
+      /negated patterns are not supported/
+    );
+  });
+});
 
 describe('fileMatchesGlobFilter', () => {
   describe('no filters (empty include and exclude)', () => {
@@ -178,7 +240,7 @@ describe('selectChangedProjectsAndFiles (project-drop gate)', () => {
 
     const { changedProjects, changedFiles, consideredFileCount } =
       selectChangedProjectsAndFiles(
-        projects,
+        Object.entries(projects),
         globs(['**/*.ts']),
         globs(['**/*.spec.ts'])
       );
@@ -196,7 +258,7 @@ describe('selectChangedProjectsAndFiles (project-drop gate)', () => {
     };
 
     const { changedProjects, changedFiles, consideredFileCount } =
-      selectChangedProjectsAndFiles(projects, [], []);
+      selectChangedProjectsAndFiles(Object.entries(projects), [], []);
 
     expect(changedProjects).toEqual(['proj-a', 'proj-b']);
     expect(changedFiles.map((f) => f.path)).toEqual([
@@ -213,12 +275,33 @@ describe('selectChangedProjectsAndFiles (project-drop gate)', () => {
     };
 
     const { changedProjects, changedFiles, consideredFileCount } =
-      selectChangedProjectsAndFiles(projects, [], globs(['**/*.spec.ts']));
+      selectChangedProjectsAndFiles(
+        Object.entries(projects),
+        [],
+        globs(['**/*.spec.ts'])
+      );
 
     expect(changedProjects).toEqual([]);
     expect(changedFiles).toEqual([]);
     // Nothing survived, but two files were considered — the caller uses this to
     // tell "entire batch filtered out" apart from "nothing changed".
     expect(consideredFileCount).toBe(2);
+  });
+
+  it('reports projects in the order the caller supplied them', () => {
+    // Taking entries rather than an object is what makes this hold: a plain
+    // object hoists the integer-like key `2024` to the front.
+    const projects = new Map([
+      ['zebra', [makeFile('zebra/x.ts')]],
+      ['2024', [makeFile('2024/y.ts')]],
+    ]);
+
+    const { changedProjects } = selectChangedProjectsAndFiles(
+      projects,
+      globs(['**/*.ts']),
+      []
+    );
+
+    expect(changedProjects).toEqual(['zebra', '2024']);
   });
 });

--- a/packages/nx/src/daemon/server/file-watching/glob-filter.spec.ts
+++ b/packages/nx/src/daemon/server/file-watching/glob-filter.spec.ts
@@ -10,39 +10,39 @@ import type { ChangedFile } from './changed-projects';
 // Convenience: the filter helpers take precompiled matchers, so tests compile
 // their raw patterns up front (mirroring how the daemon compiles once at
 // registration).
-const globs = (patterns: string[]) => compileGlobs(patterns, '--include');
+const globs = (patterns: string[]) => compileGlobs(patterns, '--includeFiles');
 
 describe('compileGlobs', () => {
   // A negated pattern used to be compiled and handed straight to minimatch,
   // where it inverted its own result inside an OR-list — so
-  // `--include "**/*.ts" "!**/*.spec.ts"` *kept* spec files and
-  // `--exclude "!**/*.spec.ts"` dropped everything that was not a spec. Both
-  // read as the exact opposite of what they did, so they are rejected.
+  // `--includeFiles "**/*.ts" "!**/*.spec.ts"` *kept* spec files and
+  // `--excludeFiles "!**/*.spec.ts"` dropped everything that was not a spec.
+  // Both read as the exact opposite of what they did, so they are rejected.
   it('rejects a negated pattern and points at the other flag', () => {
-    expect(() => compileGlobs(['!**/*.spec.ts'], '--include')).toThrow(
-      /negated patterns are not supported.*--exclude/s
+    expect(() => compileGlobs(['!**/*.spec.ts'], '--includeFiles')).toThrow(
+      /negated patterns are not supported.*--excludeFiles/s
     );
-    expect(() => compileGlobs(['!**/*.spec.ts'], '--exclude')).toThrow(
-      /negated patterns are not supported.*--include/s
+    expect(() => compileGlobs(['!**/*.spec.ts'], '--excludeFiles')).toThrow(
+      /negated patterns are not supported.*--includeFiles/s
     );
   });
 
   it('rejects an empty pattern (what an unset shell variable expands to)', () => {
-    expect(() => compileGlobs([''], '--include')).toThrow(
+    expect(() => compileGlobs([''], '--includeFiles')).toThrow(
       /the pattern is empty/
     );
-    expect(() => compileGlobs(['   '], '--exclude')).toThrow(
+    expect(() => compileGlobs(['   '], '--excludeFiles')).toThrow(
       /the pattern is empty/
     );
   });
 
   it('strips a leading ./ so a tsconfig-style pattern still matches', () => {
-    const matchers = compileGlobs(['./src/**/*.ts'], '--include');
+    const matchers = compileGlobs(['./src/**/*.ts'], '--includeFiles');
     expect(fileMatchesGlobFilter('src/app/main.ts', matchers, [])).toBe(true);
   });
 
   it('leaves a valid pattern untouched', () => {
-    const matchers = compileGlobs(['**/*.ts'], '--include');
+    const matchers = compileGlobs(['**/*.ts'], '--includeFiles');
     expect(fileMatchesGlobFilter('src/app/main.ts', matchers, [])).toBe(true);
     expect(fileMatchesGlobFilter('src/app/main.css', matchers, [])).toBe(false);
   });
@@ -50,26 +50,25 @@ describe('compileGlobs', () => {
 
 describe('normalizeWatchGlobs', () => {
   it('passes undefined through (the flag was not used)', () => {
-    expect(normalizeWatchGlobs(undefined, '--include')).toBeUndefined();
+    expect(normalizeWatchGlobs(undefined, '--includeFiles')).toBeUndefined();
   });
 
   it('rejects a flag passed with no patterns, which would disable the filter', () => {
-    expect(() => normalizeWatchGlobs([], '--include')).toThrow(
-      /--include was passed without any glob patterns/
+    expect(() => normalizeWatchGlobs([], '--includeFiles')).toThrow(
+      /--includeFiles was passed without any glob patterns/
     );
   });
 
   it('normalizes each pattern', () => {
-    expect(normalizeWatchGlobs(['./src/**', '**/*.ts'], '--include')).toEqual([
-      'src/**',
-      '**/*.ts',
-    ]);
+    expect(
+      normalizeWatchGlobs(['./src/**', '**/*.ts'], '--includeFiles')
+    ).toEqual(['src/**', '**/*.ts']);
   });
 
   it('rejects a negated pattern', () => {
-    expect(() => normalizeWatchGlobs(['!**/*.spec.ts'], '--exclude')).toThrow(
-      /negated patterns are not supported/
-    );
+    expect(() =>
+      normalizeWatchGlobs(['!**/*.spec.ts'], '--excludeFiles')
+    ).toThrow(/negated patterns are not supported/);
   });
 });
 

--- a/packages/nx/src/daemon/server/file-watching/glob-filter.ts
+++ b/packages/nx/src/daemon/server/file-watching/glob-filter.ts
@@ -1,29 +1,43 @@
-import { minimatch } from 'minimatch';
+import { Minimatch } from 'minimatch';
 import type { ChangedFile } from './changed-projects';
+
+// `dot: true` lets `**` traverse and match dot-prefixed segments (e.g. a file
+// inside `.config/`), which the default minimatch behavior would skip.
+const GLOB_OPTIONS = { dot: true };
+
+/**
+ * Compiles raw glob pattern strings into reusable {@link Minimatch} matchers.
+ *
+ * Patterns are invariant for the life of a watch subscription, so compiling
+ * once here (at registration) avoids re-parsing/re-compiling every pattern on
+ * every file-change batch on the daemon hot path.
+ */
+export function compileGlobs(patterns: readonly string[]): Minimatch[] {
+  return patterns.map((pattern) => new Minimatch(pattern, GLOB_OPTIONS));
+}
 
 /**
  * Returns true if the given file path passes the include/exclude glob filters.
+ * Accepts precompiled matchers (see {@link compileGlobs}) so no pattern is
+ * parsed here.
  *
  * Rules:
- * - If `include` is non-empty, the file must match at least one pattern.
- * - If `exclude` is non-empty, the file must NOT match any pattern.
+ * - If `include` is non-empty, the file must match at least one matcher.
+ * - If `exclude` is non-empty, the file must NOT match any matcher.
  * - When both lists are empty every file is accepted.
+ *
+ * Paths are matched as they arrive from the watcher: workspace-relative.
  */
 export function fileMatchesGlobFilter(
   filePath: string,
-  include: readonly string[],
-  exclude: readonly string[]
+  include: readonly Minimatch[],
+  exclude: readonly Minimatch[]
 ): boolean {
-  const opts = { dot: true };
-
-  if (
-    include.length > 0 &&
-    !include.some((p) => minimatch(filePath, p, opts))
-  ) {
+  if (include.length > 0 && !include.some((m) => m.match(filePath))) {
     return false;
   }
 
-  if (exclude.length > 0 && exclude.some((p) => minimatch(filePath, p, opts))) {
+  if (exclude.length > 0 && exclude.some((m) => m.match(filePath))) {
     return false;
   }
 
@@ -33,14 +47,54 @@ export function fileMatchesGlobFilter(
 /**
  * Filters an array of `ChangedFile` objects, keeping only those whose `path`
  * passes the include/exclude glob filter.
+ *
+ * When there are no filters this is a true zero-cost identity: the original
+ * array is returned by reference with no allocation.
  */
 export function filterChangedFiles(
   files: ChangedFile[],
-  include: readonly string[],
-  exclude: readonly string[]
+  include: readonly Minimatch[],
+  exclude: readonly Minimatch[]
 ): ChangedFile[] {
   if (include.length === 0 && exclude.length === 0) {
     return files;
   }
   return files.filter((f) => fileMatchesGlobFilter(f.path, include, exclude));
+}
+
+/**
+ * Applies the include/exclude filter to each project's changed files and drops
+ * any project whose files are entirely filtered out (the "project-drop gate").
+ * A project is only reported when at least one of its changed files survives
+ * the filter.
+ *
+ * `consideredFileCount` is the number of changed files seen before filtering,
+ * so callers can tell "nothing changed" apart from "everything was filtered
+ * out" (useful for debugging a misconfigured pattern).
+ */
+export function selectChangedProjectsAndFiles(
+  projectFilesByName: Record<string, ChangedFile[]>,
+  include: readonly Minimatch[],
+  exclude: readonly Minimatch[]
+): {
+  changedProjects: string[];
+  changedFiles: ChangedFile[];
+  consideredFileCount: number;
+} {
+  const changedProjects: string[] = [];
+  const changedFiles: ChangedFile[] = [];
+  let consideredFileCount = 0;
+
+  for (const [projectName, projectFiles] of Object.entries(
+    projectFilesByName
+  )) {
+    consideredFileCount += projectFiles.length;
+    const filteredFiles = filterChangedFiles(projectFiles, include, exclude);
+    if (filteredFiles.length > 0) {
+      changedProjects.push(projectName);
+      changedFiles.push(...filteredFiles);
+    }
+  }
+
+  return { changedProjects, changedFiles, consideredFileCount };
 }

--- a/packages/nx/src/daemon/server/file-watching/glob-filter.ts
+++ b/packages/nx/src/daemon/server/file-watching/glob-filter.ts
@@ -1,0 +1,46 @@
+import { minimatch } from 'minimatch';
+import type { ChangedFile } from './changed-projects';
+
+/**
+ * Returns true if the given file path passes the include/exclude glob filters.
+ *
+ * Rules:
+ * - If `include` is non-empty, the file must match at least one pattern.
+ * - If `exclude` is non-empty, the file must NOT match any pattern.
+ * - When both lists are empty every file is accepted.
+ */
+export function fileMatchesGlobFilter(
+  filePath: string,
+  include: readonly string[],
+  exclude: readonly string[]
+): boolean {
+  const opts = { dot: true };
+
+  if (
+    include.length > 0 &&
+    !include.some((p) => minimatch(filePath, p, opts))
+  ) {
+    return false;
+  }
+
+  if (exclude.length > 0 && exclude.some((p) => minimatch(filePath, p, opts))) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Filters an array of `ChangedFile` objects, keeping only those whose `path`
+ * passes the include/exclude glob filter.
+ */
+export function filterChangedFiles(
+  files: ChangedFile[],
+  include: readonly string[],
+  exclude: readonly string[]
+): ChangedFile[] {
+  if (include.length === 0 && exclude.length === 0) {
+    return files;
+  }
+  return files.filter((f) => fileMatchesGlobFilter(f.path, include, exclude));
+}

--- a/packages/nx/src/daemon/server/file-watching/glob-filter.ts
+++ b/packages/nx/src/daemon/server/file-watching/glob-filter.ts
@@ -6,7 +6,7 @@ import type { ChangedFile } from './changed-projects';
 const GLOB_OPTIONS = { dot: true };
 
 /** The CLI flag a set of patterns came from, used to build error messages. */
-export type WatchGlobFlag = '--include' | '--exclude';
+export type WatchGlobFlag = '--includeFiles' | '--excludeFiles';
 
 /**
  * Validates and normalizes a single raw watch glob.
@@ -18,8 +18,9 @@ export type WatchGlobFlag = '--include' | '--exclude';
  *   pattern's own result, and both filters combine their patterns with OR, so
  *   a negated pattern can only ever widen the set it lives in. That makes the
  *   familiar gitignore/eslint idiom mean the opposite of how it reads:
- *   `--include "**\/*.ts" "!**\/*.spec.ts"` would *keep* the spec files, and
- *   `--exclude "!**\/*.spec.ts"` would drop everything that is *not* a spec.
+ *   `--includeFiles "**\/*.ts" "!**\/*.spec.ts"` would *keep* the spec files,
+ *   and `--excludeFiles "!**\/*.spec.ts"` would drop everything that is *not* a
+ *   spec.
  *   Negation already has a first-class spelling here — the other flag.
  * - An empty (or whitespace-only) pattern, which matches nothing. It is what
  *   an unset shell variable expands to, so it is always a mistake.
@@ -37,7 +38,7 @@ export function normalizeWatchGlob(
       `Invalid ${flag} pattern ${JSON.stringify(
         pattern
       )}: negated patterns are not supported. Use ${
-        flag === '--include' ? '--exclude' : '--include'
+        flag === '--includeFiles' ? '--excludeFiles' : '--includeFiles'
       } to express the opposite set.`
     );
   }
@@ -56,9 +57,9 @@ export function normalizeWatchGlob(
 /**
  * Validates and normalizes the patterns for one flag as they enter the system
  * from the CLI. Unlike {@link compileGlobs} this also rejects a flag that was
- * passed with no value at all (`nx watch --all --include -- ...`), which yargs
- * parses as `[]` and which would otherwise disable the filter entirely — the
- * opposite of what was asked for.
+ * passed with no value at all (`nx watch --all --includeFiles -- ...`), which
+ * yargs parses as `[]` and which would otherwise disable the filter entirely —
+ * the opposite of what was asked for.
  */
 export function normalizeWatchGlobs(
   patterns: string[] | undefined,

--- a/packages/nx/src/daemon/server/file-watching/glob-filter.ts
+++ b/packages/nx/src/daemon/server/file-watching/glob-filter.ts
@@ -5,15 +5,94 @@ import type { ChangedFile } from './changed-projects';
 // inside `.config/`), which the default minimatch behavior would skip.
 const GLOB_OPTIONS = { dot: true };
 
+/** The CLI flag a set of patterns came from, used to build error messages. */
+export type WatchGlobFlag = '--include' | '--exclude';
+
+/**
+ * Validates and normalizes a single raw watch glob.
+ *
+ * Two inputs are rejected outright rather than accepted and quietly matched
+ * against nothing:
+ *
+ * - A leading `!`. Minimatch implements negation by inverting that *one*
+ *   pattern's own result, and both filters combine their patterns with OR, so
+ *   a negated pattern can only ever widen the set it lives in. That makes the
+ *   familiar gitignore/eslint idiom mean the opposite of how it reads:
+ *   `--include "**\/*.ts" "!**\/*.spec.ts"` would *keep* the spec files, and
+ *   `--exclude "!**\/*.spec.ts"` would drop everything that is *not* a spec.
+ *   Negation already has a first-class spelling here — the other flag.
+ * - An empty (or whitespace-only) pattern, which matches nothing. It is what
+ *   an unset shell variable expands to, so it is always a mistake.
+ *
+ * A leading `./` is stripped rather than rejected: patterns are matched
+ * against workspace-root-relative paths, which never carry that prefix, but
+ * `./src/**` is a natural thing to copy out of a tsconfig.
+ */
+export function normalizeWatchGlob(
+  pattern: string,
+  flag: WatchGlobFlag
+): string {
+  if (pattern.startsWith('!')) {
+    throw new Error(
+      `Invalid ${flag} pattern ${JSON.stringify(
+        pattern
+      )}: negated patterns are not supported. Use ${
+        flag === '--include' ? '--exclude' : '--include'
+      } to express the opposite set.`
+    );
+  }
+
+  if (pattern.trim() === '') {
+    throw new Error(
+      `Invalid ${flag} pattern ${JSON.stringify(
+        pattern
+      )}: the pattern is empty, so it would match no files.`
+    );
+  }
+
+  return pattern.startsWith('./') ? pattern.slice(2) : pattern;
+}
+
+/**
+ * Validates and normalizes the patterns for one flag as they enter the system
+ * from the CLI. Unlike {@link compileGlobs} this also rejects a flag that was
+ * passed with no value at all (`nx watch --all --include -- ...`), which yargs
+ * parses as `[]` and which would otherwise disable the filter entirely — the
+ * opposite of what was asked for.
+ */
+export function normalizeWatchGlobs(
+  patterns: string[] | undefined,
+  flag: WatchGlobFlag
+): string[] | undefined {
+  if (patterns === undefined) {
+    return undefined;
+  }
+
+  if (patterns.length === 0) {
+    throw new Error(`${flag} was passed without any glob patterns.`);
+  }
+
+  return patterns.map((pattern) => normalizeWatchGlob(pattern, flag));
+}
+
 /**
  * Compiles raw glob pattern strings into reusable {@link Minimatch} matchers.
  *
  * Patterns are invariant for the life of a watch subscription, so compiling
  * once here (at registration) avoids re-parsing/re-compiling every pattern on
  * every file-change batch on the daemon hot path.
+ *
+ * Patterns are validated here as well as at the CLI boundary because
+ * `daemonClient.registerFileWatcher` is a public API that other packages call
+ * directly, so this is the only choke point every pattern passes through.
  */
-export function compileGlobs(patterns: readonly string[]): Minimatch[] {
-  return patterns.map((pattern) => new Minimatch(pattern, GLOB_OPTIONS));
+export function compileGlobs(
+  patterns: readonly string[],
+  flag: WatchGlobFlag
+): Minimatch[] {
+  return patterns.map(
+    (pattern) => new Minimatch(normalizeWatchGlob(pattern, flag), GLOB_OPTIONS)
+  );
 }
 
 /**
@@ -71,9 +150,13 @@ export function filterChangedFiles(
  * `consideredFileCount` is the number of changed files seen before filtering,
  * so callers can tell "nothing changed" apart from "everything was filtered
  * out" (useful for debugging a misconfigured pattern).
+ *
+ * Takes `[projectName, files]` entries rather than an object so the caller
+ * owns the iteration order — a plain object hoists integer-like keys, which
+ * would silently reorder a project named e.g. `2024` in `changedProjects`.
  */
 export function selectChangedProjectsAndFiles(
-  projectFilesByName: Record<string, ChangedFile[]>,
+  projectFilesByName: Iterable<[string, ChangedFile[]]>,
   include: readonly Minimatch[],
   exclude: readonly Minimatch[]
 ): {
@@ -85,9 +168,7 @@ export function selectChangedProjectsAndFiles(
   const changedFiles: ChangedFile[] = [];
   let consideredFileCount = 0;
 
-  for (const [projectName, projectFiles] of Object.entries(
-    projectFilesByName
-  )) {
+  for (const [projectName, projectFiles] of projectFilesByName) {
     consideredFileCount += projectFiles.length;
     const filteredFiles = filterChangedFiles(projectFiles, include, exclude);
     if (filteredFiles.length > 0) {

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -347,7 +347,23 @@ async function handleMessage(socket: Socket, data: Buffer) {
       mode
     );
   } else if (payload.type === 'REGISTER_FILE_WATCHER') {
-    registerFileWatcherSocket({ socket, config: payload.config });
+    // Registration throws on an invalid include/exclude glob. It can't go
+    // through `handleResult` like its siblings because this message is
+    // fire-and-forget: the client treats anything arriving on a watch socket
+    // as a file-change notification, so a success response would be misread.
+    // Only the error path responds — the same thing `handleResult` does on
+    // failure — so a bad pattern surfaces in the terminal of the client that
+    // sent it instead of rejecting unhandled and taking the workspace-wide
+    // daemon down with no explanation.
+    try {
+      registerFileWatcherSocket({ socket, config: payload.config });
+    } catch (error) {
+      await respondWithErrorAndExit(
+        socket,
+        '[REGISTER_FILE_WATCHER]',
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
   } else if (isRegisterProjectGraphListenerMessage(payload)) {
     registeredProjectGraphListenerSockets.push(socket);
   } else if (isHandleGlobMessage(payload)) {

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -102,7 +102,7 @@ import { routeWorkspaceChanges } from './file-watching/route-workspace-changes';
 import {
   hasRegisteredFileWatcherSockets,
   notifyFileWatcherSocketsOfError,
-  registeredFileWatcherSockets,
+  registerFileWatcherSocket,
   removeRegisteredFileWatcherSocket,
 } from './file-watching/file-watcher-sockets';
 import {
@@ -347,7 +347,7 @@ async function handleMessage(socket: Socket, data: Buffer) {
       mode
     );
   } else if (payload.type === 'REGISTER_FILE_WATCHER') {
-    registeredFileWatcherSockets.push({ socket, config: payload.config });
+    registerFileWatcherSocket({ socket, config: payload.config });
   } else if (isRegisterProjectGraphListenerMessage(payload)) {
     registeredProjectGraphListenerSockets.push(socket);
   } else if (isHandleGlobMessage(payload)) {


### PR DESCRIPTION
## Current Behavior

`nx watch` re-runs the given command for every file change in the watched projects. There is no way to narrow the trigger to specific file types or paths — e.g. watching only `**/*.ts` changes while ignoring spec files — so commands re-run on irrelevant changes.

## Expected Behavior

`nx watch` accepts two new options:

- `--include`: comma/space-delimited glob patterns; a changed file must match at least one to re-trigger the command (defaults to everything).
- `--exclude`: comma/space-delimited glob patterns; a changed file matching any of these never triggers, even if it matched an include.

```shell
nx watch --all --includeFiles="**/*.ts" --excludeFiles="**/*.spec.ts" -- echo $NX_FILE_CHANGES
```

Filtering happens daemon-side in `notifyFileWatcherSockets`, where the project→files mapping exists, so a project only counts as changed (and only re-triggers a `$NX_PROJECT_NAME` command) when at least one of its changed files survives the filter. Matching uses `minimatch` with `dot: true`; global workspace files are filtered the same way. When neither flag is passed there is zero overhead (fast-path returns the original arrays).

Includes 16 unit tests for the new `glob-filter` helper (include-only, exclude-only, combined, dotfiles, project dropped when all its files are filtered out).

## Related Issue(s)

N/A — feature work coordinated via Polygraph session `watch-filter-d1d4fdda`.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/watch-filter-d1d4fdda)
<!-- polygraph-session-end -->